### PR TITLE
feat: Enable event processor to bootstrap from non genesis checkpoint

### DIFF
--- a/crates/walrus-service/bin/node.rs
+++ b/crates/walrus-service/bin/node.rs
@@ -589,6 +589,7 @@ impl EventProcessorRuntime {
             Some(event_processor_config) => Ok(Some(Arc::new(
                 EventProcessor::new(
                     event_processor_config,
+                    sui_config.rpc.clone(),
                     read_client.get_system_package_id(),
                     sui_config.event_polling_interval,
                     db_path,

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -296,6 +296,7 @@ impl StorageNodeBuilder {
                 Some(event_processor_config) => Box::new(
                     EventProcessor::new(
                         event_processor_config,
+                        sui_config.rpc.clone(),
                         read_client.get_system_package_id(),
                         sui_config.event_polling_interval,
                         &config.storage_path,

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -1311,6 +1311,7 @@ pub mod test_cluster {
             for _ in test_cluster_builder.storage_node_test_configs().iter() {
                 let event_processor = walrus_event::event_processor::EventProcessor::new(
                     event_processor_config,
+                    event_processor_config.rest_url.clone(),
                     sui_read_client.get_system_package_id(),
                     Duration::from_millis(100),
                     tempfile::tempdir()
@@ -1357,19 +1358,12 @@ pub mod test_cluster {
 fn create_event_processor_config(
     sui_cluster: Arc<TestClusterHandle>,
 ) -> anyhow::Result<EventProcessorConfig> {
-    // Save genesis in a temp file
-    let genesis_dir = tempfile::tempdir()?;
-    let genesis = sui_cluster.cluster().get_genesis();
-    let genesis_file_path = genesis_dir.into_path().join("genesis.json");
-    genesis.save(&genesis_file_path)?;
-
     // FullNode rest url
     let rest_url = sui_cluster.cluster().fullnode_handle.rpc_url.clone();
 
     // Event processor config
     let event_processor_config = EventProcessorConfig {
         rest_url,
-        sui_genesis_path: genesis_file_path,
         pruning_interval: 3600,
     };
 


### PR DESCRIPTION
Today event processor only bootstraps from genesis checkpoint. This is unsustainable for existing networks like testnet and mainnet (fine for private testnet however). This PR allows node bootstrapping from the checkpoint when walrus package was published first.