### PR TITLE
chore: update test/coverage config and add CI job for E2E tests

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -50,6 +50,7 @@ jobs:
     outputs:
       isRust: ${{ steps.diff.outputs.isRust }}
       isMove: ${{ steps.diff.outputs.isMove }}
+      relevantForE2eTests: ${{ steps.diff.outputs.relevantForE2eTests }}
     steps:
       - uses: actions/checkout@v4
       - name: Detect Changes
@@ -67,6 +68,11 @@ jobs:
               - 'Cargo.lock'
               - 'rust-toolchain'
               - 'deny.toml'
+              - '.github/workflows/code.yml'
+            relevantForE2eTests:
+              - 'crates/walrus-sui/**'
+              - 'crates/walrus-e2e-tests/**'
+              - 'contracts/**'
               - '.github/workflows/code.yml'
 
   dependencies:
@@ -90,8 +96,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v1.6.1
 
-  test:
-    name: Test Rust code and report coverage
+  # TODO(mlegner): Currently running all tests on all PRs touching Rust code.
+  # If the running time gets too long, we may need to remove the integration and E2E tests and/or
+  # not do the coverage analysis on PRs.
+  test-coverage:
+    name: Run all Rust tests and report coverage
     needs: diff
     if: ${{ github.event_name == 'schedule' || needs.diff.outputs.isRust == 'true' }}
     runs-on: ubuntu-ghcloud
@@ -107,14 +116,8 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
       - run: cargo install cargo-tarpaulin@0.27.3
 
-      - name: Run tests (including integration tests) and record coverage
-        run: >
-          cargo tarpaulin --workspace --skip-clean
-          --lib --bins --examples --tests --doc
-          --out html --out xml
-          --exclude-files "crates/**/tests/*"
-          --exclude-files "crates/**/benches/*"
-          -- --include-ignored
+      - name: Run tests (including integration E2E tests) and record coverage
+        run: cargo tarpaulin
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
@@ -138,6 +141,17 @@ jobs:
         if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
         with:
           path: code-coverage-results.md
+
+  e2e-tests:
+    name: End-to-end tests
+    needs: diff
+    if: ${{ github.event_name == 'schedule' || needs.diff.outputs.relevantForE2eTests == 'true' }}
+    runs-on: ubuntu-ghcloud
+    steps:
+      - uses: actions/checkout@v4
+      # Don't cache as this shouldn't be run too often and would bring us above GitHub's 10GB limit.
+      - name: Run E2E tests
+        run: cargo test -p walrus-sui -p walrus-e2e-tests -- --include-ignored
 
   lint:
     name: Lint Rust code
@@ -212,7 +226,8 @@ jobs:
     needs:
       - diff
       - dependencies
-      - test
+      - test-coverage
+      - e2e-tests
       - lint
       - build
       - test-move

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 # Rust build and test files
 **/target
 tarpaulin-report.html
+build_rs_cov.profraw
+cobertura.xml
 
 # Move-related files
 build/

--- a/.tarpaulin.toml
+++ b/.tarpaulin.toml
@@ -1,0 +1,25 @@
+[default]
+workspace = true
+skip-clean = true
+run-types = [
+  "Bins",
+  "Doctests",
+  "Examples",
+  "Lib",
+  "Tests",
+]
+out = [
+  "Html",
+  "Xml",
+]
+# Don't include test and benchmark code in the coverage result.
+exclude-files = [
+  "crates/**/benches/**/*",
+  "crates/**/tests/**/*",
+  "crates/**/test_utils/**/*",
+  "crates/walrus-test-utils/**/*",
+  "crates/walrus-e2e-tests/**/*",
+]
+args = [
+  "--include-ignored"
+]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,13 +47,22 @@ run the tool as follows:
 
 ```sh
 cargo install cargo-tarpaulin
-cargo tarpaulin --workspace --skip-clean --lib --bins --examples --tests --doc --out html
+cargo tarpaulin --out html
 ```
 
 This creates a file `tarpaulin-report.html`, which shows you coverage statistics as well as which individual lines are
 or aren't covered by tests. Other valid output formats are `json`, `stdout`, `xml`, and `lcov`.
 
-The exact command we use in our CI pipeline is visible in [.github/workflows/code.yml](.github/workflows/code.yml).
+The configuration file for Tarpaulin is [.tarpaulin.toml](./.tarpaulin.toml).
+
+## Integration and end-to-end tests
+
+Integration and end-to-end tests are excluded by default when running `cargo test` as they depend on additional packages
+and take longer to run. You can run these test as follows:
+
+```sh
+cargo test -- --ignored
+```
 
 ## Benchmarks
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,6 @@
 [workspace]
 resolver = "2"
 members = ["crates/*"]
-default-members = [
-  "crates/walrus-core",
-  "crates/walrus-service",
-  "crates/walrus-test-utils",
-  "crates/walrus-sui",
-]
 
 [workspace.package]
 version = "0.1.0"

--- a/crates/walrus-e2e-tests/tests/test_publish_package.rs
+++ b/crates/walrus-e2e-tests/tests/test_publish_package.rs
@@ -6,6 +6,7 @@ use test_cluster::TestClusterBuilder;
 use walrus_e2e_tests::publish_package;
 
 #[tokio::test]
+#[ignore = "ignore E2E tests by default"]
 async fn test_publish_blob_storage_package_and_check_events() -> anyhow::Result<()> {
     let mut test_cluster = TestClusterBuilder::new().build().await;
     let wallet = &mut test_cluster.wallet;

--- a/crates/walrus-sui/tests/test_walrus_sui.rs
+++ b/crates/walrus-sui/tests/test_walrus_sui.rs
@@ -15,6 +15,7 @@ use walrus_e2e_tests::publish_package;
 use walrus_sui::{client::WalrusSuiClient, types::EpochStatus};
 
 #[tokio::test]
+#[ignore = "ignore integration tests by default"]
 async fn test_register_blob() -> anyhow::Result<()> {
     let test_cluster = TestClusterBuilder::new().build().await;
     let mut wallet = test_cluster.wallet;
@@ -59,6 +60,7 @@ async fn test_register_blob() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+#[ignore = "ignore integration tests by default"]
 async fn test_get_system() -> anyhow::Result<()> {
     let test_cluster = TestClusterBuilder::new().build().await;
     let mut wallet = test_cluster.wallet;


### PR DESCRIPTION
- ignore integration and E2E tests by default
- exclude test and benchmark code from coverage analysis
- add CI job to run integration and E2E tests on relevant changes
- add some docs on how to run excluded tests and compute coverage

Currently, the test-coverage job still runs all tests (including integration and E2E tests). We may have to revisit our coverage-reporting approach as soon as that job's run time becomes too long.

Closes #59 