### PR TITLE
refactor(core): decrease memory usage of blob encoding

### DIFF
--- a/crates/walrus-core/src/encoding/basic_encoding.rs
+++ b/crates/walrus-core/src/encoding/basic_encoding.rs
@@ -15,7 +15,6 @@ pub struct Encoder {
     symbol_size: u16,
 }
 
-// TODO(mlegner): Check if memory management and copying can be improved for Encoder (#45).
 impl Encoder {
     /// Creates a new `Encoder` for the provided `data` with the specified arguments.
     ///

--- a/crates/walrus-core/src/encoding/config.rs
+++ b/crates/walrus-core/src/encoding/config.rs
@@ -135,6 +135,7 @@ pub struct EncodingConfig {
     /// number of symbols per primary sliver. It must be strictly less than 2/3 of `n_shards`.
     pub(crate) source_symbols_secondary: u16,
     /// The number of shards.
+    // INV: n_shards - 1 <= u16::MAX as u32
     pub(crate) n_shards: u32,
     /// Encoding plan to speed up the primary encoding.
     encoding_plan_primary: SourceBlockEncodingPlan,
@@ -290,7 +291,10 @@ impl EncodingConfig {
     /// # Errors
     ///
     /// Returns a [`DataTooLargeError`] if the `blob` is too large to be encoded.
-    pub fn get_blob_encoder(&self, blob: &[u8]) -> Result<BlobEncoder, DataTooLargeError> {
+    pub fn get_blob_encoder<'a>(
+        &'a self,
+        blob: &'a [u8],
+    ) -> Result<BlobEncoder, DataTooLargeError> {
         BlobEncoder::new(self, blob)
     }
 

--- a/crates/walrus-core/src/encoding/slivers.rs
+++ b/crates/walrus-core/src/encoding/slivers.rs
@@ -72,6 +72,8 @@ impl<T: EncodingAxis> Sliver<T> {
 
     /// Creates a new `Sliver` with empty data of specified length.
     ///
+    /// The `length` parameter specifies the number of symbols.
+    ///
     /// # Panics
     ///
     /// Panics if `symbol_size == 0`.

--- a/crates/walrus-core/src/encoding/symbols.rs
+++ b/crates/walrus-core/src/encoding/symbols.rs
@@ -29,17 +29,14 @@ impl Symbols {
     ///
     /// # Panics
     ///
-    /// Panics if the slice does not contain complete symbols, i.e., if
-    /// `slice.len() % symbol_size != 0` or if `symbol_size == 0`.
-    pub fn new(symbols: Vec<u8>, symbol_size: u16) -> Self {
+    /// Panics if the `data` does not contain complete symbols, i.e., if
+    /// `data.len() % symbol_size != 0` or if `symbol_size == 0`.
+    pub fn new(data: Vec<u8>, symbol_size: u16) -> Self {
         assert!(
-            symbols.len() % symbol_size as usize == 0,
-            "the slice must contain complete symbols"
+            data.len() % symbol_size as usize == 0,
+            "the provided data must contain complete symbols"
         );
-        Symbols {
-            data: symbols,
-            symbol_size,
-        }
+        Symbols { data, symbol_size }
     }
 
     /// Shortens the `data` in [`Symbols`], keeping the first `len` symbols and dropping the
@@ -63,6 +60,27 @@ impl Symbols {
         assert!(symbol_size != 0);
         Symbols {
             data: vec![0; n_symbols * symbol_size as usize],
+            symbol_size,
+        }
+    }
+
+    /// Creates a new empty `Symbols` struct with an internal vector of provided capacity.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `symbol_size == 0`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use walrus_core::encoding::Symbols;
+    /// #
+    /// assert!(Symbols::with_capacity(42, 1).is_empty());
+    /// ```
+    pub fn with_capacity(capacity: usize, symbol_size: u16) -> Self {
+        assert!(symbol_size != 0);
+        Symbols {
+            data: Vec::<u8>::with_capacity(capacity),
             symbol_size,
         }
     }


### PR DESCRIPTION
This avoids storing the same data multiple times and attempts to free memory as soon as it is no longer required. As a result, this reduces the overhead to roughly 4.5x the blob size at most, which is what we need for the sliver pairs.

Closes #45 