### PR TITLE
fix(core): improve blob encoding by swapping encodings

### DIFF
--- a/crates/walrus-core/src/encoding/blob_encoding.rs
+++ b/crates/walrus-core/src/encoding/blob_encoding.rs
@@ -276,8 +276,8 @@ impl<'a> ExpandedMessageMatrix<'a> {
             symbol_size,
         };
         expanded_matrix.fill_systematic_with_rows();
-        expanded_matrix.expand_columns_for_primary();
-        expanded_matrix.expand_all_rows();
+        expanded_matrix.expand_rows_for_secondary();
+        expanded_matrix.expand_all_columns();
         expanded_matrix
     }
 
@@ -308,10 +308,9 @@ impl<'a> ExpandedMessageMatrix<'a> {
         })
     }
 
-    /// Expands the first `source_symbols_secondary` columns from `self.columns` to get all
-    /// remaining primary slivers.
-    fn expand_columns_for_primary(&mut self) {
-        for col_index in 0..self.n_columns {
+    /// Expands all columns to completely fill the `n_shards * n_shards` expanded message matrix.
+    fn expand_all_columns(&mut self) {
+        for col_index in 0..self.config.n_shards().get().into() {
             let mut column = Symbols::with_capacity(self.n_rows, self.symbol_size);
             self.matrix.iter().take(self.n_rows).for_each(|row| {
                 let _ = column.extend(&row[col_index]);
@@ -329,10 +328,10 @@ impl<'a> ExpandedMessageMatrix<'a> {
         }
     }
 
-    /// Expands all `n_shards` primary slivers (rows) to completely fill the `n_shards * n_shards`
-    /// expanded message matrix.
-    fn expand_all_rows(&mut self) {
-        for row in self.matrix.iter_mut() {
+    /// Expands the first `source_symbols_primary` primary slivers (rows) to get all remaining
+    /// secondary slivers.
+    fn expand_rows_for_secondary(&mut self) {
+        for row in self.matrix.iter_mut().take(self.n_rows) {
             for (col_index, symbol) in self
                 .config
                 .get_encoder::<Secondary>(&row[0..self.n_columns])


### PR DESCRIPTION
Swapping the order of primary and secondary encoding reduces the number of individual encodings from ~5n/3 to ~4n/3, which results in an actual speedup of ~10%.

Benchmarks output (comparison to latest `main`):
```console
$ cargo bench -p walrus-core -- --baseline main encode_with_metadata     
   Compiling walrus-core v0.1.0 (/Users/markuslegner/github/walrus/crates/walrus-core)
    Finished `bench` profile [optimized] target(s) in 2.83s
     Running benches/basic_encoding.rs (target/release/deps/basic_encoding-42645709c368166d)
     Running benches/blob_encoding.rs (target/release/deps/blob_encoding-fa3dae64e5bf72fb)
Benchmarking blob_encoding/encode_with_metadata/1B: Warming up for 10.000 ms
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.0s.
blob_encoding/encode_with_metadata/1B
                        time:   [805.00 ms 806.72 ms 808.19 ms]
                        thrpt:  [1.2373   B/s 1.2396   B/s 1.2422   B/s]
                 change:
                        time:   [-10.201% -8.7583% -7.7847%] (p = 0.00 < 0.05)
                        thrpt:  [+8.4419% +9.5990% +11.360%]
                        Performance has improved.
Found 3 outliers among 10 measurements (30.00%)
  2 (20.00%) low severe
  1 (10.00%) high mild
Benchmarking blob_encoding/encode_with_metadata/1KiB: Warming up for 10.000 ms
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.1s.
blob_encoding/encode_with_metadata/1KiB
                        time:   [804.02 ms 805.51 ms 807.08 ms]
                        thrpt:  [1.2390 KiB/s 1.2415 KiB/s 1.2438 KiB/s]
                 change:
                        time:   [-12.045% -11.028% -10.135%] (p = 0.00 < 0.05)
                        thrpt:  [+11.278% +12.395% +13.694%]
                        Performance has improved.
Benchmarking blob_encoding/encode_with_metadata/1MiB: Warming up for 10.000 ms
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.9s.
blob_encoding/encode_with_metadata/1MiB
                        time:   [884.91 ms 886.46 ms 888.21 ms]
                        thrpt:  [1.1259 MiB/s 1.1281 MiB/s 1.1301 MiB/s]
                 change:
                        time:   [-15.331% -13.955% -12.945%] (p = 0.00 < 0.05)
                        thrpt:  [+14.870% +16.218% +18.106%]
                        Performance has improved.
Found 3 outliers among 10 measurements (30.00%)
  1 (10.00%) low mild
  1 (10.00%) high mild
  1 (10.00%) high severe
Benchmarking blob_encoding/encode_with_metadata/16MiB: Warming up for 10.000 ms
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 10.9s.
blob_encoding/encode_with_metadata/16MiB
                        time:   [1.0800 s 1.0871 s 1.0957 s]
                        thrpt:  [14.603 MiB/s 14.718 MiB/s 14.814 MiB/s]
                 change:
                        time:   [-12.470% -11.172% -10.060%] (p = 0.00 < 0.05)
                        thrpt:  [+11.185% +12.577% +14.247%]
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe
Benchmarking blob_encoding/encode_with_metadata/256MiB: Warming up for 10.000 ms
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 44.2s.
blob_encoding/encode_with_metadata/256MiB
                        time:   [4.4150 s 4.5223 s 4.6804 s]
                        thrpt:  [54.696 MiB/s 56.608 MiB/s 57.984 MiB/s]
                 change:
                        time:   [-6.7925% -4.1213% -0.7721%] (p = 0.03 < 0.05)
                        thrpt:  [+0.7781% +4.2985% +7.2875%]
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking blob_encoding/encode_with_metadata/1GiB: Warming up for 10.000 ms
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 162.3s.
blob_encoding/encode_with_metadata/1GiB
                        time:   [15.934 s 16.007 s 16.084 s]
                        thrpt:  [63.665 MiB/s 63.971 MiB/s 64.265 MiB/s]
                 change:
                        time:   [-13.281% -12.713% -12.099%] (p = 0.00 < 0.05)
                        thrpt:  [+13.765% +14.565% +15.315%]
                        Performance has improved.
```