### PR TITLE
feat(client): make reserve and register atomic

### DIFF
--- a/crates/walrus-core/src/metadata.rs
+++ b/crates/walrus-core/src/metadata.rs
@@ -11,7 +11,13 @@ use fastcrypto::hash::{Blake2b256, HashFunction};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    encoding::{source_symbols_for_n_shards, DataTooLargeError, EncodingAxis, EncodingConfig},
+    encoding::{
+        encoded_blob_length_for_n_shards,
+        source_symbols_for_n_shards,
+        DataTooLargeError,
+        EncodingAxis,
+        EncodingConfig,
+    },
     merkle::{MerkleTree, Node as MerkleNode, DIGEST_LEN},
     BlobId,
     EncodingType,
@@ -223,6 +229,18 @@ impl BlobMetadata {
         encoding_config: &EncodingConfig,
     ) -> Result<NonZeroU16, DataTooLargeError> {
         encoding_config.symbol_size_for_blob_from_nonzero(self.unencoded_length)
+    }
+
+    /// Returns the encoded size of the blob.
+    ///
+    /// This infers the number of shards from the length of the `hashes` vector.
+    ///
+    /// Returns `None` if `hashes.len()` is not between `1` and `u16::MAX` or if the `unencoded_length` cannot be encoded
+    pub fn encoded_size(&self) -> Option<u64> {
+        encoded_blob_length_for_n_shards(
+            NonZeroU16::new(self.hashes.len().try_into().ok()?)?,
+            self.unencoded_length.get(),
+        )
     }
 }
 

--- a/crates/walrus-service/bin/client.rs
+++ b/crates/walrus-service/bin/client.rs
@@ -35,7 +35,6 @@ use walrus_service::{
         get_sui_read_client_from_rpc_node_or_wallet,
         load_configuration,
         load_wallet_context,
-        price_for_encoded_length,
         print_walrus_info,
         read_blob_from_file,
         success,
@@ -46,7 +45,10 @@ use walrus_service::{
     client::{BlobStoreResult, Client},
     daemon::ClientDaemon,
 };
-use walrus_sui::client::{ContractClient, ReadClient};
+use walrus_sui::{
+    client::{ContractClient, ReadClient},
+    utils::price_for_encoded_length,
+};
 
 #[derive(Parser, Debug, Clone, Deserialize)]
 #[command(author, version, about = "Walrus client", long_about = None)]

--- a/crates/walrus-service/src/cli_utils.rs
+++ b/crates/walrus-service/src/cli_utils.rs
@@ -6,7 +6,6 @@
 use std::{
     fmt::{self, Display},
     fs,
-    num::NonZeroU16,
     path::{Path, PathBuf},
 };
 
@@ -29,7 +28,7 @@ use walrus_core::{
 };
 use walrus_sui::{
     client::{ReadClient, SuiContractClient, SuiReadClient},
-    utils::{storage_units_from_size, BYTES_PER_UNIT_SIZE},
+    utils::{price_for_unencoded_length, storage_units_from_size, BYTES_PER_UNIT_SIZE},
 };
 
 use crate::client::{default_configuration_paths, string_prefix, Blocklist, Client, Config};
@@ -288,22 +287,6 @@ impl Display for HumanReadableMist {
         let sui = mist_to_sui(value);
         write!(f, "{sui:.digits$} SUI",)
     }
-}
-
-/// Computes the price in MIST given the unencoded blob size.
-pub fn price_for_unencoded_length(
-    unencoded_length: u64,
-    n_shards: NonZeroU16,
-    price_per_unit_size: u64,
-    epochs: u64,
-) -> Option<u64> {
-    encoded_blob_length_for_n_shards(n_shards, unencoded_length)
-        .map(|encoded_length| price_for_encoded_length(encoded_length, price_per_unit_size, epochs))
-}
-
-/// Computes the price in MIST given the encoded blob size.
-pub fn price_for_encoded_length(encoded_length: u64, price_per_unit_size: u64, epochs: u64) -> u64 {
-    storage_units_from_size(encoded_length) * price_per_unit_size * epochs
 }
 
 fn mist_to_sui(mist: u64) -> f64 {

--- a/crates/walrus-service/tests/test_client.rs
+++ b/crates/walrus-service/tests/test_client.rs
@@ -154,7 +154,7 @@ async fn test_inconsistency(failed_shards: &[usize]) -> anyhow::Result<()> {
     // Register blob.
     let blob_sui_object = client
         .as_ref()
-        .reserve_blob(&metadata, blob.len(), 1)
+        .reserve_and_register_blob(&metadata, 1)
         .await?;
 
     // Wait to ensure that the storage nodes received the registration event.

--- a/crates/walrus-simtest/tests/simtest.rs
+++ b/crates/walrus-simtest/tests/simtest.rs
@@ -9,6 +9,7 @@ use walrus_service::{client::BlobStoreResult, test_cluster};
 // Tests that we can create a Walrus cluster with a Sui cluster and running basic
 // operations deterministically.
 #[sim_test(check_determinism)]
+#[ignore = "ignore simtests by default"]
 async fn test_walrus_basic_determinism() {
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
         // TODO: remove once Sui simtest can work with these features.

--- a/crates/walrus-stress/src/generator/write_client.rs
+++ b/crates/walrus-stress/src/generator/write_client.rs
@@ -127,7 +127,7 @@ impl WriteClient {
         let blob_sui_object = self
             .client
             .as_ref()
-            .reserve_blob(&metadata, blob.len(), epochs)
+            .reserve_and_register_blob(&metadata, epochs)
             .await?;
 
         // Wait to ensure that the storage nodes received the registration event.

--- a/crates/walrus-sui/src/contracts.rs
+++ b/crates/walrus-sui/src/contracts.rs
@@ -3,7 +3,6 @@
 
 //! Walrus contract bindings. Provides an interface for looking up contract function,
 //! modules, and type names.
-//!
 
 use anyhow::{Context, Result};
 use move_core_types::{identifier::Identifier, language_storage::StructTag as MoveStructTag};
@@ -18,29 +17,29 @@ use sui_types::TypeTag;
 /// Implementors of this trait are convertible from [SuiMoveStruct]s and can
 /// identify their associated contract type.
 pub trait AssociatedContractStruct: TryFrom<SuiMoveStruct> {
-    /// [`StructTag`] corresponding to the move struct associated type
+    /// [`StructTag`] corresponding to the Move struct associated type.
     const CONTRACT_STRUCT: StructTag<'static>;
 }
 
-/// A trait for types that correspond to a sui event.
+/// A trait for types that correspond to a Sui event.
 ///
 /// Implementors of this trait are convertible from [SuiEvent]s and can
 /// identify their associated contract type.
 pub trait AssociatedSuiEvent: TryFrom<SuiEvent> {
-    /// [`StructTag`] corresponding to the move struct of the associated event
+    /// [`StructTag`] corresponding to the Move struct of the associated event.
     const EVENT_STRUCT: StructTag<'static>;
 }
 
 /// Tag identifying contract functions based on their name and module.
 #[derive(Debug)]
 pub struct FunctionTag<'a> {
-    /// Move function name
+    /// Move function name.
     pub name: &'a str,
-    /// Move module of the function
+    /// Move module of the function.
     pub module: &'a str,
-    /// Type parameters of the function
+    /// Type parameters of the function.
     pub type_params: Vec<TypeTag>,
-    /// Number of sui objects that are outputs of the function
+    /// Number of Sui objects that are outputs of the function.
     pub n_object_outputs: u16,
 }
 
@@ -57,14 +56,14 @@ impl<'a> FunctionTag<'a> {
 /// Tag identifying contract structs based on their name and module.
 #[derive(Debug, PartialEq, Eq)]
 pub struct StructTag<'a> {
-    /// Move struct name
+    /// Move struct name.
     pub name: &'a str,
-    /// Move module of the struct
+    /// Move module of the struct.
     pub module: &'a str,
 }
 
 impl<'a> StructTag<'a> {
-    /// Return a Move StructTag for the identified struct, within the published contract module.
+    /// Returns a Move StructTag for the identified struct, within the published contract module.
     pub fn to_move_struct_tag(
         &self,
         package: ObjectID,
@@ -95,7 +94,7 @@ impl<'a> From<&'a MoveStructTag> for StructTag<'a> {
 macro_rules! contract_ident {
     (struct $modname:ident::$itemname:ident) => {
         #[allow(non_upper_case_globals)]
-        #[doc=stringify!([StructTag] for the move struct $modname::$itemname)]
+        #[doc=stringify!([StructTag] for the Move struct $modname::$itemname)]
         pub const $itemname: StructTag = StructTag {
             module: stringify!($modname),
             name: stringify!($itemname),
@@ -106,7 +105,7 @@ macro_rules! contract_ident {
     };
     (fn $modname:ident::$itemname:ident, $n_out:expr) => {
         #[allow(non_upper_case_globals)]
-        #[doc=stringify!([FunctionTag] for the move function $modname::$itemname)]
+        #[doc=stringify!([FunctionTag] for the Move function $modname::$itemname)]
         pub const $itemname: FunctionTag = FunctionTag {
             module: stringify!($modname),
             name: stringify!($itemname),
@@ -116,7 +115,7 @@ macro_rules! contract_ident {
     };
 }
 
-/// Module for tags corresponding to the move module `storage_resource`
+/// Module for tags corresponding to the Move module `storage_resource`.
 pub mod storage_resource {
     use super::*;
 
@@ -128,7 +127,7 @@ pub mod storage_resource {
     contract_ident!(struct storage_resource::Storage);
 }
 
-/// Module for tags corresponding to the move module `system`
+/// Module for tags corresponding to the Move module `system`.
 pub mod system {
     use super::*;
 
@@ -138,14 +137,14 @@ pub mod system {
     contract_ident!(fn system::invalidate_blob_id);
 }
 
-/// Module for tags corresponding to the move module `committee`
+/// Module for tags corresponding to the Move module `committee`.
 pub mod committee {
     use super::*;
 
     contract_ident!(struct committee::Committee);
 }
 
-/// Module for tags corresponding to the move module `storage_node`
+/// Module for tags corresponding to the Move module `storage_node`.
 pub mod storage_node {
     use super::*;
 
@@ -153,7 +152,7 @@ pub mod storage_node {
     contract_ident!(fn storage_node::create_storage_node_info, 1);
 }
 
-/// Module for tags corresponding to the move module `blob`
+/// Module for tags corresponding to the Move module `blob`.
 pub mod blob {
     use super::*;
 
@@ -162,7 +161,7 @@ pub mod blob {
     contract_ident!(struct blob::Blob);
 }
 
-/// Module for tags corresponding to the move module `blob_events`
+/// Module for tags corresponding to the Move module `blob_events`.
 pub mod blob_events {
     use super::*;
 

--- a/crates/walrus-sui/tests/test_walrus_sui.rs
+++ b/crates/walrus-sui/tests/test_walrus_sui.rs
@@ -63,8 +63,8 @@ async fn test_register_certify_blob() -> anyhow::Result<()> {
         .blob_events(polling_duration, None)
         .await?;
 
-    let size = 10_000;
-    let resource_size = encoding_config.encoded_blob_length(size).unwrap();
+    let size = NonZeroU64::new(10_000).unwrap();
+    let resource_size = encoding_config.encoded_blob_length(size.get()).unwrap();
     let storage_resource = walrus_client
         .as_ref()
         .reserve_space(resource_size, 3)
@@ -80,11 +80,7 @@ async fn test_register_certify_blob() -> anyhow::Result<()> {
         1, 2, 3, 4, 5, 6, 7, 8,
     ];
 
-    let blob_id = BlobId::from_metadata(
-        Node::from(root_hash),
-        EncodingType::RedStuff,
-        NonZeroU64::new(size).unwrap(),
-    );
+    let blob_id = BlobId::from_metadata(Node::from(root_hash), EncodingType::RedStuff, size);
     let blob_obj = walrus_client
         .as_ref()
         .register_blob(
@@ -96,7 +92,7 @@ async fn test_register_certify_blob() -> anyhow::Result<()> {
         )
         .await?;
     assert_eq!(blob_obj.blob_id, blob_id);
-    assert_eq!(blob_obj.size, size);
+    assert_eq!(blob_obj.size, size.get());
     assert_eq!(blob_obj.certified_epoch, None);
     assert_eq!(blob_obj.storage, storage_resource);
     assert_eq!(blob_obj.stored_epoch, 0);
@@ -159,11 +155,7 @@ async fn test_register_certify_blob() -> anyhow::Result<()> {
         1, 2, 3, 4, 5, 6, 7, 0,
         1, 2, 3, 4, 5, 6, 7, 0,
     ];
-    let blob_id = BlobId::from_metadata(
-        Node::from(root_hash),
-        EncodingType::RedStuff,
-        NonZeroU64::new(size).unwrap(),
-    );
+    let blob_id = BlobId::from_metadata(Node::from(root_hash), EncodingType::RedStuff, size);
 
     let blob_obj = walrus_client
         .as_ref()


### PR DESCRIPTION
The main change is the new
`walrus_sui::client::ContractClient::reserve_and_register_blob` method, which is used in `walrus_service::client`. The implementation of this in `SuiContractClient` is accompanied with some refactoring of the contract calls.

Besides this main change, this commit contains the following changes:
- more useful error messages for empty blobs and missing gas coin
- move price computations from `walrus_service::cli_utils` to `walrus_sui::utils`
- ignore simtest by default
- improve some docstrings

Closes #587

Related to #565, #581