### PR TITLE
chore: reduce overhead of generating blobs in stress client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11663,7 +11663,6 @@ dependencies = [
  "tokio",
  "walrus-core",
  "walrus-service",
- "walrus-stress",
  "walrus-sui",
 ]
 

--- a/crates/walrus-orchestrator/Cargo.toml
+++ b/crates/walrus-orchestrator/Cargo.toml
@@ -28,7 +28,6 @@ thiserror.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 walrus-core.workspace = true
 walrus-service.workspace = true
-walrus-stress.workspace = true
 walrus-sui.workspace = true
 
 [dev-dependencies]

--- a/crates/walrus-stress/src/generator/blob.rs
+++ b/crates/walrus-stress/src/generator/blob.rs
@@ -1,0 +1,32 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use rand::{rngs::StdRng, Rng};
+
+#[derive(Debug)]
+pub(crate) struct BlobData {
+    bytes: Vec<u8>,
+    rng: StdRng,
+}
+
+impl BlobData {
+    /// Create a random blob of a given size.
+    pub fn random(mut rng: StdRng, size: usize) -> Self {
+        Self {
+            bytes: (0..size).map(|_| rng.gen::<u8>()).collect(),
+            rng,
+        }
+    }
+
+    /// Changes the blob by incrementing (wrapping) a randomly chosen byte.
+    pub fn refresh(&mut self) {
+        let index = self.rng.gen_range(0..self.bytes.len());
+        self.bytes[index] = self.bytes[index].wrapping_add(1);
+    }
+}
+
+impl AsRef<[u8]> for BlobData {
+    fn as_ref(&self) -> &[u8] {
+        &self.bytes
+    }
+}

--- a/crates/walrus-stress/src/main.rs
+++ b/crates/walrus-stress/src/main.rs
@@ -62,12 +62,9 @@ async fn main() -> anyhow::Result<()> {
     tracing::info!("Starting metrics server on {metrics_address}");
 
     // Start the write transaction generator.
-    tracing::info!("Initializing clients...");
-    let mut load_generator = LoadGenerator::new(n_clients, config, args.sui_network).await?;
-    tracing::info!("Finished initializing clients...");
-    tracing::info!("Starting load generator...");
-    load_generator
-        .start(target_load, args.blob_size.get(), &metrics)
-        .await?;
+    let mut load_generator =
+        LoadGenerator::new(n_clients, args.blob_size.get(), config, args.sui_network).await?;
+
+    load_generator.start(target_load, &metrics).await?;
     Ok(())
 }


### PR DESCRIPTION
This makes it feasible to also run with large blobs since we are no longer generating one random blob per write from scratch.