### PR TITLE
fix(client): avoid reading `Blob` object after certification

### DIFF
--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -174,7 +174,7 @@ async fn test_inconsistency(failed_shards: &[usize]) -> anyhow::Result<()> {
     // Certify blob.
     let certificate = client
         .as_ref()
-        .store_metadata_and_pairs(&metadata, &pairs)
+        .send_blob_data_and_get_certificate(&metadata, &pairs)
         .await?;
 
     // Stop the nodes in the failure set.

--- a/crates/walrus-sui/tests/test_walrus_sui.rs
+++ b/crates/walrus-sui/tests/test_walrus_sui.rs
@@ -137,11 +137,10 @@ async fn test_register_certify_blob() -> anyhow::Result<()> {
 
     let certificate = get_default_blob_certificate(blob_id, 1);
 
-    let blob_obj = walrus_client
+    walrus_client
         .as_ref()
         .certify_blob(blob_obj, &certificate)
         .await?;
-    assert_eq!(blob_obj.certified_epoch, Some(1));
 
     // Make sure that we got the expected event
     let ContractEvent::BlobEvent(BlobEvent::Certified(blob_certified)) =
@@ -150,7 +149,7 @@ async fn test_register_certify_blob() -> anyhow::Result<()> {
         bail!("unexpected event type. expecting BlobCertified");
     };
     assert_eq!(blob_certified.blob_id, blob_id);
-    assert_eq!(Some(blob_registered.epoch), blob_obj.certified_epoch);
+    assert_eq!(Some(blob_registered.epoch), Some(1));
     assert_eq!(blob_certified.end_epoch, storage_resource.end_epoch);
 
     // Drop event stream
@@ -197,7 +196,7 @@ async fn test_register_certify_blob() -> anyhow::Result<()> {
     };
     assert_eq!(blob_registered.blob_id, blob_id);
 
-    let _blob_obj = walrus_client
+    walrus_client
         .as_ref()
         .certify_blob(blob_obj, &get_default_blob_certificate(blob_id, 1))
         .await?;


### PR DESCRIPTION
The only purpose of this was to check that the `certified_epoch` was updated correctly. However, we *know* that this must have happened if the `certify_blob` contract completed without error. We can therefore simply modify the `Blob` object locally and safe one RPC request.

This speeds up the write process and avoids spurious errors in case of load-balancing between Sui full nodes.

Closes #728