### PR TITLE
chore: remove cargo-check from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,12 +46,6 @@ repos:
     language: rust
     types: [rust]
     pass_filenames: false
-  - id: cargo-check
-    name: cargo-check
-    entry: cargo check
-    language: rust
-    files: ^(crates/|Cargo\.(toml|lock)$)
-    pass_filenames: false
   - id: cargo-test
     name: cargo-test
     entry: cargo nextest run


### PR DESCRIPTION
This is sometimes flakey when rebasing branches and is redundant with the clippy checks.