### PR TITLE
refactor: continue event indices on start

### DIFF
--- a/crates/walrus-service/src/storage/event_cursor_table.rs
+++ b/crates/walrus-service/src/storage/event_cursor_table.rs
@@ -48,10 +48,16 @@ impl EventCursorTable {
             &ReadWriteOptions::default(),
         )?;
 
-        Ok(Self {
+        let this = Self {
             inner,
-            event_queue: Arc::new(Mutex::new(EventSequencer::default())),
-        })
+            event_queue: Arc::default(),
+        };
+
+        let next_index = this.get_sequentially_processed_event_count()?;
+        *this.event_queue.lock().unwrap() =
+            EventSequencer::continue_from(next_index.try_into().expect("64-bit architecture"));
+
+        Ok(this)
     }
 
     pub fn options(config: &DatabaseConfig) -> (&'static str, Options) {

--- a/crates/walrus-service/src/storage/event_sequencer.rs
+++ b/crates/walrus-service/src/storage/event_sequencer.rs
@@ -25,6 +25,14 @@ impl EventSequencer {
         Self::default()
     }
 
+    /// Creates a new `EventSequencer`, that continues sequencing from the provided next index.
+    pub fn continue_from(next_index: usize) -> Self {
+        Self {
+            head_index: next_index,
+            ..Self::default()
+        }
+    }
+
     /// Adds the provided (index, EventID) pair to those observed.
     ///
     /// # Panics


### PR DESCRIPTION
Refactor the storage node to load the last processed event index from storage, and continue its event counter from that value. This will enable globally mapping the event index to the cursor being processed.