### PR TITLE
chore(client): reduce default gas budget to 0.1 SUI

### DIFF
--- a/crates/walrus-service/src/client/cli/args.rs
+++ b/crates/walrus-service/src/client/cli/args.rs
@@ -536,7 +536,7 @@ mod default {
     use walrus_sui::utils::SuiNetwork;
 
     pub(crate) fn gas_budget() -> u64 {
-        500_000_000
+        100_000_000
     }
 
     pub(crate) fn epochs() -> EpochCount {


### PR DESCRIPTION
Otherwise, users that get 1 SUI from the faucet and then exchange 0.5 SUI for WAL cannot send anymore transactions.

I believe 0.1 SUI should be sufficient for anything the client does.