### PR TITLE
chore: fix editorconfig config and fix findings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,7 +17,7 @@ trim_trailing_whitespace = true
 indent_size = unset
 max_line_length = 150
 
-[{*.yml,*.yaml,*.toml}]
+[{*.json,*.sh,*.toml,*.yml,*.yaml,cargo-simtest}]
 indent_size = 2
 max_line_length = 150
 
@@ -25,13 +25,7 @@ max_line_length = 150
 indent_size = unset
 
 # Ignore paths
-[{
-    .git/**/*,**/*.lock,
-    **/Move.toml,
-    LICENSE,
-    docs/devnet-public/glossary.md,
-    crates/walrus-orchestrator/assets/*
-}]
+[{.git/**/*,**/*.lock,**/Move.toml,LICENSE,docs/devnet-public/glossary.md,crates/walrus-orchestrator/assets/*,.editorconfig}]
 charset = unset
 end_of_line = unset
 indent_size = unset

--- a/contracts/blob_store/sources/bls_aggregate.move
+++ b/contracts/blob_store/sources/bls_aggregate.move
@@ -107,7 +107,8 @@ module blob_store::bls_aggregate {
     /// Test committee
     public fun new_bls_committee_for_testing(): BlsCommittee {
         // Pk corresponding to secret key scalar(117)
-        let pub_key_bytes = x"95eacc3adc09c827593f581e8e2de068bf4cf5d0c0eb29e5372f0d23364788ee0f9beb112c8a7e9c2f0c720433705cf0";
+        let pub_key_bytes =
+        x"95eacc3adc09c827593f581e8e2de068bf4cf5d0c0eb29e5372f0d23364788ee0f9beb112c8a7e9c2f0c720433705cf0"; // editorconfig-checker-disable-line
         let storage_node = storage_node::new_for_testing(pub_key_bytes, 100);
         BlsCommittee { members: vector[storage_node], n_shards: 100 }
     }

--- a/contracts/walrus/sources/system/bls_aggregate.move
+++ b/contracts/walrus/sources/system/bls_aggregate.move
@@ -107,7 +107,7 @@ use walrus::storage_node;
 /// Test committee
 public fun new_bls_committee_for_testing(): BlsCommittee {
     // Pk corresponding to secret key scalar(117)
-    let pub_key_bytes = x"95eacc3adc09c827593f581e8e2de068bf4cf5d0c0eb29e5372f0d23364788ee0f9beb112c8a7e9c2f0c720433705cf0";
+    let pub_key_bytes = x"95eacc3adc09c827593f581e8e2de068bf4cf5d0c0eb29e5372f0d23364788ee0f9beb112c8a7e9c2f0c720433705cf0"; // editorconfig-checker-disable-line
     let storage_node = storage_node::new_for_testing(pub_key_bytes, 100);
     BlsCommittee { members: vector[storage_node], n_shards: 100 }
 }

--- a/contracts/walrus/tests/bls_test_utils.move
+++ b/contracts/walrus/tests/bls_test_utils.move
@@ -22,7 +22,7 @@ public fun bls_min_pk_from_sk(sk: &vector<u8>): vector<u8> {
 #[test]
 fun test_bls_pk() {
     let sk = x"0000000000000000000000000000000000000000000000000000000000000075";
-    let pub_key_bytes = x"95eacc3adc09c827593f581e8e2de068bf4cf5d0c0eb29e5372f0d23364788ee0f9beb112c8a7e9c2f0c720433705cf0";
+    let pub_key_bytes = x"95eacc3adc09c827593f581e8e2de068bf4cf5d0c0eb29e5372f0d23364788ee0f9beb112c8a7e9c2f0c720433705cf0"; // editorconfig-checker-disable-line
     assert!(bls_min_pk_from_sk(&sk) == pub_key_bytes)
 }
 

--- a/crates/walrus-core/src/encoding/slivers.rs
+++ b/crates/walrus-core/src/encoding/slivers.rs
@@ -421,7 +421,8 @@ impl SliverPair {
         self.primary.index.into()
     }
 
-    /// Creates a new sliver pair containing two empty [`SliverData`] instances of the specified size.
+    /// Creates a new sliver pair containing two empty [`SliverData`] instances of the specified
+    /// size.
     pub fn new_empty(
         config: &EncodingConfig,
         symbol_size: NonZeroU16,

--- a/crates/walrus-core/src/messages.rs
+++ b/crates/walrus-core/src/messages.rs
@@ -79,7 +79,8 @@ impl<T> SignedMessage<T> {
 }
 
 impl<T> SignedMessage<T> {
-    /// Extracts the underlying message and verifies the signature on this message under `public_key`.
+    /// Extracts the underlying message and verifies the signature on this message under
+    /// `public_key`.
     pub fn verify_signature_and_get_message<I>(
         &self,
         public_key: &PublicKey,

--- a/crates/walrus-event/src/blob_writer.rs
+++ b/crates/walrus-event/src/blob_writer.rs
@@ -222,7 +222,7 @@ impl EventBlobWriter {
         self.client.store_metadata(&blob_metadata).await?;
         // TODO: Once shard assignment per storage node will be read from walrus
         // system object at the beginning of the walrus epoch, we can only store the blob for
-        // shards that are locally assigned to this node
+        // shards that are locally assigned to this node. (#682)
         try_join_all(sliver_pairs.iter().map(|sliver_pair| async {
             self.client
                 .store_sliver(
@@ -259,8 +259,8 @@ impl EventBlobWriter {
         }))
         .await
         .map(|_| ())?;
-        // TODO: Once slivers are stored locally, invoke the new sui contract endpoint to certify the
-        // event blob
+        // TODO: Once slivers are stored locally, invoke the new sui contract endpoint to certify
+        // the event blob. (#683)
         let event_blob_metadata = EventBlobMetadata {
             blob_id: *blob_metadata.blob_id(),
             start: self.start.as_ref().cloned().unwrap_or_default(),

--- a/crates/walrus-event/src/checkpoint_processor.rs
+++ b/crates/walrus-event/src/checkpoint_processor.rs
@@ -225,11 +225,12 @@ impl CheckpointProcessor {
             let next_checkpoint = prev_checkpoint.inner().sequence_number().saturating_add(1);
             let Ok(checkpoint) = self.get_full_checkpoint(next_checkpoint).await else {
                 // TODO:
-                // 1. Read walrus events from event blobs s we've fallen behind the first unpruned
-                // checkpoint on the fullnode or the fullnode doesn't have the new checkpoint yet
-                // 2. Reset the committee and previous checkpoint using a light client
-                // based approach so we can continue processing events from full node
-                // 3. Reset the walrus package store with the latest walrus package object from fullnode
+                // 1. Read walrus events from event blobs as we've fallen behind the first unpruned
+                //    checkpoint on the fullnode or the fullnode doesn't have the new checkpoint yet
+                // 2. Reset the committee and previous checkpoint using a light client based
+                //    approach so we can continue processing events from full node
+                // 3. Reset the walrus package store with the latest walrus package object from
+                //    fullnode
                 bail!("Failed to get checkpoint {}", next_checkpoint);
             };
             let Some(committee) = self.committee_store.get(&())? else {

--- a/crates/walrus-event/src/event_blob.rs
+++ b/crates/walrus-event/src/event_blob.rs
@@ -45,7 +45,8 @@ pub struct BlobEntry {
 }
 
 impl BlobEntry {
-    /// The maximum length of a varint in bytes. This is the maximum length of the length field of a blob.
+    /// The maximum length of a varint in bytes. This is the maximum length of the length field of a
+    /// blob.
     pub const MAX_VARINT_LENGTH: usize = 10;
     /// The number of bytes used to encode the encoding of the event. This is a single byte.
     pub const EVENT_ENCODING_BYTES: usize = 1;

--- a/crates/walrus-sdk/src/client.rs
+++ b/crates/walrus-sdk/src/client.rs
@@ -667,7 +667,9 @@ mod tests {
             confirmation: (|e| e.confirmation(&BLOB_ID).0, "confirmation"),
             sliver: (|e| e.sliver::<Primary>(&BLOB_ID, SliverPairIndex(1)).0, "slivers/1/primary"),
             recovery_symbol: (
-                |e| e.recovery_symbol::<Primary>(&BLOB_ID, SliverPairIndex(1), SliverPairIndex(2)).0,
+                |e| e.recovery_symbol::<Primary>(
+                    &BLOB_ID, SliverPairIndex(1), SliverPairIndex(2)
+                ).0,
                 "slivers/1/primary/2"
             ),
             inconsistency_proof: (

--- a/crates/walrus-service/src/common/api.rs
+++ b/crates/walrus-service/src/common/api.rs
@@ -235,7 +235,9 @@ macro_rules! rest_api_error {
                 let mut response = self.to_response();
 
                 if self.status() == StatusCode::INTERNAL_SERVER_ERROR {
-                    response.extensions_mut().insert($crate::common::telemetry::InternalError(Arc::new(self)));
+                    response.extensions_mut().insert(
+                        $crate::common::telemetry::InternalError(Arc::new(self))
+                    );
                 }
 
                 response

--- a/crates/walrus-service/src/common/telemetry.rs
+++ b/crates/walrus-service/src/common/telemetry.rs
@@ -115,7 +115,9 @@ impl MakeHttpSpan {
 
     /// Record the server's address as the host identified in the header, or forwarded by a proxy.
     fn record_server_address<B>(&self, request: &Request<B>, span: &Span) {
-        // Set the server address based on https://opentelemetry.io/docs/specs/semconv/http/http-spans/
+        // Set the server address based on
+        // https://opentelemetry.io/docs/specs/semconv/http/http-spans/
+        //
         // Should be the first of:
         // - The original host which may be passed by the reverse proxy in the Forwarded#host,
         //   X-Forwarded-Host, or a similar header.

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -1762,9 +1762,13 @@ mod tests {
             .client
             .sync_shard::<Primary>(ShardIndex(0), BLOB_ID, 10, 1, &ProtocolKeyPair::generate())
             .await;
-        assert!(matches!(response,
-                Err(err) if err.http_status_code() == Some(StatusCode::UNAUTHORIZED) &&
-                            err.to_string().contains("The client is not authorized to perform sync shard operation")));
+        assert!(matches!(
+            response,
+            Err(err) if err.http_status_code() == Some(StatusCode::UNAUTHORIZED) &&
+                        err.to_string().contains(
+                            "The client is not authorized to perform sync shard operation"
+                        )
+        ));
 
         Ok(())
     }
@@ -1829,7 +1833,10 @@ mod tests {
         assert!(matches!(
             status,
             Err(err) if err.http_status_code() == Some(StatusCode::BAD_REQUEST) &&
-                err.to_string().contains("The request came from an epoch that is too old: 0. Current epoch is 10")));
+                err.to_string().contains(
+                    "The request came from an epoch that is too old: 0. Current epoch is 10"
+                )
+        ));
 
         Ok(())
     }

--- a/crates/walrus-service/src/node/blob_sync.rs
+++ b/crates/walrus-service/src/node/blob_sync.rs
@@ -162,7 +162,9 @@ impl BlobSyncHandler {
                 }
                 sync_result = synchronizer.run() => match sync_result {
                     Ok(()) => {
-                        node.mark_event_completed(synchronizer.event_index, &synchronizer.event_id)?;
+                        node.mark_event_completed(
+                            synchronizer.event_index, &synchronizer.event_id
+                        )?;
                         Ok(None)
                     }
                     // NOTE(jsmith): This changes behaviour from the previous implementation.

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -1209,7 +1209,8 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    /// Tests that the storage returns correct error when trying to sync a shard that does not exist.
+    /// Tests that the storage returns correct error when trying to sync a shard that does not
+    /// exist.
     #[tokio::test]
     async fn handle_sync_shard_request_shard_not_found() -> TestResult {
         let storage = empty_storage();

--- a/crates/walrus-service/src/node/storage/blob_info.rs
+++ b/crates/walrus-service/src/node/storage/blob_info.rs
@@ -131,8 +131,10 @@ impl BlobInfoV1 {
     }
 
     /// Updates the status of the blob.
+    ///
     /// If the new status is higher than the current status, the status is updated.
-    /// If the new status is the same as the current status, the status with the higher end epoch is kept.
+    /// If the new status is the same as the current status, the status with the higher end epoch is
+    /// kept.
     fn update_status(
         &mut self,
         blob_id: &BlobId,

--- a/crates/walrus-service/src/node/storage/shard.rs
+++ b/crates/walrus-service/src/node/storage/shard.rs
@@ -32,7 +32,8 @@ pub enum ShardStatus {
     /// The shard is active in this node serving reads and writes.
     Active,
 
-    /// The shard is locked for moving to another node. Shard does not accept any more writes in this status.
+    /// The shard is locked for moving to another node. Shard does not accept any more writes in
+    /// this status.
     LockedToMove,
 }
 
@@ -195,8 +196,8 @@ impl ShardStorage {
         }
     }
 
-    /// Returns the name and options for the column families for a shard's primary and secondary sliver
-    /// with the specified index.
+    /// Returns the name and options for the column families for a shard's primary and secondary
+    /// sliver with the specified index.
     pub(crate) fn slivers_column_family_options(
         id: ShardIndex,
         db_config: &DatabaseConfig,
@@ -236,8 +237,8 @@ impl ShardStorage {
             .unwrap_or_default()
             .into_iter()
             .filter_map(|cf_name| match id_from_column_family_name(&cf_name) {
-                // To check existing shards, we only need to look at whether the secondary sliver column
-                // was created or not, as it was created after the primary sliver column.
+                // To check existing shards, we only need to look at whether the secondary sliver
+                // column was created or not, as it was created after the primary sliver column.
                 Some((shard_index, SliverType::Secondary)) => Some(shard_index),
                 Some((_, SliverType::Primary)) | None => None,
             })
@@ -505,7 +506,10 @@ mod tests {
     param_test! {
         test_parse_column_family_name: [
             primary: ("shard-10/primary-slivers", Some((ShardIndex(10), SliverType::Primary))),
-            secondary: ("shard-20/secondary-slivers", Some((ShardIndex(20), SliverType::Secondary))),
+            secondary: (
+                "shard-20/secondary-slivers",
+                Some((ShardIndex(20), SliverType::Secondary))
+            ),
             invalid_id: ("shard-a/primary-slivers", None),
             invalid_sliver_type: ("shard-20/random-slivers", None),
             invalid_sliver_name: ("shard-20/slivers", None),

--- a/crates/walrus-stress/src/generator.rs
+++ b/crates/walrus-stress/src/generator.rs
@@ -299,7 +299,11 @@ impl LoadGenerator {
             tokio::select! {
                 _ = write_interval.tick() => {
                     self.metrics.observe_benchmark_duration(Instant::now().duration_since(start));
-                    self.write_burst(writes_per_burst, write_interval.period(), inconsistent_blob_rate);
+                    self.write_burst(
+                        writes_per_burst,
+                        write_interval.period(),
+                        inconsistent_blob_rate,
+                    );
                 }
                 _ = read_interval.tick() => {
                     self.metrics.observe_benchmark_duration(Instant::now().duration_since(start));

--- a/crates/walrus-stress/src/main.rs
+++ b/crates/walrus-stress/src/main.rs
@@ -55,8 +55,10 @@ struct Args {
     /// The binary logarithm of the maximum blob size to use for the load generation.
     #[clap(long, default_value = "20")]
     max_size_log2: u8,
-    /// The period in milliseconds to check if gas needs to be refilled. This is useful for continuous load testing
-    /// where the gas budget need to be refilled periodically.
+    /// The period in milliseconds to check if gas needs to be refilled.
+    ///
+    /// This is useful for continuous load testing where the gas budget need to be refilled
+    /// periodically.
     #[clap(long, default_value = "1000")]
     gas_refill_period_millis: NonZeroU64,
     /// The fraction of writes that write inconsistent blobs.

--- a/crates/walrus-sui/src/test_utils.rs
+++ b/crates/walrus-sui/src/test_utils.rs
@@ -220,7 +220,8 @@ pub mod using_msim {
 
     use super::TestClusterHandle;
 
-    /// Returns a handle to a newly created global instance of a Sui test cluster and the wallet config path.
+    /// Returns a handle to a newly created global instance of a Sui test cluster and the wallet
+    /// config path.
     pub async fn global_sui_test_cluster() -> Arc<TestClusterHandle> {
         Arc::new(TestClusterHandle::new().await)
     }


### PR DESCRIPTION
I noticed that the editorconfig-checker fails to parse the multiline pattern and silently fails in that case... 🤦 

This fixes the config file and addresses all the findings that found their way into the codebase since the issue with the config file exists.