### PR TITLE
test: fix integration test after the new contract update

### DIFF
--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -1056,7 +1056,8 @@ pub mod test_cluster {
             .collect::<Vec<_>>();
         let n_shards = node_weights.iter().sum::<usize>() as u16;
 
-        let system_ctx = create_and_init_system(&mut wallet.inner, n_shards, 0).await?;
+        // TODO(#814): make epoch duration in test configurable. Currently hardcoded to 1 hour.
+        let system_ctx = create_and_init_system(&mut wallet.inner, n_shards, 0, 3600000).await?;
 
         let mut contract_clients = vec![];
         for _ in members.iter() {

--- a/crates/walrus-service/src/testbed.rs
+++ b/crates/walrus-service/src/testbed.rs
@@ -266,7 +266,8 @@ pub async fn deploy_walrus_contract(
     let sui_client = admin_wallet.get_client().await?;
     request_sui_from_faucet(admin_wallet.active_address()?, &sui_network, &sui_client).await?;
 
-    let system_ctx = create_and_init_system(&mut admin_wallet, n_shards, 0).await?;
+    // TODO(#814): make epoch duration in test configurable. Currently hardcoded to 1 hour.
+    let system_ctx = create_and_init_system(&mut admin_wallet, n_shards, 0, 3600000).await?;
 
     // TODO(#794): Contract is published, and system&staking objects are created. However, the
     // system currently is not moving forward due to that storage nodes are not registered.

--- a/crates/walrus-sui/src/system_setup.rs
+++ b/crates/walrus-sui/src/system_setup.rs
@@ -146,6 +146,7 @@ pub async fn create_system_and_staking_objects(
     init_cap: ObjectID,
     n_shards: u16,
     epoch_zero_duration_ms: u64,
+    epoch_duration_ms: u64,
     gas_budget: u64,
 ) -> Result<(ObjectID, ObjectID)> {
     let mut pt_builder = ProgrammableTransactionBuilder::new();
@@ -155,6 +156,7 @@ pub async fn create_system_and_staking_objects(
 
     let init_cap_arg = pt_builder.input(init_cap_ref.into())?;
     let epoch_zero_duration_arg = pt_builder.pure(epoch_zero_duration_ms)?;
+    let epoch_duration_arg = pt_builder.pure(epoch_duration_ms)?;
     let n_shards_arg = pt_builder.pure(n_shards)?;
     let clock_arg = pt_builder.obj(ObjectArg::SharedObject {
         id: SUI_CLOCK_OBJECT_ID,
@@ -171,6 +173,7 @@ pub async fn create_system_and_staking_objects(
         vec![
             init_cap_arg,
             epoch_zero_duration_arg,
+            epoch_duration_arg,
             n_shards_arg,
             clock_arg,
         ],

--- a/crates/walrus-sui/src/test_utils/system_setup.rs
+++ b/crates/walrus-sui/src/test_utils/system_setup.rs
@@ -52,7 +52,8 @@ pub async fn publish_with_default_system(
 ) -> Result<(ObjectID, ObjectID)> {
     // Default system config, compatible with current tests
 
-    let system_context = create_and_init_system(admin_wallet, 100, 0).await?;
+    // TODO(#814): make epoch duration in test configurable. Currently hardcoded to 1 hour.
+    let system_context = create_and_init_system(admin_wallet, 100, 0, 3600000).await?;
 
     // Set up node params.
     // Pk corresponding to secret key scalar(117)
@@ -118,6 +119,7 @@ pub async fn create_and_init_system(
     admin_wallet: &mut WalletContext,
     n_shards: u16,
     epoch_zero_duration_ms: u64,
+    epoch_duration_ms: u64,
 ) -> Result<SystemContext> {
     let (package_id, cap_id, treasury_cap) = publish_coin_and_system_package(
         admin_wallet,
@@ -132,6 +134,7 @@ pub async fn create_and_init_system(
         cap_id,
         n_shards,
         epoch_zero_duration_ms,
+        epoch_duration_ms,
         DEFAULT_GAS_BUDGET,
     )
     .await?;

--- a/crates/walrus-sui/src/types/move_structs.rs
+++ b/crates/walrus-sui/src/types/move_structs.rs
@@ -311,6 +311,8 @@ pub(crate) struct StakingInnerV1 {
     pub(crate) id: ObjectID,
     /// The number of shards in the system.
     pub(crate) n_shards: NonZeroU16,
+    /// The duration of an epoch in ms. Does not affect the first (zero) epoch.
+    pub(crate) epoch_duration: u64,
     /// Special parameter, used only for the first epoch. The timestamp when the
     /// first epoch can be started.
     pub(crate) first_epoch_start: u64,


### PR DESCRIPTION
A `epoch_duration` field was added to the API in #791 