### PR TITLE
chore!: change accounting unit for storage

### DIFF
--- a/contracts/walrus/sources/system/redstuff.move
+++ b/contracts/walrus/sources/system/redstuff.move
@@ -90,7 +90,7 @@ fun test_encoded_size() {
 
 #[test]
 fun test_zero_size() {
-    //test should fail here
+    // test should fail here
     encoded_blob_length(0, 10);
 }
 

--- a/contracts/walrus/sources/system/system_state_inner.move
+++ b/contracts/walrus/sources/system/system_state_inner.move
@@ -24,7 +24,7 @@ use walrus::{
 const MAX_MAX_EPOCHS_AHEAD: u32 = 1000;
 
 // Keep in sync with the same constant in `crates/walrus-sui/utils.rs`.
-const BYTES_PER_UNIT_SIZE: u64 = 1_024;
+const BYTES_PER_UNIT_SIZE: u64 = 1_024 * 1_024; // 1 MiB
 
 // Errors
 const EStorageExceeded: u64 = 1;

--- a/crates/walrus-service/bin/deploy.rs
+++ b/crates/walrus-service/bin/deploy.rs
@@ -85,10 +85,10 @@ struct DeploySystemContractArgs {
     testbed_config_path: Option<PathBuf>,
     // Note: The storage unit is set in `crates/walrus-sui/utils.rs`. Change the unit in
     // the doc comment here if it changes.
-    /// The price in FROST to set per unit of storage (1 KiB) per epoch.
+    /// The price in FROST to set per unit of storage (1 MiB) per epoch.
     #[arg(long, default_value_t = config::defaults::storage_price())]
     storage_price: u64,
-    /// The price in FROST to set for writing one unit of storage (1 KiB).
+    /// The price in FROST to set for writing one unit of storage (1 MiB).
     #[arg(long, default_value_t = config::defaults::write_price())]
     write_price: u64,
     /// The storage capacity in bytes to deploy the system with.

--- a/crates/walrus-service/bin/node.rs
+++ b/crates/walrus-service/bin/node.rs
@@ -202,10 +202,10 @@ struct ConfigArgs {
     /// If not provided, the RPC node from the wallet's active environment will be used.
     sui_rpc: Option<String>,
     #[clap(long, default_value_t = config::defaults::storage_price())]
-    /// Initial vote for the storage price in FROST per KiB per epoch.
+    /// Initial vote for the storage price in FROST per MiB per epoch.
     storage_price: u64,
     #[clap(long, default_value_t = config::defaults::write_price())]
-    /// Initial vote for the write price in FROST per KiB.
+    /// Initial vote for the write price in FROST per MiB.
     write_price: u64,
     #[clap(long, default_value_t = config::defaults::gas_budget())]
     /// Gas budget for transactions.

--- a/crates/walrus-service/src/client/resource.rs
+++ b/crates/walrus-service/src/client/resource.rs
@@ -330,18 +330,19 @@ impl<'a, C: ContractClient> ResourceManager<'a, C> {
 
 #[cfg(test)]
 mod tests {
+    use walrus_sui::utils::BYTES_PER_UNIT_SIZE;
     use walrus_test_utils::param_test;
 
     use super::*;
 
     param_test! {
         test_price_computation: [
-            one_epoch: (1024, 1, (1, 1), (2, 1)),
-            two_epochs: (1024, 2, (1, 1), (3, 1)),
-            higher_write: (1024, 1, (1, 2), (3, 2)),
-            larger_blob: (2048, 1, (1, 2), (6, 4)),
-            even_larger_blob: (2049, 1, (1, 2), (9, 6)),
-            more_epochs: (2049, 2, (1, 2), (12, 6)),
+            one_epoch: (BYTES_PER_UNIT_SIZE, 1, (1, 1), (2, 1)),
+            two_epochs: (BYTES_PER_UNIT_SIZE, 2, (1, 1), (3, 1)),
+            higher_write: (BYTES_PER_UNIT_SIZE, 1, (1, 2), (3, 2)),
+            larger_blob: (2*BYTES_PER_UNIT_SIZE, 1, (1, 2), (6, 4)),
+            even_larger_blob: (2*BYTES_PER_UNIT_SIZE + 1, 1, (1, 2), (9, 6)),
+            more_epochs: (2*BYTES_PER_UNIT_SIZE + 1, 2, (1, 2), (12, 6)),
         ]
     }
     fn test_price_computation(

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -394,12 +394,12 @@ pub mod defaults {
 
     /// The default vote for the storage price.
     pub fn storage_price() -> u64 {
-        5
+        100
     }
 
     /// The default vote for the write price.
     pub fn write_price() -> u64 {
-        1
+        2000
     }
 
     /// Returns true iff the value is the default.

--- a/crates/walrus-sui/src/utils.rs
+++ b/crates/walrus-sui/src/utils.rs
@@ -53,8 +53,11 @@ use crate::{
 };
 
 // Keep in sync with the same constant in `contracts/walrus/sources/system.move`.
+// The storage unit is used in doc comments for CLI arguments in the files
+// `crates/walrus-service/bin/deploy.rs` and `crates/walrus-service/bin/node.rs`.
+// Change the unit there if it changes.
 /// The number of bytes per storage unit.
-pub const BYTES_PER_UNIT_SIZE: u64 = 1024;
+pub const BYTES_PER_UNIT_SIZE: u64 = 1_024 * 1_024; // 1 MiB
 
 /// Calculates the number of storage units required to store a blob with the
 /// given encoded size.


### PR DESCRIPTION
Changes accounting unit to 1 MiB.
Also sets defaults, s.t. with an epoch duration of one day, storing 1GiB for 1 year costs 0.17 WAL (~= 0.3$ with 1 SUI/WAL and 1.8 USD/SUI) + a write fee of ~0.01  WAL.  

Breaking changes: changes the accounting unit for storage