### PR TITLE
fix: clean up all `unwrap`s in production code

### DIFF
--- a/crates/walrus-event/src/checkpoint_processor.rs
+++ b/crates/walrus-event/src/checkpoint_processor.rs
@@ -259,7 +259,7 @@ impl CheckpointProcessor {
                             })?;
                     }
                 }
-                let tx_events = tx.events.unwrap();
+                let tx_events = tx.events.unwrap_or_default();
                 for (seq, tx_event) in tx_events
                     .data
                     .into_iter()

--- a/crates/walrus-sdk/src/lib.rs
+++ b/crates/walrus-sdk/src/lib.rs
@@ -23,7 +23,7 @@ pub fn server_name_from_public_key(public_key: &NetworkPublicKey) -> String {
 
     let mut server_name = String::new();
     for byte in public_key_bytes.iter().take(N_PUBLIC_KEY_BYTES_IN_SUBJECT) {
-        write!(&mut server_name, "{:x}", byte).unwrap();
+        write!(&mut server_name, "{byte:x}").expect("write on a string always succeeds");
     }
     server_name.push_str(".network.walrus.alt");
     server_name

--- a/crates/walrus-sdk/src/tls.rs
+++ b/crates/walrus-sdk/src/tls.rs
@@ -92,11 +92,11 @@ pub fn create_unsigned_certificate(
     let certificate = X509Certificate {
         tbs_certificate,
         signature_algorithm,
-        signature: BitString::from_bytes(&[]).unwrap(),
+        signature: BitString::from_bytes(&[]).expect("an empty bit string can always be created"),
     };
     let der = certificate
         .to_der()
-        .expect("self signed certificate is der-encodable");
+        .expect("self-signed certificate is DER-encodable");
     CertificateDer::from(der)
 }
 

--- a/crates/walrus-service/bin/deploy.rs
+++ b/crates/walrus-service/bin/deploy.rs
@@ -60,10 +60,10 @@ struct DeploySystemContractArgs {
     #[arg(long, default_value_t = 500_000_000)]
     gas_budget: u64,
     /// The total number of shards. The shards are distributed evenly among the storage nodes.
-    // Todo: accept non-even shard distributions #377
+    // TODO: accept non-even shard distributions #377
     #[arg(long, default_value_t = 1000)]
     n_shards: u16,
-    /// The list of hostnames or public ip addresses of the storage nodes.
+    /// The list of host names or public IP addresses of the storage nodes.
     #[clap(long, value_name = "ADDR", value_delimiter = ' ', num_args(4..))]
     host_addresses: Vec<String>,
     /// The port on which the REST API of the storage nodes will listen.
@@ -95,7 +95,7 @@ struct GenerateDryRunConfigsArgs {
     /// [default: <WORKING_DIR>/testbed_config.yaml]
     #[clap(long)]
     testbed_config_path: Option<PathBuf>,
-    /// The list of listening ip addresses of the storage nodes.
+    /// The list of listening IP addresses of the storage nodes.
     /// If not set, defaults to the addresses or (resolved) host names set in the testbed config.
     #[clap(long, value_name = "ADDR", value_delimiter = ' ', num_args(..))]
     listening_ips: Option<Vec<IpAddr>>,
@@ -175,7 +175,8 @@ mod commands {
 
         // Deploy the system contract.
         let number_of_shards = NonZeroU16::new(n_shards).context("number of shards must be > 0")?;
-        let committee_size = NonZeroU16::new(host_addresses.len() as u16).unwrap();
+        let committee_size = NonZeroU16::new(host_addresses.len() as u16)
+            .expect("the argument specification ensures that the length is at least 4");
         let shards_information = even_shards_allocation(number_of_shards, committee_size);
 
         let testbed_config = deploy_walrus_contract(DeployTestbedContractParameters {

--- a/crates/walrus-service/src/node/blob_sync.rs
+++ b/crates/walrus-service/src/node/blob_sync.rs
@@ -289,8 +289,7 @@ impl BlobSynchronizer {
         let mut sliver_sync_futures: FuturesUnordered<_> = self
             .storage()
             .shards()
-            .iter()
-            .flat_map(|&shard| {
+            .flat_map(|shard| {
                 [
                     Either::Left(
                         self.recover_sliver::<Primary>(shard, &metadata)

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -328,7 +328,9 @@ impl<T: SupportedKeyPair> PathOrInPlace<TaggedKeyPair<T>> {
                 .map_err(|err: KeyPairParseError| anyhow::anyhow!(err.to_string()))?;
             *value = Some(decoded)
         };
-        Ok(self.get().unwrap())
+        Ok(self
+            .get()
+            .expect("we just made sure that the value is some"))
     }
 }
 

--- a/crates/walrus-service/src/node/metrics.rs
+++ b/crates/walrus-service/src/node/metrics.rs
@@ -33,10 +33,12 @@ pub(super) use with_label;
 
 macro_rules! create_metric {
     ($metric_type:ty, $registry:ident, $opts:expr) => {{
-        <$metric_type>::with_opts($opts).unwrap()
+        <$metric_type>::with_opts($opts)
+            .expect("this must be called with valid metrics type and options")
     }};
     ($metric_type:ty, $registry:ident, $opts:expr, $label_names:expr) => {{
-        <$metric_type>::new($opts.into(), $label_names).unwrap()
+        <$metric_type>::new($opts.into(), $label_names)
+            .expect("this must be called with valid metrics type, options, and labels")
     }};
 }
 

--- a/crates/walrus-service/src/node/server.rs
+++ b/crates/walrus-service/src/node/server.rs
@@ -82,7 +82,7 @@ impl From<&StorageNodeConfig> for UserServerConfig {
 
             Some(TlsCertificateSource::GenerateSelfSigned {
                 server_name,
-                network_key_pair: config.network_key_pair.get().cloned().unwrap(),
+                network_key_pair: config.network_key_pair().clone(),
             })
         };
 
@@ -288,7 +288,11 @@ where
             }
         };
         // Returns only once bind has been completed
-        let _ = handle.as_ref().unwrap().listening().await;
+        let _ = handle
+            .as_ref()
+            .expect("we only break if the handle is some")
+            .listening()
+            .await;
     }
 
     fn define_routes(&self) -> Router<Arc<S>> {

--- a/crates/walrus-service/src/node/server/routes.rs
+++ b/crates/walrus-service/src/node/server/routes.rs
@@ -8,14 +8,12 @@ use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
 };
-use fastcrypto::traits::EncodeDecodeBase64;
 use tracing::Level;
 use walrus_core::{
     encoding::{Primary as PrimaryEncoding, Secondary as SecondaryEncoding},
     messages::{InvalidBlobIdAttestation, SignedSyncShardRequest, StorageConfirmation},
     metadata::{BlobMetadata, UnverifiedBlobMetadataWithId, VerifiedBlobMetadataWithId},
     InconsistencyProof,
-    PublicKey,
     RecoverySymbol,
     Sliver,
     SliverPairIndex,
@@ -453,9 +451,8 @@ pub async fn health_info<S: SyncServiceState>(
 )]
 pub async fn sync_shard<S: SyncServiceState>(
     State(state): State<Arc<S>>,
-    Authorization(base64_public_key): Authorization,
+    Authorization(public_key): Authorization,
     Bcs(signed_request): Bcs<SignedSyncShardRequest>,
 ) -> Result<Response, OrRejection<SyncShardServiceError>> {
-    let public_key = PublicKey::decode_base64(&base64_public_key).unwrap();
     Ok(Bcs(state.sync_shard(public_key, signed_request)?).into_response())
 }

--- a/crates/walrus-service/src/node/shard_sync.rs
+++ b/crates/walrus-service/src/node/shard_sync.rs
@@ -66,9 +66,7 @@ impl ShardSyncHandler {
     /// Restarts syncing shards that were previously syncing. This method is used when restarting
     /// the node.
     pub async fn restart_syncs(&self) -> Result<(), anyhow::Error> {
-        for shard_index in self.node.storage.shards() {
-            let shard_storage = self.node.storage.shard_storage(shard_index).unwrap();
-
+        for shard_storage in self.node.storage.shard_storages() {
             // Restart the syncing task for shards that were previously syncing (in ActiveSync
             // status).
             let shard_status = shard_storage.status()?;

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -394,8 +394,13 @@ impl Storage {
     }
 
     /// Returns the indices of the shards managed by the storage.
-    pub fn shards(&self) -> Vec<ShardIndex> {
-        self.shards.keys().copied().collect()
+    pub fn shards(&self) -> impl ExactSizeIterator<Item = ShardIndex> + '_ {
+        self.shards.keys().copied()
+    }
+
+    /// Returns an iterator over the shard storages managed by the storage.
+    pub fn shard_storages(&self) -> impl ExactSizeIterator<Item = &Arc<ShardStorage>> {
+        self.shards.values()
     }
 
     /// Returns a handle over the storage for a single shard.

--- a/crates/walrus-service/src/node/storage/event_cursor_table.rs
+++ b/crates/walrus-service/src/node/storage/event_cursor_table.rs
@@ -127,5 +127,5 @@ fn update_cursor_and_progress(
         current_val = Some((updated_progress, cursor));
     }
 
-    current_val.map(|value| bcs::to_bytes(&value).unwrap())
+    current_val.map(|value| bcs::to_bytes(&value).expect("this can be BCS-encoded"))
 }

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -606,7 +606,7 @@ impl TestCluster {
                 network_address: node.rest_api_address.into(),
                 public_key: node.public_key.clone(),
                 network_public_key: node.network_public_key.clone(),
-                shard_ids: node.storage_node.shards(),
+                shard_ids: node.storage_node.shards().collect(),
             })
             .collect();
         Committee::new(members, 0)

--- a/crates/walrus-stress/src/metrics.rs
+++ b/crates/walrus-stress/src/metrics.rs
@@ -41,14 +41,14 @@ impl ClientMetrics {
                 "Duration of the benchmark",
                 registry,
             )
-            .unwrap(),
+            .expect("this is a valid metrics registration"),
             submitted: register_counter_vec_with_registry!(
                 "submitted",
                 "Number of submitted transactions",
                 &["workload"],
                 registry,
             )
-            .unwrap(),
+            .expect("this is a valid metrics registration"),
             latency_s: register_histogram_vec_with_registry!(
                 "latency_s",
                 "Total time in seconds to to achieve finality",
@@ -56,27 +56,27 @@ impl ClientMetrics {
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
-            .unwrap(),
+            .expect("this is a valid metrics registration"),
             latency_squared_s: register_counter_vec_with_registry!(
                 "latency_squared_s",
                 "Square of total time in seconds to achieve finality",
                 &["workload"],
                 registry,
             )
-            .unwrap(),
+            .expect("this is a valid metrics registration"),
             errors: register_counter_vec_with_registry!(
                 "errors",
                 "Reports various errors",
                 &["type"],
                 registry,
             )
-            .unwrap(),
+            .expect("this is a valid metrics registration"),
             gas_refill: register_int_counter_with_registry!(
                 "gas_refill",
                 "Number of gas refills",
                 registry,
             )
-            .unwrap(),
+            .expect("this is a valid metrics registration"),
         }
     }
 


### PR DESCRIPTION
This PR removes all instances of `unwrap` in production code. This excludes tests, benchmarks, and the `walrus-orchestrator` crate.

Some cases are replaced by an `expect` explaining the reason why this can never panic. In some cases a slight rewrite of the code allowed removing the unwrapping altogether.

There are two cases where the previous behavior was potentially problematic:
- In `crates/walrus-event/src/checkpoint_processor.rs`
- The authorization header in `crates/walrus-service/src/node/server/extract.rs` and `crates/walrus-service/src/node/server/routes.rs`.

Closes #765 