### PR TITLE
feat(core): add blob encoding with creation of metadata and blob ID

### DIFF
--- a/crates/walrus-core/src/encoding/symbols.rs
+++ b/crates/walrus-core/src/encoding/symbols.rs
@@ -42,6 +42,13 @@ impl Symbols {
         }
     }
 
+    /// Shortens the `data` in [`Symbols`], keeping the first `len` symbols and dropping the
+    /// rest. If `len` is greater or equal to the [`Symbols`]’ current number of symbols, this has
+    /// no effect.
+    pub fn truncate(&mut self, len: usize) {
+        self.data.truncate(len * self.symbol_size as usize);
+    }
+
     /// Creates a new `Symbols` struct with zeroed-out data of specified length.
     ///
     /// # Arguments
@@ -192,10 +199,10 @@ impl Symbols {
         &mut self.data
     }
 
-    /// Returns the range of the underlying byte vector that contains symbol at index `index`.
+    /// Returns the range of the underlying byte vector that contains the symbols in the range.
     #[inline]
-    pub fn symbol_range(&self, index: usize) -> Range<usize> {
-        self.symbol_usize() * index..self.symbol_usize() * (index + 1)
+    pub fn symbol_range(&self, range: Range<usize>) -> Range<usize> {
+        self.symbol_usize() * range.start..self.symbol_usize() * range.end
     }
 
     /// Returns the underlying byte vector as an owned object.
@@ -209,12 +216,27 @@ impl Index<usize> for Symbols {
     type Output = [u8];
 
     fn index(&self, index: usize) -> &Self::Output {
-        &self.data[self.symbol_range(index)]
+        &self.data[self.symbol_range(index..index + 1)]
     }
 }
 
 impl IndexMut<usize> for Symbols {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        let range = self.symbol_range(index..index + 1);
+        &mut self.data[range]
+    }
+}
+
+impl Index<Range<usize>> for Symbols {
+    type Output = [u8];
+
+    fn index(&self, index: Range<usize>) -> &Self::Output {
+        &self.data[self.symbol_range(index)]
+    }
+}
+
+impl IndexMut<Range<usize>> for Symbols {
+    fn index_mut(&mut self, index: Range<usize>) -> &mut Self::Output {
         let range = self.symbol_range(index);
         &mut self.data[range]
     }

--- a/crates/walrus-service/src/storage.rs
+++ b/crates/walrus-service/src/storage.rs
@@ -167,6 +167,7 @@ pub(crate) mod tests {
     use typed_store::metrics::SamplingInterval;
     use walrus_core::{
         encoding::{EncodingAxis, Primary, Secondary, Sliver as TypedSliver},
+        metadata::SliverPairMetadata,
         EncodingType,
         Sliver,
         SliverType,
@@ -218,7 +219,12 @@ pub(crate) mod tests {
             BlobMetadata {
                 encoding_type: EncodingType::RedStuff,
                 unencoded_length: 700,
-                hashes: (0..100u8).map(|i| MerkleNode::Digest([i; 32])).collect(),
+                hashes: (0..100u8)
+                    .map(|i| SliverPairMetadata {
+                        primary_hash: MerkleNode::Digest([i; 32]),
+                        secondary_hash: MerkleNode::Digest([i; 32]),
+                    })
+                    .collect(),
             },
         )
     }


### PR DESCRIPTION
* Adds a new function `encode_with_metadata` to the `BlobEncoder` that returns sliver pairs and metadata. The metadata includes the hashes of the slivers, encoding type, and the unencoded blob size.
* Changes the `hashes` in `BlobMetadata` to a vector of `SliverPairMetadata`, such that sliver pairs map to the metadata directly.
* Minor changes to `Sliver` and `Symbol` to simplify blob ID creation and modification.

Contributes to #42
Closes: #100