### PR TITLE
ci: fix test-coverage job

### DIFF
--- a/.github/actions/run_tarpaulin/action.yml
+++ b/.github/actions/run_tarpaulin/action.yml
@@ -4,7 +4,6 @@ description: Run all tests and report coverage
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
     - run: cargo install cargo-tarpaulin@0.27.3
       shell: bash
 

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -136,6 +136,7 @@ jobs:
     env:
       RUSTC_BOOTSTRAP: 1
     steps:
+      - uses: actions/checkout@v4
       - uses: ./actions/run_tarpaulin
       - name: Add coverage PR comment
         uses: marocchino/sticky-pull-request-comment@v2

--- a/.github/workflows/scheduled_reports.yml
+++ b/.github/workflows/scheduled_reports.yml
@@ -37,6 +37,7 @@ jobs:
     env:
       RUSTC_BOOTSTRAP: 1
     steps:
+      - uses: actions/checkout@v4
       - uses: ./actions/run_tarpaulin
 
   dependencies:


### PR DESCRIPTION
Fixes an error introduced in #274.

We need to checkout the code before running a local action.