### PR TITLE
fix: set paths correctly in configs

### DIFF
--- a/crates/walrus-service/bin/node.rs
+++ b/crates/walrus-service/bin/node.rs
@@ -189,6 +189,10 @@ mod commands {
 
         fs::create_dir_all(&working_dir)
             .with_context(|| format!("Failed to create directory '{}'", working_dir.display()))?;
+        // Turn the working directory into an absolute path.
+        let working_dir = working_dir
+            .canonicalize()
+            .context("canonicalizing the working directory path failed")?;
 
         // Deploy the system contract.
         let number_of_shards = NonZeroU16::new(n_shards).context("number of shards must be > 0")?;
@@ -228,6 +232,10 @@ mod commands {
 
         fs::create_dir_all(&working_dir)
             .with_context(|| format!("Failed to create directory '{}'", working_dir.display()))?;
+        // Turn the working directory into an absolute path.
+        let working_dir = working_dir
+            .canonicalize()
+            .context("canonicalizing the working directory path failed")?;
 
         let testbed_config_path = get_testbed_config_path(testbed_config_path, &working_dir);
         let testbed_config = TestbedConfig::load(testbed_config_path)?;

--- a/crates/walrus-service/src/client/config.rs
+++ b/crates/walrus-service/src/client/config.rs
@@ -4,7 +4,7 @@
 use std::{path::PathBuf, time::Duration};
 
 use reqwest::ClientBuilder;
-use serde::{de::Error as _, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use sui_types::base_types::ObjectID;
 
 use crate::config::LoadConfig;
@@ -17,9 +17,7 @@ pub struct Config {
     /// The system walrus system object id.
     pub system_object: ObjectID,
     /// Path to the wallet configuration.
-    ///
-    /// If set, this MUST be an absolute path.
-    #[serde(default, deserialize_with = "deserialize_wallet_config")]
+    #[serde(default)]
     pub wallet_config: Option<PathBuf>,
     /// Configuration for the client's network communication.
     #[serde(default)]
@@ -144,22 +142,6 @@ impl ReqwestConfig {
             .http2_keep_alive_interval(self.http2_keep_alive_interval)
             .http2_keep_alive_while_idle(self.http2_keep_alive_while_idle)
     }
-}
-
-fn deserialize_wallet_config<'de, D>(deserializer: D) -> Result<Option<PathBuf>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let path = Option::<PathBuf>::deserialize(deserializer)?;
-    if let Some(path) = &path {
-        if !path.is_absolute() {
-            return Err(D::Error::custom(format!(
-                "an absolute path is required for the wallet config (found {})",
-                path.display()
-            )));
-        }
-    }
-    Ok(path)
 }
 
 /// Returns the default paths for the Walrus configuration file.

--- a/crates/walrus-service/src/config.rs
+++ b/crates/walrus-service/src/config.rs
@@ -10,11 +10,7 @@ use std::{
 };
 
 use anyhow::Context;
-use serde::{
-    de::{DeserializeOwned, Error as _},
-    Deserialize,
-    Serialize,
-};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_with::{
     base64::Base64,
     de::DeserializeAsWrap,
@@ -24,10 +20,7 @@ use serde_with::{
     SerializeAs,
 };
 use sui_sdk::types::base_types::ObjectID;
-use walrus_core::{
-    ensure,
-    keys::{ProtocolKeyPair, ProtocolKeyPairParseError},
-};
+use walrus_core::keys::{ProtocolKeyPair, ProtocolKeyPairParseError};
 use walrus_sui::utils::SuiNetwork;
 
 /// Trait for loading configuration from a YAML file.
@@ -80,9 +73,6 @@ pub struct SuiConfig {
     #[serde(default = "defaults::polling_interval")]
     pub event_polling_interval: Duration,
     /// Location of the wallet config.
-    ///
-    /// This MUST be an absolute path.
-    #[serde(deserialize_with = "deserialize_wallet_config")]
     pub wallet_config: PathBuf,
     /// Gas budget for transactions.
     #[serde(default = "defaults::gas_budget")]
@@ -273,23 +263,6 @@ where
         };
         wrapper.serialize(serializer)
     }
-}
-
-fn deserialize_wallet_config<'de, D>(deserializer: D) -> Result<PathBuf, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let path = PathBuf::deserialize(deserializer)?;
-
-    ensure!(
-        path.is_absolute(),
-        D::Error::custom(format!(
-            "an absolute path is required for the wallet config (found {})",
-            path.display()
-        ))
-    );
-
-    Ok(path)
 }
 
 #[cfg(test)]

--- a/crates/walrus-sui/src/utils.rs
+++ b/crates/walrus-sui/src/utils.rs
@@ -344,7 +344,7 @@ pub fn create_wallet(
     let mut keystore = FileBasedKeystore::new(&keystore_path)?;
     let (new_address, _phrase, _scheme) =
         keystore.generate_and_add_new_key(SignatureScheme::ED25519, None, None, None)?;
-    keystore.set_path(&keystore_path.canonicalize()?);
+
     let keystore = Keystore::from(keystore);
 
     let alias = sui_env.alias.clone();


### PR DESCRIPTION
- generating configs no longer fails if `set-config-dir` is not specified
  - this was a bug from using `canonicalize` on a path that didn't exist yet 
- also removes requirement that paths must be absolute when loading the config
  - we still set absolute paths, but there doesn't seem to be a good reason to enforce this when running a node or client