### PR TITLE
chore: clean up cargo-deny config

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v1.6.2
+      - uses: EmbarkStudios/cargo-deny-action@v1.6.3
         with:
           # do not check advisories on PRs to prevent sudden failure due to new announcement
           command: check bans licenses sources

--- a/deny.toml
+++ b/deny.toml
@@ -44,7 +44,7 @@ confidence-threshold = 0.8
 name = "ring"
 expression = "LicenseRef-ring"
 license-files = [
-    { path = "LICENSE", hash = 0xbd0eed23 }
+    { path = "LICENSE", hash = 0xbd0eed23 },
 ]
 
 [licenses.private]
@@ -68,7 +68,7 @@ skip-tree = [
     { name = "fastcrypto", depth = 4 },
     { name = "typed-store", depth = 6},
     { name = "test-cluster", depth = 6},
-    # several crate depend on an older version of windows-sys
+    # several crates depend on an older version of windows-sys
     { name = "windows-sys", depth = 3, version = "0.48" },
 ]
 
@@ -91,8 +91,7 @@ allow-git = [
 ]
 
 [sources.allow-org]
-# 1 or more github.com organizations to allow git sources for
+# github.com organizations to allow git sources for
 github = [
     "MystenLabs",
-    "mystenlabs",
 ]


### PR DESCRIPTION
Since 0.14.21 (cargo-deny-action 1.6.3), checks for GitHub organizations are case-insensitive.