### PR TITLE
feat: reqwest errors are logged in detail at the trace level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11860,6 +11860,7 @@ dependencies = [
  "axum-server 0.7.1",
  "bcs",
  "fastcrypto 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures",
  "mime",
  "opentelemetry 0.23.0",
  "p256",

--- a/crates/walrus-sdk/Cargo.toml
+++ b/crates/walrus-sdk/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 [dependencies]
 bcs.workspace = true
 fastcrypto.workspace = true
+futures.workspace = true
 mime.workspace = true
 opentelemetry.workspace = true
 p256.workspace = true


### PR DESCRIPTION
When debugging connectivity issues, setting the client's log level to trace will provide the debug representation of the error. This provides full details as to the source of the error.

Closes #779 