### PR TITLE
test: reduce the shard indices used in some tests

### DIFF
--- a/crates/walrus-service/src/storage.rs
+++ b/crates/walrus-service/src/storage.rs
@@ -344,8 +344,8 @@ pub(crate) mod tests {
     }
 
     pub(crate) const BLOB_ID: BlobId = BlobId([7; 32]);
-    pub(crate) const SHARD_INDEX: ShardIndex = ShardIndex(17);
-    pub(crate) const OTHER_SHARD_INDEX: ShardIndex = ShardIndex(831);
+    pub(crate) const SHARD_INDEX: ShardIndex = ShardIndex(3);
+    pub(crate) const OTHER_SHARD_INDEX: ShardIndex = ShardIndex(9);
 
     /// Returns an empty storage, with the column families for [`SHARD_INDEX`] already created.
     pub(crate) fn empty_storage() -> WithTempDir<Storage> {


### PR DESCRIPTION
With the addition of the storage node test builders, the number of shards is inferred from the shard indices, which in turn determines the encoding config and the size of the encoding/decoding state that is pre-allocated, which impacts the runtime. This commit uses smaller shard indices to reduce the resulting runtime of a few tests.