### PR TITLE
fix(core): check position in Merkle tree when verifying proofs

### DIFF
--- a/crates/walrus-core/src/encoding/slivers.rs
+++ b/crates/walrus-core/src/encoding/slivers.rs
@@ -816,7 +816,7 @@ mod tests {
             assert!(sliver
                 .recovery_symbol_for_sliver_with_proof::<Blake2b256>(shard_pair_index, &config)
                 .unwrap()
-                .verify_proof(&merkle_tree.root()));
+                .verify_proof(&merkle_tree.root(), index.into()));
         }
     }
 }

--- a/crates/walrus-core/src/encoding/symbols.rs
+++ b/crates/walrus-core/src/encoding/symbols.rs
@@ -351,8 +351,8 @@ impl<T: EncodingAxis> DecodingSymbol<T> {
 impl<T: EncodingAxis, U: MerkleAuth> DecodingSymbol<T, U> {
     /// Verifies that the decoding symbol belongs to a committed sliver by checking the Merkle proof
     /// against the `root` hash stored.
-    pub fn verify_proof(&self, root: &Node) -> bool {
-        self.proof.verify_proof(root, &self.data)
+    pub fn verify_proof(&self, root: &Node, target_index: usize) -> bool {
+        self.proof.verify_proof(root, &self.data, target_index)
     }
 
     /// Consumes the [`DecodingSymbol<T>`], removing the proof, and returns the [`DecodingSymbol`]
@@ -457,7 +457,7 @@ mod tests {
             ),
             with_proof: (
                 PrimaryDecodingSymbol::new(2, vec![1, 2, 3,]).with_proof(
-                    crate::merkle::MerkleProof::<fastcrypto::hash::Blake2b256>::new(&[], 0).unwrap()
+                    crate::merkle::MerkleProof::<fastcrypto::hash::Blake2b256>::new(&[])
                 ),
                 "DecodingSymbol{ type: primary, index: 2, proof_type: \
                     walrus_core::merkle::MerkleProof, data: [1, 2, 3] }",


### PR DESCRIPTION
So far, our Merkle proofs only checked if some leaf was included in a Merkle tree, but not its *position* in the tree. In all our use cases, we need that position check as well.

This PR changes the verification such that it takes the leaf index as an input. Some alternatives to that design, which I didn't go for:
- Simply check the index at the caller; however, I feel this is more error-prone and less elegant. 
- Have two versions, one that checks the index and one that doesn't (current behavior). However, we don't need the version without index check, so this would just be dead code.