### PR TITLE
chore: keep our dependencies up-to-date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+# Documentation for all configuration options:
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    commit-message:
+      prefix: "fix"
+      prefix-development: "chore"
+      include: "scope"
+    groups:
+      cargo-minor-and-patch-dependencies:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      github-actions-all:
+        patterns: ["*"]

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -1,0 +1,32 @@
+name: Updates
+
+on:
+  # every month
+  schedule:
+    - cron: '14 3 1 * *'
+  # on demand
+  workflow_dispatch:
+
+jobs:
+  pre-commit:
+    name: "Update pre-commit hooks and run them on all files"
+    runs-on: ubuntu-ghcloud
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: rustup update stable
+      - run: pip install pre-commit
+      - run: pre-commit autoupdate
+      - run: pre-commit run --all-files
+      - uses: peter-evans/create-pull-request@v6.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: chore/update-pre-commit-hooks
+          title: "chore: update pre-commit hooks"
+          commit-message: "chore: update pre-commit hooks"
+          body: Update pre-commit hooks to latest version.


### PR DESCRIPTION
- add Dependabot configuration
- set up monthly CI job to update pre-commit versions

This makes sure that our dependencies remain up-to-date.