### PR TITLE
chore: add micro-benchmark for basic encoding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,20 @@ or aren't covered by tests. Other valid output formats are `json`, `stdout`, `xm
 
 The exact command we use in our CI pipeline is visible in [.github/workflows/code.yml](.github/workflows/code.yml).
 
+## Benchmarks
+
+We run micro-benchmarks for encoding, decoding, and authentication using
+[Criterion.rs](https://bheisler.github.io/criterion.rs/book/criterion_rs.html). These benchmarks are not run
+automatically in our pipeline as there is an [explicit advice against doing
+this](https://bheisler.github.io/criterion.rs/book/faq.html#how-should-i-run-criterionrs-benchmarks-in-a-ci-pipeline).
+
+You can run the benchmarks by calling `cargo bench` from the project's root directory. Criterion will output some data
+to the command line and also generate HTML reports including plots; the root file is located at
+[`target/criterion/report/index.html].
+
+Criterion automatically compares the results from multiple runs. To check if your code changes improve or worsen the
+performance, run the benchmarks first on the latest `main` branch and then again with your code changes.
+
 ## Signed commits
 
 We appreciate it if you configure Git to [sign your

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1298,6 +1304,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1344,6 +1356,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-targets 0.52.4",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -1607,11 +1646,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
 dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
@@ -2906,6 +2991,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eceaaeec696539ddaf7b333340f1af35a5aa87ae3e4f3ead0532f72affab2e"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3418,6 +3513,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f0f7638c1e223529f1bfdc48c8b133b9e0b434094d1d28473161ee48b235f78"
 dependencies = [
  "nom",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5317,6 +5423,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5856,6 +5968,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
+name = "plotters"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6390,6 +6530,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d86a7c4638d42c44551f4791a20e687dbb4c3de1f33c43dd71e355cd429def1"
 dependencies = [
  "bitflags 2.4.2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -8867,6 +9027,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9651,6 +9821,7 @@ name = "walrus-core"
 version = "0.1.0"
 dependencies = [
  "bcs",
+ "criterion",
  "fastcrypto 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.8.5",
  "raptorq",

--- a/crates/walrus-core/Cargo.toml
+++ b/crates/walrus-core/Cargo.toml
@@ -18,7 +18,12 @@ thiserror = { workspace = true }
 workspace = true
 
 [dev-dependencies]
+criterion = "0.5.1"
 walrus-test-utils = { workspace = true }
 
 [features]
 test-utils = ["rand"]
+
+[[bench]]
+name = "basic_encoding"
+harness = false

--- a/crates/walrus-core/benches/basic_encoding.rs
+++ b/crates/walrus-core/benches/basic_encoding.rs
@@ -1,0 +1,93 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(missing_docs)]
+
+//! Benchmarks for the basic encoding and decoding.
+
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use raptorq::SourceBlockEncodingPlan;
+use walrus_core::encoding::{Decoder, DecodingSymbol, Encoder, Primary};
+use walrus_test_utils::{random_data, random_subset};
+
+const N_SHARDS: u32 = 1000;
+// Likely values for the number of source symbols for the primary and secondary encoding.
+// These values are consistent with BFT and are supported source-block sizes that do not require
+// padding, see https://datatracker.ietf.org/doc/html/rfc6330#section-5.6.
+const SYMBOL_COUNTS: [u16; 2] = [324, 648];
+// Can be at most `u16::MAX`.
+const SYMBOL_SIZES: [u16; 5] = [1, 16, 256, 4096, u16::MAX];
+
+fn basic_encoding(c: &mut Criterion) {
+    let mut group = c.benchmark_group("basic_encoding");
+
+    for symbol_count in SYMBOL_COUNTS {
+        let encoding_plan = SourceBlockEncodingPlan::generate(symbol_count);
+
+        for symbol_size in SYMBOL_SIZES {
+            let data_length = symbol_size as usize * symbol_count as usize;
+            let data = random_data(data_length);
+            group.throughput(criterion::Throughput::Bytes(data_length as u64));
+
+            group.bench_with_input(
+                BenchmarkId::from_parameter({
+                    let res = format!("symbol_count={},symbol_size={}", symbol_count, symbol_size);
+                    res
+                }),
+                &(symbol_count, data),
+                |b, (symbol_count, data)| {
+                    b.iter(|| {
+                        let encoder =
+                            Encoder::new(&data, *symbol_count, N_SHARDS, &encoding_plan).unwrap();
+                        let _encoded_symbols = encoder.encode_all().collect::<Vec<_>>();
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+fn basic_decoding(c: &mut Criterion) {
+    let mut group = c.benchmark_group("basic_decoding");
+    for symbol_count in SYMBOL_COUNTS {
+        let encoding_plan = SourceBlockEncodingPlan::generate(symbol_count);
+        for symbol_size in SYMBOL_SIZES {
+            let data_length = symbol_size as usize * symbol_count as usize;
+            let data = random_data(data_length);
+            group.throughput(criterion::Throughput::Bytes(data_length as u64));
+            let encoder = Encoder::new(&data, symbol_count, N_SHARDS, &encoding_plan).unwrap();
+            let symbols: Vec<_> = random_subset(
+                encoder
+                    .encode_all()
+                    .enumerate()
+                    .map(|(i, s)| DecodingSymbol::<Primary>::new(i as u32, s.into())),
+                symbol_count as usize + 1,
+            )
+            .collect();
+            group.bench_with_input(
+                BenchmarkId::from_parameter({
+                    let res = format!("symbol_count={},symbol_size={}", symbol_count, symbol_size);
+                    res
+                }),
+                &(symbol_count, symbol_size, symbols),
+                |b, (symbol_count, symbol_size, symbols)| {
+                    b.iter_batched(
+                        || symbols.clone(),
+                        |symbols| {
+                            let mut decoder = Decoder::new(*symbol_count, *symbol_size);
+                            let _decoded_data = &decoder.decode(symbols).unwrap();
+                        },
+                        BatchSize::SmallInput,
+                    );
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, basic_encoding, basic_decoding);
+criterion_main!(benches);

--- a/crates/walrus-core/src/encoding/blob_encoding.rs
+++ b/crates/walrus-core/src/encoding/blob_encoding.rs
@@ -460,7 +460,6 @@ impl<'a, T: EncodingAxis> BlobDecoder<'a, T> {
 #[cfg(test)]
 mod tests {
 
-    use rand::{rngs::StdRng, SeedableRng};
     use walrus_test_utils::{param_test, random_data, random_subset};
 
     use super::*;
@@ -546,7 +545,6 @@ mod tests {
 
         let slivers_for_decoding = random_subset(
             config.get_blob_encoder(&blob).unwrap().encode(),
-            &mut StdRng::seed_from_u64(42),
             cmp::max(source_symbols_primary, source_symbols_secondary) as usize,
         );
 
@@ -645,13 +643,9 @@ mod tests {
             .get_blob_encoder(&blob)
             .unwrap()
             .encode_with_metadata();
-        let slivers_for_decoding = random_subset(
-            slivers,
-            &mut StdRng::seed_from_u64(23),
-            source_symbols_primary as usize,
-        )
-        .map(|s| s.primary)
-        .collect::<Vec<_>>();
+        let slivers_for_decoding = random_subset(slivers, source_symbols_primary as usize)
+            .map(|s| s.primary)
+            .collect::<Vec<_>>();
         let (blob_dec, metadata_dec) = get_encoding_config()
             .get_blob_decoder(blob.len())
             .unwrap()

--- a/crates/walrus-core/src/encoding/slivers.rs
+++ b/crates/walrus-core/src/encoding/slivers.rs
@@ -356,7 +356,6 @@ impl SliverPair {
 #[cfg(test)]
 mod tests {
     use fastcrypto::hash::Blake2b256;
-    use rand::{rngs::StdRng, SeedableRng};
     use walrus_test_utils::{param_test, random_subset, Result};
 
     use super::*;
@@ -494,7 +493,6 @@ mod tests {
             blob,
         );
         let n_to_recover_from = source_symbols_primary.max(source_symbols_secondary) as usize;
-        let mut rng = StdRng::seed_from_u64(42);
 
         for pair in pairs.iter() {
             // Get a random subset of recovery symbols.
@@ -502,7 +500,6 @@ mod tests {
                 pairs
                     .iter()
                     .map(|p| p.recovery_symbol_pair_for_sliver(pair.index()).unwrap()),
-                &mut rng,
                 n_to_recover_from,
             )
             .collect();

--- a/crates/walrus-test-utils/src/lib.rs
+++ b/crates/walrus-test-utils/src/lib.rs
@@ -173,10 +173,10 @@ macro_rules! assert_unordered_eq {
     };
 }
 
-/// Gets a random subset of `count` elements of `data` in an arbitrary order.
+/// Gets a random subset of `count` elements of `data` in an arbitrary order using the provided RNG.
 ///
 /// If the `data` has fewer elements than `count` the original number of elements is returned.
-pub fn random_subset<T: Clone>(
+pub fn random_subset_from_rng<T: Clone>(
     data: impl IntoIterator<Item = T>,
     mut rng: &mut impl RngCore,
     count: usize,
@@ -184,6 +184,17 @@ pub fn random_subset<T: Clone>(
     let mut data: Vec<_> = data.into_iter().collect();
     data.shuffle(&mut rng);
     data.into_iter().take(count)
+}
+
+/// Gets a random subset of `count` elements of `data` in an arbitrary order using a newly generated
+/// RNG with fixed seed.
+///
+/// If the `data` has fewer elements than `count` the original number of elements is returned.
+pub fn random_subset<T: Clone>(
+    data: impl IntoIterator<Item = T>,
+    count: usize,
+) -> impl Iterator<Item = T> + Clone {
+    random_subset_from_rng(data, &mut StdRng::seed_from_u64(42), count)
 }
 
 /// Creates a byte vector of length `data_length` filled with random data using the provided RNG.


### PR DESCRIPTION
This adds a first micro-benchmark for the basic encoding. If there is an agreement about the general approach, I will add more benchmarks for the blob encoding, the Merkle trees, and the blob ID generation.

Contributes to #58 