### PR TITLE
feat: Update smart contract to certify event blobs

### DIFF
--- a/contracts/wal/Move.lock
+++ b/contracts/wal/Move.lock
@@ -21,6 +21,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.34.2"
+compiler-version = "1.33.0"
 edition = "2024.beta"
 flavor = "sui"

--- a/contracts/wal_exchange/Move.lock
+++ b/contracts/wal_exchange/Move.lock
@@ -30,6 +30,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.34.2"
+compiler-version = "1.33.0"
 edition = "2024.beta"
 flavor = "sui"

--- a/contracts/walrus/Move.lock
+++ b/contracts/walrus/Move.lock
@@ -40,6 +40,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.34.2"
+compiler-version = "1.33.0"
 edition = "2024.beta"
 flavor = "sui"

--- a/contracts/walrus/sources/staking/storage_node.move
+++ b/contracts/walrus/sources/staking/storage_node.move
@@ -5,7 +5,9 @@
 module walrus::storage_node;
 
 use std::string::String;
-use sui::{bls12381::{G1, g1_from_bytes}, group_ops::Element};
+use sui::bls12381::{G1, g1_from_bytes};
+use sui::group_ops::Element;
+use walrus::event_blob::EventBlobAttestation;
 
 // Error codes
 const EInvalidNetworkPublicKey: u64 = 1;
@@ -25,6 +27,7 @@ public struct StorageNodeCap has key, store {
     id: UID,
     node_id: ID,
     last_epoch_sync_done: u32,
+    last_event_blob_attestation: Option<EventBlobAttestation>,
 }
 
 /// A public constructor for the StorageNodeInfo.
@@ -51,11 +54,14 @@ public(package) fun new_cap(node_id: ID, ctx: &mut TxContext): StorageNodeCap {
         id: object::new(ctx),
         node_id,
         last_epoch_sync_done: 0,
+        last_event_blob_attestation: option::none(),
     }
 }
 
 /// Return the public key of the storage node.
-public(package) fun public_key(self: &StorageNodeInfo): &Element<G1> { &self.public_key }
+public(package) fun public_key(self: &StorageNodeInfo): &Element<G1> {
+    &self.public_key
+}
 
 /// Return the node ID of the storage node.
 public fun id(cap: &StorageNodeInfo): ID { cap.node_id }
@@ -63,12 +69,30 @@ public fun id(cap: &StorageNodeInfo): ID { cap.node_id }
 /// Return the pool ID of the storage node.
 public fun node_id(cap: &StorageNodeCap): ID { cap.node_id }
 
-/// Return the last epoch in which the storage node attested that it has finished syncing.
-public fun last_epoch_sync_done(cap: &StorageNodeCap): u32 { cap.last_epoch_sync_done }
+/// Return the last epoch in which the storage node attested that it has
+/// finished syncing.
+public fun last_epoch_sync_done(cap: &StorageNodeCap): u32 {
+    cap.last_epoch_sync_done
+}
 
-/// Set the last epoch in which the storage node attested that it has finished syncing.
+/// Set the last epoch in which the storage node attested that it has finished
+/// syncing.
 public(package) fun set_last_epoch_sync_done(self: &mut StorageNodeCap, epoch: u32) {
     self.last_epoch_sync_done = epoch;
+}
+
+/// Return the latest event blob attestion.
+public fun last_event_blob_attestation(cap: &mut StorageNodeCap): Option<EventBlobAttestation> {
+    cap.last_event_blob_attestation
+}
+
+/// Set the last epoch in which the storage node attested that it has finished
+/// syncing.
+public(package) fun set_last_event_blob_attestation(
+    self: &mut StorageNodeCap,
+    attestation: EventBlobAttestation,
+) {
+    self.last_event_blob_attestation = option::some(attestation);
 }
 
 #[test_only]

--- a/contracts/walrus/sources/system/event_blob.move
+++ b/contracts/walrus/sources/system/event_blob.move
@@ -1,0 +1,159 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Module to certify event blobs.
+module walrus::event_blob;
+
+use sui::vec_map::VecMap;
+
+// === Definitions related to event blob certification ===
+
+/// Event blob index which was attested by a storage node.
+public struct EventBlobAttestation has store, copy, drop {
+    checkpoint_sequence_num: u64,
+    epoch: u32,
+}
+
+/// State of a certified event blob.
+public struct EventBlob has copy, store, drop {
+    /// Blob id of the certified event blob.
+    blob_id: u256,
+    /// Ending sui checkpoint of the certified event blob.
+    ending_checkpoint_sequence_number: u64,
+}
+
+/// State of event blob stream.
+#[allow(unused_field)]
+public struct EventBlobCertificationState has key, store {
+    id: UID,
+    /// Latest certified event blob.
+    latest_certified_blob: Option<EventBlob>,
+    /// Current event blob being attested.
+    aggregate_weight_per_blob: VecMap<u256, u16>,
+}
+
+// === Accessors related to event blob attestation ===
+
+public(package) fun new_attestation(
+    checkpoint_sequence_num: u64,
+    epoch: u32,
+): EventBlobAttestation {
+    EventBlobAttestation {
+        checkpoint_sequence_num,
+        epoch,
+    }
+}
+
+public(package) fun last_attested_event_blob_checkpoint_seq_num(self: &EventBlobAttestation): u64 {
+    self.checkpoint_sequence_num
+}
+
+public(package) fun last_attested_event_blob_epoch(self: &EventBlobAttestation): u32 { self.epoch }
+
+// === Accessors for EventBlob ===
+
+public(package) fun new_event_blob(
+    ending_checkpoint_sequence_number: u64,
+    blob_id: u256,
+): EventBlob {
+    EventBlob {
+        blob_id,
+        ending_checkpoint_sequence_number,
+    }
+}
+
+/// Returns the blob id of the event blob
+public(package) fun blob_id(self: &EventBlob): u256 {
+    self.blob_id
+}
+
+/// Returns the ending checkpoint sequence number of the event blob
+public(package) fun ending_checkpoint_sequence_number(self: &EventBlob): u64 {
+    self.ending_checkpoint_sequence_number
+}
+
+// === Accessors for EventBlobCertificationState ===
+
+/// Creates a blob state with no signers and no last checkpoint sequence number
+public(package) fun create_with_empty_state(ctx: &mut TxContext): EventBlobCertificationState {
+    let id = object::new(ctx);
+    EventBlobCertificationState {
+        id,
+        latest_certified_blob: option::none(),
+        aggregate_weight_per_blob: sui::vec_map::empty(),
+    }
+}
+
+/// Returns the blob id of the latest certified event blob
+public(package) fun get_latest_certified_blob_id(self: &EventBlobCertificationState): Option<u256> {
+    self.latest_certified_blob.map!(|state| state.blob_id())
+}
+
+/// Returns the checkpoint sequence number of the latest certified event
+/// blob
+public(package) fun get_latest_certified_checkpoint_sequence_number(
+    self: &EventBlobCertificationState,
+): Option<u64> {
+    self.latest_certified_blob.map!(|state| state.ending_checkpoint_sequence_number())
+}
+
+/// Returns true if a blob is already certified or false otherwise
+public(package) fun is_blob_already_certified(
+    self: &EventBlobCertificationState,
+    ending_checkpoint_sequence_num: u64,
+): bool {
+    self
+        .get_latest_certified_checkpoint_sequence_number()
+        .map!(
+            |
+                latest_certified_sequence_num,
+            | latest_certified_sequence_num >= ending_checkpoint_sequence_num,
+        )
+        .get_with_default(false)
+}
+
+/// Updates the latest certified event blob
+public(package) fun update_latest_certified_event_blob(
+    self: &mut EventBlobCertificationState,
+    checkpoint_sequence_number: u64,
+    blob_id: u256,
+) {
+    self.get_latest_certified_checkpoint_sequence_number().do!(|latest_certified_sequence_num| {
+        assert!(checkpoint_sequence_number > latest_certified_sequence_num);
+    });
+    self.latest_certified_blob =
+        option::some(
+            new_event_blob(checkpoint_sequence_number, blob_id),
+        );
+}
+
+/// Update the aggregate weight of an event blob
+public(package) fun update_aggregate_weight(
+    self: &mut EventBlobCertificationState,
+    blob_id: u256,
+    weight: u16,
+): u16 {
+    let agg_weight = self.aggregate_weight_per_blob.get_mut(&blob_id);
+    *agg_weight = *agg_weight + weight;
+    *agg_weight
+}
+
+/// Start tracking which nodes are signing the event blob with given id for
+/// event blob certification
+public(package) fun start_tracking_blob(self: &mut EventBlobCertificationState, blob_id: u256) {
+    if (!self.aggregate_weight_per_blob.contains(&blob_id)) {
+        self.aggregate_weight_per_blob.insert(blob_id, 0);
+    };
+}
+
+/// Stop tracking nodes for the given blob id
+public(package) fun stop_tracking_blob(self: &mut EventBlobCertificationState, blob_id: u256) {
+    if (self.aggregate_weight_per_blob.contains(&blob_id)) {
+        self.aggregate_weight_per_blob.remove(&blob_id);
+    };
+}
+
+/// Reset blob certification state upon epoch change
+public(package) fun reset(self: &mut EventBlobCertificationState) {
+    self.aggregate_weight_per_blob = sui::vec_map::empty();
+}

--- a/contracts/walrus/sources/system/messages.move
+++ b/contracts/walrus/sources/system/messages.move
@@ -149,6 +149,12 @@ public(package) fun certify_blob_message(message: CertifiedMessage): CertifiedBl
     CertifiedBlobMessage { epoch, blob_id }
 }
 
+/// Constructs the certified blob message, note this is only
+/// used for event blobs
+public(package) fun certified_event_blob_message(epoch: u32, blob_id: u256): CertifiedBlobMessage {
+    CertifiedBlobMessage { epoch, blob_id }
+}
+
 /// Construct the certified invalid Blob ID message, note that constructing
 /// implies a certified message, that is already checked.
 public(package) fun invalid_blob_id_message(message: CertifiedMessage): CertifiedInvalidBlobId {

--- a/contracts/walrus/tests/system/event_blob_tests.move
+++ b/contracts/walrus/tests/system/event_blob_tests.move
@@ -1,0 +1,239 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module walrus::event_blob_tests;
+
+use sui::test_utils::destroy;
+use walrus::blob::{Self};
+use walrus::storage_node;
+use walrus::system::{Self, System};
+use walrus::system_state_inner;
+use walrus::test_node::{test_nodes, TestStorageNode};
+
+const RED_STUFF: u8 = 0;
+
+const ROOT_HASH: u256 = 0xABC;
+const SIZE: u64 = 5_000_000;
+
+#[test]
+public fun test_event_blob_certify_happy_path() {
+    let ctx = &mut tx_context::dummy();
+    let mut system: system::System = system::new_for_testing_with_multiple_members(
+        ctx,
+    );
+    // Total of 10 nodes all with equal weights
+    assert!(system.committee().to_vec_map().size() == 10);
+    let mut nodes = test_nodes();
+    set_storage_node_caps(&system, ctx, &mut nodes);
+    let blob_id = blob::derive_blob_id(ROOT_HASH, RED_STUFF, SIZE);
+    let mut index = 0;
+    while (index < 10) {
+        system.certify_event_blob(
+            nodes.borrow_mut(index).cap_mut(),
+            blob_id,
+            ROOT_HASH,
+            SIZE,
+            RED_STUFF,
+            100,
+            0,
+            ctx,
+        );
+        let state = system.inner().get_event_blob_certification_state();
+        if (index < 6) {
+            assert!(state.get_latest_certified_checkpoint_sequence_number().is_none());
+        } else {
+            // 7th node signing the blob triggers blob certification
+            assert!(state.get_latest_certified_checkpoint_sequence_number().is_some());
+        };
+        index = index + 1
+    };
+    nodes.destroy!(|node| node.destroy());
+    destroy(system);
+}
+
+#[test, expected_failure(abort_code = system_state_inner::ERepeatedAttestation)]
+public fun test_event_blob_certify_repeated_attestation() {
+    let ctx = &mut tx_context::dummy();
+    let mut system: system::System = system::new_for_testing_with_multiple_members(
+        ctx,
+    );
+    // Total of 10 nodes
+    assert!(system.committee().to_vec_map().size() == 10);
+    let mut nodes = test_nodes();
+    set_storage_node_caps(&system, ctx, &mut nodes);
+    let blob_id = blob::derive_blob_id(ROOT_HASH, RED_STUFF, SIZE);
+    let mut index = 0;
+    while (index < 10) {
+        // Every node is going to attest the blob twice but their
+        // votes are only going to be counted once
+        system.certify_event_blob(
+            nodes.borrow_mut(index).cap_mut(),
+            blob_id,
+            ROOT_HASH,
+            SIZE,
+            RED_STUFF,
+            100,
+            0,
+            ctx,
+        );
+        system.certify_event_blob(
+            nodes.borrow_mut(index).cap_mut(),
+            blob_id,
+            ROOT_HASH,
+            SIZE,
+            RED_STUFF,
+            100,
+            0,
+            ctx,
+        );
+        let state = system.inner().get_event_blob_certification_state();
+        if (index < 6) {
+            assert!(state.get_latest_certified_checkpoint_sequence_number().is_none());
+        } else {
+            assert!(state.get_latest_certified_checkpoint_sequence_number().is_some());
+        };
+        index = index + 1
+    };
+    nodes.destroy!(|node| node.destroy());
+    destroy(system);
+}
+
+#[test, expected_failure(abort_code = system_state_inner::EIncorrectAttestation)]
+public fun test_multiple_event_blobs_in_flight() {
+    let ctx = &mut tx_context::dummy();
+    let mut system: system::System = system::new_for_testing_with_multiple_members(
+        ctx,
+    );
+    // Total of 10 nodes
+    assert!(system.committee().to_vec_map().size() == 10);
+    let mut nodes = test_nodes();
+    set_storage_node_caps(&system, ctx, &mut nodes);
+    let blob1 = blob::derive_blob_id(0xabc, RED_STUFF, SIZE);
+    let blob2 = blob::derive_blob_id(0xdef, RED_STUFF, SIZE);
+
+    let mut index = 0;
+    while (index < 6) {
+        system.certify_event_blob(
+            nodes.borrow_mut(index).cap_mut(),
+            blob1,
+            0xabc,
+            SIZE,
+            RED_STUFF,
+            100,
+            0,
+            ctx,
+        );
+        system.certify_event_blob(
+            nodes.borrow_mut(index).cap_mut(),
+            blob2,
+            0xdef,
+            SIZE,
+            RED_STUFF,
+            200,
+            0,
+            ctx,
+        );
+        let state = system.inner().get_event_blob_certification_state();
+        assert!(state.get_latest_certified_checkpoint_sequence_number().is_none());
+        index = index + 1
+    };
+    nodes.destroy!(|node| node.destroy());
+    destroy(system);
+}
+
+#[test]
+public fun test_event_blob_certify_change_epoch() {
+    let ctx = &mut tx_context::dummy();
+    let mut system: system::System = system::new_for_testing_with_multiple_members(
+        ctx,
+    );
+    // Total of 10 nodes
+    assert!(system.committee().to_vec_map().size() == 10);
+    let mut nodes = test_nodes();
+    set_storage_node_caps(&system, ctx, &mut nodes);
+    let blob_id = blob::derive_blob_id(ROOT_HASH, RED_STUFF, SIZE);
+    let mut index = 0;
+    while (index < 6) {
+        system.certify_event_blob(
+            nodes.borrow_mut(index).cap_mut(),
+            blob_id,
+            ROOT_HASH,
+            SIZE,
+            RED_STUFF,
+            100,
+            0,
+            ctx,
+        );
+        let state = system.inner().get_event_blob_certification_state();
+        assert!(state.get_latest_certified_checkpoint_sequence_number().is_none());
+        index = index + 1
+    };
+    // increment epoch
+    let mut new_committee = *system.committee();
+    new_committee.increment_epoch_for_testing();
+    let balance = system.advance_epoch(
+        new_committee,
+        walrus::epoch_parameters::epoch_params_for_testing(),
+    );
+    balance.destroy_for_testing();
+    // 7th node attesting is not going to certify the blob as all other nodes
+    // attested
+    // the blob in previous epoch
+    system.certify_event_blob(
+        nodes.borrow_mut(index).cap_mut(),
+        blob_id,
+        ROOT_HASH,
+        SIZE,
+        RED_STUFF,
+        100,
+        1,
+        ctx,
+    );
+    let state = system.inner().get_event_blob_certification_state();
+    assert!(state.get_latest_certified_checkpoint_sequence_number().is_none());
+    index = 0;
+    // All nodes sign the blob in current epoch
+    while (index < 10) {
+        // 7th node already attested
+        if (index == 6) {
+            index = index + 1;
+            continue
+        };
+        system.certify_event_blob(
+            nodes.borrow_mut(index).cap_mut(),
+            blob_id,
+            ROOT_HASH,
+            SIZE,
+            RED_STUFF,
+            100,
+            1,
+            ctx,
+        );
+        let state = system.inner().get_event_blob_certification_state();
+        if (index < 5) {
+            assert!(state.get_latest_certified_checkpoint_sequence_number().is_none());
+        } else {
+            assert!(state.get_latest_certified_checkpoint_sequence_number().is_some());
+        };
+        index = index + 1
+    };
+    nodes.destroy!(|node| node.destroy());
+    destroy(system);
+}
+
+// === Helper functions ===
+
+fun set_storage_node_caps(
+    system: &System,
+    ctx: &mut TxContext,
+    nodes: &mut vector<TestStorageNode>,
+) {
+    let (node_ids, _values) = system.committee().to_vec_map().into_keys_values();
+    let mut index = 0;
+    node_ids.do!(|node_id| {
+        let storage_cap = storage_node::new_cap(node_id, ctx);
+        nodes.borrow_mut(index).set_storage_node_cap(storage_cap);
+        index = index + 1;
+    });
+}


### PR DESCRIPTION
This PR updates walrus smart contracts to also start certifying event blobs. Each node will invoke the contract endpoint and upon reaching majority, the blob will be certified and a certified event emitted.