### PR TITLE
feat!: generate protocol keys randomly, allow specifying hostnames

### DIFF
--- a/crates/walrus-service/src/config.rs
+++ b/crates/walrus-service/src/config.rs
@@ -4,7 +4,7 @@
 //! Storage client configuration module.
 
 use std::{
-    net::{Ipv4Addr, SocketAddr},
+    net::SocketAddr,
     path::{Path, PathBuf},
     time::Duration,
 };
@@ -21,7 +21,7 @@ use serde_with::{
 };
 use sui_sdk::types::base_types::ObjectID;
 use walrus_core::keys::{ProtocolKeyPair, ProtocolKeyPairParseError};
-use walrus_sui::utils::SuiNetwork;
+use walrus_sui::{types::NetworkAddress, utils::SuiNetwork};
 
 /// Trait for loading configuration from a YAML file.
 pub trait LoadConfig: DeserializeOwned {
@@ -81,6 +81,17 @@ pub struct SuiConfig {
 
 impl LoadConfig for SuiConfig {}
 
+/// Node-specific Testbed configuration.
+#[serde_with::serde_as]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct TestbedNodeConfig {
+    /// The REST API address of the node.
+    pub network_address: NetworkAddress,
+    /// The key of the node.
+    #[serde_as(as = "Base64")]
+    pub keypair: ProtocolKeyPair,
+}
+
 /// Configuration for a Walrus Testbed.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct TestbedConfig {
@@ -88,10 +99,7 @@ pub struct TestbedConfig {
     #[serde(default = "defaults::network")]
     pub sui_network: SuiNetwork,
     /// The list of ip addresses of the storage nodes.
-    pub ips: Vec<Ipv4Addr>,
-    /// The port on which the REST API of the storage nodes will listen.
-    #[serde(default = "defaults::rest_api_port")]
-    pub rest_api_port: u16,
+    pub nodes: Vec<TestbedNodeConfig>,
     /// Object ID of the walrus package.
     pub pkg_id: ObjectID,
     /// Object ID of walrus system object.

--- a/scripts/local-testbed.sh
+++ b/scripts/local-testbed.sh
@@ -103,7 +103,7 @@ if ! $existing; then
     # Deploy system contract
     echo Deploying system contract...
     cargo run --bin walrus-node -- deploy-system-contract \
-    --working-dir $working_dir --sui-network $network --n-shards $shards --ips $ips
+    --working-dir $working_dir --sui-network $network --n-shards $shards --host-addresses $ips
 
     # Generate configs
     echo Generating configuration...


### PR DESCRIPTION
BREAKING CHANGE: changes cli argument from `ips` to `host-addresses` when deploying contract

closes #434 
closes #483 