### PR TITLE
feat(move): ensure that the storage resource size is exact

### DIFF
--- a/contracts/walrus/sources/system.move
+++ b/contracts/walrus/sources/system.move
@@ -61,8 +61,8 @@ public fun reserve_space(
 }
 
 /// Registers a new blob in the system.
-/// `size` is the size of the unencoded blob. The reserved space in `storage` must be at
-/// least the size of the encoded blob.
+/// `size` is the size of the unencoded blob. The reserved space in `storage` must be
+/// exactly the size of the encoded blob.
 public fun register_blob(
     self: &mut System,
     storage: Storage,

--- a/contracts/walrus/sources/system/blob.move
+++ b/contracts/walrus/sources/system/blob.move
@@ -106,8 +106,8 @@ public(package) fun derive_blob_id(root_hash: u256, encoding_type: u8, size: u64
 }
 
 /// Creates a new blob in `registered_epoch`.
-/// `size` is the size of the unencoded blob. The reserved space in `storage` must be at
-/// least the size of the encoded blob.
+/// `size` is the size of the unencoded blob. The reserved space in `storage` must be
+/// exactly the size of the encoded blob.
 public(package) fun new(
     storage: Storage,
     blob_id: u256,
@@ -132,7 +132,7 @@ public(package) fun new(
         encoding_type,
         n_shards,
     );
-    assert!(encoded_size <= storage.storage_size(), EResourceSize);
+    assert!(encoded_size == storage.storage_size(), EResourceSize);
 
     // Cryptographically verify that the Blob ID authenticates
     // both the size and fe_type.

--- a/contracts/walrus/sources/system/system_state_inner.move
+++ b/contracts/walrus/sources/system/system_state_inner.move
@@ -164,8 +164,8 @@ public(package) fun invalidate_blob_id(
 }
 
 /// Registers a new blob in the system.
-/// `size` is the size of the unencoded blob. The reserved space in `storage` must be at
-/// least the size of the encoded blob.
+/// `size` is the size of the unencoded blob. The reserved space in `storage` must be
+/// exactly the size of the encoded blob.
 public(package) fun register_blob(
     self: &mut SystemStateInnerV1,
     storage: Storage,


### PR DESCRIPTION
Integrates the changes discussed in #702 