### PR TITLE
fix(core): minor issue with number of recovery symbols

### DIFF
--- a/crates/walrus-core/src/encoding/config.rs
+++ b/crates/walrus-core/src/encoding/config.rs
@@ -374,8 +374,8 @@ pub fn decoding_safety_limit(n_shards: NonZeroU16) -> u16 {
 /// Computes the number of primary and secondary source symbols starting from the number of shards.
 ///
 /// The computation is as follows:
-/// - `source_symbols_primary = n_shards - f - decoding_safety_limit(n_shards)`
-/// - `source_symbols_secondary = n_shards - 2f - decoding_safety_limit(n_shards)`
+/// - `source_symbols_primary = n_shards - 2f - decoding_safety_limit(n_shards)`
+/// - `source_symbols_secondary = n_shards - f - decoding_safety_limit(n_shards)`
 #[inline]
 pub fn source_symbols_for_n_shards(n_shards: NonZeroU16) -> (NonZeroU16, NonZeroU16) {
     let safety_limit = decoding_safety_limit(n_shards);

--- a/crates/walrus-core/src/encoding/symbols.rs
+++ b/crates/walrus-core/src/encoding/symbols.rs
@@ -471,13 +471,13 @@ where
         })
 }
 
-/// Returns the minimum number of symbols required for recovery.
+/// Returns the minimum number of symbols required to recover a sliver of [`EncodingAxis`] T.
 pub fn min_symbols_for_recovery<T: EncodingAxis>(n_shards: NonZeroU16) -> u16 {
     let max_n_faulty = crate::bft::max_n_faulty(n_shards);
     if T::IS_PRIMARY {
-        2 * max_n_faulty + 1
+        n_shards.get() - max_n_faulty
     } else {
-        max_n_faulty + 1
+        n_shards.get() - 2 * max_n_faulty
     }
 }
 


### PR DESCRIPTION
Fixes a small problem with the computation of the number of recovery symbols.
Also fixes an incorrect docstring.

In practice, this may have been an issue only when `n_shards > 3f+1` (strictly), and the number of shards is small.