### PR TITLE
feat(encoding): add symbol and sliver recovery

### DIFF
--- a/crates/walrus-core/src/encoding/symbols.rs
+++ b/crates/walrus-core/src/encoding/symbols.rs
@@ -105,10 +105,14 @@ impl Symbols {
     /// Returns a [`DecodingSymbol`] at the provided index.
     ///
     /// Returns `None` if the `index` is out of bounds.
-    pub fn decoding_symbol_at(&self, index: u32) -> Option<DecodingSymbol> {
+    pub fn decoding_symbol_at(
+        &self,
+        data_index: usize,
+        symbol_index: u32,
+    ) -> Option<DecodingSymbol> {
         Some(DecodingSymbol {
-            index,
-            data: self[index as usize].into(),
+            index: symbol_index,
+            data: self[data_index].into(),
         })
     }
 


### PR DESCRIPTION
Implements the following functionality:

* Create recovery symbols from slivers
* Recover slivers from recovery symbols
* Testing: allows tests with different encoding configs

Depends on #61 and #64
Contributes to #28
Closes #29