### PR TITLE
test: fix the local testbed setup

### DIFF
--- a/crates/walrus-service/src/client.rs
+++ b/crates/walrus-service/src/client.rs
@@ -7,7 +7,7 @@ use anyhow::{anyhow, Result};
 use fastcrypto::{bls12381::min_pk::BLS12381AggregateSignature, traits::AggregateAuthenticator};
 use futures::Future;
 use reqwest::{Client as ReqwestClient, ClientBuilder};
-use tokio::time::Duration;
+use tokio::time::{sleep, Duration};
 use tracing::Instrument;
 use walrus_core::{
     encoding::{BlobDecoder, EncodingAxis, EncodingConfig, Sliver, SliverPair},
@@ -98,6 +98,10 @@ impl<T: ContractClient> Client<T> {
                 metadata.metadata().encoding_type,
             )
             .await?;
+
+        // We need to wait to be sure that the storage nodes received the registration event.
+        sleep(Duration::from_secs(1)).await;
+
         let certificate = self.store_metadata_and_pairs(&metadata, pairs).await?;
         self.sui_client
             .certify_blob(&blob_sui_object, &certificate)

--- a/crates/walrus-service/src/testbed.rs
+++ b/crates/walrus-service/src/testbed.rs
@@ -111,10 +111,16 @@ pub async fn testbed_configs(
 
     let sui_client = admin_wallet.get_client().await?;
     // Get coins from faucet for the wallets.
-    let faucet_requests = [
-        request_sui_from_faucet(admin_wallet.active_address()?, sui_network, &sui_client),
-        request_sui_from_faucet(client_wallet.active_address()?, sui_network, &sui_client),
-    ];
+    let mut faucet_requests = Vec::with_capacity(4);
+    for wallet in [&mut admin_wallet, &mut client_wallet] {
+        for _ in 0..2 {
+            faucet_requests.push(request_sui_from_faucet(
+                wallet.active_address()?,
+                sui_network,
+                &sui_client,
+            ))
+        }
+    }
     try_join_all(faucet_requests).await?;
 
     // Publish package and set up system object

--- a/scripts/local-testbed.sh
+++ b/scripts/local-testbed.sh
@@ -3,6 +3,8 @@
 
 #!/bin/bash
 
+set -euo pipefail
+
 trap ctrl_c INT
 function ctrl_c() {
     tmux kill-server
@@ -28,24 +30,24 @@ fi
 working_dir="./working_dir"
 
 # Print configs
+echo Generating configuration...
 cargo run --bin walrus-node -- generate-dry-run-configs \
---working-dir $working_dir --committee-size $committee_size --total-shards $shards
+--working-dir $working_dir --committee-size $committee_size --n-shards $shards
 
 # Spawn nodes
 for i in $(seq -w 0 $((committee_size-1))); do
     tmux new -d -s "n$i" \
     "cargo run --bin walrus-node -- run \
     --config-path $working_dir/dryrun-node-$i.yaml --cleanup-storage \
-    from-client-config --client-config-path $working_dir/client_config.yaml \
-    --storage-node-index $i |& tee $working_dir/n$i.log"
+    on-chain --storage-node-index $i |& tee $working_dir/n$i.log"
 done
 
-echo "Spawned $committee_size nodes in separate tmux sessions handing a total of $shards shards."
+echo "\nSpawned $committee_size nodes in separate tmux sessions handing a total of $shards shards."
 
 # Instructions to run a client
-echo "\nTo run a client, use the following command:"
-echo "$ echo \"123456\" > blob.txt"
-echo "$ cargo run --bin client -- --config working_dir/client_config.yaml store blob.txt"
+echo "\nTo store a file (e.g., the README.md) on the testbed, use the following command:"
+echo "$ cargo run --bin client --\
+    --config working_dir/client_config.yaml --wallet working_dir/sui_client.yaml store README.md 1"
 
 while true; do
     sleep 1


### PR DESCRIPTION
- Call the faucet twice to ensure that two coins are available (one for payment and one for gas).
- Sleep between registering a blob and sending data to storage nodes.
- Fix incorrect commands and instructions in testbed script.
- Fail early in testbed script.

Closes #290 