### PR TITLE
fix(core): use latest raptorq version including ESI fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6152,8 +6152,7 @@ dependencies = [
 [[package]]
 name = "raptorq"
 version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc8cd0bcb2d520fff368264b5a6295e064c60955349517d09b14473afae4856"
+source = "git+https://github.com/cberner/raptorq?rev=da79ac2ba51e99484c81901fe293a2d8b32add49#da79ac2ba51e99484c81901fe293a2d8b32add49"
 
 [[package]]
 name = "raw-cpuid"

--- a/crates/walrus-core/Cargo.toml
+++ b/crates/walrus-core/Cargo.toml
@@ -9,7 +9,8 @@ license = { workspace = true }
 [dependencies]
 bcs = { workspace = true }
 fastcrypto = { workspace = true }
-raptorq = "1.8.1"
+# TODO(mlegner): Update as soon as there is an official release with the ESI fix.
+raptorq = { git = "https://github.com/cberner/raptorq", rev = "da79ac2ba51e99484c81901fe293a2d8b32add49" }
 serde = { version = "1.0.197", features = ["derive"] }
 thiserror = { workspace = true }
 

--- a/crates/walrus-core/src/encoding/symbols.rs
+++ b/crates/walrus-core/src/encoding/symbols.rs
@@ -9,6 +9,7 @@ use std::{
     slice::{Chunks, ChunksMut},
 };
 
+use raptorq::{EncodingPacket, PayloadId};
 use serde::{Deserialize, Serialize};
 
 use super::{EncodingAxis, Primary, Secondary, WrongSymbolSizeError};
@@ -255,6 +256,13 @@ pub struct DecodingSymbol<T: EncodingAxis, U = ()> {
     proof: U,
     /// Marker representing whether this symbol is used to decode primary or secondary slivers.
     _axis: PhantomData<T>,
+}
+
+impl<T: EncodingAxis, U> DecodingSymbol<T, U> {
+    /// Converts the `DecodingSymbol` to an [`EncodingPacket`] expected by the [`raptorq::Decoder`].
+    pub fn into_encoding_packet(self) -> EncodingPacket {
+        EncodingPacket::new(PayloadId::new(0, self.index), self.data)
+    }
 }
 
 impl<T: EncodingAxis> DecodingSymbol<T> {

--- a/crates/walrus-core/src/encoding/utils.rs
+++ b/crates/walrus-core/src/encoding/utils.rs
@@ -3,9 +3,7 @@
 
 #[cfg(test)]
 use rand::RngCore;
-use raptorq::{EncodingPacket, ObjectTransmissionInformation, PayloadId};
-
-use super::{DecodingSymbol, EncodingAxis};
+use raptorq::{EncodingPacket, ObjectTransmissionInformation};
 
 /// Creates a new [`ObjectTransmissionInformation`] for the given `symbol_size`.
 ///
@@ -43,27 +41,6 @@ pub fn compute_symbol_size(data_length: usize, n_symbols: usize) -> Option<u16> 
 #[inline]
 pub fn packet_to_data(packet: EncodingPacket) -> Vec<u8> {
     packet.split().1
-}
-
-/// This function is necessary to convert from the index to the symbol ID used by the raptorq
-/// library.
-///
-/// It is needed because currently the [raptorq] library currently uses the ISI in the
-/// [`PayloadId`]. The two can be converted with the knowledge of the number of source symbols (`K`
-/// in the RFC's terminology) and padding symbols (`K' - K` in the RFC's terminology).
-// TODO(mlegner): Update if the raptorq library changes its behavior.
-pub fn encoding_packet_from_symbol<T: EncodingAxis, U>(
-    symbol: DecodingSymbol<T, U>,
-    n_source_symbols: u16,
-    n_padding_symbols: u16,
-) -> EncodingPacket {
-    let isi = symbol.index
-        + if n_padding_symbols == 0 || symbol.index < n_source_symbols as u32 {
-            0
-        } else {
-            n_padding_symbols as u32
-        };
-    EncodingPacket::new(PayloadId::new(0, isi), symbol.data)
 }
 
 #[cfg(test)]

--- a/deny.toml
+++ b/deny.toml
@@ -78,6 +78,7 @@ unknown-registry = "deny"
 # in the allow list is encountered
 unknown-git = "deny"
 allow-git = [
+    "https://github.com/cberner/raptorq",
     "https://github.com/mystenmark/tokio-madsim-fork",
     "https://github.com/mystenmark/async-task",
     "https://github.com/wlmyng/jsonrpsee",


### PR DESCRIPTION
My upstream PR to use the correct encoding symbol IDs has been merged: https://github.com/cberner/raptorq/pull/165

This simplifies the decoding as we can use a symbol/sliver's index directly as the ESI.