### PR TITLE
chore: clean up outdated references to `blob_store` contracts

### DIFF
--- a/.licensesnipignore
+++ b/.licensesnipignore
@@ -1,3 +1,1 @@
-contracts/blob_store/sources/tests/bls_tests.move
-contracts/blob_store/sources/tests/committee_cert_tests.move
 scripts/move_coverage.sh

--- a/contracts/walrus/sources/staking/storage_node.move
+++ b/contracts/walrus/sources/staking/storage_node.move
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Copies `blob_store::storage_node` with only addition of `StorageNodeCap` struct.
 #[allow(unused_field, unused_function, unused_variable, unused_use)]
 module walrus::storage_node;
 

--- a/contracts/walrus/sources/system/storage_resource.move
+++ b/contracts/walrus/sources/system/storage_resource.move
@@ -30,8 +30,8 @@ public fun storage_size(self: &Storage): u64 {
 }
 
 /// Constructor for [Storage] objects.
-/// Necessary to allow `blob_store::system` to create storage objects.
-/// Cannot be called outside of the current module and [blob_store::system].
+/// Necessary to allow `walrus::system` to create storage objects.
+/// Cannot be called outside of the current module and [walrus::system].
 public(package) fun create_storage(
     start_epoch: u32,
     end_epoch: u32,

--- a/crates/walrus-core/src/encoding/config.rs
+++ b/crates/walrus-core/src/encoding/config.rs
@@ -447,7 +447,7 @@ fn source_symbols_per_blob_for_n_shards(n_shards: NonZeroU16) -> NonZeroU32 {
 /// size cannot be computed.
 ///
 /// This computation is the same as done by the function of the same name in
-/// `contracts/blob_store/redstuff.move` and should be kept in sync.
+/// `contracts/walrus/sources/system/redstuff.move` and should be kept in sync.
 #[inline]
 pub fn encoded_blob_length_for_n_shards(
     n_shards: NonZeroU16,
@@ -463,7 +463,7 @@ pub fn encoded_blob_length_for_n_shards(
 /// metadata and the blob ID. Returns `None` if the blob size cannot be computed.
 ///
 /// This computation is the same as done by the function of the same name in
-/// `contracts/blob_store/redstuff.move` and should be kept in sync.
+/// `contracts/walrus/sources/system/redstuff.move` and should be kept in sync.
 pub fn encoded_slivers_length_for_n_shards(
     n_shards: NonZeroU16,
     unencoded_length: u64,
@@ -528,7 +528,7 @@ mod tests {
         ]
     }
     /// These tests replicate the tests for `encoded_blob_length` in
-    /// `contracts/blob_store/redstuff.move` and should be kept in sync.
+    /// `contracts/walrus/sources/system/redstuff.move` and should be kept in sync.
     fn test_encoded_size(blob_size: usize, n_shards: u16, expected_encoded_size: u64) {
         assert_eq!(
             EncodingConfig::new(NonZeroU16::new(n_shards).unwrap())

--- a/crates/walrus-orchestrator/src/protocol/target.rs
+++ b/crates/walrus-orchestrator/src/protocol/target.rs
@@ -94,7 +94,7 @@ mod default_node_parameters {
     }
 
     pub fn default_contract_path() -> PathBuf {
-        PathBuf::from("./contracts/blob_store")
+        PathBuf::from("./contracts/walrus")
     }
 }
 

--- a/crates/walrus-service/bin/deploy.rs
+++ b/crates/walrus-service/bin/deploy.rs
@@ -54,7 +54,7 @@ struct DeploySystemContractArgs {
     #[clap(long, default_value = "testnet")]
     sui_network: SuiNetwork,
     /// The directory in which the contracts are located.
-    #[clap(long, default_value = "./contracts/blob_store")]
+    #[clap(long, default_value = "./contracts/walrus")]
     contract_path: PathBuf,
     /// Gas budget for sui transactions to publish the contracts and set up the system.
     #[arg(long, default_value_t = 500_000_000)]

--- a/crates/walrus-sui/src/client.rs
+++ b/crates/walrus-sui/src/client.rs
@@ -553,7 +553,7 @@ impl ContractClient for SuiContractClient {
         certificate: &ConfirmationCertificate,
     ) -> SuiClientResult<Blob> {
         // Sort the list of signers, since the move contract requires them to be in
-        // ascending order (see `blob_store::bls_aggregate::verify_certificate`)
+        // ascending order (see `walrus::system::bls_aggregate::verify_certificate`)
         let mut signers = certificate.signers.clone();
         signers.sort_unstable();
         let res = self
@@ -582,7 +582,7 @@ impl ContractClient for SuiContractClient {
         certificate: &InvalidBlobCertificate,
     ) -> SuiClientResult<()> {
         // Sort the list of signers, since the move contract requires them to be in
-        // ascending order (see `blob_store::bls_aggregate::verify_certificate`)
+        // ascending order (see `walrus::system::bls_aggregate::verify_certificate`)
         let mut signers = certificate.signers.clone();
         signers.sort_unstable();
         self.move_call_and_transfer(

--- a/crates/walrus-sui/src/utils.rs
+++ b/crates/walrus-sui/src/utils.rs
@@ -46,7 +46,7 @@ use crate::{
     contracts::{self, AssociatedContractStruct},
 };
 
-// Keep in sync with the same constant in `contracts/blob_store/system.move`.
+// Keep in sync with the same constant in `contracts/walrus/sources/system.move`.
 /// The number of bytes per storage unit.
 pub const BYTES_PER_UNIT_SIZE: u64 = 1024;
 

--- a/deny.toml
+++ b/deny.toml
@@ -106,5 +106,4 @@ allow-git = [
 # github.com organizations to allow git sources for
 github = [
     "MystenLabs",
-    "quinn-rs",
 ]


### PR DESCRIPTION
Also fix the `move_coverage.sh` script to work with empty directories.