### PR TITLE
fix: don't print stack traces in logs except for errors

### DIFF
--- a/crates/walrus-service/src/committee.rs
+++ b/crates/walrus-service/src/committee.rs
@@ -137,8 +137,12 @@ impl NodeCommitteeServiceInner<StorageNodeClient> {
             .iter()
             .filter_map(|member| {
                 let url = Url::parse(&member.rest_api_url())
-                    .inspect_err(|err| {
-                        tracing::warn!(?member, ?err, "unable to parse REST-API URL, skipping node")
+                    .inspect_err(|error| {
+                        tracing::warn!(
+                            ?member,
+                            %error,
+                            "unable to parse REST-API URL, skipping node"
+                        )
                     })
                     .ok()?;
 
@@ -202,7 +206,7 @@ impl<T: NodeClient> NodeCommitteeServiceInner<T> {
                         tracing::debug!("metadata retrieved successfully");
                         return metadata;
                     }
-                    Ok(Err(err)) => tracing::debug!(?err, "metadata request failed"),
+                    Ok(Err(error)) => tracing::debug!(%error, "metadata request failed"),
                     Err(_) => tracing::debug!("request to node timed out"),
                 }
             }


### PR DESCRIPTION
Otherwise, with debug logging, we get extremely verbose and unnecessary log entries like 
```
2024-05-14T06:39:03.551449Z DEBUG get_and_verify_metadata: walrus_service::committee: metadata request failed err=request for metadata failed

Caused by:
    HTTP status client error (404 Not Found) for url (http://127.0.0.1:9189/v1/blobs/MYeuzUPD0_4WoXhDi-zoolrUrzsoKovXiDVOzDusqs0/metadata): Not found

Stack backtrace:
   0: std::backtrace_rs::backtrace::libunwind::trace
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/../../backtrace/src/backtrace/libunwind.rs:105:5
   1: std::backtrace_rs::backtrace::trace_unsynchronized
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2: std::backtrace::Backtrace::create
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/backtrace.rs:331:13
   3: <E as anyhow::context::ext::StdError>::ext_context
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/anyhow-1.0.83/src/context.rs:27:29
   4: anyhow::context::<impl anyhow::Context<T,E> for core::result::Result<T,E>>::context
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/anyhow-1.0.83/src/context.rs:54:31
   5: <walrus_sdk::client::Client as walrus_service::committee::NodeClient>::get_and_verify_metadata::{{closure}}
             at ./crates/walrus-service/src/committee.rs:232:9
   6: <tokio::time::timeout::Timeout<T> as core::future::future::Future>::poll
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/time/timeout.rs:202:33
   7: <tracing::instrument::Instrumented<T> as core::future::future::Future>::poll
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tracing-0.1.40/src/instrument.rs:321:9
   8: walrus_service::committee::NodeCommitteeServiceInner<T>::get_and_verify_metadata::{{closure}}::{{closure}}
             at ./crates/walrus-service/src/committee.rs:200:56
   9: <tracing::instrument::Instrumented<T> as core::future::future::Future>::poll
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tracing-0.1.40/src/instrument.rs:321:9
  10: walrus_service::committee::NodeCommitteeServiceInner<T>::get_and_verify_metadata::{{closure}}
             at ./crates/walrus-service/src/committee.rs:169:5
  11: <walrus_service::committee::NodeCommitteeService as walrus_service::committee::CommitteeService>::get_and_verify_metadata::{{closure}}
             at ./crates/walrus-service/src/committee.rs:263:14
  12: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/future/future.rs:123:9
  13: walrus_service::node::BlobSynchronizer::sync_metadata::{{closure}}
             at ./crates/walrus-service/src/node.rs:450:14
  14: walrus_service::node::BlobSynchronizer::sync::{{closure}}
             at ./crates/walrus-service/src/node.rs:436:50
  15: tokio::runtime::task::core::Core<T,S>::poll::{{closure}}
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/task/core.rs:328:17
  16: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/loom/std/unsafe_cell.rs:16:9
  17: tokio::runtime::task::core::Core<T,S>::poll
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/task/core.rs:317:13
  18: tokio::runtime::task::harness::poll_future::{{closure}}
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/task/harness.rs:485:19
  19: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/panic/unwind_safe.rs:272:9
  20: std::panicking::try::do_call
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/panicking.rs:552:40
  21: ___rust_try
  22: std::panicking::try
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/panicking.rs:516:19
  23: std::panic::catch_unwind
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/panic.rs:146:14
  24: tokio::runtime::task::harness::poll_future
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/task/harness.rs:473:18
  25: tokio::runtime::task::harness::Harness<T,S>::poll_inner
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/task/harness.rs:208:27
  26: tokio::runtime::task::harness::Harness<T,S>::poll
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/task/harness.rs:153:15
  27: tokio::runtime::task::raw::poll
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/task/raw.rs:271:5
  28: tokio::runtime::task::raw::RawTask::poll
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/task/raw.rs:201:18
  29: tokio::runtime::task::LocalNotified<S>::run
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/task/mod.rs:427:9
  30: tokio::runtime::scheduler::multi_thread::worker::Context::run_task::{{closure}}
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/scheduler/multi_thread/worker.rs:639:17
  31: tokio::runtime::coop::with_budget
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/coop.rs:107:5
  32: tokio::runtime::coop::budget
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/coop.rs:73:5
  33: tokio::runtime::scheduler::multi_thread::worker::Context::run_task
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/scheduler/multi_thread/worker.rs:575:9
  34: tokio::runtime::scheduler::multi_thread::worker::Context::run
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/scheduler/multi_thread/worker.rs:526:24
  35: tokio::runtime::scheduler::multi_thread::worker::run::{{closure}}::{{closure}}
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/scheduler/multi_thread/worker.rs:491:21
  36: tokio::runtime::context::scoped::Scoped<T>::set
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/context/scoped.rs:40:9
  37: tokio::runtime::context::set_scheduler::{{closure}}
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/context.rs:176:26
  38: std::thread::local::LocalKey<T>::try_with
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/thread/local.rs:284:16
  39: std::thread::local::LocalKey<T>::with
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/thread/local.rs:260:9
  40: tokio::runtime::context::set_scheduler
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/context.rs:176:9
  41: tokio::runtime::scheduler::multi_thread::worker::run::{{closure}}
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/scheduler/multi_thread/worker.rs:486:9
  42: tokio::runtime::context::runtime::enter_runtime
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/context/runtime.rs:65:16
  43: tokio::runtime::scheduler::multi_thread::worker::run
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/scheduler/multi_thread/worker.rs:478:5
  44: tokio::runtime::scheduler::multi_thread::worker::Launch::launch::{{closure}}
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/scheduler/multi_thread/worker.rs:447:45
  45: <tokio::runtime::blocking::task::BlockingTask<T> as core::future::future::Future>::poll
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/blocking/task.rs:42:21
  46: tokio::runtime::task::core::Core<T,S>::poll::{{closure}}
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/task/core.rs:328:17
  47: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/loom/std/unsafe_cell.rs:16:9
  48: tokio::runtime::task::core::Core<T,S>::poll
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/task/core.rs:317:13
  49: tokio::runtime::task::harness::poll_future::{{closure}}
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/task/harness.rs:485:19
  50: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/panic/unwind_safe.rs:272:9
  51: std::panicking::try::do_call
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/panicking.rs:552:40
  52: ___rust_try
  53: std::panicking::try
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/panicking.rs:516:19
  54: std::panic::catch_unwind
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/panic.rs:146:14
  55: tokio::runtime::task::harness::poll_future
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/task/harness.rs:473:18
  56: tokio::runtime::task::harness::Harness<T,S>::poll_inner
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/task/harness.rs:208:27
  57: tokio::runtime::task::harness::Harness<T,S>::poll
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/task/harness.rs:153:15
  58: tokio::runtime::task::raw::poll
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/task/raw.rs:271:5
  59: tokio::runtime::task::raw::RawTask::poll
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/task/raw.rs:201:18
  60: tokio::runtime::task::UnownedTask<S>::run
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/task/mod.rs:464:9
  61: tokio::runtime::blocking::pool::Task::run
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/blocking/pool.rs:159:9
  62: tokio::runtime::blocking::pool::Inner::run
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/blocking/pool.rs:513:17
  63: tokio::runtime::blocking::pool::Spawner::spawn_thread::{{closure}}
             at /Users/markuslegner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/runtime/blocking/pool.rs:471:13
  64: std::sys_common::backtrace::__rust_begin_short_backtrace
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/sys_common/backtrace.rs:155:18
  65: std::thread::Builder::spawn_unchecked_::{{closure}}::{{closure}}
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/thread/mod.rs:528:17
  66: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/panic/unwind_safe.rs:272:9
  67: std::panicking::try::do_call
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/panicking.rs:552:40
  68: ___rust_try
  69: std::panicking::try
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/panicking.rs:516:19
  70: std::panic::catch_unwind
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/panic.rs:146:14
  71: std::thread::Builder::spawn_unchecked_::{{closure}}
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/thread/mod.rs:527:30
  72: core::ops::function::FnOnce::call_once{{vtable.shim}}
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/ops/function.rs:250:5
  73: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/alloc/src/boxed.rs:2020:9
  74: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/alloc/src/boxed.rs:2020:9
  75: std::sys::pal::unix::thread::Thread::new::thread_start
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/sys/pal/unix/thread.rs:108:17
  76: __pthread_joiner_wake
```
