### PR TITLE
feat(client): add blocklist feature for daemon

### DIFF
--- a/crates/walrus-service/src/client/blocklist.rs
+++ b/crates/walrus-service/src/client/blocklist.rs
@@ -1,0 +1,68 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::HashSet, path::PathBuf};
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use serde_with::{serde_as, DisplayFromStr};
+use walrus_core::BlobId;
+
+/// Internal blocklist struct to deserialize from YAML.
+#[serde_as]
+#[derive(Debug, Deserialize, Clone, Default)]
+struct BlocklistInner(#[serde_as(as = "Vec<DisplayFromStr>")] pub Vec<BlobId>);
+
+/// A blocklist of blob IDs.
+///
+/// Supports checking if a blob ID is blocked and inserting/removing blob IDs.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Blocklist {
+    blocked_blobs: HashSet<BlobId>,
+}
+
+impl Blocklist {
+    /// Reads a blocklist of blob IDs in YAML format from the provided path.
+    ///
+    /// If no path is provided, the returned blocklist is empty.
+    ///
+    /// Returns an error if the file is not found or parsing fails.
+    pub fn new(path: &Option<PathBuf>) -> Result<Self> {
+        let Some(path) = path else {
+            return Ok(Self::default());
+        };
+
+        let blocklist: BlocklistInner =
+            serde_yaml::from_str(&std::fs::read_to_string(path).context(format!(
+                "Unable to read blocklist file at {}",
+                path.display()
+            ))?)
+            .context(format!("Parsing blocklist at {} failed", path.display()))?;
+
+        Ok(Self {
+            blocked_blobs: blocklist.0.into_iter().collect(),
+        })
+    }
+
+    /// Checks if a blob ID is blocked.
+    #[inline]
+    pub fn is_blocked(&self, blob_id: &BlobId) -> bool {
+        self.blocked_blobs.contains(blob_id)
+    }
+
+    /// Adds a blob ID to the blocklist.
+    ///
+    /// Returns whether the ID was newly inserted.
+    #[inline]
+    pub fn insert(&mut self, blob_id: BlobId) -> bool {
+        self.blocked_blobs.insert(blob_id)
+    }
+
+    /// Removes a blob ID from the blocklist.
+    ///
+    /// Returns whether the ID was previously blocked.
+    #[inline]
+    pub fn remove(&mut self, blob_id: &BlobId) -> bool {
+        self.blocked_blobs.remove(blob_id)
+    }
+}

--- a/crates/walrus-service/src/client/error.rs
+++ b/crates/walrus-service/src/client/error.rs
@@ -3,7 +3,7 @@
 
 //! The errors for the storage client and the communication with storage nodes.
 
-use walrus_core::{SliverPairIndex, SliverType};
+use walrus_core::{BlobId, SliverPairIndex, SliverType};
 use walrus_sdk::error::NodeError;
 use walrus_sui::client::SuiClientError;
 
@@ -85,6 +85,9 @@ pub enum ClientErrorKind {
     /// The config provided to the client was invalid.
     #[error("the client config provided was invalid")]
     InvalidConfig,
+    /// The blob ID is blocked.
+    #[error("the blob ID {0} is blocked")]
+    BlobIdBlocked(BlobId),
     /// A failure internal to the node.
     #[error("client internal error: {0}")]
     Other(Box<dyn std::error::Error + Send + Sync + 'static>),

--- a/crates/walrus-service/src/daemon.rs
+++ b/crates/walrus-service/src/daemon.rs
@@ -125,9 +125,10 @@ async fn retrieve_blob<T: Send + Sync>(
         }
         Err(error) => match error.kind() {
             ClientErrorKind::BlobIdDoesNotExist => {
-                tracing::info!(?blob_id, "the requested blob ID does not exist");
+                tracing::debug!(?blob_id, "the requested blob ID does not exist");
                 StatusCode::NOT_FOUND.into_response()
             }
+            ClientErrorKind::BlobIdBlocked(_) => StatusCode::FORBIDDEN.into_response(),
             _ => {
                 tracing::error!(%error, "error retrieving blob");
                 StatusCode::INTERNAL_SERVER_ERROR.into_response()
@@ -161,6 +162,7 @@ async fn store_blob<T: ContractClient>(
                 ClientErrorKind::NotEnoughConfirmations(_, _) => {
                     StatusCode::GATEWAY_TIMEOUT.into_response()
                 }
+                ClientErrorKind::BlobIdBlocked(_) => StatusCode::FORBIDDEN.into_response(),
                 _ => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
             }
         }


### PR DESCRIPTION
The blocklist is simply a list of blob IDs in YAML syntax and can be set with an optional argument. This is currently only read once during startup. Continuous updates could be added in a follow-up PR.

Both aggregator and publisher return a 403 (Forbidden) message for blocked IDs.

The functionality is added to the `Client`, so it would also work for the CLI `store` and `read`. However, I don't really see a need for this and thus haven't implemented it.

Depends on #529 
Closes #505 