### PR TITLE
chore: reformat Cargo.toml files

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -83,7 +83,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2.7.3
         with:
           save-if: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
-      - run: cargo install cargo-sort@1.0.9
+      - run: >
+          cargo install cargo-sort --git https://github.com/DevinR528/cargo-sort
+          --rev 55ec89082466f6bb246d870a8d56d166a8e1f08b
 
       - name: Check formatting with rustfmt
         run: >

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
   - id: typos
     pass_filenames: false
 - repo: https://github.com/DevinR528/cargo-sort
-  rev: v1.0.9
+  rev: 55ec89082466f6bb246d870a8d56d166a8e1f08b
   hooks:
   - id: cargo-sort
     args: ["--workspace"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,15 @@ license = "Apache-2.0"
 [workspace.dependencies]
 anyhow = "1.0.82"
 bcs = "0.1.6"
+clap = { version = "4.5.4", features = ["derive"] }
 fastcrypto = "0.1"
+futures = "0.3.30"
 move-core-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.23.0" }
 mysten-metrics = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.23.0" }
 rand = "0.8.5"
+reqwest = "0.12.4"
 serde = { version = "1.0.198", features = ["derive"] }
+serde_json = "1.0.116"
 serde_with = "3.7"
 serde_yaml = "0.9"
 sui-keys = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.23.0" }
@@ -27,15 +31,14 @@ telemetry-subscribers = { git = "https://github.com/MystenLabs/sui", tag = "test
 tempfile = "3.10.1"
 test-cluster = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.23.0" }
 thiserror = "1.0.59"
-tokio = { version = "1.37.0" }
+tokio = "1.37.0"
 tokio-stream = "0.1.15"
+tracing = "0.1.40"
+tracing-subscriber = "0.3.18"
 typed-store = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.23.0" }
 walrus-core = { path = "crates/walrus-core" }
 walrus-sui = { path = "crates/walrus-sui" }
 walrus-test-utils = { path = "crates/walrus-test-utils" }
-clap = { version = "4.5.4", features = ["derive"] }
-reqwest = { version = "0.12.4" }
-futures = "0.3.30"
 
 [workspace.lints.rust]
 missing_docs = "warn"

--- a/crates/walrus-core/Cargo.toml
+++ b/crates/walrus-core/Cargo.toml
@@ -1,29 +1,29 @@
 [package]
 name = "walrus-core"
 publish = false
-authors = { workspace = true }
-version = { workspace = true }
-edition = { workspace = true }
-license = { workspace = true }
+authors.workspace = true
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 base64 = "0.22.0"
-bcs = { workspace = true }
-fastcrypto = { workspace = true }
-rand = { workspace = true }
+bcs.workspace = true
+fastcrypto.workspace = true
+rand.workspace = true
 raptorq = "2.0.0"
-serde = { workspace = true }
+serde.workspace = true
 serde_with = { workspace = true, features = ["base64"] }
-thiserror = { workspace = true }
+thiserror.workspace = true
 
 [lints]
 workspace = true
 
 [dev-dependencies]
-anyhow = { workspace = true }
+anyhow.workspace = true
 criterion = "0.5.1"
 serde_test = "1.0.176"
-walrus-test-utils = { workspace = true }
+walrus-test-utils.workspace = true
 
 [features]
 test-utils = []

--- a/crates/walrus-orchestrator/Cargo.toml
+++ b/crates/walrus-orchestrator/Cargo.toml
@@ -1,36 +1,36 @@
 [package]
 name = "walrus-orchestrator"
 publish = false
-version = { workspace = true }
-authors = { workspace = true }
-edition = { workspace = true }
-license = { workspace = true }
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 aws-config = "1.2.0"
 aws-runtime = "1.2.0"
 aws-sdk-ec2 = "1.34.0"
-clap = { workspace = true }
+clap.workspace = true
 color-eyre = "0.6.3"
 crossterm = "0.27.0"
 eyre = "0.6.12"
-futures = { workspace = true }
+futures.workspace = true
 indoc = "2.0.5"
 prettytable-rs = "0.10"
 # TODO(alberto): Remove this dependency again (#284).
 prometheus-parse = { git = "https://github.com/asonnino/prometheus-parser", rev = "75334db" }
 reqwest = { workspace = true, features = ["json"] }
-serde = { workspace = true }
-serde_json = "1.0.116"
-serde_with = { workspace = true }
-serde_yaml = { workspace = true }
+serde.workspace = true
+serde_json.workspace = true
+serde_with.workspace = true
+serde_yaml.workspace = true
 ssh2 = "0.9.4"
-thiserror = { workspace = true }
+thiserror.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
-walrus-core = { workspace = true }
+walrus-core.workspace = true
 
 [dev-dependencies]
-tempfile = { workspace = true }
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/walrus-service/Cargo.toml
+++ b/crates/walrus-service/Cargo.toml
@@ -1,50 +1,50 @@
 [package]
 name = "walrus-service"
 publish = false
-authors = { workspace = true }
-version = { workspace = true }
-edition = { workspace = true }
-license = { workspace = true }
+authors.workspace = true
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [features]
 default = ["test-utils"]
 test-utils = ["dep:tempfile", "dep:walrus-test-utils", "walrus-core/test-utils"]
 
 [dependencies]
-anyhow = { workspace = true }
+anyhow.workspace = true
 async-trait = "0.1.80"
 axum = { version = "0.7.5", features = ["http2"] }
-bcs = { workspace = true }
+bcs.workspace = true
 clap = { workspace = true, features = ["string"] }
 colored = "2.1.0"
-fastcrypto = { workspace = true }
-futures = { workspace = true }
+fastcrypto.workspace = true
+futures.workspace = true
 git-version = "0.3.9"
 home = "0.5.9"
 mime = "0.3.17"
-mysten-metrics = { workspace = true }
+mysten-metrics.workspace = true
 prometheus = "0.13.3"
-rand = { workspace = true }
+rand.workspace = true
 regex = "1"
 reqwest = { workspace = true, features = ["json"] }
 rocksdb = "0.21"
-serde = { workspace = true }
+serde.workspace = true
 serde_with = { workspace = true, features = ["base64"] }
-serde_yaml = { workspace = true }
-sui-sdk = { workspace = true }
-sui-types = { workspace = true }
-telemetry-subscribers = { workspace = true }
+serde_yaml.workspace = true
+sui-sdk.workspace = true
+sui-types.workspace = true
+telemetry-subscribers.workspace = true
 tempfile = { workspace = true, optional = true }
-thiserror = { workspace = true }
+thiserror.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
-tokio-stream = { workspace = true }
+tokio-stream.workspace = true
 tokio-util = "0.7.10"
 tower-http = { version = "0.5.2", features = ["trace"] }
-tracing = "0.1.40"
-tracing-subscriber = "0.3.18"
-typed-store = { workspace = true }
-walrus-core = { workspace = true }
-walrus-sui = { workspace = true }
+tracing.workspace = true
+tracing-subscriber.workspace = true
+typed-store.workspace = true
+walrus-core.workspace = true
+walrus-sui.workspace = true
 walrus-test-utils = { workspace = true, optional = true }
 
 [lints]
@@ -59,7 +59,7 @@ name = "walrus-node"
 path = "bin/main.rs"
 
 [dev-dependencies]
-rand = { workspace = true }
-tempfile = { workspace = true }
+rand.workspace = true
+tempfile.workspace = true
 walrus-core = { workspace = true, features = ["test-utils"] }
-walrus-test-utils = { workspace = true }
+walrus-test-utils.workspace = true

--- a/crates/walrus-sui/Cargo.toml
+++ b/crates/walrus-sui/Cargo.toml
@@ -1,37 +1,37 @@
 [package]
 name = "walrus-sui"
 publish = false
-authors = { workspace = true }
-version = { workspace = true }
-edition = { workspace = true }
-license = { workspace = true }
+authors.workspace = true
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [features]
 default = ["test-utils"]
 test-utils = []
 
 [dependencies]
-anyhow = { workspace = true }
-bcs = { workspace = true }
-fastcrypto = { workspace = true }
-move-core-types = { workspace = true }
-reqwest = { workspace = true }
-serde = { workspace = true }
-serde_json = "1.0.116"
-sui-config = { workspace = true }
-sui-keys = { workspace = true }
-sui-move-build = { workspace = true }
-sui-sdk = { workspace = true }
-sui-types = { workspace = true }
-thiserror = { workspace = true }
+anyhow.workspace = true
+bcs.workspace = true
+fastcrypto.workspace = true
+move-core-types.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sui-config.workspace = true
+sui-keys.workspace = true
+sui-move-build.workspace = true
+sui-sdk.workspace = true
+sui-types.workspace = true
+thiserror.workspace = true
 tokio = { workspace = true, features = ["sync"] }
-tokio-stream = { workspace = true }
-tracing = "0.1.40"
-walrus-core = { workspace = true }
+tokio-stream.workspace = true
+tracing.workspace = true
+walrus-core.workspace = true
 
 [lints]
 workspace = true
 
 [dev-dependencies]
-test-cluster = { workspace = true }
-tracing-subscriber = "0.3.18"
+test-cluster.workspace = true
+tracing-subscriber.workspace = true

--- a/crates/walrus-test-utils/Cargo.toml
+++ b/crates/walrus-test-utils/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "walrus-test-utils"
 publish = false
-authors = { workspace = true }
-edition = { workspace = true }
-license = { workspace = true }
-version = { workspace = true }
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+version.workspace = true
 
 [dependencies]
-rand = { workspace = true }
-tempfile = { workspace = true }
+rand.workspace = true
+tempfile.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
Use dot notation to make the files nicer to read. Requires using the latest (unreleased) version of `cargo-sort`.