### PR TITLE
feat(move): add simple `SharedBlob` object for perpetual storage

### DIFF
--- a/contracts/walrus/sources/system/blob.move
+++ b/contracts/walrus/sources/system/blob.move
@@ -75,6 +75,10 @@ public(package) fun storage_mut(self: &mut Blob): &mut Storage {
     &mut self.storage
 }
 
+public fun end_epoch(self: &Blob): u32 {
+    self.storage.end_epoch()
+}
+
 /// Aborts if the blob is not certified or already expired.
 public(package) fun assert_certified_not_expired(self: &Blob, current_epoch: u32) {
     // Assert this is a certified blob
@@ -136,10 +140,7 @@ public(package) fun new(
 
     // Cryptographically verify that the Blob ID authenticates
     // both the size and fe_type.
-    assert!(
-        derive_blob_id(root_hash, encoding_type, size) == blob_id,
-        EInvalidBlobId,
-    );
+    assert!(derive_blob_id(root_hash, encoding_type, size) == blob_id, EInvalidBlobId);
 
     // Emit register event
     emit_blob_registered(
@@ -209,6 +210,10 @@ public(package) fun delete(self: Blob, epoch: u32): Storage {
     emit_blob_deleted(epoch, blob_id, storage.end_epoch(), object_id, certified_epoch.is_some());
     storage
 }
+
+/// Allows calling `.share()` on a `Blob` to wrap it into a shared `SharedBlob` whose lifetime can
+/// be extended by anyone.
+public use fun walrus::shared_blob::new as Blob.share;
 
 /// Allow the owner of a blob object to destroy it.
 public fun burn(blob: Blob) {

--- a/contracts/walrus/sources/system/shared_blob.move
+++ b/contracts/walrus/sources/system/shared_blob.move
@@ -1,0 +1,43 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module walrus::shared_blob;
+
+use sui::{balance::{Self, Balance}, coin::Coin};
+use wal::wal::WAL;
+use walrus::{blob::Blob, system::System};
+
+/// A wrapper around `Blob` that acts as a "tip jar" that can be funded by anyone and allows
+/// keeping the wrapped `Blob` alive indefinitely.
+public struct SharedBlob has key, store {
+    id: UID,
+    blob: Blob,
+    funds: Balance<WAL>,
+}
+
+/// Shares the provided `blob` as a `SharedBlob` with zero funds.
+public fun new(blob: Blob, ctx: &mut TxContext) {
+    transfer::share_object(SharedBlob {
+        id: object::new(ctx),
+        blob,
+        funds: balance::zero(),
+    })
+}
+
+/// Adds the provided `Coin` to the stored funds.
+public fun fund(self: &mut SharedBlob, added_funds: Coin<WAL>) {
+    self.funds.join(added_funds.into_balance());
+}
+
+/// Extends the lifetime of the wrapped `Blob` by `epochs_ahead` epochs if the stored funds are
+/// sufficient and the new lifetime does not exceed the maximum lifetime.
+public fun extend(
+    self: &mut SharedBlob,
+    system: &mut System,
+    epochs_ahead: u32,
+    ctx: &mut TxContext,
+) {
+    let mut coin = self.funds.withdraw_all().into_coin(ctx);
+    system.extend_blob(&mut self.blob, epochs_ahead, &mut coin);
+    self.funds.join(coin.into_balance());
+}


### PR DESCRIPTION
This currently has the following limitations:
- The funds can never be extracted from the shared object.
- There is no way to "revive" the wrapped blob if it ever expires.

Closes #618 