### PR TITLE
fix: force git checkout

### DIFF
--- a/crates/walrus-orchestrator/src/orchestrator.rs
+++ b/crates/walrus-orchestrator/src/orchestrator.rs
@@ -225,7 +225,7 @@ impl<P: ProtocolCommands + ProtocolMetrics> Orchestrator<P> {
         let commit = &self.settings.repository.commit;
         let command = [
             &format!("git fetch origin {commit}"),
-            &format!("(git checkout -b {commit} {commit} || git checkout origin/{commit})"),
+            &format!("(git checkout -b {commit} || git checkout -f origin/{commit})"),
             "source $HOME/.cargo/env",
             "cargo build --release",
         ]


### PR DESCRIPTION
Basically Cargo.lock has been modified on the remote machines and so git checkout origin/main failed. This can happen if we compile/run the binary manually on the remote machine (without using the orchestrator) or perhaps if we brutally interrupted the orchestrator while it was updating / recompiling the code (not sure though). This problem should now be fix by forcing git to checkout origin/main