### PR TITLE
fix: do not send epoch sync done if the node is not part of committee

### DIFF
--- a/crates/walrus-service/src/node/committee.rs
+++ b/crates/walrus-service/src/node/committee.rs
@@ -139,7 +139,6 @@ pub enum EndCommitteeChangeError {
 /// with committee members.
 ///
 /// It is associated with a single storage epoch.
-#[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait CommitteeService: std::fmt::Debug + Send + Sync {
     /// Returns the epoch associated with the committee.

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -15,6 +15,7 @@ use std::{
 };
 
 use async_trait::async_trait;
+use chrono::Utc;
 use futures::{stream::FuturesUnordered, StreamExt};
 use prometheus::Registry;
 use sui_types::base_types::ObjectID;
@@ -318,7 +319,10 @@ impl StorageNodeHandleBuilder {
 
         let contract_service = self.contract_service.unwrap_or_else(|| {
             Box::new(StubContractService {
-                system_parameters: FixedSystemParameters::default(),
+                system_parameters: FixedSystemParameters {
+                    epoch_duration: Duration::from_secs(600),
+                    epoch_zero_end: Utc::now() + Duration::from_secs(60),
+                },
             })
         });
 

--- a/crates/walrus-service/tests/epoch_change.rs
+++ b/crates/walrus-service/tests/epoch_change.rs
@@ -17,7 +17,7 @@ async fn nodes_drive_epoch_change() -> TestResult {
         test_cluster::default_setup_with_epoch_duration(epoch_duration).await?;
 
     let target_epoch: Epoch = 4;
-    // Allow time to reach the desired epoch, with an additional 20% for the jitter.
+    // Allow time to reach the desired epoch, with an additional 50% for the jitter.
     let time_to_reach_epoch = epoch_duration * target_epoch * 15 / 10;
 
     time::timeout(

--- a/crates/walrus-sui/src/client/read_client.rs
+++ b/crates/walrus-sui/src/client/read_client.rs
@@ -84,15 +84,6 @@ pub struct FixedSystemParameters {
     pub epoch_zero_end: DateTime<Utc>,
 }
 
-impl Default for FixedSystemParameters {
-    fn default() -> Self {
-        Self {
-            epoch_duration: Duration::from_secs(600),
-            epoch_zero_end: Utc::now() + Duration::from_secs(60),
-        }
-    }
-}
-
 /// Trait to read system state information and events from chain.
 pub trait ReadClient: Send + Sync {
     /// Returns the price for one unit of storage per epoch.


### PR DESCRIPTION
Fix #982 