### PR TITLE
feat: resolve `~` to home directory in paths

### DIFF
--- a/crates/walrus-orchestrator/src/settings.rs
+++ b/crates/walrus-orchestrator/src/settings.rs
@@ -64,7 +64,7 @@ pub enum CloudProvider {
     Vultr,
 }
 
-/// The testbed settings. Those are topically specified in a file.
+/// The testbed settings. Those are typically specified in a file.
 #[serde_as]
 #[derive(Serialize, Deserialize, Clone, Default)]
 pub struct Settings {
@@ -77,10 +77,14 @@ pub struct Settings {
     #[serde(skip_serializing)]
     pub token_file: PathBuf,
     /// The ssh private key to access the instances.
-    #[serde(skip_serializing)]
+    #[serde(
+        skip_serializing,
+        deserialize_with = "walrus_service::utils::resolve_home_dir"
+    )]
     pub ssh_private_key_file: PathBuf,
     /// The corresponding ssh public key registered on the instances. If not specified. the
     /// public key defaults the same path as the private key with an added extension 'pub'.
+    #[serde(deserialize_with = "walrus_service::utils::resolve_home_dir_option")]
     pub ssh_public_key_file: Option<PathBuf>,
     /// The list of cloud provider regions to deploy the testbed.
     pub regions: Vec<String>,

--- a/crates/walrus-service/bin/client.rs
+++ b/crates/walrus-service/bin/client.rs
@@ -61,7 +61,10 @@ struct App {
     /// If an invalid path is specified through this option, an error is returned.
     // NB: Keep this in sync with `walrus_service::cli_utils`.
     #[clap(short, long, verbatim_doc_comment)]
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "walrus_service::utils::resolve_home_dir_option"
+    )]
     config: Option<PathBuf>,
     /// The path to the Sui wallet configuration file.
     ///
@@ -76,7 +79,10 @@ struct App {
     /// is returned.
     // NB: Keep this in sync with `walrus_service::cli_utils`.
     #[clap(short, long, verbatim_doc_comment)]
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "walrus_service::utils::resolve_home_dir_option"
+    )]
     wallet: Option<PathBuf>,
     /// The gas budget for transactions.
     #[clap(short, long, default_value_t = default::gas_budget())]
@@ -101,6 +107,7 @@ enum Commands {
     #[clap(alias("write"))]
     Store {
         /// The file containing the blob to be published to Walrus.
+        #[serde(deserialize_with = "walrus_service::utils::resolve_home_dir")]
         file: PathBuf,
         /// The number of epochs ahead for which to store the blob.
         #[clap(short, long, default_value_t = default::epochs())]
@@ -123,7 +130,10 @@ enum Commands {
         ///
         /// If unset, prints the blob to stdout.
         #[clap(short, long)]
-        #[serde(default)]
+        #[serde(
+            default,
+            deserialize_with = "walrus_service::utils::resolve_home_dir_option"
+        )]
         out: Option<PathBuf>,
         #[clap(flatten)]
         #[serde(flatten)]
@@ -221,6 +231,7 @@ enum Commands {
     /// Encode the specified file to obtain its blob ID.
     BlobId {
         /// The file containing the blob for which to compute the blob ID.
+        #[serde(deserialize_with = "walrus_service::utils::resolve_home_dir")]
         file: PathBuf,
         /// The number of shards for which to compute the blob ID.
         ///
@@ -268,7 +279,10 @@ struct DaemonArgs {
     bind_address: SocketAddr,
     /// Path to a blocklist file containing a list (in YAML syntax) of blocked blob IDs.
     #[clap(long)]
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "walrus_service::utils::resolve_home_dir_option"
+    )]
     blocklist: Option<PathBuf>,
 }
 

--- a/crates/walrus-service/src/client/config.rs
+++ b/crates/walrus-service/src/client/config.rs
@@ -7,7 +7,7 @@ use reqwest::ClientBuilder;
 use serde::{Deserialize, Serialize};
 use sui_types::base_types::ObjectID;
 
-use crate::config::LoadConfig;
+use crate::{config::LoadConfig, utils};
 
 /// Config for the client.
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -15,7 +15,7 @@ pub struct Config {
     /// The Walrus system object ID.
     pub system_object: ObjectID,
     /// Path to the wallet configuration.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "utils::resolve_home_dir_option")]
     pub wallet_config: Option<PathBuf>,
     /// Configuration for the client's network communication.
     #[serde(default)]

--- a/crates/walrus-service/src/config.rs
+++ b/crates/walrus-service/src/config.rs
@@ -24,7 +24,7 @@ use sui_sdk::types::base_types::ObjectID;
 use walrus_core::keys::{ProtocolKeyPair, ProtocolKeyPairParseError};
 use walrus_sui::{types::NetworkAddress, utils::SuiNetwork};
 
-use crate::storage::DatabaseConfig;
+use crate::{storage::DatabaseConfig, utils};
 
 /// Trait for loading configuration from a YAML file.
 pub trait LoadConfig: DeserializeOwned {
@@ -45,6 +45,7 @@ pub trait LoadConfig: DeserializeOwned {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct StorageNodeConfig {
     /// Directory in which to persist the database
+    #[serde(deserialize_with = "utils::resolve_home_dir")]
     pub storage_path: PathBuf,
     /// Option config to tune storage db
     pub db_config: Option<DatabaseConfig>,
@@ -145,6 +146,7 @@ pub struct SuiConfig {
     )]
     pub event_polling_interval: Duration,
     /// Location of the wallet config.
+    #[serde(deserialize_with = "utils::resolve_home_dir")]
     pub wallet_config: PathBuf,
     /// Gas budget for transactions.
     #[serde(default = "defaults::gas_budget")]
@@ -239,7 +241,7 @@ pub enum PathOrInPlace<T> {
     /// A value that is not present in the config, but at a path on the filesystem.
     Path {
         /// The path from which the value can be loaded.
-        #[serde(rename = "path")]
+        #[serde(rename = "path", deserialize_with = "utils::resolve_home_dir")]
         path: PathBuf,
         /// The value loaded from the specified path.
         #[serde(skip, default = "Option::default")]

--- a/crates/walrus-service/src/lib.rs
+++ b/crates/walrus-service/src/lib.rs
@@ -12,7 +12,7 @@ pub mod daemon;
 pub mod server;
 pub mod system_events;
 pub mod testbed;
-pub(crate) mod utils;
+pub mod utils;
 
 mod node;
 pub use node::{StorageNode, StorageNodeBuilder};


### PR DESCRIPTION
So far, this only worked in direct CLI options where it is expanded by the shell. With this change, it also works for the JSON API and for paths in config files.

For example, one can now set a wallet config path in the `client_config.yaml` as follows:

```yaml
wallet_config: ~/.sui/sui_config/client.yaml
```

Also, the following JSON API example now works, which didn't before:

```sh
walrus json '{
    "config": "~/.walrus/client_config.yaml",
    "command": {"blobId": {"file": "~/.walrus/client_config.yaml"}}
}'
```

The `~` is only replaced if it occurs as a directory at the beginning of paths.