### PR TITLE
ci: fix pre-commit autoupdate and update hooks

### DIFF
--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -14,6 +14,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    env:
+      SUI_TAG: testnet-v1.22.0
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -21,7 +23,25 @@ jobs:
           python-version: '3.12'
       - run: rustup update stable
       - run: pip install pre-commit
-      - run: pre-commit autoupdate
+      - name: Run pre-commit autoupdate
+        run: >
+          pre-commit autoupdate
+          --repo https://github.com/pre-commit/pre-commit-hooks
+          --repo https://github.com/editorconfig-checker/editorconfig-checker.python
+          --repo https://github.com/crate-ci/typos
+          --repo https://github.com/DevinR528/cargo-sort
+          --repo https://github.com/EmbarkStudios/cargo-deny
+
+      - name: Restore cached sui binary
+        id: cache-sui-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: "/home/runner/.cargo/bin/sui"
+          key: ${{ runner.os }}-${{ runner.arch }}-${{ env.SUI_TAG }}
+      - name: Install sui
+        if: steps.cache-sui-restore.outputs.cache-hit != 'true'
+        run: cargo install --locked --git https://github.com/MystenLabs/sui.git --tag $SUI_TAG --debug sui
+
       - run: pre-commit run --all-files
       - uses: peter-evans/create-pull-request@v6.0.2
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v4.6.0
   hooks:
   - id: check-merge-conflict
   - id: check-yaml
@@ -21,7 +21,7 @@ repos:
       args: []
       pass_filenames: false
 - repo: https://github.com/crate-ci/typos
-  rev: v1.19.0
+  rev: v1.20.7
   hooks:
   - id: typos
     pass_filenames: false
@@ -31,7 +31,7 @@ repos:
   - id: cargo-sort
     args: ["--workspace"]
 - repo: https://github.com/EmbarkStudios/cargo-deny
-  rev: 0.14.19
+  rev: 0.14.21
   hooks:
   - id: cargo-deny
 - repo: local


### PR DESCRIPTION
This adds a missing install of sui and adds a workaround for a bug in
the `pre-commit autoupdate` command.
Apparently it doesn't work if the latest tag/release of a repo doesn't
have the `.pre-commit-hooks.yaml` file.

Also run `pre-commit autoupdate`.