### PR TITLE
feat(staking): more efficient worst-case apportionment

### DIFF
--- a/contracts/wal/Move.lock
+++ b/contracts/wal/Move.lock
@@ -21,6 +21,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.34.0"
+compiler-version = "1.34.2"
 edition = "2024.beta"
 flavor = "sui"

--- a/contracts/wal_exchange/Move.lock
+++ b/contracts/wal_exchange/Move.lock
@@ -30,6 +30,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.34.0"
+compiler-version = "1.34.2"
 edition = "2024.beta"
 flavor = "sui"


### PR DESCRIPTION
Makes the apportionment more efficient if there are many nodes. Depends on #902 . 
With a low number of nodes the apportionment is a bit less efficient since the main loop depends on the number of shards, but it is efficient enough to support 1000 nodes (gas used when subtracting setup is slightly more than 3M, limit is 5M afaik).

```
Test Statistics:

┌────────────────────────────────────────────────────────────────────────────────┬────────────┬───────────────────────────┐
│                                   Test Name                                    │    Time    │         Gas Used          │
├────────────────────────────────────────────────────────────────────────────────┼────────────┼───────────────────────────┤
│ walrus::staking_inner_tests::test_dhondt_basic                                 │   0.152    │            342            │
├────────────────────────────────────────────────────────────────────────────────┼────────────┼───────────────────────────┤
│ walrus::staking_inner_tests::test_dhondt_edge_case                             │   0.141    │            53             │
├────────────────────────────────────────────────────────────────────────────────┼────────────┼───────────────────────────┤
│ walrus::staking_inner_tests::test_dhondt_no_stake                              │   0.137    │             3             │
├────────────────────────────────────────────────────────────────────────────────┼────────────┼───────────────────────────┤
│ walrus::staking_inner_tests::test_dhondt_ties                                  │   0.143    │            106            │
├────────────────────────────────────────────────────────────────────────────────┼────────────┼───────────────────────────┤
│ walrus::staking_inner_tests::test_larger_dhondt_inputs_1000_nodes_fixed_stake  │   0.397    │          353952           │
├────────────────────────────────────────────────────────────────────────────────┼────────────┼───────────────────────────┤
│ walrus::staking_inner_tests::test_larger_dhondt_inputs_1000_nodes_random_stake │   7.484    │          7341911          │
├────────────────────────────────────────────────────────────────────────────────┼────────────┼───────────────────────────┤
│ walrus::staking_inner_tests::test_larger_dhondt_inputs_100_nodes_fixed_stake   │   0.159    │            843            │
├────────────────────────────────────────────────────────────────────────────────┼────────────┼───────────────────────────┤
│ walrus::staking_inner_tests::test_larger_dhondt_inputs_100_nodes_random_stake  │   2.224    │          247213           │
├────────────────────────────────────────────────────────────────────────────────┼────────────┼───────────────────────────┤
│ walrus::staking_inner_tests::test_larger_dhondt_setup_1000_nodes_random_stake  │   5.614    │          4121502          │
└────────────────────────────────────────────────────────────────────────────────┴────────────┴───────────────────────────┘
```