### PR TITLE
chore: add micro-benchmarks for blob en/decoding

### DIFF
--- a/crates/walrus-core/Cargo.toml
+++ b/crates/walrus-core/Cargo.toml
@@ -24,6 +24,9 @@ walrus-test-utils = { workspace = true }
 [features]
 test-utils = ["rand"]
 
+[lib]
+bench = false
+
 [[bench]]
 name = "basic_encoding"
 harness = false

--- a/crates/walrus-core/benches/constants/mod.rs
+++ b/crates/walrus-core/benches/constants/mod.rs
@@ -1,0 +1,9 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+pub const N_SHARDS: u32 = 1000;
+// Likely values for the number of source symbols for the primary and secondary encoding.
+// These values are consistent with BFT and are supported source-block sizes that do not require
+// padding, see https://datatracker.ietf.org/doc/html/rfc6330#section-5.6.
+pub const SOURCE_SYMBOLS_PRIMARY: u16 = 324;
+pub const SOURCE_SYMBOLS_SECONDARY: u16 = 648;


### PR DESCRIPTION
- Blob encoding with and without metadata.
- Blob decoding with and without verification.

Some results on my MacBook 2023 with M2 processor and 64 GB memory:

![lines](https://github.com/MystenLabs/walrus/assets/5960634/58e574ff-8cfd-434e-a323-1eecb9740aa1)

![lines](https://github.com/MystenLabs/walrus/assets/5960634/0a1b1917-2270-4fed-957d-851e20c46cfc)


Contributes to #58 