### PR TITLE
fix: Make delete blob an atomic op

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -405,8 +405,7 @@ impl StorageNode {
         event_sequence_number: usize,
         event: InvalidBlobID,
     ) -> anyhow::Result<()> {
-        self.storage.delete_metadata(&event.blob_id)?;
-        self.storage.delete_slivers(&event.blob_id)?;
+        self.storage.delete_blob(&event.blob_id)?;
         self.storage
             .maybe_advance_event_cursor(event_sequence_number, &event.event_id)?;
         Ok(())


### PR DESCRIPTION
This PR makes the two delete operations i.e. `delete_metadata` and `delete_slivers` atomic. While i don't think this is a big issue as these operations would be idempotent if there was a server restart between the first and second delete because the event is going to get reprocessed but it could still lead to some potential confusing state where the slivers exist but its metadata doesn't (or even more confusing would be entry in blob_info cf exist but not in metadata cf)