### PR TITLE
chore: small nits to active_set

### DIFF
--- a/contracts/walrus/sources/staking/active_set.move
+++ b/contracts/walrus/sources/staking/active_set.move
@@ -27,40 +27,43 @@ public struct ActiveSet has store, copy, drop {
     /// The maximum number of storage nodes in the active set.
     /// Potentially remove this field.
     max_size: u16,
-    /// The minimum amount of staked WAL in the active set. This is used to
+    /// The minimum amount of staked WAL needed to enter the active set. This is used to
     /// determine if a storage node can be added to the active set.
-    min_stake: u64,
+    threshold_stake: u64,
     /// The amount of staked WAL for each storage node in the active set.
     nodes: VecMap<ID, u64>,
-    /// The total amount of staked WAL in the active set.
-    total_stake: u64,
     /// Stores indexes of the nodes in the active set sorted by stake. This
     /// allows us to quickly find the index of a node in the sorted list of
     /// nodes. Uses `u16` to save space, as the active set can only contain up
     /// to 1000 nodes.
     idx_sorted: vector<u16>,
+    /// The total amount of staked WAL in the active set.
+    total_stake: u64,
 }
 
-/// Creates a new active set with the given `size` and `min_stake`. The
+/// Creates a new active set with the given `size` and `threshold_stake`. The
 /// latter is used to filter out storage nodes that do not have enough staked
 /// WAL to be included in the active set initially.
-public(package) fun new(max_size: u16, min_stake: u64): ActiveSet {
+public(package) fun new(max_size: u16, threshold_stake: u64): ActiveSet {
+    assert!(max_size > 0);
     ActiveSet {
         max_size,
-        min_stake,
+        threshold_stake,
         nodes: vec_map::empty(),
-        total_stake: 0,
         idx_sorted: vector[],
+        total_stake: 0,
     }
 }
 
 /// Performs the `insert` if the node is not in the active set, otherwise calls
 /// the `update`.
-public(package) fun insert_or_update(set: &mut ActiveSet, node_id: ID, staked_amount: u64) {
+/// Returns true if the node is in the set, false otherwise.
+public(package) fun insert_or_update(set: &mut ActiveSet, node_id: ID, staked_amount: u64): bool {
     if (set.nodes.contains(&node_id)) {
         update(set, node_id, staked_amount);
+        true
     } else {
-        insert(set, node_id, staked_amount);
+        insert(set, node_id, staked_amount)
     }
 }
 
@@ -79,12 +82,35 @@ public(package) fun update(set: &mut ActiveSet, node_id: ID, staked_amount: u64)
 /// active set. The node is only added if it has enough staked WAL to be included
 /// in the active set. If the active set is full, the node with the smallest
 /// staked WAL is removed to make space for the new node.
-public(package) fun insert(set: &mut ActiveSet, node_id: ID, staked_amount: u64) {
+/// Returns true if the node was inserted, false otherwise.
+public(package) fun insert(set: &mut ActiveSet, node_id: ID, staked_amount: u64): bool {
     assert!(!set.nodes.contains(&node_id));
 
     // check if the staked amount is enough to be included in the active set
-    if (staked_amount < set.min_stake) return;
+    if (staked_amount < set.threshold_stake) return false;
 
+    // If the nodes are less than the max size, insert the node
+    if (set.nodes.size() as u16 < set.max_size) {
+        insert_impl(set, node_id, staked_amount);
+        true
+    } else {
+        // find the node with the smallest staked WAL
+        let (min_node_id, cur_min_stake) = set.nodes.get_entry_by_idx(set.idx_sorted[0] as u64);
+        if (staked_amount > *cur_min_stake) {
+            // Remove the smallest node and decrease the total stake
+            let (_, min_stake) = set.nodes.remove(&*min_node_id);
+            set.total_stake = set.total_stake - min_stake;
+
+            // insert the new node as if the set was not full
+            insert_impl(set, node_id, staked_amount);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+fun insert_impl(set: &mut ActiveSet, node_id: ID, staked_amount: u64) {
     // happy path for the first node, no need to sort, just insert
     if (set.nodes.size() == 0) {
         set.total_stake = set.total_stake + staked_amount;
@@ -93,45 +119,20 @@ public(package) fun insert(set: &mut ActiveSet, node_id: ID, staked_amount: u64)
         return
     };
 
-    //
-    if (set.nodes.size() as u16 < set.max_size) {
-        set.total_stake = set.total_stake + staked_amount;
-        set.nodes.insert(node_id, staked_amount);
-
-        let map_idx = set.nodes.size() as u16 - 1;
-        let insert_idx = set
-            .idx_sorted
-            .find_index!(
-                |idx| {
-                    let (_node_id, stake) = set.nodes.get_entry_by_idx(*idx as u64);
-                    staked_amount > *stake
-                },
-            );
-
-        if (insert_idx.is_some()) {
-            insert_idx.do!(|idx| set.idx_sorted.insert(idx as u16, map_idx as u64));
-        } else {
-            set.idx_sorted.push_back(map_idx);
-        };
-
-        if (set.nodes.size() as u16 == set.max_size) {
-            let (_node_id, stake) = set.nodes.get_entry_by_idx(set.idx_sorted[0] as u64);
-            set.min_stake = *stake;
-        }
-    } else if (staked_amount > set.min_stake) {
-        // find the node with the smallest staked WAL
-        let (min_node_id, _) = set.nodes.get_entry_by_idx(set.idx_sorted[0] as u64);
-        let min_node_id = *min_node_id;
-        let (_, min_stake) = set.nodes.remove(&min_node_id);
-
-        // decrease the total staked WAL
-        set.total_stake = set.total_stake - min_stake;
-
-        // insert the new node as if the set was not full
-        insert(set, node_id, staked_amount);
-    }
-
-    // or operation didn't happen
+    assert!(set.nodes.size() as u16 < set.max_size); // internal invariant
+    set.total_stake = set.total_stake + staked_amount;
+    set.nodes.insert(node_id, staked_amount);
+    let map_idx = set.nodes.size() as u16 - 1;
+    let insert_idx = set
+        .idx_sorted
+        .find_index!(
+            |idx| {
+                let (_node_id, stake) = set.nodes.get_entry_by_idx(*idx as u64);
+                staked_amount > *stake
+            },
+        )
+        .destroy_or!(set.idx_sorted.length());
+    set.idx_sorted.insert(insert_idx as u16, map_idx as u64);
 }
 
 /// Removes the storage node with the given `node_id` from the active set.
@@ -155,10 +156,22 @@ public(package) fun size(set: &ActiveSet): u16 { set.nodes.size() as u16 }
 public(package) fun active_ids(set: &ActiveSet): vector<ID> { set.nodes.keys() }
 
 /// The minimum amount of staked WAL in the active set.
-public(package) fun min_stake(set: &ActiveSet): u64 { set.min_stake }
+public(package) fun threshold_stake(set: &ActiveSet): u64 { set.threshold_stake }
 
 /// The total amount of staked WAL in the active set.
 public(package) fun total_stake(set: &ActiveSet): u64 { set.total_stake }
+
+/// Current minimum stake needed to be in the active set.
+/// If the active set is full, the minimum stake is the stake of the node with the smallest stake.
+/// Otherwise, the minimum stake is the threshold stake.
+public(package) fun cur_min_stake(set: &ActiveSet): u64 {
+    if (set.nodes.size() == set.max_size as u64) {
+        let (_, stake) = set.nodes.get_entry_by_idx(set.idx_sorted[0] as u64);
+        *stake
+    } else {
+        set.threshold_stake
+    }
+}
 
 #[syntax(index)]
 /// Get the staked amount of the storage node with the given `node_id`.
@@ -177,27 +190,27 @@ public(package) fun get_by_stake_idx(set: &ActiveSet, idx: u64): &ID {
 
 #[test]
 fun test_insert() {
-    use sui::test_utils::assert_eq;
+    use std::unit_test::assert_eq;
 
     let mut set = new(3, 100);
     set.insert(@0x1.to_id(), 200);
     set.insert(@0x2.to_id(), 300);
     set.insert(@0x3.to_id(), 400);
 
-    assert_eq(set.size(), 3);
-    assert_eq(set.max_size(), 3);
+    assert_eq!(set.size(), 3);
+    assert_eq!(set.max_size(), 3);
 
     let active_ids = set.active_ids();
     assert!(active_ids.contains(&@0x1.to_id()));
     assert!(active_ids.contains(&@0x2.to_id()));
     assert!(active_ids.contains(&@0x3.to_id()));
-    assert_eq(set.min_stake(), 200);
+    assert_eq!(set.cur_min_stake(), 200);
 
     // now insert a node with even more staked WAL
     set.insert(@0x4.to_id(), 500);
 
-    assert_eq(set.size(), 3);
-    assert_eq(set.min_stake(), 300);
+    assert_eq!(set.size(), 3);
+    assert_eq!(set.cur_min_stake(), 300);
 
     let active_ids = set.active_ids();
     assert!(active_ids.contains(&@0x2.to_id()));
@@ -207,8 +220,8 @@ fun test_insert() {
     // and now insert a node with less staked WAL
     set.insert(@0x5.to_id(), 250);
 
-    assert_eq(set.size(), 3);
-    assert_eq(set.min_stake(), 300);
+    assert_eq!(set.size(), 3);
+    assert_eq!(set.cur_min_stake(), 300);
 
     let active_ids = set.active_ids();
     assert!(active_ids.contains(&@0x2.to_id()));
@@ -220,11 +233,23 @@ fun test_insert() {
     set.insert(@0x7.to_id(), 1000);
     set.insert(@0x8.to_id(), 1000);
 
-    assert_eq(set.size(), 3);
-    assert_eq(set.min_stake(), 1000);
+    assert_eq!(set.size(), 3);
+    assert_eq!(set.cur_min_stake(), 1000);
 
     let active_ids = set.active_ids();
     assert!(active_ids.contains(&@0x6.to_id()));
     assert!(active_ids.contains(&@0x7.to_id()));
     assert!(active_ids.contains(&@0x8.to_id()));
+}
+
+#[test]
+fun test_size_1() {
+    use std::unit_test::assert_eq;
+
+    let mut set = new(1, 100);
+    assert_eq!(set.cur_min_stake(), 100);
+    set.insert(@0x1.to_id(), 1000);
+    assert_eq!(set.cur_min_stake(), 1000);
+    set.insert(@0x2.to_id(), 1001);
+    assert_eq!(set.cur_min_stake(), 1001);
 }

--- a/contracts/walrus/tests/staking/staking_inner_tests.move
+++ b/contracts/walrus/tests/staking/staking_inner_tests.move
@@ -54,7 +54,7 @@ fun test_staking_active_set() {
     // expect the active set to be modified
     assert!(staking.active_set().total_stake() == 1000000);
     assert!(staking.active_set().active_ids().length() == 3);
-    assert!(staking.active_set().min_stake() == 0);
+    assert!(staking.active_set().cur_min_stake() == 0);
 
     // trigger `advance_epoch` to update the committee
     staking.select_committee();


### PR DESCRIPTION
- I looked into making active set more efficient, but I don't think there is much we can do currently, because we want to support updating a node's stake. This operation is not easy to do efficiently with a priority queue.
   - We could if we want to make things faster ditch VecMap for a map where the entries are sorted by the bcs bytes of the ID, but I'm not sure this would really be faster in practice 
- In the process of looking into efficiency I made a few small changes
  - Consolidated logic for inserting to avoid recursion
  - The logic for minimum stake was not valid in the situation where the set decreased in size... which can't really happen today but no reason to brittle for it IMO