### PR TITLE
test: switch simtest to use new event processor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11904,12 +11904,17 @@ name = "walrus-e2e-tests"
 version = "1.0.0"
 dependencies = [
  "anyhow",
+ "prometheus",
  "reqwest 0.12.8",
+ "sui-macros",
+ "sui-protocol-config",
+ "sui-simulator",
  "tokio",
  "tokio-stream",
  "tracing",
  "tracing-subscriber",
  "walrus-core",
+ "walrus-proc-macros",
  "walrus-sdk",
  "walrus-service",
  "walrus-sui",
@@ -12088,9 +12093,9 @@ dependencies = [
 name = "walrus-simtest"
 version = "1.0.0"
 dependencies = [
+ "futures",
  "prometheus",
  "reqwest 0.12.8",
- "sui-json-rpc-types",
  "sui-macros",
  "sui-protocol-config",
  "sui-simulator",

--- a/crates/walrus-e2e-tests/Cargo.toml
+++ b/crates/walrus-e2e-tests/Cargo.toml
@@ -8,13 +8,18 @@ license.workspace = true
 
 [dev-dependencies]
 anyhow.workspace = true
+prometheus.workspace = true
 # explicitly import reqwest in test to disable its system proxy cache. It causes indeterminism in simtest.
 reqwest = { version = "0.12.5", default-features = false, features = [ "http2", "json", "rustls-tls", "__internal_proxy_sys_no_cache" ] }
+sui-macros.workspace = true
+sui-protocol-config.workspace = true
+sui-simulator.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 walrus-core.workspace = true
+walrus-proc-macros.workspace = true
 walrus-sdk.workspace = true
 walrus-service = { workspace = true, features = ["test-utils"] }
 walrus-sui.workspace = true

--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -12,6 +12,7 @@ use walrus_core::{
     EpochCount,
     SliverPairIndex,
 };
+use walrus_proc_macros::walrus_simtest;
 use walrus_sdk::api::BlobStatus;
 use walrus_service::{
     client::{
@@ -35,7 +36,8 @@ use walrus_sui::{
 use walrus_test_utils::{async_param_test, Result as TestResult};
 
 async_param_test! {
-    #[ignore = "ignore E2E tests by default"] #[tokio::test]
+    #[ignore = "ignore E2E tests by default"]
+    #[walrus_simtest]
     test_store_and_read_blob_without_failures : [
         empty: (0),
         one_byte: (1),
@@ -49,7 +51,8 @@ async fn test_store_and_read_blob_without_failures(blob_size: usize) {
 }
 
 async_param_test! {
-    #[ignore = "ignore E2E tests by default"] #[tokio::test]
+    #[ignore = "ignore E2E tests by default"]
+    #[walrus_simtest]
     test_store_and_read_blob_with_crash_failures : [
         no_failures: (&[], &[], &[]),
         one_failure: (&[0], &[], &[]),
@@ -57,8 +60,10 @@ async_param_test! {
         f_plus_one_failures: (&[0, 4], &[], &[NotEnoughConfirmations(8, 9)]),
         all_shard_failures: (&[0, 1, 2, 3, 4], &[], &[NoValidStatusReceived]),
         f_plus_one_read_failures: (&[], &[0, 4], &[]),
-        two_f_plus_one_read_failures: (&[], &[1, 2, 4], &[NoMetadataReceived, NotEnoughSlivers]),
-        read_and_write_overlap_failures: (&[4], &[2, 3], &[NoMetadataReceived, NotEnoughSlivers]),
+        two_f_plus_one_read_failures: (
+            &[], &[1, 2, 4], &[NoMetadataReceived, NotEnoughSlivers]),
+        read_and_write_overlap_failures: (
+            &[4], &[2, 3], &[NoMetadataReceived, NotEnoughSlivers]),
     ]
 }
 async fn test_store_and_read_blob_with_crash_failures(
@@ -139,7 +144,8 @@ async fn run_store_and_read_with_crash_failures(
 }
 
 async_param_test! {
-    #[ignore = "ignore E2E tests by default"] #[tokio::test]
+    #[ignore = "ignore E2E tests by default"]
+    #[walrus_simtest]
     test_inconsistency -> TestResult : [
         no_failures: (&[]),
         one_failure: (&[0]),
@@ -219,6 +225,7 @@ async fn test_inconsistency(failed_shards: &[usize]) -> TestResult {
         panic!("should be infinite stream")
     })
     .await?;
+
     Ok(())
 }
 
@@ -238,7 +245,8 @@ fn error_kind_matches(actual: &ClientErrorKind, expected: &ClientErrorKind) -> b
 }
 
 async_param_test! {
-    #[ignore = "ignore E2E tests by default"] #[tokio::test]
+    #[ignore = "ignore E2E tests by default"]
+    #[walrus_simtest]
     test_store_with_existing_blob_resource -> TestResult : [
         reuse_resource: (1, 1, true),
         reuse_resource_two: (2, 1, true),
@@ -250,8 +258,8 @@ async_param_test! {
 /// The `epochs_ahead_registered` are the epochs ahead of the already-existing blob object.
 /// The `epochs_ahead_required` are the epochs ahead that are requested to the client when
 /// registering anew.
-/// `should_match` is a boolean that indicates if the blob object used in the final upload should
-/// be the same as the first one registered.
+/// `should_match` is a boolean that indicates if the blob object used in the final upload
+/// should be the same as the first one registered.
 async fn test_store_with_existing_blob_resource(
     epochs_ahead_registered: EpochCount,
     epochs_ahead_required: EpochCount,
@@ -308,7 +316,8 @@ async fn test_store_with_existing_blob_resource(
 }
 
 async_param_test! {
-    #[ignore = "ignore E2E tests by default"] #[tokio::test]
+    #[ignore = "ignore E2E tests by default"]
+    #[walrus_simtest]
     test_store_with_existing_storage_resource -> TestResult : [
         reuse_storage: (1, 1, true),
         reuse_storage_two: (2, 1, true),
@@ -320,8 +329,8 @@ async_param_test! {
 /// The `epochs_ahead_registered` are the epochs ahead of the already-existing storage resource.
 /// The `epochs_ahead_required` are the epochs ahead that are requested to the client when
 /// registering anew.
-/// `should_match` is a boolean that indicates if the storage object used in the final upload should
-/// be the same as the first one registered.
+/// `should_match` is a boolean that indicates if the storage object used in the final upload
+/// should be the same as the first one registered.
 async fn test_store_with_existing_storage_resource(
     epochs_ahead_registered: EpochCount,
     epochs_ahead_required: EpochCount,
@@ -379,7 +388,8 @@ async fn test_store_with_existing_storage_resource(
 }
 
 async_param_test! {
-    #[ignore = "ignore E2E tests by default"] #[tokio::test]
+    #[ignore = "ignore E2E tests by default"]
+    #[walrus_simtest]
     test_delete_blob -> TestResult : [
         no_delete: (0),
         one_delete: (1),
@@ -392,8 +402,8 @@ async fn test_delete_blob(blobs_to_create: u32) -> TestResult {
     let (_sui_cluster_handle, _cluster, client) = test_cluster::default_setup().await?;
     let blob = walrus_test_utils::random_data(314);
 
-    // Store the blob multiple times, using separate end times to obtain multiple blob objects with
-    // the same blob ID.
+    // Store the blob multiple times, using separate end times to obtain multiple blob objects
+    // with the same blob ID.
     for idx in 1..blobs_to_create + 1 {
         client
             .as_ref()
@@ -426,7 +436,7 @@ async fn test_delete_blob(blobs_to_create: u32) -> TestResult {
 }
 
 #[ignore = "ignore E2E tests by default"]
-#[tokio::test]
+#[walrus_simtest]
 async fn test_storage_nodes_delete_data_for_deleted_blobs() -> TestResult {
     let _ = tracing_subscriber::fmt::try_init();
     let (_sui_cluster_handle, _cluster, client) = test_cluster::default_setup().await?;
@@ -465,7 +475,7 @@ async fn test_storage_nodes_delete_data_for_deleted_blobs() -> TestResult {
 /// Tests that storing the same blob multiple times with possibly different end epochs,
 /// persistence, and force-store conditions always works.
 #[ignore = "ignore E2E tests by default"]
-#[tokio::test]
+#[walrus_simtest]
 async fn test_multiple_stores_same_blob() -> TestResult {
     let _ = tracing_subscriber::fmt::try_init();
     let (_sui_cluster_handle, _cluster, client) = test_cluster::default_setup().await?;

--- a/crates/walrus-event/src/event_processor.rs
+++ b/crates/walrus-event/src/event_processor.rs
@@ -128,11 +128,11 @@ impl EventProcessor {
     }
 
     pub async fn start(&self, cancellation_token: CancellationToken) -> Result<(), anyhow::Error> {
-        let (pruning_task, tailing_task) = join!(
-            self.start_pruning_events(cancellation_token.clone()),
-            self.start_tailing_checkpoints(cancellation_token.clone())
-        );
-        match (pruning_task, tailing_task) {
+        let pruning_task = self.start_pruning_events(cancellation_token.clone());
+        let tailing_task = self.start_tailing_checkpoints(cancellation_token.clone());
+        let (pruning_result, tailing_result) = join!(pruning_task, tailing_task);
+
+        match (pruning_result, tailing_result) {
             (Ok(_), Ok(_)) => Ok(()),
             (Err(e), _) | (_, Err(e)) => Err(e),
         }

--- a/crates/walrus-simtest/Cargo.toml
+++ b/crates/walrus-simtest/Cargo.toml
@@ -6,10 +6,10 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+futures.workspace = true
 prometheus.workspace = true
 # explicitly import reqwest in test to disable its system proxy cache. It causes indeterminism in simtest.
 reqwest = { version = "0.12.5", default-features = false, features = [ "http2", "json", "rustls-tls", "__internal_proxy_sys_no_cache" ] }
-sui-json-rpc-types = { workspace = true, features = ["test-utils"] }
 sui-macros.workspace = true
 sui-protocol-config.workspace = true
 tokio.workspace = true

--- a/crates/walrus-simtest/tests/simtest.rs
+++ b/crates/walrus-simtest/tests/simtest.rs
@@ -22,7 +22,7 @@ async fn walrus_basic_determinism() {
         config
     });
 
-    let (_sui_cluster, _walrus_cluster, client) = test_cluster::default_setup().await.unwrap();
+    let (_sui_cluster, _cluster, client) = test_cluster::default_setup().await.unwrap();
 
     // Write a random blob.
     let blob = walrus_test_utils::random_data(31415);

--- a/crates/walrus-sui/src/test_utils.rs
+++ b/crates/walrus-sui/src/test_utils.rs
@@ -91,7 +91,7 @@ pub fn get_default_invalid_certificate(blob_id: BlobId, epoch: Epoch) -> Invalid
 #[allow(missing_debug_implementations)]
 pub struct TestClusterHandle {
     wallet_path: Mutex<PathBuf>,
-    _cluster: TestCluster,
+    cluster: TestCluster,
 
     #[cfg(msim)]
     _node_handle: NodeHandle,
@@ -112,8 +112,13 @@ impl TestClusterHandle {
         let (cluster, wallet_path) = rx.recv().expect("should receive test_cluster");
         Self {
             wallet_path: Mutex::new(wallet_path),
-            _cluster: cluster,
+            cluster,
         }
+    }
+
+    /// Returns the test cluster reference.
+    pub fn cluster(&self) -> &TestCluster {
+        &self.cluster
     }
 
     // Creates a test Sui cluster using deterministic MSIM runtime.
@@ -140,7 +145,7 @@ impl TestClusterHandle {
         };
         Self {
             wallet_path: Mutex::new(wallet_path),
-            _cluster: cluster,
+            cluster,
             _node_handle: node_handle,
         }
     }
@@ -261,6 +266,7 @@ pub async fn new_wallet_on_sui_test_cluster(
 pub async fn sui_test_cluster() -> TestCluster {
     TestClusterBuilder::new()
         .with_num_validators(2)
+        .disable_fullnode_pruning()
         .build()
         .await
 }


### PR DESCRIPTION
This PR enables new event processor to be used an event provider in default test cluster setup allowing it to be used across simtests.
```
    Finished `simulator` profile [optimized + debuginfo] target(s) in 3m 47s
    Starting 21 tests across 15 binaries (478 skipped; run ID: 77fe4a7f-63b4-46e5-b694-0e6cb19f0f1d, nextest profile: default)
        PASS [   1.255s] walrus-service node::tests::failure_injection_tests::simtest_sync_shard_src_return_empty
        PASS [   1.334s] walrus-service node::tests::failure_injection_tests::sync_shard_shard_recovery_restart::simtest_restart_after_recovery
        PASS [   1.482s] walrus-service node::tests::failure_injection_tests::sync_shard_shard_recovery_restart::simtest_secondary5
        PASS [   1.518s] walrus-service node::tests::failure_injection_tests::sync_shard_shard_recovery_restart::simtest_secondary10
        PASS [   1.670s] walrus-service node::tests::failure_injection_tests::sync_shard_shard_recovery_restart::simtest_secondary1
        PASS [   1.674s] walrus-service node::tests::failure_injection_tests::sync_shard_shard_recovery_restart::simtest_primary5
        PASS [   1.705s] walrus-service node::tests::failure_injection_tests::sync_shard_shard_recovery_restart::simtest_primary1
        PASS [   1.758s] walrus-service node::tests::failure_injection_tests::sync_shard_shard_recovery_restart::simtest_primary10
        PASS [   1.924s] walrus-service node::tests::failure_injection_tests::sync_shard_start_from_progress::simtest_primary1
        PASS [   1.989s] walrus-service node::tests::failure_injection_tests::sync_shard_start_from_progress::simtest_primary10
        PASS [   1.031s] walrus-service node::tests::failure_injection_tests::sync_shard_start_from_progress::simtest_primary11
        PASS [   1.040s] walrus-service node::tests::failure_injection_tests::sync_shard_start_from_progress::simtest_primary15
        PASS [   1.047s] walrus-service node::tests::failure_injection_tests::sync_shard_start_from_progress::simtest_primary23
        PASS [   1.063s] walrus-service node::tests::failure_injection_tests::sync_shard_start_from_progress::simtest_primary5
        PASS [   1.036s] walrus-service node::tests::failure_injection_tests::sync_shard_start_from_progress::simtest_secondary1
        PASS [   1.093s] walrus-service node::tests::failure_injection_tests::sync_shard_start_from_progress::simtest_secondary10
        PASS [   1.128s] walrus-service node::tests::failure_injection_tests::sync_shard_start_from_progress::simtest_secondary11
        PASS [   1.140s] walrus-service node::tests::failure_injection_tests::sync_shard_start_from_progress::simtest_secondary15
        PASS [   1.072s] walrus-service node::tests::failure_injection_tests::sync_shard_start_from_progress::simtest_secondary23
        PASS [   1.064s] walrus-service node::tests::failure_injection_tests::sync_shard_start_from_progress::simtest_secondary5
        PASS [  19.175s] walrus-simtest::simtest simtest_walrus_basic_determinism
------------
     Summary [  21.462s] 21 tests run: 21 passed, 478 skipped
```