### PR TITLE
fix(client): limit the number of connections dependent on the blob size

### DIFF
--- a/crates/walrus-core/src/encoding/config.rs
+++ b/crates/walrus-core/src/encoding/config.rs
@@ -239,7 +239,8 @@ impl EncodingConfig {
 
     /// The size (in bytes) of a sliver corresponding to a blob of size `blob_size`.
     ///
-    /// Returns `None` if `blob_size == 0` or `blob_size > self.max_blob_size()`.
+    /// Returns an [`InvalidDataSizeError`] if `blob_size == 0` or `blob_size >
+    /// self.max_blob_size()`.
     #[inline]
     pub fn sliver_size_for_blob<T: EncodingAxis>(
         &self,

--- a/crates/walrus-sdk/src/client.rs
+++ b/crates/walrus-sdk/src/client.rs
@@ -367,6 +367,7 @@ impl Client {
         fields(
             walrus.blob_id = %blob_id,
             walrus.sliver.pair_index = %pair_index,
+            walrus.sliver.type_ = %A::NAME,
         ),
         err(level = Level::DEBUG)
     )]
@@ -376,6 +377,7 @@ impl Client {
         pair_index: SliverPairIndex,
         sliver: &Sliver<A>,
     ) -> Result<(), NodeError> {
+        tracing::trace!("starting to store sliver");
         let (url, template) = self.endpoints.sliver::<A>(blob_id, pair_index);
         let request = self.create_request_with_payload(Method::PUT, url, &sliver)?;
         self.send_and_parse_service_response::<String>(request, template)

--- a/crates/walrus-service/example-client-config.yaml
+++ b/crates/walrus-service/example-client-config.yaml
@@ -7,8 +7,9 @@ system_object: 0xd6f0cacdb8b365cdda24ab954a32ebc86f8b8a1707322b4cc0ba54dcbbbc577
 # communication_config:
 #   max_concurrent_writes: null
 #   max_concurrent_sliver_reads: null
-#   max_concurrent_metadata_reads: 3
+#   max_concurrent_metadata_reads: null
 #   max_concurrent_status_reads: null
+#   max_data_in_flight: null
 #   reqwest_config:
 #     total_timeout:
 #       secs: 180


### PR DESCRIPTION
This adds a added a `max_data_in_flight` config parameter with a default of 100 Mb = 12.5 MB and limits the number of connections for storing and reading slivers such that their total amount of data does not exceed that maximum.

It also decreases the default timeout to limit the impact of Byzantine nodes.

Requires some documentation changes. There we can also emphasize that the communication config may not work well for large blobs with very bad networking.

Closes #556 