### PR TITLE
feat: add initial storage interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,7 +123,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -124,8 +133,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "ark-ec"
@@ -139,7 +154,7 @@ dependencies = [
  "ark-std",
  "derivative",
  "hashbrown 0.13.2",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "zeroize",
 ]
@@ -156,7 +171,7 @@ dependencies = [
  "ark-std",
  "derivative",
  "digest 0.10.7",
- "itertools",
+ "itertools 0.10.5",
  "num-bigint",
  "num-traits",
  "paste",
@@ -302,12 +317,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bcs"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b6598a2f5d564fb7855dc6b06fd1c38cff5a72bd8b863a4d021938497b440a"
+dependencies = [
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.69.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -324,6 +369,12 @@ checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
 dependencies = [
  "bitcoin-private",
 ]
+
+[[package]]
+name = "bitflags"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "blake2"
@@ -432,6 +483,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,6 +507,18 @@ name = "cc"
 version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02f341c093d19155a6e41631ce5971aac4e9a868262212153124c15fa22d1cdc"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "cfg-if"
@@ -462,7 +536,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-targets",
+ "windows-targets 0.52.3",
 ]
 
 [[package]]
@@ -473,6 +547,17 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -792,6 +877,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,6 +964,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "ff"
@@ -1059,6 +1160,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,10 +1202,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "libloading"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "libm"
@@ -1104,10 +1230,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
+name = "librocksdb-sys"
+version = "0.16.0+8.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce3d60bc059831dc1c83903fb45c103f75db65c5a7bf22272764d9cc683e348c"
+dependencies = [
+ "bindgen",
+ "bzip2-sys",
+ "cc",
+ "glob",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
+ "zstd-sys",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037731f5d3aaa87a5675e895b63ddff1a87624bc29f77004ea829809654e48f6"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+
+[[package]]
 name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "lz4-sys"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "memchr"
@@ -1128,12 +1297,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1306,6 +1491,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
 name = "polyval"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1398,6 +1589,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1405,6 +1625,16 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
+]
+
+[[package]]
+name = "rocksdb"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd13e55d6d7b8cd0ea569161127567cd587676c99f4472f779a0279aa60a7a7"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
 ]
 
 [[package]]
@@ -1435,12 +1665,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1639,6 +1888,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1733,6 +1988,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "rustix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1799,6 +2066,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
  "backtrace",
+ "num_cpus",
  "pin-project-lite",
  "tokio-macros",
 ]
@@ -1849,6 +2117,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1866,9 +2140,23 @@ dependencies = [
 name = "walrus-service"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "bcs",
  "clap",
+ "rocksdb",
  "serde",
+ "tempfile",
+ "thiserror",
+ "tokio",
  "walrus-core",
+ "walrus-test-utils",
+]
+
+[[package]]
+name = "walrus-test-utils"
+version = "0.1.0"
+dependencies = [
+ "tokio",
 ]
 
 [[package]]
@@ -1937,7 +2225,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -1946,7 +2243,22 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.3",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -1955,14 +2267,20 @@ version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d380ba1dc7187569a8a9e91ed34b8ccfc33123bbacb8c0aed2d1ad7f3ef2dc5f"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.3",
+ "windows_aarch64_msvc 0.52.3",
+ "windows_i686_gnu 0.52.3",
+ "windows_i686_msvc 0.52.3",
+ "windows_x86_64_gnu 0.52.3",
+ "windows_x86_64_gnullvm 0.52.3",
+ "windows_x86_64_msvc 0.52.3",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1972,9 +2290,21 @@ checksum = "68e5dcfb9413f53afd9c8f86e56a7b4d86d9a2fa26090ea2dc9e40fba56c6ec6"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8dab469ebbc45798319e69eebf92308e541ce46760b49b18c6b3fe5e8965b30f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1984,9 +2314,21 @@ checksum = "2a4e9b6a7cac734a8b4138a4e1044eac3404d8326b6c0f939276560687a033fb"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b0ec9c422ca95ff34a78755cfa6ad4a51371da2a5ace67500cf7ca5f232c58"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1996,9 +2338,21 @@ checksum = "704131571ba93e89d7cd43482277d6632589b18ecf4468f591fbae0a8b101614"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42079295511643151e98d61c38c0acc444e52dd42ab456f7ccfd5152e8ecf21c"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2044,4 +2398,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.51",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.9+zstd.1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 
 [workspace.dependencies]
 walrus-core = { path = "crates/walrus-core" }
+walrus-test-utils = { path = "crates/walrus-test-utils" }
 
 [workspace.lints.rust]
 missing_docs = "warn"

--- a/crates/walrus-service/Cargo.toml
+++ b/crates/walrus-service/Cargo.toml
@@ -7,8 +7,13 @@ edition = { workspace = true }
 license = { workspace = true }
 
 [dependencies]
+anyhow = "1.0.80"
+bcs = "0.1.6"
 clap = { version = "4.5", features = ["derive"] }
+rocksdb = "0.22"
 serde = { version = "1.0.197", features = ["derive"] }
+thiserror = "1.0.57"
+tokio = { version = "1.36.0", features = ["rt-multi-thread", "macros"] }
 walrus-core = { workspace = true }
 
 [lints]
@@ -17,3 +22,7 @@ workspace = true
 [[bin]]
 name = "client"
 path = "bin/client.rs"
+
+[dev-dependencies]
+tempfile = "3"
+walrus-test-utils = { workspace = true }

--- a/crates/walrus-service/bin/storage_node.rs
+++ b/crates/walrus-service/bin/storage_node.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("hello");
+}

--- a/crates/walrus-service/src/lib.rs
+++ b/crates/walrus-service/src/lib.rs
@@ -8,3 +8,8 @@ pub mod crypto;
 pub mod encoding;
 /// Client for interacting with Move.
 pub mod move_client;
+
+mod node;
+pub use node::StorageNode;
+
+mod storage;

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -1,0 +1,6 @@
+use crate::storage::Storage;
+
+/// A Walrus storage node, responsible for 1 or more shards of data.
+pub struct StorageNode {
+    _storage: Storage,
+}

--- a/crates/walrus-service/src/storage.rs
+++ b/crates/walrus-service/src/storage.rs
@@ -1,0 +1,331 @@
+#![allow(unused)]
+use std::{collections::HashSet, path::Path};
+
+use anyhow::Context;
+use rocksdb::{ColumnFamily, ColumnFamilyDescriptor, Options, DB};
+use walrus_core::BlobId;
+
+use crate::config::ShardIndex;
+
+pub type Metadata = Vec<[u8; 32]>;
+
+/// Storage backing a [`StorageNode`][crate::StorageNode].
+///
+/// Enables storing blob metadata, which is shared across all shards. The method
+/// [`shard_storage()`][Self::shard_storage] can be used to retrieve shard-specific storage.
+pub(crate) struct Storage {
+    database: DB,
+    shards: HashSet<ShardIndex>,
+}
+
+impl Storage {
+    const METADATA_COLUMN_FAMILY_NAME: &'static str = "metadata";
+
+    /// Opens the storage database located at the specified path, creating the database if absent.
+    pub fn open(path: &Path) -> Result<Self, anyhow::Error> {
+        let mut db_opts = Options::default();
+        db_opts.create_missing_column_families(true);
+        db_opts.create_if_missing(true);
+
+        let database = DB::open_cf_descriptors(&db_opts, path, [Self::metadata_descriptor()])
+            .context("storage unable to open database")?;
+
+        Ok(Self {
+            database,
+            shards: HashSet::default(),
+        })
+    }
+
+    /// Creates storage for the specified shard, or does nothing if the storage already exists.
+    pub fn create_storage_for_shard(&mut self, shard: ShardIndex) -> Result<(), anyhow::Error> {
+        if !self.shards.contains(&shard) {
+            ShardStorage::create(shard, &mut self.database)?;
+            self.shards.insert(shard);
+        }
+
+        Ok(())
+    }
+
+    /// Returns a handle over the storage for a single shard.
+    pub fn shard_storage(&self, shard: ShardIndex) -> Option<ShardStorage> {
+        self.shards
+            .contains(&shard)
+            .then(|| ShardStorage::new(shard, &self.database))
+    }
+
+    /// Store the metadata associated with the provided blob_id.
+    pub fn put_metadata(&self, blob_id: BlobId, metadata: &Metadata) -> Result<(), anyhow::Error> {
+        // TODO(jsmith): Guarantee that serialization of metadata representation is
+        // within bcs::MAX_SEQUENCE_LENGTH and otherwise infallible.
+        let encoded_metadata =
+            bcs::to_bytes(metadata).expect("metadata should be always serializable");
+
+        self.database
+            .put_cf(self.metadata_handle(), blob_id, encoded_metadata)
+            .context("unable to put metadata")
+    }
+
+    /// Gets the metadata for a given [`BlobId`] or None.
+    pub fn get_metadata(&self, blob_id: &BlobId) -> Result<Option<Metadata>, anyhow::Error> {
+        self.database
+            .get_pinned_cf(self.metadata_handle(), blob_id)
+            .context("error retrieving metadata")?
+            .map(|raw| bcs::from_bytes(raw.as_ref()).context("failed to decode metadata"))
+            .transpose()
+    }
+
+    fn descriptors(shards: &[ShardIndex]) -> Vec<ColumnFamilyDescriptor> {
+        let mut descriptors = vec![Self::metadata_descriptor()];
+        descriptors.extend(shards.iter().map(|shard| ShardStorage::descriptors(*shard)));
+
+        descriptors
+    }
+
+    fn metadata_descriptor() -> ColumnFamilyDescriptor {
+        let mut options = Options::default();
+
+        // TODO(jsmith): Tune storage for metadata and slivers
+        // See https://rocksdb.org/blog/2021/05/26/integrated-blob-db.html
+        options.set_enable_blob_files(true);
+
+        ColumnFamilyDescriptor::new(Self::METADATA_COLUMN_FAMILY_NAME, options)
+    }
+
+    fn metadata_handle(&self) -> &ColumnFamily {
+        self.database
+            .cf_handle(Self::METADATA_COLUMN_FAMILY_NAME)
+            .expect("metadata column family must exist")
+    }
+}
+
+pub(crate) struct ShardStorage<'a> {
+    id: ShardIndex,
+    database: &'a DB,
+    shard_columns: &'a ColumnFamily,
+}
+
+impl<'a> ShardStorage<'a> {
+    fn new(id: ShardIndex, database: &'a DB) -> Self {
+        let shard_columns = database
+            .cf_handle(&Self::column_family_name(id))
+            .expect("shard's column family must be present in database");
+
+        Self {
+            id,
+            database,
+            shard_columns,
+        }
+    }
+
+    fn create(id: ShardIndex, database: &'a mut DB) -> Result<Self, anyhow::Error> {
+        let mut options = Options::default();
+        // TODO(jsmith): Tune storage for metadata and slivers
+        // See https://rocksdb.org/blog/2021/05/26/integrated-blob-db.html
+        options.set_enable_blob_files(true);
+
+        database.create_cf(Self::column_family_name(id), &options)?;
+
+        Ok(ShardStorage::new(id, database))
+    }
+
+    /// Stores the provided primary or secondary sliver for the given blob ID.
+    pub fn put_sliver(
+        &self,
+        blob_id: &BlobId,
+        sliver: &[u8],
+        is_primary: bool,
+    ) -> Result<(), anyhow::Error> {
+        self.database
+            .put_cf(
+                self.shard_columns,
+                Self::sliver_key(blob_id, is_primary),
+                sliver,
+            )
+            .context("unable to store sliver")
+    }
+
+    /// Retrieves the stored primary or secondary sliver for the given blob ID.
+    pub fn get_sliver(
+        &self,
+        blob_id: &BlobId,
+        is_primary: bool,
+    ) -> Result<Option<Vec<u8>>, anyhow::Error> {
+        self.database
+            .get_cf(self.shard_columns, Self::sliver_key(blob_id, is_primary))
+            .context("unable to store sliver")
+    }
+
+    fn column_family_name(id: ShardIndex) -> String {
+        format!("shard-{}", id)
+    }
+
+    fn sliver_key(blob_id: &BlobId, is_primary: bool) -> Vec<u8> {
+        if is_primary {
+            [b"P:".as_slice(), blob_id.as_slice()].concat()
+        } else {
+            [b"S:".as_slice(), blob_id.as_slice()].concat()
+        }
+    }
+
+    fn descriptors(shard: ShardIndex) -> ColumnFamilyDescriptor {
+        let mut options = Options::default();
+
+        // TODO(jsmith): Tune storage for metadata and slivers
+        // See https://rocksdb.org/blog/2021/05/26/integrated-blob-db.html
+        options.set_enable_blob_files(true);
+
+        ColumnFamilyDescriptor::new(Self::column_family_name(shard), options)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+    use walrus_test_utils::{param_test, Result as TestResult};
+
+    use super::*;
+
+    const BLOB_ID: BlobId = [7; 32];
+    const SHARD_INDEX: ShardIndex = 17;
+    const OTHER_SHARD_INDEX: ShardIndex = 831;
+
+    struct TempStorage {
+        storage: Storage,
+        _directory: TempDir,
+    }
+
+    impl AsRef<Storage> for TempStorage {
+        fn as_ref(&self) -> &Storage {
+            &self.storage
+        }
+    }
+
+    fn empty_storage() -> TempStorage {
+        empty_storage_with_shards(&[SHARD_INDEX])
+    }
+
+    fn empty_storage_with_shards(shards: &[ShardIndex]) -> TempStorage {
+        let directory = tempfile::tempdir().expect("temporary directory creation must succeed");
+        let mut storage = Storage::open(directory.path()).expect("storage creation must succeed");
+
+        for shard in shards {
+            storage
+                .create_storage_for_shard(*shard)
+                .expect("shard should be successfully created");
+        }
+
+        TempStorage {
+            storage,
+            _directory: directory,
+        }
+    }
+
+    fn arbitrary_metadata() -> Metadata {
+        (0..100u8).map(|i| [i; 32]).collect()
+    }
+
+    fn arbitrary_sliver() -> Vec<u8> {
+        vec![7; 1024]
+    }
+    fn other_sliver() -> Vec<u8> {
+        vec![201; 512]
+    }
+
+    #[test]
+    fn can_write_then_read_metadata() -> TestResult {
+        let storage = empty_storage();
+        let storage = storage.as_ref();
+        let metadata = arbitrary_metadata();
+
+        storage.put_metadata(BLOB_ID, &metadata)?;
+        let retrieved = storage.get_metadata(&BLOB_ID)?;
+
+        assert_eq!(retrieved, Some(metadata));
+
+        Ok(())
+    }
+
+    param_test! {
+        can_store_and_retrieve_sliver -> TestResult: [
+            primary: (true),
+            secondary: (false),
+        ]
+    }
+    fn can_store_and_retrieve_sliver(is_primary: bool) -> TestResult {
+        let storage = empty_storage();
+        let shard = storage.as_ref().shard_storage(SHARD_INDEX).unwrap();
+        let sliver = arbitrary_sliver();
+
+        shard.put_sliver(&BLOB_ID, &sliver, is_primary)?;
+        let retrieved = shard.get_sliver(&BLOB_ID, is_primary)?;
+
+        assert_eq!(retrieved, Some(sliver));
+
+        Ok(())
+    }
+
+    #[test]
+    fn stores_separate_primary_and_secondary_sliver() -> TestResult {
+        let storage = empty_storage();
+        let shard = storage.as_ref().shard_storage(SHARD_INDEX).unwrap();
+
+        let primary = arbitrary_sliver();
+        let secondary = other_sliver();
+        assert_ne!(primary, secondary);
+
+        shard.put_sliver(&BLOB_ID, &primary, true)?;
+        shard.put_sliver(&BLOB_ID, &secondary, false)?;
+
+        let retrieved_primary = shard.get_sliver(&BLOB_ID, true)?;
+        let retrieved_secondary = shard.get_sliver(&BLOB_ID, false)?;
+
+        assert_eq!(retrieved_primary, Some(primary), "invalid primary sliver");
+        assert_eq!(
+            retrieved_secondary,
+            Some(secondary),
+            "invalid secondary sliver"
+        );
+
+        Ok(())
+    }
+
+    param_test! {
+        stores_and_retrieves_for_multiple_shards -> TestResult: [
+            primary_primary: (true, true),
+            secondary_secondary: (false, false),
+            mixed: (true, false),
+        ]
+    }
+    fn stores_and_retrieves_for_multiple_shards(
+        is_first_primary: bool,
+        is_second_primary: bool,
+    ) -> TestResult {
+        let storage = empty_storage_with_shards(&[SHARD_INDEX, OTHER_SHARD_INDEX]);
+
+        let first_shard = storage.as_ref().shard_storage(SHARD_INDEX).unwrap();
+        let first_sliver = arbitrary_sliver();
+
+        let second_shard = storage.as_ref().shard_storage(OTHER_SHARD_INDEX).unwrap();
+        let second_sliver = other_sliver();
+        assert_ne!(first_sliver, second_sliver);
+
+        first_shard.put_sliver(&BLOB_ID, &first_sliver, is_first_primary)?;
+        second_shard.put_sliver(&BLOB_ID, &second_sliver, is_second_primary)?;
+
+        let first_retrieved = first_shard.get_sliver(&BLOB_ID, is_first_primary)?;
+        let second_retrieved = second_shard.get_sliver(&BLOB_ID, is_second_primary)?;
+
+        assert_eq!(
+            first_retrieved,
+            Some(first_sliver),
+            "invalid sliver from first shard"
+        );
+        assert_eq!(
+            second_retrieved,
+            Some(second_sliver),
+            "invalid sliver from second shard"
+        );
+
+        Ok(())
+    }
+}

--- a/crates/walrus-test-utils/Cargo.toml
+++ b/crates/walrus-test-utils/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "walrus-test-utils"
+publish = false
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+version = { workspace = true }
+
+[dependencies]
+
+[lints]
+workspace = true
+
+[dev-dependencies]
+tokio = { version = "1.36.0", features = ["macros"] }

--- a/crates/walrus-test-utils/src/lib.rs
+++ b/crates/walrus-test-utils/src/lib.rs
@@ -1,0 +1,172 @@
+//! Test utilities shared between various crates.
+
+/// A result type useful in tests, that wraps any error implementation.
+pub type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+/// Macro for creating parametrized *synchronous* tests.
+///
+/// The `param_test!` macro accepts the name of an existing function, followed by a list of case
+/// names and their arguments. It expands to a module with a `#[test]` function for each of the
+/// cases. Each test case calls the existing, named function with their provided arguments.
+///
+/// See [`async_param_test`] for a similar macro that works with `async` function.
+///
+/// # Examples
+///
+/// Calling a simple test function can be done as follows
+///
+/// ```
+/// # use walrus_test_utils::param_test;
+/// #
+/// param_test! {
+///     test_sum: [
+///         positive_sums: (10, 7, 17),
+///         negative_sums: (-5, -3, -8)
+///     ]
+/// }
+/// fn test_sum(lhs: i32, rhs: i32, sum: i32) {
+///     assert_eq!(lhs + rhs, sum);
+/// }
+/// ```
+///
+/// Additionally, test functions can also have return types, such as a [`Result`]:
+///
+/// ```
+/// # use std::error::Error;
+/// # use walrus_test_utils::param_test;
+/// #
+/// param_test! {
+///     test_parses -> Result<(), Box<dyn Error>>: [
+///         positive: ("21", 21),
+///         negative: ("-17", -17)
+///     ]
+/// }
+/// fn test_parses(to_parse: &str, expected: i32) -> Result<(), Box<dyn Error>> {
+///     assert_eq!(expected, to_parse.parse()?);
+///     Ok(())
+/// }
+/// ```
+///
+/// Finally, attributes such as as `#[ignore]` may be added to individual tests:
+///
+/// ```
+/// # use std::error::Error;
+/// # use walrus_test_utils::param_test;
+/// #
+/// param_test! {
+///     test_parses -> Result<(), Box<dyn Error>>: [
+///         #[ignore] positive: ("21", 21),
+///         negative: ("-17", -17)
+///     ]
+/// }
+/// fn test_parses(to_parse: &str, expected: i32) -> Result<(), Box<dyn Error>> {
+///     assert_eq!(expected, to_parse.parse()?);
+///     Ok(())
+/// }
+/// ```
+#[macro_export]
+macro_rules! param_test {
+    ($func_name:ident -> $return_ty:ty: [
+        $( $(#[$outer:meta])* $case_name:ident: ( $($args:expr),+ )  ),+$(,)?
+    ]) => {
+        mod $func_name {
+            use super::*;
+
+            $(
+                #[test]
+                $(#[$outer])*
+                fn $case_name() -> $return_ty {
+                    $func_name($($args),+)
+                }
+            )*
+        }
+    };
+    ($func_name:ident: [
+        $( $(#[$outer:meta])* $case_name:ident: ( $($args:expr),+ ) ),+$(,)?
+    ]) => {
+        param_test!($func_name -> (): [ $( $(#[$outer])* $case_name: ( $($args),+ ) ),+ ]);
+    };
+}
+
+/// Macro for creating parametrized *asynchronous* tests.
+///
+/// This macro behaves similarly to the [`param_test`] macro, however it must be used with an
+/// `async` function. For convenience, the macro expands the test cases with the `#[tokio::test]`
+/// attribute. If specifying any additional attributes to any test case, it is necessary to
+/// re-specify the `#[tokio::test]` macro for *every* test case.
+///
+/// See [`param_test`] for more information and examples.
+#[macro_export]
+macro_rules! async_param_test {
+    ($func_name:ident -> $return_ty:ty: [
+        $( $(#[$outer:meta])+ $case_name:ident: ( $($args:expr),+ ) ),+$(,)?
+    ]) => {
+        mod $func_name {
+            use super::*;
+
+            $(
+                $(#[$outer])+
+                async fn $case_name() -> $return_ty {
+                    $func_name($($args),+).await
+                }
+            )*
+        }
+    };
+    ($func_name:ident: [
+        $( $(#[$outer:meta])+ $case_name:ident: ( $($args:expr),+ ) ),+$(,)?
+    ]) => {
+        async_param_test!( $func_name -> (): [ $( $(#[$outer])+ $case_name: ($($args),+) ),* ] );
+    };
+
+    ($func_name:ident: [
+        $( $case_name:ident: ( $($args:expr),+ ) ),+$(,)?
+    ]) => {
+        async_param_test!( $func_name -> (): [ $( #[tokio::test] $case_name: ($($args),+) ),* ] );
+    };
+    ($func_name:ident -> $return_ty:ty: [
+        $( $case_name:ident: ( $($args:expr),+ ) ),+$(,)?
+    ]) => {
+        async_param_test!(
+            $func_name -> $return_ty: [ $( #[tokio::test] $case_name: ( $($args),+ ) ),* ]
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error;
+
+    param_test! {
+        test_with_no_return: [
+            case1: (true, 1, 1),
+            case2: (false, 3, 4)
+        ]
+    }
+    fn test_with_no_return(bool_arg: bool, usize_arg: usize, u32_arg: u32) {
+        assert_eq!(bool_arg, usize_arg == u32_arg as usize);
+    }
+
+    param_test! {
+        test_with_return -> Result<(), Box<dyn Error>>: [
+            case1: ("5", 5),
+            case2: ("7", 7)
+        ]
+    }
+    fn test_with_return(to_parse: &str, parsed: usize) -> Result<(), Box<dyn Error>> {
+        let result: usize = to_parse.parse()?;
+        assert_eq!(parsed, result);
+        Ok(())
+    }
+
+    async_param_test! {
+        async_test_with_return -> Result<(), Box<dyn Error>>: [
+            case1: ("5", 5),
+            case2: ("7", 7)
+        ]
+    }
+    async fn async_test_with_return(to_parse: &str, parsed: usize) -> Result<(), Box<dyn Error>> {
+        let result: usize = to_parse.parse()?;
+        assert_eq!(parsed, result);
+        Ok(())
+    }
+}

--- a/deny.toml
+++ b/deny.toml
@@ -20,7 +20,15 @@ unlicensed = "deny"
 # List of explicitly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
-allow = ["Apache-2.0", "Unicode-DFS-2016", "MIT", "BSD-2-Clause", "BSD-3-Clause", "CC0-1.0"]
+allow = [
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC0-1.0",
+    "ISC",
+    "MIT",
+    "Unicode-DFS-2016",
+]
 # Lint level for licenses considered copyleft
 copyleft = "deny"
 # Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
@@ -56,9 +64,13 @@ ignore = true
 [bans]
 # Lint level for when multiple versions of the same crate are detected
 multiple-versions = "deny"
-skip = []
+skip = [
+    { name = "itertools", version = "<=12.1"}
+]
 skip-tree = [
     { name = "fastcrypto", depth = 3 },
+    # several crate depend on an older version of windows-sys
+    { name = "windows-sys", depth = 3, version = "0.48" }
 ]
 
 # This section is considered when running `cargo deny check sources`.


### PR DESCRIPTION
This PR adds an initial interface for the storage node's storage. 

As most of the types are still pending, minimal, temporary types are currently used and are subject to change. 

Added issues #41 for the storage tuning.

Close #13, #14, and #15