### PR TITLE
feat: rename the smaller WAL unit to FROST

### DIFF
--- a/crates/walrus-service/src/client/cli.rs
+++ b/crates/walrus-service/src/client/cli.rs
@@ -326,12 +326,12 @@ impl CurrencyForDisplay for SuiCoin {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct WalCoin(u64);
 
-/// The human readable representation of the GEORGIE and WAL coins.
-pub(crate) type HumanReadableGeorgie = HumanReadableCoin<WalCoin>;
+/// The human readable representation of the FROST and WAL coins.
+pub(crate) type HumanReadableFrost = HumanReadableCoin<WalCoin>;
 
 impl CurrencyForDisplay for WalCoin {
     const SUPERUNIT_NAME: &'static str = "WAL";
-    const UNIT_NAME: &'static str = "GEORGIE";
+    const UNIT_NAME: &'static str = "FROST";
     const DECIMALS: u8 = 9;
 
     fn value(&self) -> u64 {

--- a/crates/walrus-service/src/client/cli/cli_output.rs
+++ b/crates/walrus-service/src/client/cli/cli_output.rs
@@ -19,7 +19,7 @@ use crate::client::{
         success,
         thousands_separator,
         HumanReadableBytes,
-        HumanReadableGeorgie,
+        HumanReadableFrost,
     },
     resource::RegisterBlobOp,
     responses::{
@@ -100,7 +100,7 @@ impl CliOutput for BlobStoreResult {
                     HumanReadableBytes(blob_object.size),
                     HumanReadableBytes(resource_operation.encoded_length()),
                     blob_object.id,
-                    HumanReadableGeorgie::from(*cost),
+                    HumanReadableFrost::from(*cost),
                     operation_str,
                 )
             }
@@ -154,7 +154,7 @@ impl CliOutput for DryRunOutput {
             self.blob_id,
             HumanReadableBytes(self.unencoded_size),
             HumanReadableBytes(self.encoded_size),
-            HumanReadableGeorgie::from(self.storage_cost),
+            HumanReadableFrost::from(self.storage_cost),
         )
     }
 }
@@ -276,10 +276,10 @@ impl CliOutput for InfoOutput {
             hr_storage_unit = HumanReadableBytes(*unit_size),
             max_blob_size_sep = thousands_separator(*max_blob_size),
             price_heading = "Approximate storage prices per epoch".bold().green(),
-            hr_price_per_unit_size = HumanReadableGeorgie::from(*price_per_unit_size),
-            metadata_price = HumanReadableGeorgie::from(*metadata_price),
+            hr_price_per_unit_size = HumanReadableFrost::from(*price_per_unit_size),
+            metadata_price = HumanReadableFrost::from(*metadata_price),
             marginal_size = HumanReadableBytes(*marginal_size),
-            marginal_price = HumanReadableGeorgie::from(*marginal_price),
+            marginal_price = HumanReadableFrost::from(*marginal_price),
             price_examples_heading = "Total price for example blob sizes".bold().green(),
             example_blob_output = example_blobs
                 .iter()

--- a/crates/walrus-service/src/client/responses.rs
+++ b/crates/walrus-service/src/client/responses.rs
@@ -40,7 +40,7 @@ use super::{
     cli::{BlobIdDecimal, HumanReadableBytes},
     resource::RegisterBlobOp,
 };
-use crate::client::cli::{format_event_id, HumanReadableGeorgie};
+use crate::client::cli::{format_event_id, HumanReadableFrost};
 
 /// Either an event ID or an object ID.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -285,7 +285,7 @@ impl ExampleBlobInfo {
             "{} unencoded ({} encoded): {} per epoch",
             HumanReadableBytes(self.unencoded_size),
             HumanReadableBytes(self.encoded_size),
-            HumanReadableGeorgie::from(self.price)
+            HumanReadableFrost::from(self.price)
         )
     }
 }


### PR DESCRIPTION
Our internal poll provided a clear winner for the smaller unit of the WAL token: `FROST` ❄️.