### PR TITLE
fix: Revert "fix(deps): bump Sui to testnet-v1.34.0"

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -30,7 +30,7 @@ env:
   # Don't emit giant backtraces in the CI logs.
   RUST_BACKTRACE: short
   RUSTDOCFLAGS: -D warnings
-  SUI_TAG: testnet-v1.34.0
+  SUI_TAG: testnet-v1.33.1
 
 jobs:
   diff:

--- a/.github/workflows/scheduled_reports.yml
+++ b/.github/workflows/scheduled_reports.yml
@@ -30,7 +30,7 @@ env:
   # Don't emit giant backtraces in the CI logs.
   RUST_BACKTRACE: short
   RUSTDOCFLAGS: -D warnings
-  SUI_TAG: testnet-v1.34.0
+  SUI_TAG: testnet-v1.33.1
 
 jobs:
   test-coverage:

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
       pull-requests: write
     env:
-      SUI_TAG: testnet-v1.34.0
+      SUI_TAG: testnet-v1.33.1
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-bls12-381"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c775f0d12169cba7aae4caeb547bb6a50781c7449a8aa53793827c9ec4abf488"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+]
+
+[[package]]
 name = "ark-bn254"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1284,8 +1296,8 @@ dependencies = [
 
 [[package]]
 name = "bin-version"
-version = "1.34.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+version = "1.33.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "const-str",
  "git-version",
@@ -1992,9 +2004,9 @@ dependencies = [
 [[package]]
 name = "consensus-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "mysten-network",
  "rand 0.8.5",
  "serde",
@@ -2004,7 +2016,7 @@ dependencies = [
 [[package]]
 name = "consensus-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -2019,13 +2031,13 @@ dependencies = [
  "consensus-config",
  "dashmap",
  "enum_dispatch",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "futures",
  "http 1.1.0",
  "hyper 1.4.1",
  "hyper-rustls 0.27.2",
  "hyper-util",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "mockall 0.11.4",
  "mysten-common",
  "mysten-metrics",
@@ -2907,7 +2919,7 @@ dependencies = [
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -3356,7 +3368,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto"
 version = "0.1.8"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2#3366c26a746b72707572c4f3f05915e20d5c16c2"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597#5f2c63266a065996d53f98156f0412782b468597"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -3379,7 +3391,7 @@ dependencies = [
  "ecdsa 0.16.9",
  "ed25519-consensus",
  "elliptic-curve 0.13.8",
- "fastcrypto-derive 0.1.3 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto-derive 0.1.3 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "generic-array",
  "hex",
  "hex-literal",
@@ -3422,7 +3434,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-derive"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2#3366c26a746b72707572c4f3f05915e20d5c16c2"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597#5f2c63266a065996d53f98156f0412782b468597"
 dependencies = [
  "quote 1.0.37",
  "syn 1.0.109",
@@ -3431,11 +3443,11 @@ dependencies = [
 [[package]]
 name = "fastcrypto-tbls"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2#3366c26a746b72707572c4f3f05915e20d5c16c2"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597#5f2c63266a065996d53f98156f0412782b468597"
 dependencies = [
  "bcs",
  "digest 0.10.7",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "hex",
  "itertools 0.10.5",
  "rand 0.8.5",
@@ -3450,10 +3462,10 @@ dependencies = [
 [[package]]
 name = "fastcrypto-vdf"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2#3366c26a746b72707572c4f3f05915e20d5c16c2"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597#5f2c63266a065996d53f98156f0412782b468597"
 dependencies = [
  "bcs",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "lazy_static",
  "num-bigint 0.4.6",
  "num-integer",
@@ -3467,8 +3479,9 @@ dependencies = [
 [[package]]
 name = "fastcrypto-zkp"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2#3366c26a746b72707572c4f3f05915e20d5c16c2"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597#5f2c63266a065996d53f98156f0412782b468597"
 dependencies = [
+ "ark-bls12-381",
  "ark-bn254",
  "ark-ec",
  "ark-ff",
@@ -3476,10 +3489,10 @@ dependencies = [
  "ark-relations",
  "ark-serialize",
  "ark-snark",
- "bcs",
+ "blst",
  "byte-slice-cast",
  "derive_more",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "ff 0.13.0",
  "im",
  "itertools 0.12.1",
@@ -5179,7 +5192,7 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "move-binary-format",
  "move-bytecode-verifier-meter",
@@ -5188,7 +5201,7 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "move-binary-format",
 ]
@@ -5196,12 +5209,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "enum-compat-util",
@@ -5215,12 +5228,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5235,10 +5248,9 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
- "indexmap 2.4.0",
  "move-binary-format",
  "move-core-types",
  "petgraph 0.5.1",
@@ -5248,7 +5260,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -5263,7 +5275,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -5273,7 +5285,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
@@ -5288,7 +5300,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
@@ -5303,7 +5315,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
@@ -5318,7 +5330,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5338,7 +5350,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5371,7 +5383,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5387,7 +5399,6 @@ dependencies = [
  "ref-cast",
  "serde",
  "serde_bytes",
- "serde_with 3.9.0",
  "thiserror",
  "uint",
 ]
@@ -5395,7 +5406,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5415,7 +5426,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5435,7 +5446,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "codespan",
@@ -5453,7 +5464,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -5471,7 +5482,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "hex",
@@ -5484,7 +5495,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -5497,7 +5508,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "codespan",
@@ -5521,7 +5532,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "clap",
@@ -5555,7 +5566,7 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "enum-compat-util",
  "quote 1.0.37",
@@ -5565,7 +5576,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -5580,7 +5591,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v0"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -5595,7 +5606,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v1"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -5610,7 +5621,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v2"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -5625,7 +5636,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "once_cell",
  "phf",
@@ -5635,7 +5646,7 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "move-binary-format",
  "once_cell",
@@ -5644,7 +5655,7 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "move-vm-config",
  "once_cell",
@@ -5656,7 +5667,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "better_any",
  "fail",
@@ -5675,7 +5686,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "better_any",
  "fail",
@@ -5694,7 +5705,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "better_any",
  "fail",
@@ -5713,7 +5724,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "better_any",
  "fail",
@@ -5732,7 +5743,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5746,7 +5757,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -5860,26 +5871,17 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 [[package]]
 name = "mysten-common"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
- "anyhow",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
  "futures",
- "mysten-metrics",
  "parking_lot 0.12.3",
- "prometheus",
- "reqwest 0.12.7",
- "snap",
- "sui-tls",
- "sui-types",
  "tokio",
- "tracing",
 ]
 
 [[package]]
 name = "mysten-metrics"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "async-trait",
  "axum 0.7.6",
@@ -5900,7 +5902,7 @@ dependencies = [
 [[package]]
 name = "mysten-network"
 version = "0.2.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anemo",
  "bcs",
@@ -5926,7 +5928,7 @@ dependencies = [
 [[package]]
 name = "mysten-service"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "axum 0.7.6",
@@ -5942,11 +5944,11 @@ dependencies = [
 [[package]]
 name = "mysten-util-mem"
 version = "0.11.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "cfg-if",
  "ed25519-consensus",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "fastcrypto-tbls",
  "hashbrown 0.12.3",
  "impl-trait-for-tuples",
@@ -5961,7 +5963,7 @@ dependencies = [
 [[package]]
 name = "mysten-util-mem-derive"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "proc-macro2 1.0.86",
  "syn 1.0.109",
@@ -5991,9 +5993,9 @@ dependencies = [
 [[package]]
 name = "narwhal-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "match_opt",
  "mysten-network",
  "mysten-util-mem",
@@ -6008,10 +6010,10 @@ dependencies = [
 [[package]]
 name = "narwhal-crypto"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "bcs",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "serde",
  "shared-crypto",
 ]
@@ -6019,7 +6021,7 @@ dependencies = [
 [[package]]
 name = "narwhal-network"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -6047,7 +6049,7 @@ dependencies = [
 [[package]]
 name = "narwhal-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -6057,7 +6059,7 @@ dependencies = [
  "bytes",
  "derive_builder",
  "enum_dispatch",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "futures",
  "indexmap 2.4.0",
  "mockall 0.11.4",
@@ -6188,7 +6190,6 @@ dependencies = [
  "num-integer",
  "num-traits",
  "rand 0.8.5",
- "serde",
 ]
 
 [[package]]
@@ -7361,7 +7362,7 @@ dependencies = [
 [[package]]
 name = "prometheus-closure-metric"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -8512,16 +8513,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-env"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d13536c0c431652192b75c7d5afa83dedae98f91d7e687ff30a009e9d15284fb"
-dependencies = [
- "anyhow",
- "serde",
-]
-
-[[package]]
 name = "serde-name"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8802,11 +8793,11 @@ dependencies = [
 [[package]]
 name = "shared-crypto"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "bcs",
  "eyre",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "serde",
  "serde_repr",
 ]
@@ -9188,7 +9179,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 [[package]]
 name = "sui-adapter-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9216,7 +9207,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9244,7 +9235,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9271,7 +9262,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9297,13 +9288,13 @@ dependencies = [
 
 [[package]]
 name = "sui-archival"
-version = "1.34.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+version = "1.33.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "byteorder",
  "bytes",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "futures",
  "indicatif",
  "num_enum 0.6.1",
@@ -9323,7 +9314,7 @@ dependencies = [
 [[package]]
 name = "sui-authority-aggregation"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "futures",
  "mysten-metrics",
@@ -9334,8 +9325,8 @@ dependencies = [
 
 [[package]]
 name = "sui-bridge"
-version = "1.34.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+version = "1.33.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -9348,11 +9339,10 @@ dependencies = [
  "enum_dispatch",
  "ethers",
  "eyre",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "futures",
  "lru 0.10.1",
  "move-core-types",
- "mysten-common",
  "mysten-metrics",
  "num_enum 0.6.1",
  "once_cell",
@@ -9368,7 +9358,7 @@ dependencies = [
  "sui-json-rpc-api",
  "sui-json-rpc-types",
  "sui-keys",
- "sui-sdk 1.34.0",
+ "sui-sdk 1.33.1",
  "sui-test-transaction-builder",
  "sui-types",
  "tap",
@@ -9383,7 +9373,7 @@ dependencies = [
 [[package]]
 name = "sui-config"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anemo",
  "anyhow",
@@ -9392,7 +9382,7 @@ dependencies = [
  "consensus-config",
  "csv",
  "dirs 4.0.0",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "move-vm-config",
  "narwhal-config",
  "object_store",
@@ -9412,7 +9402,7 @@ dependencies = [
 [[package]]
 name = "sui-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anemo",
  "anyhow",
@@ -9430,13 +9420,13 @@ dependencies = [
  "either",
  "enum_dispatch",
  "eyre",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "fastcrypto-tbls",
  "fastcrypto-zkp",
  "futures",
  "im",
  "indexmap 2.4.0",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "jsonrpsee",
  "lru 0.10.1",
  "mockall 0.11.4",
@@ -9499,7 +9489,7 @@ dependencies = [
 [[package]]
 name = "sui-enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -9507,7 +9497,7 @@ dependencies = [
 [[package]]
 name = "sui-execution"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-interpreter-v2",
@@ -9541,7 +9531,7 @@ dependencies = [
 [[package]]
 name = "sui-framework"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -9554,8 +9544,8 @@ dependencies = [
 
 [[package]]
 name = "sui-framework-snapshot"
-version = "1.34.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+version = "1.33.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9570,12 +9560,12 @@ dependencies = [
 [[package]]
 name = "sui-genesis-builder"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "bcs",
  "camino",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "move-binary-format",
  "move-core-types",
  "prometheus",
@@ -9598,11 +9588,11 @@ dependencies = [
 [[package]]
 name = "sui-json"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "bcs",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "move-binary-format",
  "move-bytecode-utils",
  "move-core-types",
@@ -9615,7 +9605,7 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -9625,12 +9615,12 @@ dependencies = [
  "cached",
  "chrono",
  "eyre",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "futures",
  "http-body 0.4.6",
  "hyper 1.4.1",
  "indexmap 2.4.0",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "jsonrpsee",
  "move-binary-format",
  "move-bytecode-utils",
@@ -9669,10 +9659,10 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc-api"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "jsonrpsee",
  "mysten-metrics",
  "once_cell",
@@ -9689,14 +9679,14 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc-types"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "bcs",
  "colored",
  "enum_dispatch",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
- "itertools 0.13.0",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "itertools 0.10.5",
  "json_to_table",
  "move-binary-format",
  "move-bytecode-utils",
@@ -9719,11 +9709,11 @@ dependencies = [
 [[package]]
 name = "sui-keys"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "bip32",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "rand 0.8.5",
  "regex",
  "serde",
@@ -9738,7 +9728,7 @@ dependencies = [
 [[package]]
 name = "sui-macros"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "futures",
  "once_cell",
@@ -9748,11 +9738,11 @@ dependencies = [
 
 [[package]]
 name = "sui-move-build"
-version = "1.34.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+version = "1.33.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "move-binary-format",
  "move-bytecode-utils",
  "move-bytecode-verifier",
@@ -9773,11 +9763,11 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "bcs",
  "better_any",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "fastcrypto-vdf",
  "fastcrypto-zkp",
  "indexmap 2.4.0",
@@ -9796,11 +9786,11 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "bcs",
  "better_any",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "fastcrypto-zkp",
  "linked-hash-map",
  "move-binary-format",
@@ -9817,11 +9807,11 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "bcs",
  "better_any",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "fastcrypto-zkp",
  "linked-hash-map",
  "move-binary-format",
@@ -9838,11 +9828,11 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "bcs",
  "better_any",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "fastcrypto-zkp",
  "indexmap 2.4.0",
  "move-binary-format",
@@ -9859,7 +9849,7 @@ dependencies = [
 [[package]]
 name = "sui-network"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -9869,7 +9859,7 @@ dependencies = [
  "bcs",
  "bytes",
  "dashmap",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "fastcrypto-tbls",
  "futures",
  "governor",
@@ -9894,8 +9884,8 @@ dependencies = [
 
 [[package]]
 name = "sui-node"
-version = "1.34.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+version = "1.33.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -9906,7 +9896,7 @@ dependencies = [
  "bcs",
  "bin-version",
  "clap",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "fastcrypto-zkp",
  "futures",
  "humantime",
@@ -9920,6 +9910,7 @@ dependencies = [
  "prometheus",
  "reqwest 0.12.7",
  "serde",
+ "snap",
  "sui-archival",
  "sui-config",
  "sui-core",
@@ -9946,8 +9937,8 @@ dependencies = [
 
 [[package]]
 name = "sui-open-rpc"
-version = "1.34.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+version = "1.33.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "bcs",
  "schemars",
@@ -9959,10 +9950,10 @@ dependencies = [
 [[package]]
 name = "sui-open-rpc-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "derive-syn-parse",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2 1.0.86",
  "quote 1.0.37",
  "syn 1.0.109",
@@ -9971,15 +9962,15 @@ dependencies = [
 
 [[package]]
 name = "sui-package-management"
-version = "1.34.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+version = "1.33.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "move-core-types",
  "move-package",
  "move-symbol-pool",
  "sui-json-rpc-types",
- "sui-sdk 1.34.0",
+ "sui-sdk 1.33.1",
  "sui-types",
  "thiserror",
  "tracing",
@@ -9988,7 +9979,7 @@ dependencies = [
 [[package]]
 name = "sui-package-resolver"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "async-trait",
  "bcs",
@@ -10007,7 +9998,7 @@ dependencies = [
 [[package]]
 name = "sui-proc-macros"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "msim-macros",
  "proc-macro2 1.0.86",
@@ -10019,14 +10010,13 @@ dependencies = [
 [[package]]
 name = "sui-protocol-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "clap",
  "insta",
  "move-vm-config",
  "schemars",
  "serde",
- "serde-env",
  "serde_with 3.9.0",
  "sui-protocol-config-macros",
  "tracing",
@@ -10035,7 +10025,7 @@ dependencies = [
 [[package]]
 name = "sui-protocol-config-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
@@ -10045,14 +10035,14 @@ dependencies = [
 [[package]]
 name = "sui-rest-api"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "async-trait",
  "axum 0.7.6",
  "bcs",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
- "itertools 0.13.0",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
+ "itertools 0.10.5",
  "mime",
  "mysten-network",
  "openapiv3",
@@ -10095,8 +10085,8 @@ dependencies = [
 
 [[package]]
 name = "sui-sdk"
-version = "1.34.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+version = "1.33.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10104,7 +10094,7 @@ dependencies = [
  "bcs",
  "clap",
  "colored",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "futures",
  "futures-core",
  "jsonrpsee",
@@ -10129,12 +10119,12 @@ dependencies = [
 [[package]]
 name = "sui-simulator"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anemo",
  "anemo-tower",
  "bcs",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "lru 0.10.1",
  "move-package",
  "msim",
@@ -10153,13 +10143,13 @@ dependencies = [
 [[package]]
 name = "sui-snapshot"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "bcs",
  "byteorder",
  "bytes",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "futures",
  "indicatif",
  "integer-encoding 3.0.4",
@@ -10181,7 +10171,7 @@ dependencies = [
 [[package]]
 name = "sui-storage"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10193,13 +10183,13 @@ dependencies = [
  "chrono",
  "clap",
  "eyre",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "futures",
  "hyper 1.4.1",
  "hyper-rustls 0.27.2",
  "indicatif",
  "integer-encoding 3.0.4",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "lru 0.10.1",
  "moka",
  "move-binary-format",
@@ -10231,7 +10221,7 @@ dependencies = [
 [[package]]
 name = "sui-swarm"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "futures",
@@ -10257,12 +10247,12 @@ dependencies = [
 [[package]]
 name = "sui-swarm-config"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anemo",
  "anyhow",
  "bcs",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "move-bytecode-utils",
  "narwhal-config",
  "prometheus",
@@ -10284,7 +10274,7 @@ dependencies = [
 [[package]]
 name = "sui-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "reqwest 0.12.7",
  "serde",
@@ -10295,27 +10285,27 @@ dependencies = [
 [[package]]
 name = "sui-test-transaction-builder"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "bcs",
  "move-core-types",
  "shared-crypto",
  "sui-genesis-builder",
  "sui-move-build",
- "sui-sdk 1.34.0",
+ "sui-sdk 1.33.1",
  "sui-types",
 ]
 
 [[package]]
 name = "sui-tls"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "axum 0.7.6",
  "axum-server 0.6.1",
  "ed25519",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "pkcs8 0.9.0",
  "rcgen",
  "reqwest 0.12.7",
@@ -10330,7 +10320,7 @@ dependencies = [
 [[package]]
 name = "sui-transaction-builder"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10347,7 +10337,7 @@ dependencies = [
 [[package]]
 name = "sui-transaction-checks"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "fastcrypto-zkp",
  "once_cell",
@@ -10362,7 +10352,7 @@ dependencies = [
 [[package]]
 name = "sui-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anemo",
  "anyhow",
@@ -10377,12 +10367,12 @@ dependencies = [
  "derive_more",
  "enum_dispatch",
  "eyre",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "fastcrypto-tbls",
  "fastcrypto-zkp",
  "im",
  "indexmap 2.4.0",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "jsonrpsee",
  "lru 0.10.1",
  "move-binary-format",
@@ -10432,7 +10422,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -10449,7 +10439,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -10465,7 +10455,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -10480,7 +10470,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -10633,7 +10623,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "telemetry-subscribers"
 version = "0.2.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -10708,11 +10698,11 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 [[package]]
 name = "test-cluster"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "anyhow",
  "bcs",
- "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=3366c26a746b72707572c4f3f05915e20d5c16c2)",
+ "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=5f2c63266a065996d53f98156f0412782b468597)",
  "fastcrypto-zkp",
  "futures",
  "jsonrpsee",
@@ -10729,7 +10719,7 @@ dependencies = [
  "sui-keys",
  "sui-node",
  "sui-protocol-config",
- "sui-sdk 1.34.0",
+ "sui-sdk 1.33.1",
  "sui-simulator",
  "sui-swarm",
  "sui-swarm-config",
@@ -11511,7 +11501,7 @@ dependencies = [
 [[package]]
 name = "typed-store"
 version = "0.4.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "async-trait",
  "bcs",
@@ -11520,7 +11510,7 @@ dependencies = [
  "eyre",
  "fdlimit",
  "hdrhistogram",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "msim",
  "once_cell",
  "ouroboros",
@@ -11541,9 +11531,9 @@ dependencies = [
 [[package]]
 name = "typed-store-derive"
 version = "0.3.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2 1.0.86",
  "quote 1.0.37",
  "syn 1.0.109",
@@ -11552,7 +11542,7 @@ dependencies = [
 [[package]]
 name = "typed-store-error"
 version = "0.4.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "serde",
  "thiserror",
@@ -11561,7 +11551,7 @@ dependencies = [
 [[package]]
 name = "typed-store-workspace-hack"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.34.0#c23f6057c8d60d547cf303cd9b6cb18f3d7fd780"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.33.1#776118a087171feb6d73f903082707a463721278"
 dependencies = [
  "cc",
  "lazy_static",
@@ -11933,7 +11923,7 @@ dependencies = [
  "sui-config",
  "sui-package-resolver",
  "sui-rest-api",
- "sui-sdk 1.34.0",
+ "sui-sdk 1.33.1",
  "sui-storage",
  "sui-types",
  "tempfile",
@@ -12055,7 +12045,7 @@ dependencies = [
  "serde_yaml 0.9.34+deprecated",
  "sui-macros",
  "sui-protocol-config",
- "sui-sdk 1.34.0",
+ "sui-sdk 1.33.1",
  "sui-simulator",
  "sui-types",
  "telemetry-subscribers",
@@ -12108,7 +12098,7 @@ dependencies = [
  "mysten-metrics",
  "prometheus",
  "rand 0.8.5",
- "sui-sdk 1.34.0",
+ "sui-sdk 1.33.1",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -12135,7 +12125,7 @@ dependencies = [
  "sui-config",
  "sui-keys",
  "sui-move-build",
- "sui-sdk 1.34.0",
+ "sui-sdk 1.33.1",
  "sui-simulator",
  "sui-types",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,8 @@ integer-encoding = "4.0.2"
 itertools = "0.13.0"
 mime = "0.3.17"
 mockall = "0.12.1"
-move-core-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.34.0" }
-mysten-metrics = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.34.0" }
+move-core-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.33.1" }
+mysten-metrics = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.33.1" }
 num-bigint = { version = "0.4.5", default-features = false }
 opentelemetry = { version = "=0.23.0", default-features = false, features = ["trace"] }
 p256 = "0.13.2"
@@ -55,22 +55,22 @@ serde_json = "1.0.128"
 serde_test = "1.0.177"
 serde_with = { version = "3.9", features = ["base64"] }
 serde_yaml = "0.9"
-sui-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.34.0" }
-sui-json-rpc-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.34.0" }
-sui-keys = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.34.0" }
-sui-macros = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.34.0" }
-sui-move-build = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.34.0" }
-sui-package-resolver = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.34.0" }
-sui-protocol-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.34.0" }
-sui-rest-api = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.34.0" }
-sui-sdk = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.34.0" }
-sui-simulator = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.34.0" }
-sui-storage = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.34.0" }
-sui-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.34.0" }
+sui-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.33.1" }
+sui-json-rpc-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.33.1" }
+sui-keys = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.33.1" }
+sui-macros = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.33.1" }
+sui-move-build = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.33.1" }
+sui-package-resolver = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.33.1" }
+sui-protocol-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.33.1" }
+sui-rest-api = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.33.1" }
+sui-sdk = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.33.1" }
+sui-simulator = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.33.1" }
+sui-storage = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.33.1" }
+sui-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.33.1" }
 syn = "2.0"
-telemetry-subscribers = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.34.0" }
+telemetry-subscribers = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.33.1" }
 tempfile = "3.11.0"
-test-cluster = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.34.0" }
+test-cluster = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.33.1" }
 thiserror = "1.0.64"
 tokio = "=1.36.0"
 tokio-stream = "0.1.16"
@@ -80,7 +80,7 @@ tower-http = { version = "0.5.2", features = ["trace"] }
 tracing = "0.1.40"
 tracing-opentelemetry = { version = "0.24", default-features = false }
 tracing-subscriber = { version = "0.3.18", default-features = false }
-typed-store = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.34.0" }
+typed-store = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.33.1" }
 url = "2.5.2"
 utoipa = { version = "4.2.3" }
 utoipa-redoc = { version = "4.0.0", features = ["axum"] }

--- a/contracts/wal/Move.lock
+++ b/contracts/wal/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 2
-manifest_digest = "EF3EDF575DE6A3C0BF3E7065EC8F1FDF603E0164767FBDF1E40F6746BEB7F7E9"
+manifest_digest = "A62DBA9A6F71139ADFC81CD6053E401748D7A784D8A84D3F92EF038BC1FF0483"
 deps_digest = "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082"
 dependencies = [
   { name = "Sui" },
@@ -10,17 +10,17 @@ dependencies = [
 
 [[move.package]]
 name = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.34.0", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.33.1", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 name = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.34.0", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.33.1", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { name = "MoveStdlib" },
 ]
 
 [move.toolchain-version]
-compiler-version = "1.34.0"
+compiler-version = "1.33.1"
 edition = "2024.beta"
 flavor = "sui"

--- a/contracts/wal/Move.toml
+++ b/contracts/wal/Move.toml
@@ -5,7 +5,7 @@ edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
 # authors = ["..."]      # e.g., ["Joe Smith (joesmith@noemail.com)", "John Snow (johnsnow@noemail.com)"]
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.34.0" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.33.1" }
 
 # For remote import, use the `{ git = "...", subdir = "...", rev = "..." }`.
 # Revision can be a branch, a tag, and a commit hash.

--- a/contracts/walrus/Move.lock
+++ b/contracts/walrus/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 2
-manifest_digest = "9359849A4622547B0336F069B7802EA704819526F3B12E3B071D4D8FDE2A91A2"
+manifest_digest = "BE72D6B1590739FCC4597A041C37088D847E517C2AD2702E10F9CFDA24A589BC"
 deps_digest = "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600"
 dependencies = [
   { name = "Sui" },
@@ -11,11 +11,11 @@ dependencies = [
 
 [[move.package]]
 name = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.34.0", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.33.1", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 name = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.34.0", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.33.1", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { name = "MoveStdlib" },
@@ -30,6 +30,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.34.0"
+compiler-version = "1.33.1"
 edition = "2024.beta"
 flavor = "sui"

--- a/contracts/walrus/Move.toml
+++ b/contracts/walrus/Move.toml
@@ -5,7 +5,7 @@ edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
 # authors = ["..."]      # e.g., ["Joe Smith (joesmith@noemail.com)", "John Snow (johnsnow@noemail.com)"]
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.34.0" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.33.1" }
 WAL = { local = "../wal" }
 
 # For remote import, use the `{ git = "...", subdir = "...", rev = "..." }`.


### PR DESCRIPTION
Reverts MystenLabs/walrus#848

Sui 1.34.0 has issue where fullnode may lag and not get latest tx which causes walrus transaction to fail. Let's revert back to 1.33.1. I've confirmed that this version works.