### PR TITLE
refactor: reorganize test utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9716,11 +9716,9 @@ dependencies = [
 name = "walrus-test-utils"
 version = "0.1.0"
 dependencies = [
- "fastcrypto 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.8.5",
  "tempfile",
  "tokio",
- "walrus-core",
 ]
 
 [[package]]

--- a/crates/walrus-core/Cargo.toml
+++ b/crates/walrus-core/Cargo.toml
@@ -9,6 +9,7 @@ license = { workspace = true }
 [dependencies]
 bcs = { workspace = true }
 fastcrypto = { workspace = true }
+rand = { workspace = true, optional = true }
 # TODO(mlegner): Update as soon as there is an official release with the ESI fix.
 raptorq = { git = "https://github.com/cberner/raptorq", rev = "da79ac2ba51e99484c81901fe293a2d8b32add49" }
 serde = { workspace = true }
@@ -18,5 +19,7 @@ thiserror = { workspace = true }
 workspace = true
 
 [dev-dependencies]
-rand = { workspace = true }
 walrus-test-utils = { workspace = true }
+
+[features]
+test-utils = ["rand"]

--- a/crates/walrus-core/src/encoding/basic_encoding.rs
+++ b/crates/walrus-core/src/encoding/basic_encoding.rs
@@ -180,10 +180,10 @@ impl Decoder {
 mod tests {
     use std::ops::Range;
 
-    use walrus_test_utils::{param_test, Result};
+    use walrus_test_utils::{param_test, random_data, Result};
 
     use super::*;
-    use crate::encoding::{utils, Primary};
+    use crate::encoding::Primary;
 
     #[test]
     fn encoding_empty_data_fails() {
@@ -209,7 +209,7 @@ mod tests {
             aligned_data_repair_symbols_2: (&[1, 2, 3, 4, 5, 6], 2, 2..4, true),
             aligned_data_repair_symbols_3: (&[1, 2, 3, 4, 5, 6], 3, 3..6, true),
             aligned_large_data_repair_symbols: (
-                &utils::large_random_data(42000), 100, 100..200, true
+                &random_data(42000), 100, 100..200, true
             ),
             aligned_data_too_few_symbols_1: (&[1, 2], 2, 2..3, false),
             aligned_data_too_few_symbols_2: (&[1, 2, 3], 3, 0..2, false),

--- a/crates/walrus-core/src/encoding/blob_encoding.rs
+++ b/crates/walrus-core/src/encoding/blob_encoding.rs
@@ -377,7 +377,7 @@ impl<T: EncodingAxis> BlobDecoder<T> {
 mod tests {
 
     use rand::{rngs::StdRng, SeedableRng};
-    use walrus_test_utils::param_test;
+    use walrus_test_utils::{param_test, random_data, random_subset};
 
     use super::*;
     use crate::{
@@ -450,7 +450,7 @@ mod tests {
 
     #[test]
     fn test_blob_encode_decode() {
-        let blob = utils::large_random_data(31415);
+        let blob = random_data(31415);
         let source_symbols_primary = 11;
         let source_symbols_secondary = 23;
 
@@ -460,7 +460,7 @@ mod tests {
             3 * (source_symbols_primary + source_symbols_secondary) as u32,
         );
 
-        let slivers_for_decoding = utils::get_random_subset(
+        let slivers_for_decoding = random_subset(
             config.get_blob_encoder(&blob).unwrap().encode(),
             &mut StdRng::seed_from_u64(42),
             cmp::max(source_symbols_primary, source_symbols_secondary) as usize,
@@ -501,7 +501,7 @@ mod tests {
         //    the metadata that can be computed from the sliver pairs directly.
         //
         // Takes long (O(1s)) to run.
-        let blob = utils::large_random_data(27182);
+        let blob = random_data(27182);
         let source_symbols_primary = 11;
         let source_symbols_secondary = 23;
         let n_shards = 3 * (source_symbols_primary + source_symbols_secondary) as u32;

--- a/crates/walrus-core/src/encoding/slivers.rs
+++ b/crates/walrus-core/src/encoding/slivers.rs
@@ -357,10 +357,10 @@ impl SliverPair {
 mod tests {
     use fastcrypto::hash::Blake2b256;
     use rand::{rngs::StdRng, SeedableRng};
-    use walrus_test_utils::{param_test, Result};
+    use walrus_test_utils::{param_test, random_subset, Result};
 
     use super::*;
-    use crate::encoding::{initialize_encoding_config, utils};
+    use crate::encoding::initialize_encoding_config;
 
     fn init_config_and_encode_pairs(
         source_symbols_primary: u16,
@@ -498,7 +498,7 @@ mod tests {
 
         for pair in pairs.iter() {
             // Get a random subset of recovery symbols.
-            let recovery_symbols: Vec<_> = utils::get_random_subset(
+            let recovery_symbols: Vec<_> = random_subset(
                 pairs
                     .iter()
                     .map(|p| p.recovery_symbol_pair_for_sliver(pair.index()).unwrap()),

--- a/crates/walrus-core/src/encoding/utils.rs
+++ b/crates/walrus-core/src/encoding/utils.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(test)]
-use rand::RngCore;
 use raptorq::{EncodingPacket, ObjectTransmissionInformation};
 
 /// Creates a new [`ObjectTransmissionInformation`] for the given `symbol_size`.
@@ -41,29 +39,6 @@ pub fn compute_symbol_size(data_length: usize, n_symbols: usize) -> Option<u16> 
 #[inline]
 pub fn packet_to_data(packet: EncodingPacket) -> Vec<u8> {
     packet.split().1
-}
-
-#[cfg(test)]
-pub(crate) fn large_random_data(data_length: usize) -> Vec<u8> {
-    use rand::{rngs::StdRng, SeedableRng};
-
-    let mut rng = StdRng::seed_from_u64(42);
-    let mut result = vec![0u8; data_length];
-    rng.fill_bytes(&mut result);
-    result
-}
-
-#[cfg(test)]
-pub(crate) fn get_random_subset<T: Clone>(
-    data: impl IntoIterator<Item = T>,
-    mut rng: &mut impl RngCore,
-    count: usize,
-) -> impl Iterator<Item = T> + Clone {
-    use rand::seq::SliceRandom;
-
-    let mut data: Vec<_> = data.into_iter().collect();
-    data.shuffle(&mut rng);
-    data.into_iter().take(count)
 }
 
 #[cfg(test)]

--- a/crates/walrus-core/src/test_utils.rs
+++ b/crates/walrus-core/src/test_utils.rs
@@ -1,0 +1,97 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use fastcrypto::{
+    bls12381::min_pk::BLS12381KeyPair,
+    traits::{KeyPair, Signer},
+};
+use rand::{rngs::StdRng, RngCore, SeedableRng};
+
+use crate::{
+    encoding,
+    merkle::Node,
+    metadata::{
+        BlobMetadata,
+        SliverPairMetadata,
+        UnverifiedBlobMetadataWithId,
+        VerifiedBlobMetadataWithId,
+    },
+    BlobId,
+    EncodingType,
+    SignedStorageConfirmation,
+    Sliver,
+};
+
+/// Returns a deterministic fixed key pair for testing.
+///
+/// Various testing facilities can use this key and unit-test can re-generate it to verify the
+/// correctness of inputs and outputs.
+pub fn keypair() -> BLS12381KeyPair {
+    let mut rng = StdRng::seed_from_u64(0);
+    BLS12381KeyPair::generate(&mut rng)
+}
+
+/// Returns an arbitrary sliver for testing.
+pub fn sliver() -> Sliver {
+    Sliver::Primary(encoding::Sliver::new([1, 2, 3, 4], 2, 1))
+}
+
+/// Returns an arbitrary storage confirmation for tests.
+pub fn signed_storage_confirmation() -> SignedStorageConfirmation {
+    let mut rng = StdRng::seed_from_u64(0);
+    let mut confirmation = vec![0; 32];
+    rng.fill_bytes(&mut confirmation);
+
+    let signer = keypair();
+    let signature = signer.sign(&confirmation);
+    SignedStorageConfirmation {
+        confirmation,
+        signature,
+    }
+}
+
+/// Returns a random blob ID for testing.
+pub fn random_blob_id() -> BlobId {
+    let mut rng = StdRng::seed_from_u64(0);
+    let mut bytes = [0; BlobId::LENGTH];
+    rng.fill_bytes(&mut bytes);
+    BlobId(bytes)
+}
+
+/// Returns a blob ID of given number for testing.
+pub fn blob_id_from_u64(num: u64) -> BlobId {
+    let mut blob_id = [0u8; 32];
+    blob_id[24..].copy_from_slice(&num.to_be_bytes());
+    BlobId(blob_id)
+}
+
+/// Returns an arbitrary metadata object.
+pub fn blob_metadata() -> BlobMetadata {
+    let unencoded_length = 7_000_000_000;
+    let hashes: Vec<_> = (0..100u8)
+        .map(|i| SliverPairMetadata {
+            primary_hash: Node::Digest([i; 32]),
+            secondary_hash: Node::Digest([i; 32]),
+        })
+        .collect();
+    BlobMetadata {
+        encoding_type: EncodingType::RedStuff,
+        unencoded_length,
+        hashes,
+    }
+}
+
+/// Returns an arbitrary unverified metadata object with blob ID.
+pub fn unverified_blob_metadata() -> UnverifiedBlobMetadataWithId {
+    let metadata = blob_metadata();
+    UnverifiedBlobMetadataWithId::new(BlobId::from_sliver_pair_metadata(&metadata), metadata)
+}
+
+/// Returns an arbitrary verified metadata object with blob ID.
+pub fn verified_blob_metadata() -> VerifiedBlobMetadataWithId {
+    let metadata = blob_metadata();
+    VerifiedBlobMetadataWithId::new_verified_unchecked(
+        BlobId::from_sliver_pair_metadata(&metadata),
+        metadata,
+    )
+}

--- a/crates/walrus-service/Cargo.toml
+++ b/crates/walrus-service/Cargo.toml
@@ -33,4 +33,5 @@ path = "bin/client.rs"
 rand = { workspace = true }
 reqwest = { version = "0.11.25", features = ["json"] }
 tempfile = { workspace = true }
+walrus-core = { workspace = true, features = ["test-utils"] }
 walrus-test-utils = { workspace = true }

--- a/crates/walrus-service/src/config.rs
+++ b/crates/walrus-service/src/config.rs
@@ -68,22 +68,3 @@ pub struct StorageNodePrivateParameters {
     /// The private parameters shards that the storage node is responsible for.
     pub shards: HashMap<ShardIndex, ShardPrivateParameters>,
 }
-
-impl StorageNodePrivateParameters {
-    /// Creates a new storage node private parameters for testing.
-    #[cfg(test)]
-    pub fn new_for_test() -> Self {
-        let network_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-        let network_address = network_listener.local_addr().unwrap();
-
-        let metrics_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-        let metrics_address = metrics_listener.local_addr().unwrap();
-
-        Self {
-            keypair: KeyPair::new(),
-            network_address,
-            metrics_address,
-            shards: HashMap::new(),
-        }
-    }
-}

--- a/crates/walrus-service/src/lib.rs
+++ b/crates/walrus-service/src/lib.rs
@@ -18,3 +18,6 @@ mod node;
 pub use node::StorageNode;
 
 mod storage;
+
+#[cfg(test)]
+mod test_utils;

--- a/crates/walrus-service/src/mapping.rs
+++ b/crates/walrus-service/src/mapping.rs
@@ -129,17 +129,10 @@ fn bytes_mod(bytes: &[u8], modulus: usize) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use walrus_core::encoding::Sliver;
+    use walrus_core::{encoding::Sliver, test_utils};
     use walrus_test_utils::param_test;
 
     use super::*;
-
-    // Get a blob ID of given number for testing.
-    fn blob_id_for_testing(num: u64) -> BlobId {
-        let mut blob_id = [0u8; 32];
-        blob_id[24..].copy_from_slice(&num.to_be_bytes());
-        BlobId(blob_id)
-    }
 
     // Fixture
     fn sliver_pairs(num: u32) -> Vec<SliverPair> {
@@ -154,7 +147,7 @@ mod tests {
     #[test]
     fn test_rotate_pairs() {
         let mut pairs = sliver_pairs(7);
-        let blob_id = blob_id_for_testing(17);
+        let blob_id = test_utils::blob_id_from_u64(17);
         rotate_pairs(&mut pairs, &blob_id).unwrap();
         // Check that all the pairs are is in the correct spot
         assert!(pairs
@@ -166,7 +159,7 @@ mod tests {
     #[test]
     fn test_rotate_pairs_unchecked() {
         let mut pairs = sliver_pairs(7);
-        let blob_id = blob_id_for_testing(17);
+        let blob_id = test_utils::blob_id_from_u64(17);
         rotate_pairs_unchecked(&mut pairs, &blob_id);
         // Check that all the pairs are is in the correct spot
         for (idx, pair) in pairs.iter().enumerate() {
@@ -176,8 +169,8 @@ mod tests {
             );
         }
         // Rotate again and check if the two rotations combined have been applied
-        let blob_id_2 = blob_id_for_testing(15);
-        let combined_blob_id = blob_id_for_testing(18); // 17 % 7 + 15 % 7 = 18 % 7
+        let blob_id_2 = test_utils::blob_id_from_u64(15);
+        let combined_blob_id = test_utils::blob_id_from_u64(18); // 17 % 7 + 15 % 7 = 18 % 7
         rotate_pairs_unchecked(&mut pairs, &blob_id_2);
         assert!(pairs
             .iter()
@@ -194,7 +187,7 @@ mod tests {
         let mut slivers_1 = sliver_pairs(7);
         assert!(is_rotation(&slivers_1));
         // Rotation
-        rotate_pairs(&mut slivers_1, &blob_id_for_testing(17)).unwrap();
+        rotate_pairs(&mut slivers_1, &test_utils::blob_id_from_u64(17)).unwrap();
         assert!(is_rotation(&slivers_1));
         // Incorrect shuffling
         slivers_1.swap(2, 5);
@@ -204,8 +197,8 @@ mod tests {
     #[test]
     fn test_wrong_rotation_pairs() {
         let mut pairs = sliver_pairs(7);
-        let blob_id_1 = blob_id_for_testing(17);
-        let blob_id_2 = blob_id_for_testing(18);
+        let blob_id_1 = test_utils::blob_id_from_u64(17);
+        let blob_id_2 = test_utils::blob_id_from_u64(18);
         rotate_pairs(&mut pairs, &blob_id_1).unwrap();
         assert!(
             rotate_pairs(&mut pairs, &blob_id_2)
@@ -216,7 +209,7 @@ mod tests {
     #[test]
     fn test_idempotent_rotation() {
         let mut pairs = sliver_pairs(7);
-        let blob_id = blob_id_for_testing(17);
+        let blob_id = test_utils::blob_id_from_u64(17);
         rotate_pairs(&mut pairs, &blob_id).unwrap();
         let cloned = pairs.clone();
         // Check that rotating again does not have an effect
@@ -230,7 +223,7 @@ mod tests {
         pair_idx: usize,
         shard_idx: usize,
     ) {
-        let blob_id = blob_id_for_testing(blob_id_value);
+        let blob_id = test_utils::blob_id_from_u64(blob_id_value);
         assert_eq!(
             shard_index_for_pair(pair_idx, total_shards, &blob_id),
             shard_idx
@@ -251,7 +244,7 @@ mod tests {
         shard_idx: usize,
         pair_idx: usize,
     ) {
-        let blob_id = blob_id_for_testing(blob_id_value);
+        let blob_id = test_utils::blob_id_from_u64(blob_id_value);
         assert_eq!(
             pair_index_for_shard(shard_idx, total_shards, &blob_id),
             pair_idx
@@ -284,7 +277,7 @@ mod tests {
     #[test]
     fn test_rotate_by_bytes() {
         let mut pairs = Vec::from_iter(0..5);
-        let blob_id = blob_id_for_testing(11);
+        let blob_id = test_utils::blob_id_from_u64(11);
         rotate_by_bytes(&mut pairs, blob_id.as_ref());
         assert_eq!(pairs, [4, 0, 1, 2, 3]);
     }

--- a/crates/walrus-service/src/storage/shard.rs
+++ b/crates/walrus-service/src/storage/shard.rs
@@ -146,7 +146,7 @@ fn slivers_column_family_name(id: ShardIndex) -> String {
 }
 
 #[cfg(test)]
-pub(crate) mod tests {
+mod tests {
     use std::fmt;
 
     use walrus_core::{Sliver, SliverType};

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -1,0 +1,22 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+
+use crate::{config::StorageNodePrivateParameters, crypto::KeyPair};
+
+/// Creates a new [`StorageNodePrivateParameters`] object for testing.
+pub fn storage_node_private_parameters() -> StorageNodePrivateParameters {
+    let network_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let network_address = network_listener.local_addr().unwrap();
+
+    let metrics_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let metrics_address = metrics_listener.local_addr().unwrap();
+
+    StorageNodePrivateParameters {
+        keypair: KeyPair::new(),
+        network_address,
+        metrics_address,
+        shards: HashMap::new(),
+    }
+}

--- a/crates/walrus-test-utils/Cargo.toml
+++ b/crates/walrus-test-utils/Cargo.toml
@@ -7,10 +7,8 @@ license = { workspace = true }
 version = { workspace = true }
 
 [dependencies]
-fastcrypto = { workspace = true }
 rand = { workspace = true }
 tempfile = { workspace = true }
-walrus-core = { workspace = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
- `walrus-test-utilities` contains utilities that are not directly related to Walrus itself.
- `walrus-core::test_utils` contains Walrus-specific test utilities; this module is only available with the new `test-utils` feature.
- Crate-local test utilities are in a per-crate `test_utils` module, annotated with `#[cfg(test)]`.

Closes #109