### PR TITLE
test: disable reqwest system proxy cache to gain simtest determinism in simtest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11904,6 +11904,7 @@ name = "walrus-e2e-tests"
 version = "1.0.0"
 dependencies = [
  "anyhow",
+ "reqwest 0.12.8",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -12088,6 +12089,7 @@ name = "walrus-simtest"
 version = "1.0.0"
 dependencies = [
  "prometheus",
+ "reqwest 0.12.8",
  "sui-json-rpc-types",
  "sui-macros",
  "sui-protocol-config",

--- a/crates/walrus-e2e-tests/Cargo.toml
+++ b/crates/walrus-e2e-tests/Cargo.toml
@@ -8,6 +8,8 @@ license.workspace = true
 
 [dev-dependencies]
 anyhow.workspace = true
+# explicitly import reqwest in test to disable its system proxy cache. It causes indeterminism in simtest.
+reqwest = { version = "0.12.5", default-features = false, features = [ "http2", "json", "rustls-tls", "__internal_proxy_sys_no_cache" ] }
 tokio.workspace = true
 tokio-stream.workspace = true
 tracing.workspace = true

--- a/crates/walrus-simtest/Cargo.toml
+++ b/crates/walrus-simtest/Cargo.toml
@@ -7,6 +7,8 @@ license.workspace = true
 
 [dependencies]
 prometheus.workspace = true
+# explicitly import reqwest in test to disable its system proxy cache. It causes indeterminism in simtest.
+reqwest = { version = "0.12.5", default-features = false, features = [ "http2", "json", "rustls-tls", "__internal_proxy_sys_no_cache" ] }
 sui-json-rpc-types = { workspace = true, features = ["test-utils"] }
 sui-macros.workspace = true
 sui-protocol-config.workspace = true


### PR DESCRIPTION
reqwest system proxy cache has static initialization which is incompatible with simtest determinism check.

We only disable it in integration test. Prod binary is unaffected.