### PR TITLE
ci: allow more licenses in the CI checks

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -16,11 +16,7 @@ unlicensed = "deny"
 # List of explicitly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
-allow = [
-    # "Apache-2.0",
-    # "BSD-3-Clause",
-    # "MIT",
-]
+allow = ["Apache-2.0", "Unicode-DFS-2016", "MIT"]
 # Lint level for licenses considered copyleft
 copyleft = "deny"
 # Blanket approval or denial for OSI-approved or FSF Free/Libre licenses


### PR DESCRIPTION
Do we want to allow the following liceneses in our CI checks?
```
["Apache-2.0", "Unicode-DFS-2016", "MIT"]
```
