### PR TITLE
fix: Make reqwest not require openssl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7878,7 +7878,6 @@ checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ futures = "0.3.30"
 move-core-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.26.0" }
 mysten-metrics = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.26.0" }
 rand = "0.8.5"
-reqwest = { version = "0.12.4", default-features = false, features = ["http2", "blocking", "json", "rustls-tls"] }
+reqwest = { version = "0.12.4", default-features = false, features = ["http2", "rustls-tls"] }
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"
 serde_with = { version = "3.8", features = ["base64"] }

--- a/deny.toml
+++ b/deny.toml
@@ -73,6 +73,12 @@ skip-tree = [
     # several crates depend on an older version of windows-sys
     { name = "windows-sys", depth = 3, version = "0.48" },
 ]
+deny = [
+  # TODO: Remove the following three lines after removing SSH. (#221)
+  { name = "openssl-sys", wrappers = ["libssh2-sys"] },
+  { name = "libssh2-sys", wrappers = ["ssh2"] },
+  { name = "ssh2", wrappers = ["walrus-orchestrator"] },
+]
 
 # This section is considered when running `cargo deny check sources`.
 # More documentation about the 'sources' section can be found here:


### PR DESCRIPTION
Specialise the options of the `reqwests` dependency to not use the default openssl on linux systems.