### PR TITLE
fix(staking): call `advance_epoch` on new nodes in committee

### DIFF
--- a/contracts/walrus/sources/staking/staking_pool.move
+++ b/contracts/walrus/sources/staking/staking_pool.move
@@ -442,7 +442,7 @@ public(package) fun is_withdrawing(pool: &StakingPool): bool {
     }
 }
 
-//// Returns `true` if the pool is empty.
+///  Returns `true` if the pool is empty.
 public(package) fun is_empty(pool: &StakingPool): bool {
     let pending_stake = pool.pending_stake.unwrap();
     let non_empty = pending_stake.keys().count!(|epoch| pending_stake[epoch] != 0);


### PR DESCRIPTION
This fixes the issue that caused the epoch change to fail (e.g. this [transaction](https://testnet.suivision.xyz/txblock/GTzKDrTTE7m8MbjMB3twyQMb2L5JEUCYiotAfhdwnFoh)). The issue was caused by only calling `advance_epoch` on storage nodes from the previous committee, and therefore skipped some necessary bookkeeping on new storage nodes.