### PR TITLE
feat(move): add `register_thrifty` function that minimizes storage resource use

### DIFF
--- a/contracts/blob_store/Move.toml
+++ b/contracts/blob_store/Move.toml
@@ -3,7 +3,8 @@ name = "blob_store"
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.31.1" }
+#Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.31.1" }
+Sui = { local = "../../../sui/crates/sui-framework/packages/sui-framework" }
 
 [addresses]
 blob_store = "0x0"


### PR DESCRIPTION
`blob::register` allows the storage resource to be "bigger" than the blob being registered:

```
assert!(encoded_size <= storage_size(&storage), EResourceSize);
```

This is harmless from the system's perspective, but potentially troubling for a user who uses the wrong storage resource to register a blob.

In addition to overpaying up front, `blob::extend` looks at the size of the storage resource locked in the blob, so a user who accidentally overpays once will also need to overpay upon extension.

This PR leaves the old `register` functionality in place for now, but adds a new `register_thrifty` function that splits the input storage resource into exactly the right size + returns the remainder to the user. We could also consider changing the behavior of `register` under the hood (likely will change nothing in practice given that the CLI/SDKs currently create a storage resource exactly the right size)