### PR TITLE
feat: allow blob IDs in decimal format in addition to base64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,7 +354,7 @@ dependencies = [
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
- "num-bigint 0.4.4",
+ "num-bigint 0.4.5",
  "num-traits",
  "paste",
  "rustc_version",
@@ -377,7 +377,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
- "num-bigint 0.4.4",
+ "num-bigint 0.4.5",
  "num-traits",
  "proc-macro2 1.0.81",
  "quote 1.0.36",
@@ -443,7 +443,7 @@ dependencies = [
  "ark-serialize-derive",
  "ark-std",
  "digest 0.10.7",
- "num-bigint 0.4.4",
+ "num-bigint 0.4.5",
 ]
 
 [[package]]
@@ -2491,7 +2491,7 @@ dependencies = [
  "asn1-rs",
  "displaydoc",
  "nom",
- "num-bigint 0.4.4",
+ "num-bigint 0.4.5",
  "num-traits",
  "rusticata-macros",
 ]
@@ -3289,7 +3289,7 @@ dependencies = [
  "hex-literal",
  "hkdf",
  "lazy_static",
- "num-bigint 0.4.4",
+ "num-bigint 0.4.5",
  "once_cell",
  "p256",
  "rand 0.8.5",
@@ -3343,7 +3343,7 @@ dependencies = [
  "hex-literal",
  "hkdf",
  "lazy_static",
- "num-bigint 0.4.4",
+ "num-bigint 0.4.5",
  "once_cell",
  "p256",
  "rand 0.8.5",
@@ -3412,7 +3412,7 @@ dependencies = [
  "bcs",
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=c101a5176799db3eb9c801b844e7add92153d291)",
  "lazy_static",
- "num-bigint 0.4.4",
+ "num-bigint 0.4.5",
  "num-integer",
  "num-prime",
  "num-traits",
@@ -3444,7 +3444,7 @@ dependencies = [
  "itertools 0.12.1",
  "lazy_static",
  "neptune",
- "num-bigint 0.4.4",
+ "num-bigint 0.4.5",
  "once_cell",
  "regex",
  "reqwest 0.11.27",
@@ -5224,7 +5224,7 @@ dependencies = [
  "dirs-next",
  "hex",
  "move-core-types",
- "num-bigint 0.4.4",
+ "num-bigint 0.4.5",
  "once_cell",
  "serde",
  "sha2 0.9.9",
@@ -6231,7 +6231,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3135b08af27d103b0a51f2ae0f8632117b7b185ccf931445affa8df530576a41"
 dependencies = [
- "num-bigint 0.4.4",
+ "num-bigint 0.4.5",
  "num-complex",
  "num-integer",
  "num-iter",
@@ -6252,11 +6252,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
  "rand 0.8.5",
@@ -6320,7 +6319,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64a5fe11d4135c3bcdf3a95b18b194afa9608a5f6ff034f5d857bc9a27fb0119"
 dependencies = [
- "num-bigint 0.4.4",
+ "num-bigint 0.4.5",
  "num-integer",
  "num-traits",
 ]
@@ -6334,7 +6333,7 @@ dependencies = [
  "bitvec 1.0.1",
  "either",
  "lru 0.12.3",
- "num-bigint 0.4.4",
+ "num-bigint 0.4.5",
  "num-integer",
  "num-modular",
  "num-traits",
@@ -6348,7 +6347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
- "num-bigint 0.4.4",
+ "num-bigint 0.4.5",
  "num-integer",
  "num-traits",
 ]
@@ -8932,7 +8931,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
 dependencies = [
- "num-bigint 0.4.4",
+ "num-bigint 0.4.5",
  "num-traits",
  "thiserror",
  "time",
@@ -10414,7 +10413,7 @@ dependencies = [
  "narwhal-config",
  "narwhal-crypto",
  "nonempty",
- "num-bigint 0.4.4",
+ "num-bigint 0.4.5",
  "num-traits",
  "num_enum 0.6.1",
  "once_cell",
@@ -11805,6 +11804,7 @@ dependencies = [
  "bcs",
  "criterion",
  "fastcrypto 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-bigint 0.4.5",
  "rand 0.8.5",
  "raptorq",
  "serde",

--- a/crates/walrus-core/Cargo.toml
+++ b/crates/walrus-core/Cargo.toml
@@ -13,6 +13,7 @@ test-utils = ["walrus-test-utils"]
 base64 = "0.22.1"
 bcs.workspace = true
 fastcrypto.workspace = true
+num-bigint = { version = "0.4.5", default-features = false }
 rand.workspace = true
 raptorq = "2.0.0"
 serde.workspace = true

--- a/crates/walrus-service/bin/client.rs
+++ b/crates/walrus-service/bin/client.rs
@@ -115,6 +115,9 @@ enum Commands {
     /// Read a blob from Walrus, given the blob ID.
     Read {
         /// The blob ID to be read.
+        ///
+        /// This can be either in the Walrus standard format (URL-safe base-64 string) or the value
+        /// in decimal format (as shown by the Sui explorer).
         #[serde_as(as = "DisplayFromStr")]
         blob_id: BlobId,
         /// The file path where to write the blob.
@@ -261,8 +264,11 @@ struct FileOrBlobId {
     #[clap(short, long)]
     file: Option<PathBuf>,
     /// The blob ID to be checked.
-    #[serde_as(as = "Option<DisplayFromStr>")]
+    ///
+    /// This can be either in the Walrus standard format (URL-safe base-64 string) or the value in
+    /// decimal format (as shown by the Sui explorer).
     #[clap(short, long)]
+    #[serde_as(as = "Option<DisplayFromStr>")]
     blob_id: Option<BlobId>,
 }
 


### PR DESCRIPTION
There is a theoretical overlap of valid values for the base-64 encoding and decimal values. However, this will not happen in practice as a valid blob ID in decimal format must be very small to also be a valid base-64 string. The probability of that is smaller than `10^-33`.

Contributes to #523 