### PR TITLE
ci: fix workflow to update pre-commit hooks

### DIFF
--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Install sui
         if: steps.cache-sui-restore.outputs.cache-hit != 'true'
         run: cargo install --locked --git https://github.com/MystenLabs/sui.git --tag $SUI_TAG --debug sui
+      - uses: taiki-e/install-action@v2.41.14
+        with:
+          tool: cargo-nextest
 
       - run: pre-commit run --all-files
       - uses: peter-evans/create-pull-request@v6.1.0


### PR DESCRIPTION
Since we now use nextest, we need to install this before running any pre-commit hooks, see [here](https://github.com/MystenLabs/walrus/actions/runs/10191407670/job/28192639488#step:9:59).