### PR TITLE
feat(client)!: check status before storing and improve output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11745,6 +11745,7 @@ dependencies = [
  "reqwest 0.12.4",
  "serde",
  "serde_json",
+ "serde_with 3.8.1",
  "sui-config",
  "sui-keys",
  "sui-move-build",

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ cargo run --bin walrus -- json \
         "config": "working_dir/client_config.yaml",
         "command": {
             "read": {
-                "blob_id": "4BKcDC0Ih5RJ8R0tFMz3MZVNZV8b2goT6_JiEEwNHQo"
+                "blobId": "4BKcDC0Ih5RJ8R0tFMz3MZVNZV8b2goT6_JiEEwNHQo"
             }
         }
     }'

--- a/crates/walrus-core/Cargo.toml
+++ b/crates/walrus-core/Cargo.toml
@@ -16,7 +16,7 @@ fastcrypto.workspace = true
 rand.workspace = true
 raptorq = "2.0.0"
 serde.workspace = true
-serde_with = { workspace = true, features = ["base64"] }
+serde_with.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 utoipa = { workspace = true, optional = true }

--- a/crates/walrus-sdk/src/api.rs
+++ b/crates/walrus-sdk/src/api.rs
@@ -78,7 +78,7 @@ impl Ord for BlobCertificationStatus {
 #[derive(
     Debug, Deserialize, Serialize, PartialEq, Eq, Clone, Copy, Default, Hash, utoipa::ToSchema,
 )]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", rename_all_fields = "camelCase")]
 pub enum BlobStatus {
     /// The blob does not exist (anymore) within Walrus.
     #[default]

--- a/crates/walrus-service/Cargo.toml
+++ b/crates/walrus-service/Cargo.toml
@@ -33,7 +33,7 @@ reqwest = { workspace = true, features = ["json"] }
 rocksdb = "0.22.0"
 serde.workspace = true
 serde_json.workspace = true
-serde_with = { workspace = true, features = ["base64"] }
+serde_with.workspace = true
 serde_yaml.workspace = true
 sui-sdk.workspace = true
 sui-types.workspace = true

--- a/crates/walrus-service/src/cli_utils.rs
+++ b/crates/walrus-service/src/cli_utils.rs
@@ -14,6 +14,7 @@ use colored::{ColoredString, Colorize};
 use indoc::printdoc;
 use prettytable::{format, row, Table};
 use sui_sdk::{wallet_context::WalletContext, SuiClientBuilder};
+use sui_types::event::EventID;
 use walrus_core::{
     bft,
     encoding::{
@@ -409,6 +410,11 @@ fn default_table_format() -> format::TableFormat {
         )
         .padding(1, 1)
         .build()
+}
+
+/// Format the event ID as the transaction digest and the sequence number.
+pub fn format_event_id(event_id: &EventID) -> String {
+    format!("(tx: {}, seq: {})", event_id.tx_digest, event_id.event_seq)
 }
 
 #[cfg(test)]

--- a/crates/walrus-sui/Cargo.toml
+++ b/crates/walrus-sui/Cargo.toml
@@ -18,6 +18,7 @@ move-core-types.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+serde_with.workspace = true
 sui-config.workspace = true
 sui-keys.workspace = true
 sui-move-build.workspace = true

--- a/crates/walrus-sui/src/client.rs
+++ b/crates/walrus-sui/src/client.rs
@@ -106,7 +106,7 @@ pub trait ContractClient: Send + Sync {
     /// returns the certified blob.
     fn certify_blob(
         &self,
-        blob: &Blob,
+        blob: Blob,
         certificate: &ConfirmationCertificate,
     ) -> impl Future<Output = SuiClientResult<Blob>> + Send;
 
@@ -318,7 +318,7 @@ impl ContractClient for SuiContractClient {
 
     async fn certify_blob(
         &self,
-        blob: &Blob,
+        blob: Blob,
         certificate: &ConfirmationCertificate,
     ) -> SuiClientResult<Blob> {
         // Sort the list of signers, since the move contract requires them to be in

--- a/crates/walrus-sui/src/client/read_client.rs
+++ b/crates/walrus-sui/src/client/read_client.rs
@@ -45,7 +45,7 @@ use crate::{
 const EVENT_MODULE: &str = "blob_events";
 
 /// Trait to read system state information and events from chain.
-pub trait ReadClient {
+pub trait ReadClient: Send + Sync {
     /// Returns the price for one unit of storage per epoch.
     fn price_per_unit_size(&self) -> impl Future<Output = SuiClientResult<u64>> + Send;
 

--- a/crates/walrus-sui/src/test_utils/mock_clients.rs
+++ b/crates/walrus-sui/src/test_utils/mock_clients.rs
@@ -211,7 +211,7 @@ impl ContractClient for MockContractClient {
 
     async fn certify_blob(
         &self,
-        blob: &Blob,
+        blob: Blob,
         _certificate: &ConfirmationCertificate,
     ) -> SuiClientResult<Blob> {
         self.read_client.add_event(
@@ -324,7 +324,7 @@ mod tests {
 
         let blob_obj = walrus_client
             .certify_blob(
-                &blob_obj,
+                blob_obj,
                 // Dummy certificate, currently not checked by the mock client
                 &ConfirmationCertificate::new(
                     vec![],

--- a/crates/walrus-sui/src/types.rs
+++ b/crates/walrus-sui/src/types.rs
@@ -17,6 +17,7 @@ use fastcrypto::traits::ToFromBytes;
 use move_core_types::u256::U256;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
+use serde_with::{serde_as, DisplayFromStr};
 use sui_sdk::rpc_types::{SuiEvent, SuiMoveStruct, SuiMoveValue};
 use sui_types::{base_types::ObjectID, event::EventID};
 use thiserror::Error;
@@ -32,7 +33,8 @@ use crate::{
     },
 };
 /// Sui object for storage resources.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct StorageResource {
     /// Object ID of the Sui object.
     pub id: ObjectID,
@@ -74,13 +76,16 @@ impl AssociatedContractStruct for StorageResource {
 }
 
 /// Sui object for a blob.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[serde_as]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Blob {
     /// Object ID of the Sui object.
     pub id: ObjectID,
     /// The epoch in which the blob has been registered.
     pub stored_epoch: Epoch,
     /// The blob ID.
+    #[serde_as(as = "DisplayFromStr")]
     pub blob_id: BlobId,
     /// The (unencoded) size of the blob.
     pub size: u64,

--- a/crates/walrus-sui/tests/test_walrus_sui.rs
+++ b/crates/walrus-sui/tests/test_walrus_sui.rs
@@ -119,7 +119,7 @@ async fn test_register_certify_blob() -> anyhow::Result<()> {
 
     let blob_obj = walrus_client
         .as_ref()
-        .certify_blob(&blob_obj, &certificate)
+        .certify_blob(blob_obj, &certificate)
         .await?;
     assert_eq!(blob_obj.certified, Some(0));
 
@@ -178,7 +178,7 @@ async fn test_register_certify_blob() -> anyhow::Result<()> {
 
     let _blob_obj = walrus_client
         .as_ref()
-        .certify_blob(&blob_obj, &get_default_blob_certificate(blob_id, 0))
+        .certify_blob(blob_obj, &get_default_blob_certificate(blob_id, 0))
         .await?;
 
     // Make sure that we got the expected event


### PR DESCRIPTION
- When attempting to store a blob, check the blob status first and only store it if necessary.
- Add `force` option to disable this optimization.
- Make input and output in JSON mode "camelCase".
- Extend the output for storing blobs in the JSON and HTTP APIs.

Closes #383