### PR TITLE
test: decrease parallelism for E2E tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,3 +2,8 @@
 
 [profile.default]
 retries = 2 # retry twice for a total of 3 attempts
+fail-fast = false # do not stop at first failure
+
+[[profile.default.overrides]]
+filter = 'package(walrus-e2e-tests)'
+threads-required = 4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
     name: cargo-test
     entry: cargo nextest run
     language: rust
-    files: ^(crates/|Cargo\.(toml|lock)$)
+    files: (^crates/|Cargo\.(toml|lock)$|nextest\.toml$)
     pass_filenames: false
   - id: clippy-with-tests
     name: clippy-with-tests


### PR DESCRIPTION
This fixes test failures on slower machines and speeds up tests in general, see https://github.com/MystenLabs/walrus/actions/runs/10386888430.

Closes #665 