### PR TITLE
fix: Fix event processor to read events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11939,6 +11939,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util 0.7.12",
+ "tracing",
  "typed-store",
  "url",
  "walrus-core",

--- a/crates/walrus-event/Cargo.toml
+++ b/crates/walrus-event/Cargo.toml
@@ -27,6 +27,7 @@ sui-types = { workspace = true, features = ["test-utils"] }
 tempfile = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tokio-util.workspace = true
+tracing.workspace = true
 typed-store.workspace = true
 url.workspace = true
 walrus-core.workspace = true


### PR DESCRIPTION
This PR fixes some issues found while testing simtests with the new event processor. The main fix is to track all package dependencies since we require a package's transitive dependencies for type resolution. And also use a package cache for caching package object which are derived from storage object. Tests all pass after this:
```
    Starting 21 tests across 15 binaries (473 skipped; run ID: ff4acd93-2c0f-489b-885b-1e2853205754, nextest profile: default)
        PASS [   2.418s] walrus-service node::tests::failure_injection_tests::simtest_sync_shard_src_return_empty
        PASS [   2.986s] walrus-service node::tests::failure_injection_tests::sync_shard_start_from_progress::simtest_primary10
        PASS [   3.052s] walrus-service node::tests::failure_injection_tests::sync_shard_start_from_progress::simtest_primary1
        PASS [   4.144s] walrus-service node::tests::failure_injection_tests::sync_shard_shard_recovery_restart::simtest_secondary10
        PASS [   4.147s] walrus-service node::tests::failure_injection_tests::sync_shard_shard_recovery_restart::simtest_restart_after_recovery
        PASS [   4.147s] walrus-service node::tests::failure_injection_tests::sync_shard_shard_recovery_restart::simtest_primary10
        PASS [   4.213s] walrus-service node::tests::failure_injection_tests::sync_shard_shard_recovery_restart::simtest_primary1
        PASS [   4.248s] walrus-service node::tests::failure_injection_tests::sync_shard_shard_recovery_restart::simtest_secondary5
        PASS [   4.319s] walrus-service node::tests::failure_injection_tests::sync_shard_shard_recovery_restart::simtest_primary5
        PASS [   4.379s] walrus-service node::tests::failure_injection_tests::sync_shard_shard_recovery_restart::simtest_secondary1
        PASS [   2.009s] walrus-service node::tests::failure_injection_tests::sync_shard_start_from_progress::simtest_primary11
        PASS [   1.499s] walrus-service node::tests::failure_injection_tests::sync_shard_start_from_progress::simtest_primary15
        PASS [   1.523s] walrus-service node::tests::failure_injection_tests::sync_shard_start_from_progress::simtest_primary23
        PASS [   1.633s] walrus-service node::tests::failure_injection_tests::sync_shard_start_from_progress::simtest_secondary23
        PASS [   1.644s] walrus-service node::tests::failure_injection_tests::sync_shard_start_from_progress::simtest_secondary5
        PASS [   2.033s] walrus-service node::tests::failure_injection_tests::sync_shard_start_from_progress::simtest_primary5
        PASS [   2.087s] walrus-service node::tests::failure_injection_tests::sync_shard_start_from_progress::simtest_secondary10
        PASS [   2.139s] walrus-service node::tests::failure_injection_tests::sync_shard_start_from_progress::simtest_secondary1
        PASS [   2.137s] walrus-service node::tests::failure_injection_tests::sync_shard_start_from_progress::simtest_secondary11
        PASS [   2.150s] walrus-service node::tests::failure_injection_tests::sync_shard_start_from_progress::simtest_secondary15
        PASS [  27.876s] walrus-simtest::simtest simtest_walrus_basic_determinism

```