### PR TITLE
feat: Make rocksdb options tunable as config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10932,7 +10932,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.8",
+ "winnow 0.6.9",
 ]
 
 [[package]]
@@ -12118,9 +12118,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c52e9c97a68071b23e836c9380edae937f17b9c4667bd021973efc689f618d"
+checksum = "86c949fede1d13936a99f14fafd3e76fd642b556dd2ce96287fbe2e0151bfac6"
 dependencies = [
  "memchr",
 ]

--- a/crates/walrus-service/src/config.rs
+++ b/crates/walrus-service/src/config.rs
@@ -23,6 +23,8 @@ use sui_sdk::types::base_types::ObjectID;
 use walrus_core::keys::{ProtocolKeyPair, ProtocolKeyPairParseError};
 use walrus_sui::{types::NetworkAddress, utils::SuiNetwork};
 
+use crate::storage::DatabaseConfig;
+
 /// Trait for loading configuration from a YAML file.
 pub trait LoadConfig: DeserializeOwned {
     /// Load the configuration from a YAML file located at the provided path.
@@ -43,6 +45,8 @@ pub trait LoadConfig: DeserializeOwned {
 pub struct StorageNodeConfig {
     /// Directory in which to persist the database
     pub storage_path: PathBuf,
+    /// Option config to tune storage db
+    pub db_config: Option<DatabaseConfig>,
     /// Key pair used in Walrus protocol messages
     #[serde_as(as = "PathOrInPlace<Base64>")]
     pub protocol_key_pair: PathOrInPlace<ProtocolKeyPair>,

--- a/crates/walrus-service/src/testbed.rs
+++ b/crates/walrus-service/src/testbed.rs
@@ -35,6 +35,7 @@ use crate::{
         TestbedConfig,
         TestbedNodeConfig,
     },
+    storage::DatabaseConfig,
 };
 
 /// Prefix for the node configuration file name.
@@ -397,12 +398,14 @@ pub async fn create_storage_node_configs(
         } else {
             working_dir.join(&name)
         };
+        let db_config = Some(DatabaseConfig::default());
         storage_node_configs.push(StorageNodeConfig {
             storage_path,
             protocol_key_pair: PathOrInPlace::InPlace(node.keypair),
             metrics_address,
             rest_api_address,
             sui,
+            db_config,
         });
     }
     Ok(storage_node_configs)


### PR DESCRIPTION
This PR enables setting different db options for column families as config. Other important reason to do this is to be able to benchmark storage by tuning these parameters easily.