### PR TITLE
chore(service): add tests to the walrus client & fix bugs

### DIFF
--- a/crates/walrus-core/src/lib.rs
+++ b/crates/walrus-core/src/lib.rs
@@ -226,6 +226,15 @@ impl Sliver {
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
+    /// Returns the [`Sliver<T>`][Sliver] contained within the enum.
+    pub fn to_raw<T>(self) -> Result<encoding::Sliver<T>, WrongSliverVariantError>
+    where
+        Self: TryInto<encoding::Sliver<T>>,
+        T: EncodingAxis,
+    {
+        self.try_into().map_err(|_| WrongSliverVariantError)
+    }
 }
 
 impl TryFrom<Sliver> for PrimarySliver {

--- a/crates/walrus-service/bin/client.rs
+++ b/crates/walrus-service/bin/client.rs
@@ -52,7 +52,7 @@ pub async fn main() -> Result<()> {
     initialize_encoding_config(
         config.source_symbols_primary,
         config.source_symbols_secondary,
-        config.committee.total_weight.try_into()?,
+        config.committee.total_weight as u32,
     );
     let client = Client::new(config);
     match args.command {

--- a/crates/walrus-service/bin/client/test_utils.rs
+++ b/crates/walrus-service/bin/client/test_utils.rs
@@ -1,0 +1,35 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::HashMap, net::SocketAddr, sync::Arc};
+
+use fastcrypto::traits::{KeyPair as FcKeyPair, ToFromBytes};
+use tokio_util::sync::CancellationToken;
+use typed_store::rocks::MetricConf;
+use walrus_core::{test_utils, KeyPair, PublicKey, ShardIndex};
+use walrus_service::{
+    config::StorageNodePrivateParameters,
+    server::UserServer,
+    Storage,
+    StorageNode,
+};
+use walrus_sui::types::{Committee, StorageNode as SuiStorageNode};
+use walrus_test_utils::WithTempDir;
+
+use super::cli::Config;
+
+/// Creates a new [`StorageNodePrivateParameters`] object for testing.
+pub fn storage_node_private_parameters() -> StorageNodePrivateParameters {
+    let network_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let network_address = network_listener.local_addr().unwrap();
+
+    let metrics_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let metrics_address = metrics_listener.local_addr().unwrap();
+
+    StorageNodePrivateParameters {
+        keypair: test_utils::keypair(),
+        network_address,
+        metrics_address,
+        shards: HashMap::new(),
+    }
+}

--- a/crates/walrus-service/src/client/config.rs
+++ b/crates/walrus-service/src/client/config.rs
@@ -16,6 +16,8 @@ pub struct Config {
     pub source_symbols_primary: u16,
     /// The number of source symbols for the secondary encoding.
     pub source_symbols_secondary: u16,
+    /// The number of parallel requests the client makes.
+    pub concurrent_requests: usize,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/walrus-service/src/lib.rs
+++ b/crates/walrus-service/src/lib.rs
@@ -19,6 +19,7 @@ mod node;
 pub use node::StorageNode;
 
 mod storage;
+pub use storage::Storage;
 
 #[cfg(test)]
 mod test_utils;

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -149,15 +149,21 @@ impl StorageNode {
 
         Ok(Self::new_with_storage(
             storage,
+            100,
             config.protocol_key_pair.clone(),
         ))
     }
 
-    fn new_with_storage(storage: Storage, protocol_key_pair: Arc<KeyPair>) -> Self {
+    /// Create a new storage node providing the storage directly.
+    pub fn new_with_storage(
+        storage: Storage,
+        n_shards: usize,
+        protocol_key_pair: Arc<KeyPair>,
+    ) -> Self {
         Self {
             storage,
             current_epoch: 0,
-            n_shards: NonZeroUsize::new(100).unwrap(),
+            n_shards: NonZeroUsize::new(n_shards).unwrap(),
             protocol_key_pair,
         }
     }
@@ -358,7 +364,7 @@ mod tests {
         let signing_key = BLS12381KeyPair::generate(&mut rand::thread_rng());
 
         WithTempDir {
-            inner: StorageNode::new_with_storage(storage.inner, signing_key.into()),
+            inner: StorageNode::new_with_storage(storage.inner, 100, signing_key.into()),
             temp_dir: storage.temp_dir,
         }
     }

--- a/crates/walrus-service/src/storage/shard.rs
+++ b/crates/walrus-service/src/storage/shard.rs
@@ -45,7 +45,7 @@ impl<const P: bool, T: Borrow<BlobId>> From<T> for SliverKey<P> {
 }
 
 #[derive(Debug)]
-pub(crate) struct ShardStorage {
+pub struct ShardStorage {
     id: ShardIndex,
     primary_slivers: DBMap<PrimarySliverKey, PrimarySliver>,
     secondary_slivers: DBMap<SecondarySliverKey, SecondarySliver>,
@@ -181,13 +181,9 @@ mod tests {
     use walrus_core::{Sliver, SliverType};
     use walrus_test_utils::{async_param_test, param_test, Result as TestResult, WithTempDir};
 
-    use crate::storage::tests::{
-        empty_storage,
-        empty_storage_with_shards,
-        get_sliver,
-        BLOB_ID,
-        OTHER_SHARD_INDEX,
-        SHARD_INDEX,
+    use crate::{
+        storage::tests::{empty_storage, get_sliver, BLOB_ID, OTHER_SHARD_INDEX, SHARD_INDEX},
+        test_utils::empty_storage_with_shards,
     };
 
     async_param_test! {

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -1,11 +1,22 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
+use std::{collections::HashMap, net::SocketAddr, sync::Arc};
 
-use walrus_core::test_utils;
+use fastcrypto::traits::{KeyPair as FCKeyPair, ToFromBytes};
+use tokio_util::sync::CancellationToken;
+use typed_store::rocks::MetricConf;
+use walrus_core::{test_utils, KeyPair, PublicKey, ShardIndex};
+use walrus_sui::types::{Committee, StorageNode as SuiStorageNode};
+use walrus_test_utils::WithTempDir;
 
-use crate::config::StorageNodePrivateParameters;
+use crate::{
+    config::StorageNodePrivateParameters,
+    server::UserServer,
+    Config,
+    Storage,
+    StorageNode,
+};
 
 /// Creates a new [`StorageNodePrivateParameters`] object for testing.
 pub fn storage_node_private_parameters() -> StorageNodePrivateParameters {
@@ -20,5 +31,114 @@ pub fn storage_node_private_parameters() -> StorageNodePrivateParameters {
         network_address,
         metrics_address,
         shards: HashMap::new(),
+    }
+}
+
+/// Returns an empty storage, with the column families for the specified shards already created.
+pub fn empty_storage_with_shards(shards: &[ShardIndex]) -> WithTempDir<Storage> {
+    let temp_dir = tempfile::tempdir().expect("temporary directory creation must succeed");
+    let mut storage = Storage::open(temp_dir.path(), MetricConf::default())
+        .expect("storage creation must succeed");
+
+    for shard in shards {
+        storage
+            .create_storage_for_shard(*shard)
+            .expect("shard should be successfully created");
+    }
+
+    WithTempDir {
+        inner: storage,
+        temp_dir,
+    }
+}
+
+/// Creates a new [`StorageNode`].
+pub fn new_test_storage_node(
+    shards: &[ShardIndex],
+    n_shards: usize,
+    key_pair: KeyPair,
+) -> StorageNode {
+    let storage = empty_storage_with_shards(shards);
+    StorageNode::new_with_storage(storage.inner, n_shards, Arc::new(key_pair))
+}
+
+/// Creates a new [`UserServer`].
+pub fn new_test_server(
+    shards: &[ShardIndex],
+    n_shards: usize,
+    key_pair: KeyPair,
+) -> UserServer<StorageNode> {
+    let storage_node = new_test_storage_node(shards, n_shards, key_pair);
+    UserServer::new(Arc::new(storage_node), CancellationToken::new())
+}
+
+/// Creates a new [`UserServer`] with parameters.
+pub fn new_test_server_with_address(
+    shards: &[ShardIndex],
+    n_shards: usize,
+) -> (UserServer<StorageNode>, SocketAddr, PublicKey) {
+    let StorageNodePrivateParameters {
+        keypair,
+        network_address,
+        metrics_address: _,
+        shards: _,
+    } = storage_node_private_parameters();
+    let pk = keypair.public().clone();
+    (
+        new_test_server(shards, n_shards, keypair),
+        network_address,
+        pk,
+    )
+}
+
+/// Creates and runs a new [`UserServer`] with parameters.
+pub async fn spawn_test_server(shards: &[ShardIndex], n_shards: usize) -> (SocketAddr, PublicKey) {
+    let (server, addr, pk) = new_test_server_with_address(shards, n_shards);
+    let _handle = tokio::spawn(async move { server.run(&addr).await });
+    tokio::task::yield_now().await;
+    (addr, pk)
+}
+
+/// Creates and runs a new committee of [`UserServer`s][UserServer].
+pub async fn spawn_test_committee(
+    n_symbols_primary: u16,
+    n_symbols_secondary: u16,
+    n_shards: usize,
+    nodes_shards: &[&[u16]],
+) -> Config {
+    let mut addrs_pks = vec![];
+    // Create the walrus storage nodes.
+    for shards in nodes_shards.iter() {
+        addrs_pks.push(spawn_test_server(&to_shards(shards), n_shards).await);
+    }
+    // Create the config.
+    let members = nodes_shards
+        .iter()
+        .zip(addrs_pks.into_iter())
+        .map(|(shards, (addr, pk))| to_storage_node_config(addr, pk, shards))
+        .collect::<Vec<_>>();
+
+    Config {
+        committee: Committee {
+            members,
+            epoch: 0,
+            total_weight: n_shards,
+        },
+        source_symbols_primary: n_symbols_primary,
+        source_symbols_secondary: n_symbols_secondary,
+        concurrent_requests: n_shards,
+    }
+}
+
+fn to_shards(ids: &[u16]) -> Vec<ShardIndex> {
+    ids.iter().map(|&i| ShardIndex(i)).collect()
+}
+
+fn to_storage_node_config(addr: SocketAddr, pk: PublicKey, shard_ids: &[u16]) -> SuiStorageNode {
+    SuiStorageNode {
+        name: addr.to_string(),
+        network_address: addr.to_string(),
+        public_key: pk.as_bytes().to_vec(),
+        shard_ids: shard_ids.to_vec(),
     }
 }


### PR DESCRIPTION
Adds an end to end test for the client, which stores and then reads a blob from a committee.
Also fixes a few bugs in the client (in the deserialization of messages from the storage nodes).