### PR TITLE
test: make coverage reports more robust

### DIFF
--- a/.github/actions/run_tarpaulin/action.yml
+++ b/.github/actions/run_tarpaulin/action.yml
@@ -4,7 +4,7 @@ description: Run all tests and report coverage
 runs:
   using: "composite"
   steps:
-    - run: cargo install cargo-tarpaulin@0.27.3
+    - run: cargo install --locked cargo-tarpaulin@0.30.0
       shell: bash
 
     - name: Run tests (including integration E2E tests) and record coverage

--- a/.github/workflows/scheduled_reports.yml
+++ b/.github/workflows/scheduled_reports.yml
@@ -4,6 +4,8 @@ on:
   # Run workflow once a week on Sundays.
   schedule:
     - cron: '14 3 * * 0'
+  # Run workflow on demand.
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -1,10 +1,10 @@
 name: Updates
 
 on:
-  # every month
+  # Run workflow on the first day of every month.
   schedule:
     - cron: '14 3 1 * *'
-  # on demand
+  # Run workflow on demand.
   workflow_dispatch:
 
 jobs:

--- a/.tarpaulin.toml
+++ b/.tarpaulin.toml
@@ -1,8 +1,11 @@
 [default]
-workspace = true
 skip-clean = true
 run-types = ["Bins", "Doctests", "Examples", "Lib", "Tests"]
 out = ["Html", "Xml"]
+# Use separate target directory to avoid interference with other builds.
+target-dir = "target/tarpaulin"
+# Increase timeout for longer-running tests to 3 minutes.
+timeout = "3min"
 # Don't include test and benchmark code in the coverage result.
 exclude-files = [
   "crates/**/benches/**/*",
@@ -11,4 +14,5 @@ exclude-files = [
   "crates/walrus-orchestrator/**/*",
   "crates/walrus-test-utils/**/*",
 ]
+# Include all tests, even longer integration tests.
 args = ["--include-ignored"]


### PR DESCRIPTION
- increase timeout
- build in separate directory
- remove the "workspace" flag to only test default members

Also update the version of tarpaulin used in CI and enable running the weekly CI workflow manually and improve some comments.