### PR TITLE
feat(client): improved default config paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4527,6 +4527,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12063,6 +12072,7 @@ dependencies = [
  "home",
  "humantime",
  "indoc",
+ "itertools 0.13.0",
  "mime",
  "mockall 0.12.1",
  "mysten-metrics",

--- a/crates/walrus-core/src/lib.rs
+++ b/crates/walrus-core/src/lib.rs
@@ -67,7 +67,7 @@ pub type Epoch = u64;
 // Schema definition for the type alias used in OpenAPI schemas.
 #[derive(Debug)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[schema(as = Epoch)]
+#[cfg_attr(feature = "utoipa", schema(as = Epoch))]
 #[allow(dead_code)]
 pub struct EpochSchema(u64);
 

--- a/crates/walrus-service/Cargo.toml
+++ b/crates/walrus-service/Cargo.toml
@@ -24,6 +24,7 @@ git-version = "0.3.9"
 home = "0.5.9"
 humantime = "2.1.0"
 indoc = "2.0.5"
+itertools = "0.13.0"
 mime.workspace = true
 mysten-metrics.workspace = true
 opentelemetry.workspace = true

--- a/crates/walrus-service/bin/client.rs
+++ b/crates/walrus-service/bin/client.rs
@@ -57,15 +57,18 @@ use walrus_sui::{
 #[clap(rename_all = "kebab-case")]
 #[serde(rename_all = "camelCase")]
 struct App {
-    /// The path to the wallet configuration file.
+    /// The path to the Walrus configuration file.
     ///
-    /// The Walrus configuration is taken from the following locations:
+    /// If a path is specified through this option, the CLI attempts to read the specified file and
+    /// returns an error if the path is invalid.
     ///
-    /// 1. From this configuration parameter, if set.
-    /// 2. From `./client_config.yaml`.
-    /// 3. From `~/.walrus/client_config.yaml`.
+    /// If no path is specified explicitly, the CLI looks for `client_config.yaml` or
+    /// `client_config.yml` in the following locations (in order):
     ///
-    /// If an invalid path is specified through this option, an error is returned.
+    /// 1. The current working directory (`./`).
+    /// 2. If the environment variable `XDG_CONFIG_HOME` is set, in `$XDG_CONFIG_HOME/walrus/`.
+    /// 3. In `~/.config/walrus/`.
+    /// 4. In `~/.walrus/`.
     // NB: Keep this in sync with `walrus_service::cli_utils`.
     #[clap(short, long, verbatim_doc_comment)]
     #[serde(

--- a/crates/walrus-service/src/cli_utils.rs
+++ b/crates/walrus-service/src/cli_utils.rs
@@ -46,6 +46,7 @@ pub const DEFAULT_RPC_URL: &str = TESTNET_RPC;
 
 /// Returns the path if it is `Some` or any of the default paths if they exist (attempt in order).
 pub fn path_or_defaults_if_exist(path: &Option<PathBuf>, defaults: &[PathBuf]) -> Option<PathBuf> {
+    tracing::debug!(?path, ?defaults, "looking for configuration file");
     let mut path = path.clone();
     for default in defaults {
         if path.is_some() {


### PR DESCRIPTION
Look for the client configuration file also in
`$XDG_CONFIG_HOME/walrus/` (if the variable is set) and `~/.config/walrus/`.

Also support `client_config.yml` in addition to `client_config.yaml`.

Closes #534