### PR TITLE
feat(client): add version option

### DIFF
--- a/crates/walrus-core/src/utils.rs
+++ b/crates/walrus-core/src/utils.rs
@@ -15,6 +15,14 @@ use alloc::{
 /// then consider including that crate.
 ///
 /// [const_str]: https://docs.rs/const-str/latest/const_str/
+///
+/// # Examples
+///
+/// ```
+/// # use walrus_core::concat_const_str;
+/// #
+/// assert_eq!(concat_const_str!("1", "2", "3"), "123");
+/// ```
 #[macro_export]
 macro_rules! concat_const_str {
     ($($str:expr),+ $(,)?) => {{
@@ -33,9 +41,9 @@ macro_rules! concat_const_str {
             let mut output = [0u8; OUTPUT_LENGTH];
             let mut output_index = 0;
             let mut str_index = 0;
-            let mut byte_index = 0;
 
             while str_index < STRS.len() {
+                let mut byte_index = 0;
                 let current_bytes = STRS[str_index].as_bytes();
                 while byte_index < current_bytes.len() {
                     output[output_index] = current_bytes[byte_index];

--- a/crates/walrus-service/bin/client.rs
+++ b/crates/walrus-service/bin/client.rs
@@ -39,6 +39,7 @@ use walrus_service::{
         success,
         HumanReadableBytes,
         HumanReadableMist,
+        VERSION,
     },
     client::{BlobStoreResult, Client},
     daemon::ClientDaemon,
@@ -47,6 +48,8 @@ use walrus_sui::client::ReadClient;
 
 #[derive(Parser, Debug, Clone, Deserialize)]
 #[command(author, version, about = "Walrus client", long_about = None)]
+#[clap(name = env!("CARGO_BIN_NAME"))]
+#[clap(version = VERSION)]
 #[clap(rename_all = "kebab-case")]
 #[serde(rename_all = "camelCase")]
 struct App {

--- a/crates/walrus-service/bin/node.rs
+++ b/crates/walrus-service/bin/node.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+
 //! Walrus Storage Node entry point.
 
 use std::{
@@ -24,6 +25,7 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 use walrus_core::keys::ProtocolKeyPair;
 use walrus_service::{
+    cli_utils::VERSION,
     config::{
         defaults::{METRICS_PORT, REST_API_PORT},
         LoadConfig,
@@ -34,22 +36,6 @@ use walrus_service::{
     StorageNode,
 };
 use walrus_sui::utils::SuiNetwork;
-
-const GIT_REVISION: &str = {
-    if let Some(revision) = option_env!("GIT_REVISION") {
-        revision
-    } else {
-        let version = git_version::git_version!(
-            args = ["--always", "--abbrev=12", "--dirty", "--exclude", "*"],
-            fallback = ""
-        );
-        if version.is_empty() {
-            panic!("unable to query git revision");
-        }
-        version
-    }
-};
-const VERSION: &str = walrus_core::concat_const_str!(env!("CARGO_PKG_VERSION"), "-", GIT_REVISION);
 
 #[derive(Parser)]
 #[clap(rename_all = "kebab-case")]

--- a/crates/walrus-service/src/cli_utils.rs
+++ b/crates/walrus-service/src/cli_utils.rs
@@ -33,6 +33,25 @@ use walrus_sui::{
 
 use crate::client::{default_configuration_paths, string_prefix, Blocklist, Client, Config};
 
+/// The Git revision obtained through `git describe` at compile time.
+pub const GIT_REVISION: &str = {
+    if let Some(revision) = option_env!("GIT_REVISION") {
+        revision
+    } else {
+        let version = git_version::git_version!(
+            args = ["--always", "--abbrev=12", "--dirty", "--exclude", "*"],
+            fallback = ""
+        );
+        if version.is_empty() {
+            panic!("unable to query git revision");
+        }
+        version
+    }
+};
+/// The version consisting of the package version and git revision.
+pub const VERSION: &str =
+    walrus_core::concat_const_str!(env!("CARGO_PKG_VERSION"), "-", GIT_REVISION);
+
 /// Default URL of the testnet RPC node.
 pub const TESTNET_RPC: &str = "https://fullnode.testnet.sui.io:443";
 /// Default RPC URL to connect to if none is specified explicitly or in the wallet config.


### PR DESCRIPTION
Also fix version output for `walrus-node`.

Closes #526 