### PR TITLE
fix: get event index from event cursor table

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -465,7 +465,7 @@ impl StorageNode {
         let mut event_blob_writer =
             EventBlobWriter::new(&self.inner.db_root_dir_path, self.inner.clone())?;
         let from_event_id = storage.get_event_cursor()?.map(|(_, cursor)| cursor);
-        let from_element_index = self.get_last_committed_event_index(&event_blob_writer)?;
+        let from_element_index = storage.get_sequentially_processed_event_count()?;
         let event_cursor = EventStreamCursor::new(from_event_id, from_element_index);
         let event_stream = Box::into_pin(self.inner.event_manager.events(event_cursor).await?);
         let next_index: usize = from_element_index.try_into().expect("64-bit architecture");


### PR DESCRIPTION
Currently, at least in tests, `get_last_committed_event_index()` always returns 0 because `event_blob_writer.latest_committed_event_index()` is always None. I think `prev_blob_id` is not populated, so reading that table upon restarting EventBlobWriter doesn't read the lasted committed blob index.

However, I'm not sure this is actually a fix. This just made the test passing. My guess is that we are still using the old SuiSystemEventProvider at the moment, so this is temporarily fine?