### PR TITLE
fix(deps): upgrade all dependencies

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -30,7 +30,7 @@ env:
   # Don't emit giant backtraces in the CI logs.
   RUST_BACKTRACE: short
   RUSTDOCFLAGS: -D warnings
-  SUI_TAG: testnet-v1.22.0
+  SUI_TAG: testnet-v1.23.0
 
 jobs:
   diff:

--- a/.github/workflows/scheduled_reports.yml
+++ b/.github/workflows/scheduled_reports.yml
@@ -28,7 +28,7 @@ env:
   # Don't emit giant backtraces in the CI logs.
   RUST_BACKTRACE: short
   RUSTDOCFLAGS: -D warnings
-  SUI_TAG: testnet-v1.22.0
+  SUI_TAG: testnet-v1.23.0
 
 jobs:
   test-coverage:

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
       pull-requests: write
     env:
-      SUI_TAG: testnet-v1.22.0
+      SUI_TAG: testnet-v1.23.0
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "android-tzdata"
@@ -158,7 +158,7 @@ dependencies = [
  "rand 0.8.5",
  "rcgen",
  "ring 0.16.20",
- "rustls 0.21.10",
+ "rustls 0.21.11",
  "rustls-webpki 0.101.7",
  "serde",
  "serde_json",
@@ -178,7 +178,7 @@ version = "0.0.0"
 source = "git+https://github.com/mystenlabs/anemo.git?rev=26d415eb9aa6a2417be3c03c57d6e93c30bd1ad7#26d415eb9aa6a2417be3c03c57d6e93c30bd1ad7"
 dependencies = [
  "prettyplease 0.1.25",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -369,7 +369,7 @@ checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
  "num-bigint 0.4.4",
  "num-traits",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -442,7 +442,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -503,7 +503,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
  "synstructure",
@@ -515,7 +515,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -560,9 +560,9 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -572,13 +572,13 @@ source = "git+https://github.com/mystenmark/async-task?rev=4e45b26e11126b191701b
 
 [[package]]
 name = "async-trait"
-version = "0.1.79"
+version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
+checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -682,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ec2"
-version = "1.33.0"
+version = "1.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa2ed8d05f0cf52913e9174d775d892c97077c6968a483a5a684ce81cdf104c"
+checksum = "4b58453a3033a5c2e1631abec61b6915c507a726d628a0c2d7b81578d81be1b3"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -807,9 +807,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.60.7"
+version = "0.60.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f10fa66956f01540051b0aa7ad54574640f748f9839e843442d99b970d3aff9"
+checksum = "4a7de001a1b9a25601016d8057ea16e31a45fdca3751304c8edf4ad72e706c08"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -846,9 +846,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de34bcfa1fb3c82a80e252a753db34a6658e07f23d3a5b3fc96919518fa7a3f5"
+checksum = "44e7945379821074549168917e89e60630647e186a69243248f08c6d168b975a"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -865,7 +865,7 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "pin-utils",
- "rustls 0.21.10",
+ "rustls 0.21.11",
  "tokio",
  "tracing",
 ]
@@ -915,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.60.7"
+version = "0.60.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "872c68cf019c0e4afc5de7753c4f7288ce4b71663212771bf5e4542eb9346ca9"
+checksum = "d123fbc2a4adc3c301652ba8e149bf4bc1d1725affb9784eb20c953ace06bf55"
 dependencies = [
  "xmlparser",
 ]
@@ -986,7 +986,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.2.0",
+ "hyper 1.3.1",
  "hyper-util",
  "itoa",
  "matchit 0.7.3",
@@ -1058,7 +1058,7 @@ dependencies = [
  "http-body 0.4.6",
  "hyper 0.14.28",
  "pin-project-lite",
- "rustls 0.21.10",
+ "rustls 0.21.11",
  "rustls-pemfile 1.0.4",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -1219,7 +1219,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3deeecb812ca5300b7d3f66f730cc2ebd3511c3d36c691dd79c165d5b19a26e3"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -1245,13 +1245,13 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
- "prettyplease 0.2.17",
- "proc-macro2 1.0.79",
+ "prettyplease 0.2.19",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1495,9 +1495,9 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "bytecount"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
+checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "bytemuck"
@@ -1577,7 +1577,7 @@ checksum = "e10ca87c81aaa3a949dbbe2b5e6c2c45dbc94ba4897e45ea31ff9ec5087be3dc"
 dependencies = [
  "cached_proc_macro_types",
  "darling 0.14.4",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -1593,31 +1593,6 @@ name = "camino"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
-]
 
 [[package]]
 name = "cast"
@@ -1636,12 +1611,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.92"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2678b2e3449475e95b0aa6f9b506a28e61b3dc8996592b983695e8ebb58a8b41"
+checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
 dependencies = [
  "jobserver",
  "libc",
+ "once_cell",
 ]
 
 [[package]]
@@ -1661,9 +1637,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1671,7 +1647,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -1752,9 +1728,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
  "heck 0.5.0",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1846,7 +1822,7 @@ dependencies = [
 [[package]]
 name = "consensus-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "fastcrypto 0.1.7",
  "mysten-network",
@@ -1858,7 +1834,7 @@ dependencies = [
 [[package]]
 name = "consensus-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -1889,6 +1865,7 @@ dependencies = [
  "tap",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tonic 0.11.0",
  "tonic-build",
  "tower",
@@ -2208,7 +2185,7 @@ checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "strsim 0.10.0",
  "syn 1.0.109",
@@ -2222,10 +2199,10 @@ checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "strsim 0.10.0",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2247,7 +2224,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core 0.20.8",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2341,7 +2318,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -2352,7 +2329,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e79116f119dd1dba1abf1f3405f03b9b0e79a27a3883864bfebded8a3dc768cd"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -2373,7 +2350,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
 dependencies = [
  "darling 0.14.4",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -2395,7 +2372,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case 0.4.0",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "rustc_version",
  "syn 1.0.109",
@@ -2490,9 +2467,9 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2585,9 +2562,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
 
 [[package]]
 name = "elliptic-curve"
@@ -2652,7 +2629,7 @@ dependencies = [
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -2664,9 +2641,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
 dependencies = [
  "once_cell",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2693,15 +2670,6 @@ checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "error-chain"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
-dependencies = [
- "version_check",
 ]
 
 [[package]]
@@ -2851,7 +2819,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c0c2af2157f416cb885e11d36cd0de2753f6d5384752d364075c835f5f8f891"
 dependencies = [
  "convert_case 0.6.0",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -2963,7 +2931,7 @@ dependencies = [
  "num-bigint 0.3.3",
  "num-integer",
  "num-traits",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -3113,9 +3081,9 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3219,9 +3187,9 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3573,9 +3541,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
+checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -3618,7 +3586,7 @@ dependencies = [
  "http 0.2.12",
  "hyper 0.14.28",
  "log",
- "rustls 0.21.10",
+ "rustls 0.21.11",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -3645,7 +3613,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.2.0",
+ "hyper 1.3.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -3664,7 +3632,7 @@ dependencies = [
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
- "hyper 1.2.0",
+ "hyper 1.3.1",
  "pin-project-lite",
  "socket2 0.5.6",
  "tokio",
@@ -3750,7 +3718,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -3916,9 +3884,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+checksum = "685a7d121ee3f65ae4fddd72b25a04bb36b6af81bc0828f7d5434c0fe60fa3a2"
 dependencies = [
  "libc",
 ]
@@ -4027,7 +3995,7 @@ source = "git+https://github.com/wlmyng/jsonrpsee.git?rev=b1b300784795f6a64d0fcd
 dependencies = [
  "heck 0.4.1",
  "proc-macro-crate",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -4133,7 +4101,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -4342,16 +4310,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
 dependencies = [
  "cfg-if",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "moka"
-version = "0.12.5"
+version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1911e88d5831f748a4097a43862d129e3c6fca831eecac9b8db6d01d93c9de2"
+checksum = "9e0d88686dc561d743b40de8269b26eaf0dc58781bde087b0984646602021d08"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -4359,7 +4327,6 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.1",
  "rustc_version",
- "skeptic",
  "smallvec",
  "tagptr",
  "thiserror",
@@ -4370,12 +4337,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "enum-compat-util",
@@ -4389,12 +4356,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4409,7 +4376,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4421,24 +4388,36 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
  "move-borrow-graph",
+ "move-bytecode-verifier-meter",
  "move-core-types",
  "move-vm-config",
  "petgraph 0.5.1",
 ]
 
 [[package]]
+name = "move-bytecode-verifier-meter"
+version = "0.1.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
+dependencies = [
+ "move-binary-format",
+ "move-core-types",
+ "move-vm-config",
+]
+
+[[package]]
 name = "move-bytecode-verifier-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
  "move-borrow-graph",
+ "move-bytecode-verifier-meter",
  "move-core-types",
  "move-vm-config",
  "petgraph 0.5.1",
@@ -4447,11 +4426,12 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
  "move-borrow-graph",
+ "move-bytecode-verifier-meter",
  "move-core-types",
  "move-vm-config",
  "petgraph 0.5.1",
@@ -4460,11 +4440,12 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
  "move-borrow-graph",
+ "move-bytecode-verifier-meter",
  "move-core-types",
  "move-vm-config",
  "petgraph 0.5.1",
@@ -4473,7 +4454,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "difference",
@@ -4491,7 +4472,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4510,7 +4491,6 @@ dependencies = [
  "move-proc-macros",
  "move-symbol-pool",
  "once_cell",
- "pathdiff",
  "petgraph 0.5.1",
  "regex",
  "serde",
@@ -4523,13 +4503,14 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "bcs",
  "enum-compat-util",
  "ethnum",
  "hex",
+ "leb128",
  "move-proc-macros",
  "num",
  "once_cell",
@@ -4538,13 +4519,14 @@ dependencies = [
  "ref-cast",
  "serde",
  "serde_bytes",
+ "thiserror",
  "uint",
 ]
 
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4563,7 +4545,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4582,7 +4564,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "codespan",
@@ -4600,7 +4582,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "move-command-line-common",
@@ -4612,7 +4594,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -4630,7 +4612,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "hex",
@@ -4643,7 +4625,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -4656,7 +4638,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "codespan",
@@ -4681,7 +4663,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "clap",
@@ -4707,6 +4689,7 @@ dependencies = [
  "toml",
  "toml_edit",
  "treeline",
+ "vfs",
  "walkdir",
  "whoami",
 ]
@@ -4714,17 +4697,17 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "enum-compat-util",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "clap",
@@ -4746,7 +4729,7 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -4756,7 +4739,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -4779,7 +4762,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "hex",
@@ -4801,7 +4784,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-v0"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "hex",
@@ -4823,7 +4806,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-v1"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "hex",
@@ -4845,7 +4828,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-v2"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "hex",
@@ -4867,7 +4850,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "once_cell",
  "phf",
@@ -4877,7 +4860,7 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "move-binary-format",
  "once_cell",
@@ -4886,7 +4869,7 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "move-vm-config",
  "once_cell",
@@ -4898,7 +4881,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "better_any",
  "fail",
@@ -4918,7 +4901,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "better_any",
  "fail",
@@ -4938,7 +4921,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "better_any",
  "fail",
@@ -4958,7 +4941,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "better_any",
  "fail",
@@ -4978,7 +4961,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4992,7 +4975,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -5037,7 +5020,7 @@ version = "0.1.0"
 source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=6f88ec84644cb1a6809c010f1f534d0d09e0cd89#6f88ec84644cb1a6809c010f1f534d0d09e0cd89"
 dependencies = [
  "darling 0.14.4",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -5091,7 +5074,7 @@ checksum = "1d6d4752e6230d8ef7adf7bd5d8c4b1f6561c1014c5ba9a37445ccefe18aa1db"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
  "synstructure",
@@ -5106,7 +5089,7 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 [[package]]
 name = "mysten-common"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "futures",
  "parking_lot 0.12.1",
@@ -5116,7 +5099,7 @@ dependencies = [
 [[package]]
 name = "mysten-metrics"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "async-trait",
  "axum 0.6.20",
@@ -5136,7 +5119,7 @@ dependencies = [
 [[package]]
 name = "mysten-network"
 version = "0.2.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anemo",
  "bcs",
@@ -5160,7 +5143,7 @@ dependencies = [
 [[package]]
 name = "mysten-util-mem"
 version = "0.11.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "cfg-if",
  "ed25519-consensus",
@@ -5179,9 +5162,9 @@ dependencies = [
 [[package]]
 name = "mysten-util-mem-derive"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "syn 1.0.109",
  "synstructure",
 ]
@@ -5209,7 +5192,7 @@ dependencies = [
 [[package]]
 name = "narwhal-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "fastcrypto 0.1.7",
  "match_opt",
@@ -5226,7 +5209,7 @@ dependencies = [
 [[package]]
 name = "narwhal-crypto"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "bcs",
  "fastcrypto 0.1.7",
@@ -5237,7 +5220,7 @@ dependencies = [
 [[package]]
 name = "narwhal-executor"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "async-trait",
  "bcs",
@@ -5266,7 +5249,7 @@ dependencies = [
 [[package]]
 name = "narwhal-network"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -5295,7 +5278,7 @@ dependencies = [
 [[package]]
 name = "narwhal-node"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anemo",
  "arc-swap",
@@ -5335,7 +5318,7 @@ dependencies = [
 [[package]]
 name = "narwhal-primary"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -5375,7 +5358,7 @@ dependencies = [
 [[package]]
 name = "narwhal-storage"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "fastcrypto 0.1.7",
  "fastcrypto-tbls",
@@ -5397,7 +5380,7 @@ dependencies = [
 [[package]]
 name = "narwhal-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anemo",
  "fastcrypto 0.1.7",
@@ -5430,7 +5413,7 @@ dependencies = [
 [[package]]
 name = "narwhal-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -5474,7 +5457,7 @@ dependencies = [
 [[package]]
 name = "narwhal-worker"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -5589,9 +5572,9 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
+checksum = "3135b08af27d103b0a51f2ae0f8632117b7b185ccf931445affa8df530576a41"
 dependencies = [
  "num-bigint 0.4.4",
  "num-complex",
@@ -5724,9 +5707,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5822,9 +5805,9 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5962,9 +5945,9 @@ checksum = "ec4c6225c69b4ca778c0aea097321a64c421cf4577b331c61b229267edabb6f8"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-error",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -6038,7 +6021,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -6114,12 +6097,6 @@ name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
-
-[[package]]
-name = "pathdiff"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pbkdf2"
@@ -6198,9 +6175,9 @@ checksum = "c35eeed0a3fab112f75165fdc026b3913f4183133f19b49be773ac9ea966e8bd"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -6262,9 +6239,9 @@ checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
 dependencies = [
  "phf_generator",
  "phf_shared",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -6291,9 +6268,9 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -6440,18 +6417,18 @@ version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "prettyplease"
-version = "0.2.17"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
+checksum = "5ac2cf0f2e4f42b49f5ffd07dae8d746508ef7526c13940e5f524012ae6c6550"
 dependencies = [
- "proc-macro2 1.0.79",
- "syn 2.0.58",
+ "proc-macro2 1.0.81",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -6506,7 +6483,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
  "version_check",
@@ -6518,7 +6495,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "version_check",
 ]
@@ -6534,9 +6511,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
 ]
@@ -6559,7 +6536,7 @@ dependencies = [
 [[package]]
 name = "prometheus-closure-metric"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -6641,11 +6618,11 @@ dependencies = [
  "multimap",
  "once_cell",
  "petgraph 0.6.4",
- "prettyplease 0.2.17",
+ "prettyplease 0.2.19",
  "prost 0.12.4",
  "prost-types",
  "regex",
- "syn 2.0.58",
+ "syn 2.0.60",
  "tempfile",
 ]
 
@@ -6657,7 +6634,7 @@ checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
  "itertools 0.10.5",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -6670,9 +6647,9 @@ checksum = "19de2de2a00075bf566bee3bd4db014b11587e84184d3f7a791bc17f1a8e9e48"
 dependencies = [
  "anyhow",
  "itertools 0.12.1",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -6709,17 +6686,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "pulldown-cmark"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
-dependencies = [
- "bitflags 2.5.0",
- "memchr",
- "unicase",
 ]
 
 [[package]]
@@ -6765,7 +6731,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.21.10",
+ "rustls 0.21.11",
  "thiserror",
  "tokio",
  "tracing",
@@ -6781,7 +6747,7 @@ dependencies = [
  "rand 0.8.5",
  "ring 0.16.20",
  "rustc-hash",
- "rustls 0.21.10",
+ "rustls 0.21.11",
  "slab",
  "thiserror",
  "tinyvec",
@@ -6816,7 +6782,7 @@ version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
 ]
 
 [[package]]
@@ -6973,9 +6939,9 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a25d631e41bfb5fdcde1d4e2215f62f7f0afa3ff11e26563765bd6ea1d229aeb"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -7040,9 +7006,9 @@ version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fddb4f8d99b0a2ebafc65a87a69a7b9875e4b1ae1f00db265d300ef7f28bccc"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -7118,7 +7084,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.10",
+ "rustls 0.21.11",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -7140,9 +7106,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e6cc1e89e689536eb5aeede61520e874df5a4707df811cd5da4aa5fbb2aae19"
+checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
 dependencies = [
  "base64 0.22.0",
  "bytes",
@@ -7153,7 +7119,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.2.0",
+ "hyper 1.3.1",
  "hyper-tls",
  "hyper-util",
  "ipnet",
@@ -7319,9 +7285,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.32"
+version = "0.38.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+checksum = "e3cc72858054fcff6d7dea32df2aeaee6a7c24227366d7ea429aada2f26b16ad"
 dependencies = [
  "bitflags 2.5.0",
  "errno",
@@ -7344,9 +7310,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.10"
+version = "0.21.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+checksum = "7fecbfb7b1444f477b345853b1fce097a2c6fb637b2bfb87e6bc5db0f043fae4"
 dependencies = [
  "log",
  "ring 0.17.8",
@@ -7356,9 +7322,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99008d7ad0bbbea527ec27bddbc0e432c5b87d8175178cee68d2eec9c4a1813c"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
  "ring 0.17.8",
@@ -7487,7 +7453,7 @@ version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c767fd6fa65d9ccf9cf026122c1b555f2ef9a4f0cea69da4d7dbc3e258d30967"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "serde_derive_internals",
  "syn 1.0.109",
@@ -7584,15 +7550,12 @@ name = "semver"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
 dependencies = [
  "serde_derive",
 ]
@@ -7629,13 +7592,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -7644,16 +7607,16 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
  "indexmap 2.2.6",
  "itoa",
@@ -7677,9 +7640,9 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -7744,9 +7707,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
 dependencies = [
  "darling 0.20.8",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -7756,9 +7719,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6561dc161a9224638a31d876ccdfefbc1df91d3f3a8342eddb35f055d48c7655"
 dependencies = [
  "darling 0.20.8",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -7868,7 +7831,7 @@ dependencies = [
 [[package]]
 name = "shared-crypto"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "bcs",
  "eyre",
@@ -7906,9 +7869,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
@@ -7967,21 +7930,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "skeptic"
-version = "0.13.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d23b015676c90a0f01c197bfdc786c20342c73a0afdda9025adb0bc42940a8"
-dependencies = [
- "bytecount",
- "cargo_metadata",
- "error-chain",
- "glob",
- "pulldown-cmark",
- "tempfile",
- "walkdir",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8022,7 +7970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990079665f075b699031e9c08fd3ab99be5029b96f3b78dc0709e8f77e4efebf"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -8169,7 +8117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "rustversion",
  "syn 1.0.109",
@@ -8190,7 +8138,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 [[package]]
 name = "sui-adapter-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8198,6 +8146,7 @@ dependencies = [
  "move-binary-format",
  "move-bytecode-utils",
  "move-bytecode-verifier",
+ "move-bytecode-verifier-meter",
  "move-core-types",
  "move-vm-config",
  "move-vm-profiler",
@@ -8216,13 +8165,14 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "bcs",
  "leb128",
  "move-binary-format",
  "move-bytecode-utils",
+ "move-bytecode-verifier-meter",
  "move-bytecode-verifier-v0",
  "move-core-types",
  "move-vm-config",
@@ -8243,13 +8193,14 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "bcs",
  "leb128",
  "move-binary-format",
  "move-bytecode-utils",
+ "move-bytecode-verifier-meter",
  "move-bytecode-verifier-v1",
  "move-core-types",
  "move-vm-config",
@@ -8269,13 +8220,14 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "bcs",
  "leb128",
  "move-binary-format",
  "move-bytecode-utils",
+ "move-bytecode-verifier-meter",
  "move-bytecode-verifier-v2",
  "move-core-types",
  "move-vm-config",
@@ -8295,7 +8247,7 @@ dependencies = [
 [[package]]
 name = "sui-archival"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -8320,7 +8272,7 @@ dependencies = [
 [[package]]
 name = "sui-authority-aggregation"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "futures",
  "mysten-metrics",
@@ -8332,7 +8284,7 @@ dependencies = [
 [[package]]
 name = "sui-config"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anemo",
  "anyhow",
@@ -8359,7 +8311,7 @@ dependencies = [
 [[package]]
 name = "sui-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anemo",
  "anyhow",
@@ -8449,7 +8401,7 @@ dependencies = [
 [[package]]
 name = "sui-enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -8457,10 +8409,11 @@ dependencies = [
 [[package]]
 name = "sui-execution"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "move-binary-format",
  "move-bytecode-verifier",
+ "move-bytecode-verifier-meter",
  "move-bytecode-verifier-v0",
  "move-bytecode-verifier-v1",
  "move-bytecode-verifier-v2",
@@ -8488,7 +8441,7 @@ dependencies = [
 [[package]]
 name = "sui-framework"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8507,7 +8460,7 @@ dependencies = [
 [[package]]
 name = "sui-framework-snapshot"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8522,7 +8475,7 @@ dependencies = [
 [[package]]
 name = "sui-genesis-builder"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8550,7 +8503,7 @@ dependencies = [
 [[package]]
 name = "sui-json"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8561,14 +8514,13 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sui-framework",
  "sui-types",
 ]
 
 [[package]]
 name = "sui-json-rpc"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8616,7 +8568,7 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc-api"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "fastcrypto 0.1.7",
@@ -8636,7 +8588,7 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc-types"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8656,6 +8608,7 @@ dependencies = [
  "sui-enum-compat-util",
  "sui-json",
  "sui-macros",
+ "sui-package-resolver",
  "sui-protocol-config",
  "sui-types",
  "tabled",
@@ -8665,7 +8618,7 @@ dependencies = [
 [[package]]
 name = "sui-keys"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "bip32",
@@ -8684,7 +8637,7 @@ dependencies = [
 [[package]]
 name = "sui-macros"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "futures",
  "once_cell",
@@ -8694,8 +8647,8 @@ dependencies = [
 
 [[package]]
 name = "sui-move-build"
-version = "1.22.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+version = "1.23.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "fastcrypto 0.1.7",
@@ -8718,7 +8671,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "bcs",
  "better_any",
@@ -8739,7 +8692,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "bcs",
  "better_any",
@@ -8760,7 +8713,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "bcs",
  "better_any",
@@ -8781,7 +8734,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "bcs",
  "better_any",
@@ -8802,7 +8755,7 @@ dependencies = [
 [[package]]
 name = "sui-network"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -8836,8 +8789,8 @@ dependencies = [
 
 [[package]]
 name = "sui-node"
-version = "1.22.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+version = "1.23.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -8887,8 +8840,8 @@ dependencies = [
 
 [[package]]
 name = "sui-open-rpc"
-version = "1.22.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+version = "1.23.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "bcs",
  "schemars",
@@ -8900,35 +8853,54 @@ dependencies = [
 [[package]]
 name = "sui-open-rpc-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.10.5",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
  "unescape",
 ]
 
 [[package]]
+name = "sui-package-resolver"
+version = "0.1.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
+dependencies = [
+ "async-trait",
+ "bcs",
+ "eyre",
+ "lru",
+ "move-binary-format",
+ "move-core-types",
+ "serde",
+ "sui-rest-api",
+ "sui-types",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "sui-proc-macros"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "msim-macros",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "sui-enum-compat-util",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
 name = "sui-protocol-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "clap",
  "insta",
+ "move-vm-config",
  "schemars",
  "serde",
  "serde_with 2.3.3",
@@ -8939,9 +8911,9 @@ dependencies = [
 [[package]]
 name = "sui-protocol-config-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -8949,7 +8921,7 @@ dependencies = [
 [[package]]
 name = "sui-rest-api"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "axum 0.6.20",
@@ -8968,8 +8940,8 @@ dependencies = [
 
 [[package]]
 name = "sui-sdk"
-version = "1.22.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+version = "1.23.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9001,7 +8973,7 @@ dependencies = [
 [[package]]
 name = "sui-simulator"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -9025,7 +8997,7 @@ dependencies = [
 [[package]]
 name = "sui-snapshot"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9053,7 +9025,7 @@ dependencies = [
 [[package]]
 name = "sui-storage"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9104,7 +9076,7 @@ dependencies = [
 [[package]]
 name = "sui-swarm"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "futures",
@@ -9130,7 +9102,7 @@ dependencies = [
 [[package]]
 name = "sui-swarm-config"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anemo",
  "anyhow",
@@ -9156,7 +9128,7 @@ dependencies = [
 [[package]]
 name = "sui-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "reqwest 0.11.27",
  "serde",
@@ -9167,7 +9139,7 @@ dependencies = [
 [[package]]
 name = "sui-test-transaction-builder"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "bcs",
  "move-core-types",
@@ -9181,7 +9153,7 @@ dependencies = [
 [[package]]
 name = "sui-tls"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "axum 0.6.20",
@@ -9191,7 +9163,7 @@ dependencies = [
  "pkcs8 0.9.0",
  "rcgen",
  "reqwest 0.11.27",
- "rustls 0.21.10",
+ "rustls 0.21.11",
  "rustls-webpki 0.101.7",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -9202,7 +9174,7 @@ dependencies = [
 [[package]]
 name = "sui-transaction-builder"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9219,7 +9191,7 @@ dependencies = [
 [[package]]
 name = "sui-transaction-checks"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "fastcrypto-zkp",
  "once_cell",
@@ -9234,7 +9206,7 @@ dependencies = [
 [[package]]
 name = "sui-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anemo",
  "anyhow",
@@ -9297,12 +9269,13 @@ dependencies = [
 [[package]]
 name = "sui-verifier-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
  "move-bytecode-utils",
  "move-bytecode-verifier",
+ "move-bytecode-verifier-meter",
  "move-core-types",
  "move-vm-config",
  "sui-protocol-config",
@@ -9312,11 +9285,12 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
  "move-bytecode-utils",
+ "move-bytecode-verifier-meter",
  "move-bytecode-verifier-v0",
  "move-core-types",
  "move-vm-config",
@@ -9327,11 +9301,12 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
  "move-bytecode-utils",
+ "move-bytecode-verifier-meter",
  "move-bytecode-verifier-v1",
  "move-core-types",
  "move-vm-config",
@@ -9341,11 +9316,12 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
  "move-bytecode-utils",
+ "move-bytecode-verifier-meter",
  "move-bytecode-verifier-v2",
  "move-core-types",
  "move-vm-config",
@@ -9370,18 +9346,18 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.58"
+version = "2.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
+checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "unicode-ident",
 ]
@@ -9404,7 +9380,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
  "unicode-xid 0.2.4",
@@ -9450,7 +9426,7 @@ checksum = "99f688a08b54f4f02f0a3c382aefdb7884d3d69609f785bd253dc033243e3fe4"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-error",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -9470,7 +9446,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "telemetry-subscribers"
 version = "0.2.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -9544,7 +9520,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 [[package]]
 name = "test-cluster"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "anyhow",
  "fastcrypto-zkp",
@@ -9573,22 +9549,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -9721,9 +9697,9 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -9731,9 +9707,9 @@ name = "tokio-macros"
 version = "2.2.0"
 source = "git+https://github.com/mystenmark/tokio-madsim-fork.git?rev=e47aafebf98e9c1734a8848a1876d5946c44bdd1#e47aafebf98e9c1734a8848a1876d5946c44bdd1"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -9774,7 +9750,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.10",
+ "rustls 0.21.11",
  "tokio",
 ]
 
@@ -9784,7 +9760,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
- "rustls 0.22.3",
+ "rustls 0.22.4",
  "rustls-pki-types",
  "tokio",
 ]
@@ -9930,11 +9906,11 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4ef6dd70a610078cb4e338a0f79d06bc759ff1b22d2120c2ff02ae264ba9c2"
 dependencies = [
- "prettyplease 0.2.17",
- "proc-macro2 1.0.79",
+ "prettyplease 0.2.19",
+ "proc-macro2 1.0.81",
  "prost-build",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -10060,9 +10036,9 @@ version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -10161,7 +10137,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b79e2e9c9ab44c6d7c20d5976961b47e8f49ac199154daa514b77cd1ab536625"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -10217,7 +10193,7 @@ dependencies = [
 [[package]]
 name = "typed-store"
 version = "0.4.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "async-trait",
  "bcs",
@@ -10245,10 +10221,10 @@ dependencies = [
 [[package]]
 name = "typed-store-derive"
 version = "0.3.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "itertools 0.10.5",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
  "syn 1.0.109",
 ]
@@ -10256,7 +10232,7 @@ dependencies = [
 [[package]]
 name = "typed-store-error"
 version = "0.4.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.22.0#036299745992f68c409fa830eae5ecdaffcbbf9d"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.23.0#db6e04d4ce7de0cdfc5b20ae5a9310b581bb8e9f"
 dependencies = [
  "serde",
  "thiserror",
@@ -10527,7 +10503,7 @@ dependencies = [
  "indoc",
  "prettytable-rs",
  "prometheus-parse",
- "reqwest 0.12.3",
+ "reqwest 0.12.4",
  "serde",
  "serde_json",
  "serde_with 3.7.0",
@@ -10558,7 +10534,7 @@ dependencies = [
  "prometheus",
  "rand 0.8.5",
  "regex",
- "reqwest 0.12.3",
+ "reqwest 0.12.4",
  "rocksdb",
  "serde",
  "serde_with 3.7.0",
@@ -10588,7 +10564,7 @@ dependencies = [
  "bcs",
  "fastcrypto 0.1.8",
  "move-core-types",
- "reqwest 0.12.3",
+ "reqwest 0.12.4",
  "serde",
  "serde_json",
  "sui-config",
@@ -10660,9 +10636,9 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
  "wasm-bindgen-shared",
 ]
 
@@ -10694,9 +10670,9 @@ version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -10809,7 +10785,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -10827,7 +10803,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -10847,17 +10823,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
 ]
 
 [[package]]
@@ -10868,9 +10845,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -10880,9 +10857,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -10892,9 +10869,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -10904,9 +10887,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -10916,9 +10899,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -10928,9 +10911,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -10940,9 +10923,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winreg"
@@ -11036,9 +11019,9 @@ version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -11056,9 +11039,9 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
- "proc-macro2 1.0.79",
+ "proc-macro2 1.0.81",
  "quote 1.0.36",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,32 +9,32 @@ edition = "2021"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-anyhow = "1.0.80"
+anyhow = "1.0.82"
 bcs = "0.1.6"
 fastcrypto = "0.1"
-move-core-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.22.0" }
-mysten-metrics = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.22.0" }
+move-core-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.23.0" }
+mysten-metrics = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.23.0" }
 rand = "0.8.5"
-serde = { version = "1.0.197", features = ["derive"] }
+serde = { version = "1.0.198", features = ["derive"] }
 serde_with = "3.7"
 serde_yaml = "0.9"
-sui-keys = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.22.0" }
-sui-move-build = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.22.0" }
-sui-sdk = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.22.0" }
-sui-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.22.0" }
-sui-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.22.0" }
-telemetry-subscribers = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.22.0" }
+sui-keys = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.23.0" }
+sui-move-build = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.23.0" }
+sui-sdk = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.23.0" }
+sui-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.23.0" }
+sui-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.23.0" }
+telemetry-subscribers = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.23.0" }
 tempfile = "3.10.1"
-test-cluster = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.22.0" }
-thiserror = "1.0.57"
+test-cluster = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.23.0" }
+thiserror = "1.0.59"
 tokio = { version = "1.37.0" }
-tokio-stream = "0.1.14"
-typed-store = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.22.0" }
+tokio-stream = "0.1.15"
+typed-store = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.23.0" }
 walrus-core = { path = "crates/walrus-core" }
 walrus-sui = { path = "crates/walrus-sui" }
 walrus-test-utils = { path = "crates/walrus-test-utils" }
 clap = { version = "4.5.4", features = ["derive"] }
-reqwest = { version = "0.12.3" }
+reqwest = { version = "0.12.4" }
 futures = "0.3.30"
 
 [workspace.lints.rust]

--- a/contracts/blob_store/Move.lock
+++ b/contracts/blob_store/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 1
-manifest_digest = "A3738CFB0471C67AA519E96B0FBDE90080E2D5FDEDCFBE9BCA07002C2EB665BF"
+manifest_digest = "8820D2726F6512EBEEB4FDDFDE4BD460687BA1D7CB7696D9BFFCD2921CB78FE6"
 deps_digest = "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082"
 dependencies = [
   { name = "Sui" },
@@ -10,17 +10,17 @@ dependencies = [
 
 [[move.package]]
 name = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.22.0", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.23.0", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 name = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.22.0", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.23.0", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { name = "MoveStdlib" },
 ]
 
 [move.toolchain-version]
-compiler-version = "1.22.0"
-edition = "legacy"
+compiler-version = "1.23.0"
+edition = "2024.beta"
 flavor = "sui"

--- a/contracts/blob_store/Move.toml
+++ b/contracts/blob_store/Move.toml
@@ -3,7 +3,7 @@ name = "blob_store"
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.22.0" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.23.0" }
 
 [addresses]
 blob_store = "0x0"

--- a/crates/walrus-orchestrator/Cargo.toml
+++ b/crates/walrus-orchestrator/Cargo.toml
@@ -9,7 +9,7 @@ license = { workspace = true }
 [dependencies]
 aws-config = "1.2.0"
 aws-runtime = "1.2.0"
-aws-sdk-ec2 = "1.33.0"
+aws-sdk-ec2 = "1.34.0"
 clap = { workspace = true }
 color-eyre = "0.6.3"
 crossterm = "0.27.0"
@@ -21,7 +21,7 @@ prettytable-rs = "0.10"
 prometheus-parse = { git = "https://github.com/asonnino/prometheus-parser", rev = "75334db" }
 reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true }
-serde_json = "1.0.115"
+serde_json = "1.0.116"
 serde_with = { workspace = true }
 serde_yaml = { workspace = true }
 ssh2 = "0.9.4"

--- a/crates/walrus-service/Cargo.toml
+++ b/crates/walrus-service/Cargo.toml
@@ -12,7 +12,7 @@ test-utils = ["dep:tempfile", "dep:walrus-test-utils", "walrus-core/test-utils"]
 
 [dependencies]
 anyhow = { workspace = true }
-async-trait = "0.1.79"
+async-trait = "0.1.80"
 axum = { version = "0.7.5", features = ["http2"] }
 bcs = { workspace = true }
 clap = { workspace = true, features = ["string"] }

--- a/crates/walrus-sui/Cargo.toml
+++ b/crates/walrus-sui/Cargo.toml
@@ -17,7 +17,7 @@ fastcrypto = { workspace = true }
 move-core-types = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
-serde_json = "1.0.115"
+serde_json = "1.0.116"
 sui-config = { workspace = true }
 sui-keys = { workspace = true }
 sui-move-build = { workspace = true }

--- a/deny.toml
+++ b/deny.toml
@@ -9,8 +9,9 @@ ignore = [
     "RUSTSEC-2020-0095",
     # rust-yaml is not maintained, but is a dependency in many of our packages.
     "RUSTSEC-2024-0320",
-    # Ignore the h2 advisory as we do not have control over most of the H2 usage.
-    "RUSTSEC-2024-0332",
+    # We have a vulnerable version of `rustls` in our dependency tree through the old version of
+    # jsonrpsee used by sui.
+    "RUSTSEC-2024-0336",
 ]
 
 # This section is considered when running `cargo deny check licenses`


### PR DESCRIPTION
This updates all direct and indirect dependencies to their latest version, including Sui. This also addresses most cases of vulnerable `rustls` versions ([RUSTSEC-2024-0336](https://rustsec.org/advisories/RUSTSEC-2024-0336)). Unfortunately, we still have a vulnerable `rustls` via an old version of `jsonrpsee` pulled in via `sui`.

Also updates the `cargo-deny` configuration.