### PR TITLE
docs: add basic repository documentation

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,28 @@
+# Walrus Code of Conduct
+
+Walrus is a part of the Sui ecosystem and follows the same code of conduct.
+
+As an open source project, we encourage free discussion rooted in respect.
+We endeavor to always be mindful of others' perspectives and ask all
+fellow contributors to do the same. We welcome you to the Sui platform
+and ask you to help us grow it with relevant, on-point contributions.
+
+## Our pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## More information
+
+See the central [Sui Code of Conduct](https://docs.sui.io/code-of-conduct) for
+full details.
+
+Our Code of Conduct is adapted from the
+[Contributor Covenant version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# How to Contribute
+
+## GitHub flow
+
+We generally follow the [GitHub flow](https://docs.github.com/en/get-started/quickstart/github-flow) in our project. In
+a nutshell, this requires the following steps to contribute:
+
+1. [Fork the repository](https://docs.github.com/en/get-started/quickstart/contributing-to-projects) (only required if
+   you don't have write access to the repository).
+1. [Create a feature branch](https://docs.github.com/en/get-started/quickstart/github-flow#create-a-branch).
+1. [Make changes and create a
+   commit](https://docs.github.com/en/get-started/quickstart/contributing-to-projects#making-and-pushing-changes)
+1. Push your changes to GitHub and [create a pull
+   request](https://docs.github.com/en/get-started/quickstart/contributing-to-projects#making-a-pull-request) (PR);
+   note that we enforce a particular style for the PR titles, see [below](#commit-messages).
+1. Wait for maintainers to review your changes and, if necessary, revise your PR.
+1. When all requirements are met, a reviewer or the PR author (if they have write permissions) can merge the PR.
+
+## Commit messages
+
+To ensure a consistent Git history (from which we can later easily generate changelogs automatically), we always squash
+commits when merging a PR and enforce that all PR titles comply with the [conventional-commit
+format](https://www.conventionalcommits.org/en/v1.0.0/). For examples, please take a look at our [commit
+history](https://github.com/MystenLabs/walrus/commits/main).
+
+## Pre-commit hooks
+
+We have CI jobs running for every PR to test and lint the repository. You can install Git pre-commit hooks to ensure
+that these check pass even *before pushing your changes* to GitHub. To use this, the following steps are required:
+
+1. Install [Rust](https://www.rust-lang.org/tools/install).
+1. [Install pre-commit](https://pre-commit.com/#install) using `pip` or your OS's package manager.
+1. Run `pre-commit install` in the repository.
+
+After this setup, the code will be checked, reformatted, and tested whenever you create a Git commit.
+
+You can also use a custom pre-commit configuration if you wish:
+
+1. Create a file `.custom-pre-commit-config.yaml` (this is set to be ignored by Git).
+1. Run `pre-commit install -c .custom-pre-commit-config.yaml`.
+
+## Test coverage
+
+We would like to cover as much code as possible with tests. Ideally you would add unit tests for all code you
+contribute. To analyze test coverage, we use [Tarpaulin](https://crates.io/crates/cargo-tarpaulin). You can install and
+run the tool as follows:
+
+```sh
+cargo install cargo-tarpaulin
+cargo tarpaulin --workspace --skip-clean --lib --bins --examples --tests --doc --out html
+```
+
+This creates a file `tarpaulin-report.html`, which shows you coverage statistics as well as which individual lines are
+or aren't covered by tests. Other valid output formats are `json`, `stdout`, `xml`, and `lcov`.
+
+The exact command we use in our CI pipeline is visible in [.github/workflows/code.yml](.github/workflows/code.yml).
+
+## Signed commits
+
+We appreciate it if you configure Git to [sign your
+commits](https://gist.github.com/troyfontaine/18c9146295168ee9ca2b30c00bd1b41e).

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# walrus
-A decentralized blob store using Sui for coordination and governance.
+# Walrus
+
+A decentralized blob store using [Sui](https://github.com/MystenLabs/sui) for coordination and governance.
+
+## Contributing
+
+If you observe a bug or want to request a feature, please search for an existing
+[issue](https://github.com/MystenLabs/walrus/issues) on this topic and, if none exists, create a new one. If you would
+like to contribute code directly (which we highly appreciate), please familiarize yourself with our [contributing
+workflow](./CONTRIBUTING.md).
+
+## License
+
+This project is licensed under the Apache License, Version 2.0 ([LICENSE](LICENSE) or
+<https://www.apache.org/licenses/LICENSE-2.0>).


### PR DESCRIPTION
The code of conduct is adapted from the [Sui](https://github.com/MystenLabs/sui) repository.

The contributing documentation is adapted from [scion-rs](https://github.com/MystenLabs/scion-rs).

There are some references to components that are added in separate PRs (#5, #6).

All conventions and linter configurations are negotiable of course.