### PR TITLE
test: use move test BuildConfig in tests to avoid multiple tests use the same install_dir

### DIFF
--- a/crates/walrus-sui/src/system_setup.rs
+++ b/crates/walrus-sui/src/system_setup.rs
@@ -65,7 +65,12 @@ pub(crate) async fn publish_package(
     let sender = wallet.active_address()?;
     let sui = wallet.get_client().await?;
 
-    let build_config = BuildConfig::default();
+    let build_config = if cfg!(any(test, feature = "test-utils")) {
+        BuildConfig::new_for_testing()
+    } else {
+        BuildConfig::default()
+    };
+
     let compiled_package = build_config
         .build(&package_path)
         .expect("Building package failed");


### PR DESCRIPTION
Fix flakiness in CI