### PR TITLE
chore: bump cargo-deny again to fix pre-commit issue

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
   - id: cargo-sort
     args: ["--workspace"]
 - repo: https://github.com/EmbarkStudios/cargo-deny
-  rev: 0.14.18
+  rev: 0.14.19
   hooks:
   - id: cargo-deny
 - repo: local


### PR DESCRIPTION
`pre-commit` was failing (again) due to issues with dependencies of `cargo-deny`. They released another new version yesterday which seems to fix it.