### PR TITLE
feat: checkpoint based event processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anstyle-parse"
@@ -1566,9 +1566,9 @@ checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "bytemuck"
-version = "1.16.3"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "102087e286b4677862ea56cf8fc58bb2cdfa8725c40ffb80fe3a008eb7f2fc83"
+checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
 
 [[package]]
 name = "byteorder"
@@ -1578,9 +1578,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 dependencies = [
  "serde",
 ]
@@ -1748,7 +1748,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1801,9 +1801,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.13"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fbb260a053428790f3de475e304ff84cdbc4face759ea7a3e64c1edd938a7fc"
+checksum = "11d8838454fda655dafd3accb2b6e2bea645b9e4078abe84a22ceb947235c5cc"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1811,9 +1811,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.13"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64b17d7ea74e9f833c7dbf2cbe4fb12ff26783eda4782a8975b72f895c9b4d99"
+checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2261,7 +2261,7 @@ checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags 2.5.0",
  "crossterm_winapi",
- "mio 1.0.1",
+ "mio 1.0.2",
  "parking_lot 0.12.1",
  "rustix",
  "signal-hook",
@@ -4819,7 +4819,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5040,9 +5040,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -7046,9 +7046,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.11"
+version = "2.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95"
+checksum = "311fb059dee1a7b802f036316d790138c613a4e8b180c822e3925a662e9f0c95"
 dependencies = [
  "memchr",
  "thiserror",
@@ -7057,9 +7057,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.11"
+version = "2.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a548d2beca6773b1c244554d36fcf8548a8a58e74156968211567250e48e49a"
+checksum = "f73541b156d32197eecda1a4014d7f868fd2bcb3c550d5386087cfba442bf69c"
 dependencies = [
  "pest",
  "pest_generator",
@@ -7067,9 +7067,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.11"
+version = "2.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c93a82e8d145725dcbaf44e5ea887c8a869efdcc28706df2d08c69e17077183"
+checksum = "c35eeed0a3fab112f75165fdc026b3913f4183133f19b49be773ac9ea966e8bd"
 dependencies = [
  "pest",
  "pest_meta",
@@ -7080,9 +7080,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.11"
+version = "2.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a941429fea7e08bedec25e4f6785b6ffaacc6b755da98df5ef3e7dcf4a124c4f"
+checksum = "2adbf29bb9776f28caece835398781ab24435585fe0d4dc1374a61db5accedca"
 dependencies = [
  "once_cell",
  "pest",
@@ -7971,9 +7971,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -8644,6 +8644,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_as"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee4afe4c5c3b69699c4267ae42b838e911466d7ca0005046adc93ac95bb16dd"
+
+[[package]]
 name = "serde_bytes"
 version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8676,9 +8682,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.122"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
+checksum = "66ad62847a56b3dba58cc891acd13884b9c61138d330c0d7b6181713d4fce38d"
 dependencies = [
  "indexmap 2.2.6",
  "itoa",
@@ -8936,7 +8942,7 @@ checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
 dependencies = [
  "libc",
  "mio 0.8.11",
- "mio 1.0.1",
+ "mio 1.0.2",
  "signal-hook",
 ]
 
@@ -10756,15 +10762,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.11.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fcd239983515c23a32fb82099f97d0b11b8c72f654ed659363a95c3dad7a53"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
  "fastrand",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11941,6 +11947,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "walrus-event"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bcs",
+ "move-core-types",
+ "rocksdb",
+ "serde",
+ "serde_as",
+ "serde_json",
+ "serde_with 2.3.3",
+ "sui-config",
+ "sui-json-rpc-types",
+ "sui-package-resolver",
+ "sui-rest-api",
+ "sui-sdk 1.30.1",
+ "sui-storage",
+ "sui-types",
+ "tempfile",
+ "tokio",
+ "tokio-stream",
+ "tokio-util 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typed-store",
+]
+
+[[package]]
 name = "walrus-orchestrator"
 version = "0.1.0"
 dependencies = [
@@ -12345,7 +12378,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -12363,7 +12396,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -12383,18 +12425,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -12405,9 +12447,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -12417,9 +12459,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -12429,15 +12471,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -12447,9 +12489,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -12459,9 +12501,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -12471,9 +12513,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -12483,9 +12525,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,16 @@ serde_test = "1.0.176"
 serde_with = { version = "3.9", features = ["base64"] }
 serde_yaml = "0.9"
 sui-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.30.1" }
+sui-json-rpc-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.30.1" }
 sui-keys = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.30.1" }
 sui-macros = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.30.1" }
 sui-move-build = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.30.1" }
+sui-package-resolver = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.30.1" }
 sui-protocol-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.30.1" }
+sui-rest-api = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.30.1" }
 sui-sdk = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.30.1" }
 sui-simulator = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.30.1" }
+sui-storage = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.30.1" }
 sui-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.30.1" }
 telemetry-subscribers = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.30.1" }
 tempfile = "3.11.0"
@@ -72,6 +76,7 @@ typed-store = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.30.
 utoipa = { version = "4.2.3" }
 utoipa-redoc = { version = "4.0.0", features = ["axum"] }
 walrus-core = { path = "crates/walrus-core" }
+walrus-event = { path = "crates/walrus-event" }
 walrus-sdk = { path = "crates/walrus-sdk" }
 walrus-service = { path = "crates/walrus-service" }
 walrus-sui = { path = "crates/walrus-sui" }

--- a/crates/walrus-event/Cargo.toml
+++ b/crates/walrus-event/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "walrus-event"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+async-trait = "0.1.81"
+bcs.workspace = true
+move-core-types.workspace = true
+rocksdb.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_as = "0.0.1"
+serde_json = "1.0.120"
+serde_with = "2.3.3"
+sui-config.workspace = true
+sui-json-rpc-types = { workspace = true, features = ["test-utils"] }
+sui-package-resolver.workspace = true
+sui-rest-api.workspace = true
+sui-sdk.workspace = true
+sui-storage.workspace = true
+sui-types = { workspace = true, features = ["test-utils"] }
+tempfile = { workspace = true, optional = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tokio-stream.workspace = true
+tokio-util.workspace = true
+typed-store.workspace = true
+
+[features]
+default = ["test-utils"]
+test-utils = ["dep:tempfile"]

--- a/crates/walrus-event/src/checkpoint_processor.rs
+++ b/crates/walrus-event/src/checkpoint_processor.rs
@@ -1,0 +1,543 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use std::{path::PathBuf, sync::Arc, time::Duration};
+
+use anyhow::{anyhow, bail, Result};
+use async_trait::async_trait;
+use move_core_types::annotated_value::{MoveDatatypeLayout, MoveTypeLayout};
+use rocksdb::Options;
+use serde::{Deserialize, Serialize};
+use sui_config::genesis::Genesis;
+use sui_package_resolver::{error::Error as PackageResolverError, Package, PackageStore, Resolver};
+use sui_rest_api::Client;
+use sui_sdk::rpc_types::SuiEvent;
+use sui_storage::verify_checkpoint_with_committee;
+use sui_types::{
+    base_types::ObjectID,
+    committee::Committee,
+    full_checkpoint_content::CheckpointData,
+    messages_checkpoint::{CheckpointSequenceNumber, TrustedCheckpoint, VerifiedCheckpoint},
+    object::Object,
+};
+use tokio::time::{sleep, Instant};
+use tokio_util::sync::CancellationToken;
+use typed_store::{
+    rocks,
+    rocks::{errors::typed_store_err_from_rocks_err, DBMap, MetricConf, ReadWriteOptions},
+    Map,
+};
+
+use crate::EventConfig;
+
+#[allow(dead_code)]
+const CHECKPOINT_STORE: &str = "checkpoint_store";
+#[allow(dead_code)]
+const WALRUS_PACKAGE_STORE: &str = "walrus_package_store";
+#[allow(dead_code)]
+const COMMITTEE_STORE: &str = "committee_store";
+#[allow(dead_code)]
+const EVENT_STORE: &str = "event_store";
+const MAX_TIMEOUT: Duration = Duration::from_secs(60);
+const RETRY_DELAY: Duration = Duration::from_secs(5);
+
+#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
+pub struct CheckpointOrderedEventID {
+    sequence: CheckpointSequenceNumber,
+    counter: u64,
+}
+
+impl CheckpointOrderedEventID {
+    fn new(sequence: CheckpointSequenceNumber, counter: u64) -> Self {
+        CheckpointOrderedEventID { sequence, counter }
+    }
+}
+
+#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
+pub struct CheckpointSuiEvent {
+    pub serialized_event: Vec<u8>,
+    pub checkpoint_sequence_number: CheckpointOrderedEventID,
+}
+
+#[derive(Clone)]
+pub struct CheckpointProcessor {
+    /// Full node REST client.
+    client: Client,
+    /// The address of the Walrus system package.
+    system_pkg_id: ObjectID,
+    /// Event to read next.
+    event_store_next_cursor: CheckpointOrderedEventID,
+    /// Store which only stores the latest checkpoint.
+    checkpoint_store: DBMap<(), TrustedCheckpoint>,
+    /// Store which only stores the latest Walrus package.
+    walrus_package_store: DBMap<(), Object>,
+    /// Store which only stores the latest Sui committee.
+    committee_store: DBMap<(), Committee>,
+    /// Store which only stores all uncommitted events.
+    event_store: DBMap<CheckpointOrderedEventID, CheckpointSuiEvent>,
+}
+#[allow(dead_code)]
+impl CheckpointProcessor {
+    async fn poll(&mut self, timeout: Duration) -> Result<Vec<CheckpointSuiEvent>> {
+        let mut events = vec![];
+        let mut iter = self.event_store.unbounded_iter();
+        iter = iter.skip_to(&self.event_store_next_cursor)?;
+        let start_time = std::time::Instant::now();
+        while start_time.elapsed() < timeout {
+            if let Some((checkpoint_event_id, event)) = iter.next() {
+                events.push(event.clone());
+                self.event_store_next_cursor = CheckpointOrderedEventID::new(
+                    checkpoint_event_id.sequence,
+                    checkpoint_event_id.counter.saturating_add(1),
+                );
+            } else {
+                break;
+            }
+        }
+        Ok(events)
+    }
+
+    async fn commit(&mut self, committed_event_id: CheckpointOrderedEventID) -> Result<()> {
+        let iter = self.event_store.unbounded_iter();
+        let rev_iter = iter.skip_to(&committed_event_id)?.reverse();
+        let mut write_batch = self.event_store.batch();
+        for (event_id, _) in rev_iter {
+            write_batch
+                .delete_batch(&self.event_store, std::iter::once(event_id))
+                .map_err(|e| anyhow!("Failed to remove event from event store: {}", e))?;
+        }
+        write_batch
+            .write()
+            .map_err(|e| anyhow!("Failed to remove event from event store: {}", e))?;
+        Ok(())
+    }
+
+    pub async fn start(&self) -> Result<CancellationToken> {
+        let cancellation_token = CancellationToken::new();
+        tokio::task::spawn(Self::start_tailing_checkpoints(
+            self.clone(),
+            cancellation_token.clone(),
+        ));
+        Ok(cancellation_token)
+    }
+
+    async fn get_full_checkpoint(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> Result<CheckpointData> {
+        let start_time = Instant::now();
+
+        loop {
+            match self.client.get_full_checkpoint(sequence_number).await {
+                Ok(checkpoint) => return Ok(checkpoint),
+                Err(inner) => {
+                    let elapsed = start_time.elapsed();
+                    if elapsed >= MAX_TIMEOUT {
+                        return Err(inner);
+                    }
+                    let delay = RETRY_DELAY.min(MAX_TIMEOUT - elapsed);
+                    sleep(delay).await;
+                }
+            }
+        }
+    }
+
+    async fn start_tailing_checkpoints(self, cancel_token: CancellationToken) -> Result<()> {
+        while !cancel_token.is_cancelled() {
+            let Some(prev_checkpoint) = self.checkpoint_store.get(&())? else {
+                bail!("No checkpoint found in the checkpoint store");
+            };
+            let next_checkpoint = prev_checkpoint.inner().sequence_number().saturating_add(1);
+            let Ok(checkpoint) = self.get_full_checkpoint(next_checkpoint).await else {
+                // TODO:
+                // 1. Read walrus events from event blobs s we've fallen behind the first unpruned
+                // checkpoint on the fullnode or the fullnode doesn't have the new checkpoint yet
+                // 2. Reset the committee and previous checkpoint using a light client
+                // based approach so we can continue processing events from full node
+                // 3. Reset the walrus package store with the latest walrus package object from fullnode
+                bail!("Failed to get checkpoint {}", next_checkpoint);
+            };
+            let Some(committee) = self.committee_store.get(&())? else {
+                bail!("No committee found in the committee store");
+            };
+            let verified_checkpoint = verify_checkpoint_with_committee(
+                Arc::new(committee.clone()),
+                &VerifiedCheckpoint::new_from_verified(prev_checkpoint.into_inner()),
+                checkpoint.checkpoint_summary.clone(),
+            )
+            .map_err(|checkpoint| {
+                anyhow!(
+                    "Failed to verify sui checkpoint: {}",
+                    checkpoint.sequence_number
+                )
+            })?;
+            let resolver = Resolver::new(self.clone());
+            let mut write_batch = self.event_store.batch();
+            for tx in checkpoint.transactions.into_iter() {
+                for object in tx.output_objects.into_iter() {
+                    if object.id() == self.system_pkg_id {
+                        write_batch
+                            .insert_batch(&self.walrus_package_store, std::iter::once(((), object)))
+                            .map_err(|e| {
+                                anyhow!("Failed to insert object into walrus package store: {}", e)
+                            })?;
+                    }
+                }
+                let tx_events = tx.events.unwrap();
+                for (seq, tx_event) in tx_events
+                    .data
+                    .into_iter()
+                    .filter(|event| event.package_id == self.system_pkg_id)
+                    .enumerate()
+                {
+                    let move_type_layout = resolver
+                        .type_layout(move_core_types::language_storage::TypeTag::Struct(
+                            Box::new(tx_event.type_.clone()),
+                        ))
+                        .await?;
+                    let move_datatype_layout = match move_type_layout {
+                        MoveTypeLayout::Struct(s) => Some(MoveDatatypeLayout::Struct(s)),
+                        MoveTypeLayout::Enum(e) => Some(MoveDatatypeLayout::Enum(e)),
+                        _ => None,
+                    }
+                    .ok_or(anyhow!("Failed to get move datatype layout"))?;
+                    let sui_event = SuiEvent::try_from(
+                        tx_event,
+                        *tx.transaction.digest(),
+                        seq as u64,
+                        None,
+                        move_datatype_layout,
+                    )?;
+                    let checkpoint_event_id = CheckpointOrderedEventID::new(
+                        *checkpoint.checkpoint_summary.sequence_number(),
+                        seq as u64,
+                    );
+                    let checkpoint_event = CheckpointSuiEvent {
+                        serialized_event: serde_json::to_vec(&sui_event)?,
+                        checkpoint_sequence_number: checkpoint_event_id.clone(),
+                    };
+                    write_batch
+                        .insert_batch(
+                            &self.event_store,
+                            std::iter::once((checkpoint_event_id, checkpoint_event)),
+                        )
+                        .map_err(|e| anyhow!("Failed to insert event into event store: {}", e))?;
+                }
+            }
+            if let Some(end_of_epoch_data) = &checkpoint.checkpoint_summary.end_of_epoch_data {
+                let next_committee = end_of_epoch_data
+                    .next_epoch_committee
+                    .iter()
+                    .cloned()
+                    .collect();
+                let committee = Committee::new(
+                    checkpoint.checkpoint_summary.epoch().saturating_add(1),
+                    next_committee,
+                );
+                write_batch
+                    .insert_batch(&self.committee_store, std::iter::once(((), committee)))
+                    .map_err(|e| {
+                        anyhow!("Failed to insert committee into committee store: {}", e)
+                    })?;
+            }
+            write_batch
+                .insert_batch(
+                    &self.checkpoint_store,
+                    std::iter::once(((), verified_checkpoint.serializable_ref())),
+                )
+                .map_err(|e| anyhow!("Failed to insert checkpoint into checkpoint store: {}", e))?;
+            write_batch.write()?;
+        }
+        Ok(())
+    }
+
+    pub async fn new_for_testing() -> Result<Self, anyhow::Error> {
+        let metric_conf = MetricConf::default();
+        let mut db_opts = Options::default();
+        db_opts.create_missing_column_families(true);
+        db_opts.create_if_missing(true);
+        let dir: PathBuf = tempfile::tempdir()
+            .expect("Failed to open temporary directory")
+            .into_path();
+        let database = rocks::open_cf_opts(
+            dir,
+            Some(db_opts),
+            metric_conf,
+            &[
+                (CHECKPOINT_STORE, rocksdb::Options::default()),
+                (WALRUS_PACKAGE_STORE, rocksdb::Options::default()),
+                (COMMITTEE_STORE, rocksdb::Options::default()),
+                (EVENT_STORE, rocksdb::Options::default()),
+            ],
+        )?;
+        if database.cf_handle(CHECKPOINT_STORE).is_none() {
+            database
+                .create_cf(CHECKPOINT_STORE, &rocksdb::Options::default())
+                .map_err(typed_store_err_from_rocks_err)?;
+        }
+        if database.cf_handle(WALRUS_PACKAGE_STORE).is_none() {
+            database
+                .create_cf(WALRUS_PACKAGE_STORE, &rocksdb::Options::default())
+                .map_err(typed_store_err_from_rocks_err)?;
+        }
+        if database.cf_handle(COMMITTEE_STORE).is_none() {
+            database
+                .create_cf(COMMITTEE_STORE, &rocksdb::Options::default())
+                .map_err(typed_store_err_from_rocks_err)?;
+        }
+        if database.cf_handle(EVENT_STORE).is_none() {
+            database
+                .create_cf(EVENT_STORE, &rocksdb::Options::default())
+                .map_err(typed_store_err_from_rocks_err)?;
+        }
+        let checkpoint_store = DBMap::reopen(
+            &database,
+            Some(CHECKPOINT_STORE),
+            &ReadWriteOptions::default(),
+            false,
+        )?;
+        let walrus_package_store = DBMap::reopen(
+            &database,
+            Some(WALRUS_PACKAGE_STORE),
+            &ReadWriteOptions::default(),
+            false,
+        )?;
+        let committee_store = DBMap::reopen(
+            &database,
+            Some(CHECKPOINT_STORE),
+            &ReadWriteOptions::default(),
+            false,
+        )?;
+        let event_store = DBMap::<CheckpointOrderedEventID, CheckpointSuiEvent>::reopen(
+            &database,
+            Some(EVENT_STORE),
+            &ReadWriteOptions::default(),
+            false,
+        )?;
+        Ok(CheckpointProcessor {
+            client: Client::new("http://localhost:8080".to_string()),
+            walrus_package_store,
+            checkpoint_store,
+            committee_store,
+            event_store,
+            system_pkg_id: ObjectID::random(),
+            event_store_next_cursor: CheckpointOrderedEventID::new(0, 0),
+        })
+    }
+
+    pub async fn new(config: EventConfig) -> Result<Self, anyhow::Error> {
+        // return a new CheckpointProcessor
+        let client = Client::new(config.rest_url);
+        let metric_conf = MetricConf::default();
+        let mut db_opts = Options::default();
+        db_opts.create_missing_column_families(true);
+        db_opts.create_if_missing(true);
+        let database = rocks::open_cf_opts(
+            config.path,
+            Some(db_opts),
+            metric_conf,
+            &[
+                (CHECKPOINT_STORE, rocksdb::Options::default()),
+                (WALRUS_PACKAGE_STORE, rocksdb::Options::default()),
+                (COMMITTEE_STORE, rocksdb::Options::default()),
+                (EVENT_STORE, rocksdb::Options::default()),
+            ],
+        )?;
+        if database.cf_handle(CHECKPOINT_STORE).is_none() {
+            database
+                .create_cf(CHECKPOINT_STORE, &rocksdb::Options::default())
+                .map_err(typed_store_err_from_rocks_err)?;
+        }
+        if database.cf_handle(WALRUS_PACKAGE_STORE).is_none() {
+            database
+                .create_cf(WALRUS_PACKAGE_STORE, &rocksdb::Options::default())
+                .map_err(typed_store_err_from_rocks_err)?;
+        }
+        if database.cf_handle(COMMITTEE_STORE).is_none() {
+            database
+                .create_cf(COMMITTEE_STORE, &rocksdb::Options::default())
+                .map_err(typed_store_err_from_rocks_err)?;
+        }
+        if database.cf_handle(EVENT_STORE).is_none() {
+            database
+                .create_cf(EVENT_STORE, &rocksdb::Options::default())
+                .map_err(typed_store_err_from_rocks_err)?;
+        }
+        let checkpoint_store = DBMap::reopen(
+            &database,
+            Some(CHECKPOINT_STORE),
+            &ReadWriteOptions::default(),
+            false,
+        )?;
+        let walrus_package_store = DBMap::reopen(
+            &database,
+            Some(WALRUS_PACKAGE_STORE),
+            &ReadWriteOptions::default(),
+            false,
+        )?;
+        let committee_store = DBMap::reopen(
+            &database,
+            Some(CHECKPOINT_STORE),
+            &ReadWriteOptions::default(),
+            false,
+        )?;
+        let event_store = DBMap::reopen(
+            &database,
+            Some(EVENT_STORE),
+            &ReadWriteOptions::default(),
+            false,
+        )?;
+        if checkpoint_store.is_empty() {
+            // This is a fresh start as there is no prev disk state
+            committee_store.schedule_delete_all()?;
+            event_store.schedule_delete_all()?;
+            walrus_package_store.schedule_delete_all()?;
+            let genesis = Genesis::load(config.sui_genesis_path)?;
+            let genesis_committee = genesis.committee()?;
+            let checkpoint = genesis.checkpoint();
+            committee_store.insert(&(), &genesis_committee)?;
+            checkpoint_store.insert(&(), checkpoint.serializable_ref())?;
+        }
+        let event_iter = event_store.unbounded_iter();
+        let event_store_next_cursor = event_iter
+            .seek_to_first()
+            .next()
+            .map(|item| item.0)
+            .unwrap_or(CheckpointOrderedEventID::new(0, 0));
+        let checkpoint_processor = CheckpointProcessor {
+            client,
+            walrus_package_store,
+            checkpoint_store,
+            committee_store,
+            event_store,
+            system_pkg_id: config.system_pkg_id,
+            event_store_next_cursor,
+        };
+        Ok(checkpoint_processor)
+    }
+}
+
+#[async_trait]
+impl PackageStore for CheckpointProcessor {
+    async fn fetch(
+        &self,
+        id: move_core_types::account_address::AccountAddress,
+    ) -> sui_package_resolver::Result<Arc<Package>> {
+        let Some(walrus_system_pkg) =
+            self.walrus_package_store.get(&()).map_err(|store_error| {
+                PackageResolverError::Store {
+                    store: "RocksDB",
+                    source: Arc::new(store_error),
+                }
+            })?
+        else {
+            return Err(PackageResolverError::PackageNotFound(id));
+        };
+        Ok(Arc::new(Package::read_from_object(&walrus_system_pkg)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use sui_sdk::rpc_types::SuiEvent;
+    use typed_store::Map;
+
+    use crate::checkpoint_processor::{
+        CheckpointOrderedEventID,
+        CheckpointProcessor,
+        CheckpointSuiEvent,
+    };
+
+    #[tokio::test]
+    async fn test_poll() {
+        let mut processor = CheckpointProcessor::new_for_testing().await.unwrap();
+        // add 100 events to the event store
+        let mut expected_events = vec![];
+        for i in 0..100 {
+            let event = CheckpointSuiEvent {
+                serialized_event: serde_json::to_vec(&SuiEvent::random_for_testing()).unwrap(),
+                checkpoint_sequence_number: CheckpointOrderedEventID::new(0, i),
+            };
+            expected_events.push(event.clone());
+            let key: CheckpointOrderedEventID = CheckpointOrderedEventID::new(0, i);
+            processor.event_store.insert(&key, &event).unwrap();
+        }
+
+        // poll events
+        let events = processor.poll(Duration::from_secs(100)).await.unwrap();
+        assert_eq!(events.len(), 100);
+        // assert events are the same
+        for (expected, actual) in expected_events.iter().zip(events.iter()) {
+            assert_eq!(expected, actual);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_multiple_poll() {
+        let mut processor = CheckpointProcessor::new_for_testing().await.unwrap();
+        // add 100 events to the event store
+        let mut expected_events1 = vec![];
+        for i in 0..100 {
+            let event = CheckpointSuiEvent {
+                serialized_event: serde_json::to_vec(&SuiEvent::random_for_testing()).unwrap(),
+                checkpoint_sequence_number: CheckpointOrderedEventID::new(0, i),
+            };
+            expected_events1.push(event.clone());
+            let key: CheckpointOrderedEventID = CheckpointOrderedEventID::new(0, i);
+            processor.event_store.insert(&key, &event).unwrap();
+        }
+
+        // poll events
+        let events = processor.poll(Duration::from_secs(100)).await.unwrap();
+        assert_eq!(events.len(), 100);
+        // assert events are the same
+        for (expected, actual) in expected_events1.iter().zip(events.iter()) {
+            assert_eq!(expected, actual);
+        }
+        let mut expected_events2 = vec![];
+        for i in 100..200 {
+            let event = CheckpointSuiEvent {
+                serialized_event: serde_json::to_vec(&SuiEvent::random_for_testing()).unwrap(),
+                checkpoint_sequence_number: CheckpointOrderedEventID::new(0, i),
+            };
+            expected_events2.push(event.clone());
+            let key: CheckpointOrderedEventID = CheckpointOrderedEventID::new(0, i);
+            processor.event_store.insert(&key, &event).unwrap();
+        }
+
+        let events = processor.poll(Duration::from_secs(100)).await.unwrap();
+        assert_eq!(events.len(), 100);
+        // assert events are the same
+        for (expected, actual) in expected_events2.iter().zip(events.iter()) {
+            assert_eq!(expected, actual);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_commit() {
+        let mut processor = CheckpointProcessor::new_for_testing().await.unwrap();
+        // add 100 events to the event store
+        let mut expected_events = vec![];
+        for i in 0..100 {
+            let event = CheckpointSuiEvent {
+                serialized_event: serde_json::to_vec(&SuiEvent::random_for_testing()).unwrap(),
+                checkpoint_sequence_number: CheckpointOrderedEventID::new(0, i),
+            };
+            expected_events.push(event.clone());
+            let key: CheckpointOrderedEventID = CheckpointOrderedEventID::new(0, i);
+            processor.event_store.insert(&key, &event).unwrap();
+        }
+        // commit first 10 events
+        let committed_event_id = CheckpointOrderedEventID::new(0, 9);
+        processor.commit(committed_event_id.clone()).await.unwrap();
+
+        // poll events
+        let events = processor.poll(Duration::from_secs(100)).await.unwrap();
+        assert_eq!(events.len(), 90);
+        // assert events are the same
+        for (expected, actual) in expected_events.iter().skip(10).zip(events.iter()) {
+            assert_eq!(expected, actual);
+        }
+    }
+}

--- a/crates/walrus-event/src/lib.rs
+++ b/crates/walrus-event/src/lib.rs
@@ -1,0 +1,22 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use sui_types::base_types::ObjectID;
+
+mod checkpoint_processor;
+
+/// Configuration for event processing.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct EventConfig {
+    /// The REST URL of the fullnode.
+    pub rest_url: String,
+    /// The URL of the checkpoint client to connect to.
+    pub path: PathBuf,
+    /// The path to the Sui genesis file.
+    pub sui_genesis_path: PathBuf,
+    /// ObjectID of the Walrus system package.
+    pub system_pkg_id: ObjectID,
+}

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -247,7 +247,6 @@ impl StorageNodeBuilder {
                 MetricConf::new("storage"),
             )?
         };
-
         let sui_config_and_client =
             if self.event_provider.is_none() || self.committee_service_factory.is_none() {
                 Some(create_read_client(config).await?)

--- a/deny.toml
+++ b/deny.toml
@@ -12,6 +12,8 @@ ignore = [
     # We have a vulnerable version of `rustls` in our dependency tree through the old version of
     # jsonrpsee used by sui.
     "RUSTSEC-2024-0336",
+    # object-store is not maintained, but is a dependency in many of our packages.
+    "RUSTSEC-2024-0358"
 ]
 
 # This section is considered when running `cargo deny check licenses`


### PR DESCRIPTION
This PR adds the following new functionalities:
1. Use checkpoints to read walrus events
2. Verify checkpoints using chain of reference and committee
3. Store events in a local store
4. Prune events once committed
5. Store local state on disk for restart functionality

What is not added yet:
1. Ability to catch up from walrus events stored on walrus
2. Ability to start writing walrus event blobs
3. Switching the current event provider interface to start using new framework
4. Tests