### PR TITLE
fix: Update README.md to move from sui-test-binary to sui start

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ client](#using-the-walrus-client) and prints the path to that configuration file
 
 Note that while the Walrus storage nodes of this testbed run on your local machine, the Sui devnet
 is used by default to deploy and interact with the contracts. To run the testbed fully locally, simply
-[start a local network with: `sui start --with-faucet --force-regenesis`](https://docs.sui.io/guides/developer/getting-started/local-network)
-and specify `localnet` when starting the Walrus testbed.
+[start a local network with `sui start --with-faucet --force-regenesis`](https://docs.sui.io/guides/developer/getting-started/local-network)
+(requires `sui` to be v1.28.0 or higher) and specify `localnet` when starting the Walrus testbed.
 
 ## Hardware requirements
 


### PR DESCRIPTION
[PR #18204 ](https://github.com/mystenLabs/sui/pull/18204) in main sui repository has integrated `sui-test-validator` into `sui start`. That binary will soon be deprecated, so this PR updates the README file to correctly point on how to use `sui start` instead of `sui-test-validator`.