### PR TITLE
fix: Make sure duplicate events are not processed or written in blob

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,18 +291,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-bls12-381"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c775f0d12169cba7aae4caeb547bb6a50781c7449a8aa53793827c9ec4abf488"
-dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-serialize",
- "ark-std",
-]
-
-[[package]]
 name = "ark-bn254"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1296,8 +1284,8 @@ dependencies = [
 
 [[package]]
 name = "bin-version"
-version = "1.33.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+version = "1.35.0"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "const-str",
  "git-version",
@@ -2004,9 +1992,9 @@ dependencies = [
 [[package]]
 name = "consensus-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "mysten-network",
  "rand 0.8.5",
  "serde",
@@ -2016,7 +2004,7 @@ dependencies = [
 [[package]]
 name = "consensus-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -2031,13 +2019,13 @@ dependencies = [
  "consensus-config",
  "dashmap",
  "enum_dispatch",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "futures",
  "http 1.1.0",
  "hyper 1.4.1",
  "hyper-rustls 0.27.2",
  "hyper-util",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "mockall 0.11.4",
  "mysten-common",
  "mysten-metrics",
@@ -2919,7 +2907,7 @@ dependencies = [
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -3368,7 +3356,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto"
 version = "0.1.8"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597#5f2c63266a065996d53f98156f0412782b468597"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2#3366c26a746b72707572c4f3f05915e20d5c16c2"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -3391,7 +3379,7 @@ dependencies = [
  "ecdsa 0.16.9",
  "ed25519-consensus",
  "elliptic-curve 0.13.8",
- "fastcrypto-derive 0.1.3 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto-derive 0.1.3 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "generic-array",
  "hex",
  "hex-literal",
@@ -3434,7 +3422,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-derive"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597#5f2c63266a065996d53f98156f0412782b468597"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2#3366c26a746b72707572c4f3f05915e20d5c16c2"
 dependencies = [
  "quote 1.0.36",
  "syn 1.0.109",
@@ -3443,11 +3431,11 @@ dependencies = [
 [[package]]
 name = "fastcrypto-tbls"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597#5f2c63266a065996d53f98156f0412782b468597"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2#3366c26a746b72707572c4f3f05915e20d5c16c2"
 dependencies = [
  "bcs",
  "digest 0.10.7",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "hex",
  "itertools 0.10.5",
  "rand 0.8.5",
@@ -3462,10 +3450,10 @@ dependencies = [
 [[package]]
 name = "fastcrypto-vdf"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597#5f2c63266a065996d53f98156f0412782b468597"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2#3366c26a746b72707572c4f3f05915e20d5c16c2"
 dependencies = [
  "bcs",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "lazy_static",
  "num-bigint 0.4.6",
  "num-integer",
@@ -3479,9 +3467,8 @@ dependencies = [
 [[package]]
 name = "fastcrypto-zkp"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597#5f2c63266a065996d53f98156f0412782b468597"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2#3366c26a746b72707572c4f3f05915e20d5c16c2"
 dependencies = [
- "ark-bls12-381",
  "ark-bn254",
  "ark-ec",
  "ark-ff",
@@ -3489,10 +3476,10 @@ dependencies = [
  "ark-relations",
  "ark-serialize",
  "ark-snark",
- "blst",
+ "bcs",
  "byte-slice-cast",
  "derive_more",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "ff 0.13.0",
  "im",
  "itertools 0.12.1",
@@ -5192,7 +5179,7 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "move-binary-format",
  "move-bytecode-verifier-meter",
@@ -5201,7 +5188,7 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "move-binary-format",
 ]
@@ -5209,12 +5196,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "enum-compat-util",
@@ -5228,12 +5215,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5248,9 +5235,10 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
+ "indexmap 2.4.0",
  "move-binary-format",
  "move-core-types",
  "petgraph 0.5.1",
@@ -5260,7 +5248,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -5275,7 +5263,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -5285,7 +5273,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
@@ -5300,7 +5288,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
@@ -5315,7 +5303,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
@@ -5330,7 +5318,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5350,7 +5338,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5383,7 +5371,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5399,6 +5387,7 @@ dependencies = [
  "ref-cast",
  "serde",
  "serde_bytes",
+ "serde_with 3.9.0",
  "thiserror",
  "uint",
 ]
@@ -5406,7 +5395,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5426,7 +5415,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5446,7 +5435,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "codespan",
@@ -5464,7 +5453,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -5482,7 +5471,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "hex",
@@ -5495,7 +5484,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -5508,7 +5497,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "codespan",
@@ -5532,7 +5521,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "clap",
@@ -5566,7 +5555,7 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "enum-compat-util",
  "quote 1.0.36",
@@ -5576,7 +5565,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -5591,7 +5580,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v0"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -5606,7 +5595,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v1"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -5621,7 +5610,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v2"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -5636,7 +5625,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "once_cell",
  "phf",
@@ -5646,7 +5635,7 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "move-binary-format",
  "once_cell",
@@ -5655,7 +5644,7 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "move-vm-config",
  "once_cell",
@@ -5667,7 +5656,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "better_any",
  "fail",
@@ -5686,7 +5675,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "better_any",
  "fail",
@@ -5705,7 +5694,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "better_any",
  "fail",
@@ -5724,7 +5713,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "better_any",
  "fail",
@@ -5743,7 +5732,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5757,7 +5746,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -5871,17 +5860,26 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 [[package]]
 name = "mysten-common"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
+ "anyhow",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "futures",
+ "mysten-metrics",
  "parking_lot 0.12.3",
+ "prometheus",
+ "reqwest 0.12.7",
+ "snap",
+ "sui-tls",
+ "sui-types",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "mysten-metrics"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "async-trait",
  "axum 0.7.5",
@@ -5902,7 +5900,7 @@ dependencies = [
 [[package]]
 name = "mysten-network"
 version = "0.2.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anemo",
  "bcs",
@@ -5928,7 +5926,7 @@ dependencies = [
 [[package]]
 name = "mysten-service"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "axum 0.7.5",
@@ -5944,11 +5942,11 @@ dependencies = [
 [[package]]
 name = "mysten-util-mem"
 version = "0.11.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "cfg-if",
  "ed25519-consensus",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "fastcrypto-tbls",
  "hashbrown 0.12.3",
  "impl-trait-for-tuples",
@@ -5963,7 +5961,7 @@ dependencies = [
 [[package]]
 name = "mysten-util-mem-derive"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "proc-macro2 1.0.86",
  "syn 1.0.109",
@@ -5993,9 +5991,9 @@ dependencies = [
 [[package]]
 name = "narwhal-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "match_opt",
  "mysten-network",
  "mysten-util-mem",
@@ -6010,10 +6008,10 @@ dependencies = [
 [[package]]
 name = "narwhal-crypto"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "bcs",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "serde",
  "shared-crypto",
 ]
@@ -6021,7 +6019,7 @@ dependencies = [
 [[package]]
 name = "narwhal-network"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -6049,7 +6047,7 @@ dependencies = [
 [[package]]
 name = "narwhal-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -6059,7 +6057,7 @@ dependencies = [
  "bytes",
  "derive_builder",
  "enum_dispatch",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "futures",
  "indexmap 2.4.0",
  "mockall 0.11.4",
@@ -6190,6 +6188,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "rand 0.8.5",
+ "serde",
 ]
 
 [[package]]
@@ -7362,7 +7361,7 @@ dependencies = [
 [[package]]
 name = "prometheus-closure-metric"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -8513,6 +8512,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-env"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d13536c0c431652192b75c7d5afa83dedae98f91d7e687ff30a009e9d15284fb"
+dependencies = [
+ "anyhow",
+ "serde",
+]
+
+[[package]]
 name = "serde-name"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8793,11 +8802,11 @@ dependencies = [
 [[package]]
 name = "shared-crypto"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "bcs",
  "eyre",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "serde",
  "serde_repr",
 ]
@@ -9179,7 +9188,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 [[package]]
 name = "sui-adapter-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9207,7 +9216,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9235,7 +9244,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9262,7 +9271,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9288,13 +9297,13 @@ dependencies = [
 
 [[package]]
 name = "sui-archival"
-version = "1.33.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+version = "1.35.0"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "byteorder",
  "bytes",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "futures",
  "indicatif",
  "num_enum 0.6.1",
@@ -9314,7 +9323,7 @@ dependencies = [
 [[package]]
 name = "sui-authority-aggregation"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "futures",
  "mysten-metrics",
@@ -9325,8 +9334,8 @@ dependencies = [
 
 [[package]]
 name = "sui-bridge"
-version = "1.33.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+version = "1.35.0"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -9339,10 +9348,11 @@ dependencies = [
  "enum_dispatch",
  "ethers",
  "eyre",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "futures",
  "lru 0.10.1",
  "move-core-types",
+ "mysten-common",
  "mysten-metrics",
  "num_enum 0.6.1",
  "once_cell",
@@ -9358,7 +9368,7 @@ dependencies = [
  "sui-json-rpc-api",
  "sui-json-rpc-types",
  "sui-keys",
- "sui-sdk 1.33.1",
+ "sui-sdk 1.35.0",
  "sui-test-transaction-builder",
  "sui-types",
  "tap",
@@ -9373,7 +9383,7 @@ dependencies = [
 [[package]]
 name = "sui-config"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anemo",
  "anyhow",
@@ -9382,7 +9392,7 @@ dependencies = [
  "consensus-config",
  "csv",
  "dirs 4.0.0",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "move-vm-config",
  "narwhal-config",
  "object_store",
@@ -9402,7 +9412,7 @@ dependencies = [
 [[package]]
 name = "sui-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anemo",
  "anyhow",
@@ -9420,13 +9430,13 @@ dependencies = [
  "either",
  "enum_dispatch",
  "eyre",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "fastcrypto-tbls",
  "fastcrypto-zkp",
  "futures",
  "im",
  "indexmap 2.4.0",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "jsonrpsee",
  "lru 0.10.1",
  "mockall 0.11.4",
@@ -9489,7 +9499,7 @@ dependencies = [
 [[package]]
 name = "sui-enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -9497,7 +9507,7 @@ dependencies = [
 [[package]]
 name = "sui-execution"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-interpreter-v2",
@@ -9531,7 +9541,7 @@ dependencies = [
 [[package]]
 name = "sui-framework"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -9544,8 +9554,8 @@ dependencies = [
 
 [[package]]
 name = "sui-framework-snapshot"
-version = "1.33.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+version = "1.35.0"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9560,12 +9570,12 @@ dependencies = [
 [[package]]
 name = "sui-genesis-builder"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "bcs",
  "camino",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "move-binary-format",
  "move-core-types",
  "prometheus",
@@ -9588,11 +9598,11 @@ dependencies = [
 [[package]]
 name = "sui-json"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "bcs",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "move-binary-format",
  "move-bytecode-utils",
  "move-core-types",
@@ -9605,7 +9615,7 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -9615,12 +9625,12 @@ dependencies = [
  "cached",
  "chrono",
  "eyre",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "futures",
  "http-body 0.4.6",
  "hyper 1.4.1",
  "indexmap 2.4.0",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "jsonrpsee",
  "move-binary-format",
  "move-bytecode-utils",
@@ -9659,10 +9669,10 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc-api"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "jsonrpsee",
  "mysten-metrics",
  "once_cell",
@@ -9679,14 +9689,14 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc-types"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "bcs",
  "colored",
  "enum_dispatch",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
- "itertools 0.10.5",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "itertools 0.13.0",
  "json_to_table",
  "move-binary-format",
  "move-bytecode-utils",
@@ -9709,11 +9719,11 @@ dependencies = [
 [[package]]
 name = "sui-keys"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "bip32",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "rand 0.8.5",
  "regex",
  "serde",
@@ -9728,7 +9738,7 @@ dependencies = [
 [[package]]
 name = "sui-macros"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "futures",
  "once_cell",
@@ -9738,11 +9748,11 @@ dependencies = [
 
 [[package]]
 name = "sui-move-build"
-version = "1.33.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+version = "1.35.0"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "move-binary-format",
  "move-bytecode-utils",
  "move-bytecode-verifier",
@@ -9763,11 +9773,11 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "bcs",
  "better_any",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "fastcrypto-vdf",
  "fastcrypto-zkp",
  "indexmap 2.4.0",
@@ -9786,11 +9796,11 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "bcs",
  "better_any",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "fastcrypto-zkp",
  "linked-hash-map",
  "move-binary-format",
@@ -9807,11 +9817,11 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "bcs",
  "better_any",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "fastcrypto-zkp",
  "linked-hash-map",
  "move-binary-format",
@@ -9828,11 +9838,11 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "bcs",
  "better_any",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "fastcrypto-zkp",
  "indexmap 2.4.0",
  "move-binary-format",
@@ -9849,7 +9859,7 @@ dependencies = [
 [[package]]
 name = "sui-network"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -9859,7 +9869,7 @@ dependencies = [
  "bcs",
  "bytes",
  "dashmap",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "fastcrypto-tbls",
  "futures",
  "governor",
@@ -9884,8 +9894,8 @@ dependencies = [
 
 [[package]]
 name = "sui-node"
-version = "1.33.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+version = "1.35.0"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -9896,7 +9906,7 @@ dependencies = [
  "bcs",
  "bin-version",
  "clap",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "fastcrypto-zkp",
  "futures",
  "humantime",
@@ -9910,7 +9920,6 @@ dependencies = [
  "prometheus",
  "reqwest 0.12.7",
  "serde",
- "snap",
  "sui-archival",
  "sui-config",
  "sui-core",
@@ -9937,8 +9946,8 @@ dependencies = [
 
 [[package]]
 name = "sui-open-rpc"
-version = "1.33.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+version = "1.35.0"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "bcs",
  "schemars",
@@ -9950,10 +9959,10 @@ dependencies = [
 [[package]]
 name = "sui-open-rpc-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "derive-syn-parse",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2 1.0.86",
  "quote 1.0.36",
  "syn 1.0.109",
@@ -9962,15 +9971,15 @@ dependencies = [
 
 [[package]]
 name = "sui-package-management"
-version = "1.33.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+version = "1.35.0"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "move-core-types",
  "move-package",
  "move-symbol-pool",
  "sui-json-rpc-types",
- "sui-sdk 1.33.1",
+ "sui-sdk 1.35.0",
  "sui-types",
  "thiserror",
  "tracing",
@@ -9979,7 +9988,7 @@ dependencies = [
 [[package]]
 name = "sui-package-resolver"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "async-trait",
  "bcs",
@@ -9998,7 +10007,7 @@ dependencies = [
 [[package]]
 name = "sui-proc-macros"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "msim-macros",
  "proc-macro2 1.0.86",
@@ -10010,13 +10019,14 @@ dependencies = [
 [[package]]
 name = "sui-protocol-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "clap",
  "insta",
  "move-vm-config",
  "schemars",
  "serde",
+ "serde-env",
  "serde_with 3.9.0",
  "sui-protocol-config-macros",
  "tracing",
@@ -10025,7 +10035,7 @@ dependencies = [
 [[package]]
 name = "sui-protocol-config-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.36",
@@ -10035,14 +10045,14 @@ dependencies = [
 [[package]]
 name = "sui-rest-api"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "async-trait",
  "axum 0.7.5",
  "bcs",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
- "itertools 0.10.5",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "itertools 0.13.0",
  "mime",
  "mysten-network",
  "openapiv3",
@@ -10085,8 +10095,8 @@ dependencies = [
 
 [[package]]
 name = "sui-sdk"
-version = "1.33.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+version = "1.35.0"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10094,7 +10104,7 @@ dependencies = [
  "bcs",
  "clap",
  "colored",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "futures",
  "futures-core",
  "jsonrpsee",
@@ -10119,12 +10129,12 @@ dependencies = [
 [[package]]
 name = "sui-simulator"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anemo",
  "anemo-tower",
  "bcs",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "lru 0.10.1",
  "move-package",
  "msim",
@@ -10143,13 +10153,13 @@ dependencies = [
 [[package]]
 name = "sui-snapshot"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "bcs",
  "byteorder",
  "bytes",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "futures",
  "indicatif",
  "integer-encoding 3.0.4",
@@ -10171,7 +10181,7 @@ dependencies = [
 [[package]]
 name = "sui-storage"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10183,13 +10193,13 @@ dependencies = [
  "chrono",
  "clap",
  "eyre",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "futures",
  "hyper 1.4.1",
  "hyper-rustls 0.27.2",
  "indicatif",
  "integer-encoding 3.0.4",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "lru 0.10.1",
  "moka",
  "move-binary-format",
@@ -10221,7 +10231,7 @@ dependencies = [
 [[package]]
 name = "sui-swarm"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "futures",
@@ -10247,12 +10257,12 @@ dependencies = [
 [[package]]
 name = "sui-swarm-config"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anemo",
  "anyhow",
  "bcs",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "move-bytecode-utils",
  "narwhal-config",
  "prometheus",
@@ -10274,7 +10284,7 @@ dependencies = [
 [[package]]
 name = "sui-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "reqwest 0.12.7",
  "serde",
@@ -10285,27 +10295,27 @@ dependencies = [
 [[package]]
 name = "sui-test-transaction-builder"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "bcs",
  "move-core-types",
  "shared-crypto",
  "sui-genesis-builder",
  "sui-move-build",
- "sui-sdk 1.33.1",
+ "sui-sdk 1.35.0",
  "sui-types",
 ]
 
 [[package]]
 name = "sui-tls"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "axum 0.7.5",
  "axum-server 0.6.1",
  "ed25519",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "pkcs8 0.9.0",
  "rcgen",
  "reqwest 0.12.7",
@@ -10320,7 +10330,7 @@ dependencies = [
 [[package]]
 name = "sui-transaction-builder"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10337,7 +10347,7 @@ dependencies = [
 [[package]]
 name = "sui-transaction-checks"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "fastcrypto-zkp",
  "once_cell",
@@ -10352,7 +10362,7 @@ dependencies = [
 [[package]]
 name = "sui-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anemo",
  "anyhow",
@@ -10367,12 +10377,12 @@ dependencies = [
  "derive_more",
  "enum_dispatch",
  "eyre",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "fastcrypto-tbls",
  "fastcrypto-zkp",
  "im",
  "indexmap 2.4.0",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "jsonrpsee",
  "lru 0.10.1",
  "move-binary-format",
@@ -10422,7 +10432,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -10439,7 +10449,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -10455,7 +10465,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -10470,7 +10480,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -10623,7 +10633,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "telemetry-subscribers"
 version = "0.2.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -10698,11 +10708,11 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 [[package]]
 name = "test-cluster"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "anyhow",
  "bcs",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "fastcrypto-zkp",
  "futures",
  "jsonrpsee",
@@ -10719,7 +10729,7 @@ dependencies = [
  "sui-keys",
  "sui-node",
  "sui-protocol-config",
- "sui-sdk 1.33.1",
+ "sui-sdk 1.35.0",
  "sui-simulator",
  "sui-swarm",
  "sui-swarm-config",
@@ -11496,7 +11506,7 @@ dependencies = [
 [[package]]
 name = "typed-store"
 version = "0.4.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "async-trait",
  "bcs",
@@ -11505,7 +11515,7 @@ dependencies = [
  "eyre",
  "fdlimit",
  "hdrhistogram",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "msim",
  "once_cell",
  "ouroboros",
@@ -11526,9 +11536,9 @@ dependencies = [
 [[package]]
 name = "typed-store-derive"
 version = "0.3.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2 1.0.86",
  "quote 1.0.36",
  "syn 1.0.109",
@@ -11537,7 +11547,7 @@ dependencies = [
 [[package]]
 name = "typed-store-error"
 version = "0.4.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "serde",
  "thiserror",
@@ -11546,7 +11556,7 @@ dependencies = [
 [[package]]
 name = "typed-store-workspace-hack"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
+source = "git+https://github.com/MystenLabs/sui?rev=aa71f238844d67ac9fc40849443e370b83306fad#aa71f238844d67ac9fc40849443e370b83306fad"
 dependencies = [
  "cc",
  "lazy_static",
@@ -11917,12 +11927,13 @@ dependencies = [
  "sui-config",
  "sui-package-resolver",
  "sui-rest-api",
- "sui-sdk 1.33.1",
+ "sui-sdk 1.35.0",
  "sui-storage",
  "sui-types",
  "tempfile",
  "tokio",
  "tokio-util 0.7.12",
+ "tracing",
  "typed-store",
  "url",
  "walrus-core",
@@ -11999,6 +12010,7 @@ dependencies = [
  "byteorder",
  "clap",
  "colored",
+ "downcast",
  "enum_dispatch",
  "fastcrypto 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
@@ -12030,7 +12042,7 @@ dependencies = [
  "serde_yaml 0.9.34+deprecated",
  "sui-macros",
  "sui-protocol-config",
- "sui-sdk 1.33.1",
+ "sui-sdk 1.35.0",
  "sui-simulator",
  "sui-types",
  "telemetry-subscribers",
@@ -12081,7 +12093,7 @@ dependencies = [
  "mysten-metrics",
  "prometheus",
  "rand 0.8.5",
- "sui-sdk 1.33.1",
+ "sui-sdk 1.35.0",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -12108,7 +12120,7 @@ dependencies = [
  "sui-config",
  "sui-keys",
  "sui-move-build",
- "sui-sdk 1.33.1",
+ "sui-sdk 1.35.0",
  "sui-simulator",
  "sui-types",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ chrono = "0.4"
 clap = { version = "4.5.17", features = ["derive"] }
 colored = "2.1.0"
 criterion = "0.5.1"
+downcast = "0.11.0"
 enum_dispatch = "0.3"
 fastcrypto = "0.1.8"
 futures = { version = "0.3.30", default-features = false, features = ["async-await", "std"] }
@@ -33,8 +34,8 @@ integer-encoding = "4.0.2"
 itertools = "0.13.0"
 mime = "0.3.17"
 mockall = "0.12.1"
-move-core-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.33.1" }
-mysten-metrics = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.33.1" }
+move-core-types = { git = "https://github.com/MystenLabs/sui", rev = "aa71f238844d67ac9fc40849443e370b83306fad" }
+mysten-metrics = { git = "https://github.com/MystenLabs/sui", rev = "aa71f238844d67ac9fc40849443e370b83306fad" }
 num-bigint = { version = "0.4.5", default-features = false }
 opentelemetry = { version = "=0.23.0", default-features = false, features = ["trace"] }
 p256 = "0.13.2"
@@ -54,21 +55,21 @@ serde_json = "1.0.128"
 serde_test = "1.0.177"
 serde_with = { version = "3.9", features = ["base64"] }
 serde_yaml = "0.9"
-sui-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.33.1" }
-sui-json-rpc-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.33.1" }
-sui-keys = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.33.1" }
-sui-macros = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.33.1" }
-sui-move-build = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.33.1" }
-sui-package-resolver = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.33.1" }
-sui-protocol-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.33.1" }
-sui-rest-api = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.33.1" }
-sui-sdk = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.33.1" }
-sui-simulator = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.33.1" }
-sui-storage = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.33.1" }
-sui-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.33.1" }
-telemetry-subscribers = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.33.1" }
+sui-config = { git = "https://github.com/MystenLabs/sui", rev = "aa71f238844d67ac9fc40849443e370b83306fad" }
+sui-json-rpc-types = { git = "https://github.com/MystenLabs/sui", rev = "aa71f238844d67ac9fc40849443e370b83306fad" }
+sui-keys = { git = "https://github.com/MystenLabs/sui", rev = "aa71f238844d67ac9fc40849443e370b83306fad" }
+sui-macros = { git = "https://github.com/MystenLabs/sui", rev = "aa71f238844d67ac9fc40849443e370b83306fad" }
+sui-move-build = { git = "https://github.com/MystenLabs/sui", rev = "aa71f238844d67ac9fc40849443e370b83306fad" }
+sui-package-resolver = { git = "https://github.com/MystenLabs/sui", rev = "aa71f238844d67ac9fc40849443e370b83306fad" }
+sui-protocol-config = { git = "https://github.com/MystenLabs/sui", rev = "aa71f238844d67ac9fc40849443e370b83306fad" }
+sui-rest-api = { git = "https://github.com/MystenLabs/sui", rev = "aa71f238844d67ac9fc40849443e370b83306fad" }
+sui-sdk = { git = "https://github.com/MystenLabs/sui", rev = "aa71f238844d67ac9fc40849443e370b83306fad" }
+sui-simulator = { git = "https://github.com/MystenLabs/sui", rev = "aa71f238844d67ac9fc40849443e370b83306fad" }
+sui-storage = { git = "https://github.com/MystenLabs/sui", rev = "aa71f238844d67ac9fc40849443e370b83306fad" }
+sui-types = { git = "https://github.com/MystenLabs/sui", rev = "aa71f238844d67ac9fc40849443e370b83306fad" }
+telemetry-subscribers = { git = "https://github.com/MystenLabs/sui", rev = "aa71f238844d67ac9fc40849443e370b83306fad" }
 tempfile = "3.11.0"
-test-cluster = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.33.1" }
+test-cluster = { git = "https://github.com/MystenLabs/sui", rev = "aa71f238844d67ac9fc40849443e370b83306fad" }
 thiserror = "1.0.63"
 tokio = "=1.36.0"
 tokio-stream = "0.1.16"
@@ -78,7 +79,7 @@ tower-http = { version = "0.5.2", features = ["trace"] }
 tracing = "0.1.40"
 tracing-opentelemetry = { version = "0.24", default-features = false }
 tracing-subscriber = { version = "0.3.18", default-features = false }
-typed-store = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.33.1" }
+typed-store = { git = "https://github.com/MystenLabs/sui", rev = "aa71f238844d67ac9fc40849443e370b83306fad" }
 url = "2.5.2"
 utoipa = { version = "4.2.3" }
 utoipa-redoc = { version = "4.0.0", features = ["axum"] }

--- a/crates/walrus-event/Cargo.toml
+++ b/crates/walrus-event/Cargo.toml
@@ -32,7 +32,7 @@ url.workspace = true
 walrus-core.workspace = true
 walrus-sdk.workspace = true
 walrus-sui.workspace = true
-
+tracing.workspace = true
 [features]
 default = ["test-utils"]
 test-utils = ["dep:tempfile"]

--- a/crates/walrus-service/Cargo.toml
+++ b/crates/walrus-service/Cargo.toml
@@ -43,6 +43,7 @@ node = [
 test-utils = [
     "client",
     "node",
+    "dep:downcast",
     "dep:tempfile",
     "walrus-core/test-utils",
     "dep:walrus-test-utils"
@@ -59,6 +60,7 @@ bcs.workspace = true
 byteorder.workspace = true
 clap.workspace = true
 colored = { workspace = true, optional = true }
+downcast = { workspace = true, optional = true }
 enum_dispatch = { workspace = true, optional = true }
 fastcrypto.workspace = true
 futures.workspace = true

--- a/crates/walrus-service/src/node/server.rs
+++ b/crates/walrus-service/src/node/server.rs
@@ -22,7 +22,7 @@ use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use tower::ServiceBuilder;
 use tower_http::trace::TraceLayer;
-use tracing::Instrument;
+use tracing::{info, Instrument};
 use utoipa::OpenApi as _;
 use utoipa_redoc::{Redoc, Servable as _};
 use walrus_core::{encoding::max_sliver_size_for_n_shards, keys::NetworkKeyPair};
@@ -168,6 +168,8 @@ where
             let handle = self.handle.lock().await;
             assert!(handle.is_none(), "run can only be called once");
         }
+
+        info!("starting server on {}", self.config.bind_address);
 
         let request_layers = ServiceBuilder::new()
             .layer(middleware::from_fn_with_state(

--- a/crates/walrus-service/src/node/storage/event_blob_writer.rs
+++ b/crates/walrus-service/src/node/storage/event_blob_writer.rs
@@ -400,7 +400,7 @@ mod tests {
             .expect("Failed to open temporary directory")
             .into_path();
         let node = StorageNodeHandle::builder()
-            .with_system_event_provider(vec![])
+            .with_system_event_manager(vec![])
             .with_shard_assignment(&[ShardIndex(0)])
             .with_node_started(true)
             .build()

--- a/crates/walrus-simtest/Cargo.toml
+++ b/crates/walrus-simtest/Cargo.toml
@@ -11,6 +11,7 @@ sui-json-rpc-types = { workspace = true, features = ["test-utils"] }
 sui-macros.workspace = true
 sui-protocol-config.workspace = true
 tokio.workspace = true
+futures.workspace = true
 tracing.workspace = true
 walrus-core.workspace = true
 walrus-service = { workspace = true, features = ["test-utils"] }

--- a/crates/walrus-sui/src/test_utils.rs
+++ b/crates/walrus-sui/src/test_utils.rs
@@ -90,7 +90,7 @@ pub fn get_default_invalid_certificate(blob_id: BlobId, epoch: Epoch) -> Invalid
 #[allow(missing_debug_implementations)]
 pub struct TestClusterHandle {
     wallet_path: Mutex<PathBuf>,
-    _cluster: TestCluster,
+    cluster: TestCluster,
 
     #[cfg(msim)]
     _node_handle: NodeHandle,
@@ -111,8 +111,12 @@ impl TestClusterHandle {
         let (cluster, wallet_path) = rx.recv().expect("should receive test_cluster");
         Self {
             wallet_path: Mutex::new(wallet_path),
-            _cluster: cluster,
+            cluster,
         }
+    }
+
+    pub fn cluster(&self) -> &TestCluster {
+        &self.cluster
     }
 
     // Creates a test Sui cluster using deterministic MSIM runtime.
@@ -139,7 +143,7 @@ impl TestClusterHandle {
         };
         Self {
             wallet_path: Mutex::new(wallet_path),
-            _cluster: cluster,
+            cluster,
             _node_handle: node_handle,
         }
     }
@@ -260,6 +264,7 @@ pub async fn new_wallet_on_sui_test_cluster(
 pub async fn sui_test_cluster() -> TestCluster {
     TestClusterBuilder::new()
         .with_num_validators(2)
+        .disable_fullnode_pruning()
         .build()
         .await
 }

--- a/crates/walrus-test-utils/src/lib.rs
+++ b/crates/walrus-test-utils/src/lib.rs
@@ -407,6 +407,7 @@ mod tests {
         ]
     }
     async fn async_sum_no_return_with_shared_meta(lhs: usize, rhs: usize, total: usize) {
+        #[cfg(not(msim))]
         tokio::time::resume(); // Panics if not paused.
         assert_eq!(lhs + rhs, total);
     }
@@ -423,6 +424,7 @@ mod tests {
         rhs: usize,
         total: usize,
     ) -> Result<(), Box<dyn Error>> {
+        #[cfg(not(msim))]
         tokio::time::resume(); // Panics if not paused.
         assert_eq!(lhs + rhs, total);
         Ok(())
@@ -455,6 +457,7 @@ mod tests {
         rhs: usize,
         total: usize,
     ) -> Result<(), Box<dyn Error>> {
+        #[cfg(not(msim))]
         tokio::time::resume(); // Panics if not paused.
         assert_eq!(lhs + rhs, total);
         Ok(())


### PR DESCRIPTION
Thanks to @halfprice, we discovered a couple issues which are now being fixed in this PR:
1. event_blob_writer was deleting the local dir on startup
2. event_sequencer was being fed events which it may have already committed. This could happen when event blob writer is behind event sequencer and upon restart, we start from the event index which has already been committed by the sequencer.