### PR TITLE
chore: update cargo-deny config for new behavior

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -76,9 +76,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v1.5.15
+      - uses: EmbarkStudios/cargo-deny-action@v1.6.1
         with:
-          # do not check advisories to prevent sudden failure due to new announcement
+          # do not check advisories on PRs to prevent sudden failure due to new announcement
           command: check bans licenses sources
 
   dependencies-schedule:
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v1.5.15
+      - uses: EmbarkStudios/cargo-deny-action@v1.6.1
 
   test:
     name: Test Rust code and report coverage

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
   - id: cargo-sort
     args: ["--workspace"]
 - repo: https://github.com/EmbarkStudios/cargo-deny
-  rev: 0.14.15
+  rev: 0.14.16
   hooks:
   - id: cargo-deny
 - repo: local

--- a/deny.toml
+++ b/deny.toml
@@ -2,11 +2,7 @@
 # More documentation for the advisories section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
-vulnerability = "deny"
-unmaintained = "deny"
-notice = "deny"
-unsound = "deny"
-
+version = 2
 ignore = [
     "RUSTSEC-2023-0071",
     # difference 2.0.0 is unmaintained
@@ -17,8 +13,7 @@ ignore = [
 # More documentation for the licenses section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
 [licenses]
-# The lint level for crates which do not have a detectable license
-unlicensed = "deny"
+version = 2
 # List of explicitly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
@@ -34,27 +29,11 @@ allow = [
     "MPL-2.0",
     "Unicode-DFS-2016",
 ]
-# Lint level for licenses considered copyleft
-copyleft = "deny"
-# Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
-allow-osi-fsf-free = "neither"
-# Lint level used when no other predicates are matched
-# 1. License isn't in the allow or deny lists
-# 2. License isn't copyleft
-# 3. License isn't OSI/FSF, or allow-osi-fsf-free = "neither"
-default = "deny"
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
 # canonical license text of a valid SPDX license file.
 # [possible values: any between 0.0 and 1.0].
 confidence-threshold = 0.8
-# Allow 1 or more licenses on a per-crate basis, so that particular licenses
-# aren't accepted for every possible crate as with the normal allow list
-exceptions = [
-    # { allow = [
-    #     "Unicode-DFS-2016",
-    # ], name = "unicode-ident" },
-]
 
 [[licenses.clarify]]
 name = "ring"


### PR DESCRIPTION
In particular, remove deprecated fields.
See [cargo-deny#606][606] and [cargo-deny#611][611] for further details.

[606]: https://github.com/EmbarkStudios/cargo-deny/pull/606
[611]: https://github.com/EmbarkStudios/cargo-deny/pull/611