### PR TITLE
fix(server): remove the request body limit on the PUT metadata

### DIFF
--- a/crates/walrus-service/src/server.rs
+++ b/crates/walrus-service/src/server.rs
@@ -19,7 +19,7 @@ use tokio_util::sync::CancellationToken;
 use tower_http::trace::{MakeSpan, TraceLayer};
 use tracing::Level;
 use walrus_core::{
-    encoding::{max_sliver_size_for_n_shards, metadata_length_for_n_shards},
+    encoding::max_sliver_size_for_n_shards,
     messages::StorageConfirmation,
     metadata::{BlobMetadata, UnverifiedBlobMetadataWithId},
     BlobId,
@@ -140,13 +140,7 @@ impl<S: ServiceState + Send + Sync + 'static> UserServer<S> {
         let app = Router::new()
             .route(
                 METADATA_ENDPOINT,
-                put(Self::store_metadata)
-                    .route_layer(DefaultBodyLimit::max(
-                        usize::try_from(metadata_length_for_n_shards(self.state.n_shards()))
-                            .expect("running on 64bit arch (see hardware requirements)")
-                            + HEADROOM,
-                    ))
-                    .get(Self::retrieve_metadata),
+                put(Self::store_metadata).get(Self::retrieve_metadata),
             )
             .route(
                 SLIVER_ENDPOINT,


### PR DESCRIPTION
The maximum size of the metadata is actually always lower than the default maximum request body limit (for reasonable number of shards).

Further, it seems that the limit that was set (`metatadata_length + headroom`) was not large enough, and caused storing metadata to fail in some cases.

Reverting fixes this problem up to ~30k shards. If we plan to go above that number, we may need to revisit.