### PR TITLE
fix: Convert error log to warn in event processor

### DIFF
--- a/crates/walrus-event/src/event_processor.rs
+++ b/crates/walrus-event/src/event_processor.rs
@@ -41,7 +41,7 @@ use tokio::{
     time::{sleep, Instant},
 };
 use tokio_util::sync::CancellationToken;
-use tracing::error;
+use tracing::warn;
 use typed_store::{
     rocks,
     rocks::{errors::typed_store_err_from_rocks_err, DBMap, MetricConf, ReadWriteOptions},
@@ -247,7 +247,7 @@ impl EventProcessor {
                         result.err().unwrap()
                     );
                 } else {
-                    error!(
+                    warn!(
                         "Failed to read checkpoint from full node: {}",
                         result.err().unwrap()
                     );


### PR DESCRIPTION
This log confuses us sometimes but this is not a real error, as we could be trying to downlaod a checkpoint which is not produced yet. So make it a warn for now