### PR TITLE
feat(core): add verification to blob decoding

### DIFF
--- a/crates/walrus-core/src/encoding.rs
+++ b/crates/walrus-core/src/encoding.rs
@@ -23,7 +23,13 @@ mod config;
 pub use config::{get_encoding_config, initialize_encoding_config, EncodingConfig};
 
 mod errors;
-pub use errors::{DataTooLargeError, EncodeError, RecoveryError, WrongSymbolSizeError};
+pub use errors::{
+    DataTooLargeError,
+    DecodingVerificationError,
+    EncodeError,
+    RecoveryError,
+    WrongSymbolSizeError,
+};
 
 mod slivers;
 pub use slivers::{PrimarySliver, SecondarySliver, Sliver, SliverPair};

--- a/crates/walrus-core/src/encoding/errors.rs
+++ b/crates/walrus-core/src/encoding/errors.rs
@@ -44,3 +44,9 @@ pub enum RecoveryError {
 #[derive(Debug, Error, PartialEq, Eq)]
 #[error("the size of the symbols provided does not match the size of the existing symbols")]
 pub struct WrongSymbolSizeError;
+
+/// Error returned when the verification of a reconstructed blob fails. Verification failure occurs
+/// when the provided blob ID does not match the blob ID computed from the reconstructed blob.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+#[error("decoding verification failed because the blob ID does not match the provided metadata")]
+pub struct DecodingVerificationError;


### PR DESCRIPTION
* Adds an encoding function that only computes the metadata without allocating the slivers;
* adds a decoding fuction that also checks the blob id of the decoded blob, by recomputing it.

Closes: #112