### PR TITLE
feat(node): several minor improvements

### DIFF
--- a/crates/walrus-service/src/node/committee/committee_service.rs
+++ b/crates/walrus-service/src/node/committee/committee_service.rs
@@ -646,6 +646,13 @@ async fn add_members_from_committee<T: NodeService>(
     committee: &Committee,
     encoding_config: &Arc<EncodingConfig>,
 ) -> Result<(), anyhow::Error> {
+    if committee.epoch == 0 {
+        tracing::info!(
+            "we are in the genesis epoch, not creating any services for committee members"
+        );
+        return Ok(());
+    }
+
     let mut n_created = 0usize;
 
     for member in committee.members() {

--- a/crates/walrus-service/src/node/epoch_change_driver.rs
+++ b/crates/walrus-service/src/node/epoch_change_driver.rs
@@ -110,6 +110,12 @@ impl EpochChangeDriver {
     /// `schedule_*` methods for alternatives that will retry until successful.
     pub async fn schedule_relevant_calls_for_current_epoch(&self) -> Result<(), anyhow::Error> {
         let (epoch, state) = self.contract_service.get_epoch_and_state().await?;
+
+        if epoch == 0 {
+            tracing::info!("not scheduling any epoch-change calls in genesis epoch");
+            return Ok(());
+        }
+
         let next_epoch = NonZero::new(epoch + 1).expect("incremented value is non-zero");
 
         match state {

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -1522,7 +1522,7 @@ where
 #[cfg(test)]
 #[allow(unused)]
 pub(crate) fn test_committee(weights: &[u16]) -> Committee {
-    test_committee_with_epoch(weights, 0)
+    test_committee_with_epoch(weights, 1)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- Do not fail when started in genesis epoch.
- Do not call `voting_end` in genesis epoch.
- More useful error if full node does not provide the REST endpoint for checkpoints.
- Reduce log level for expected unavailable checkpoints to 'trace'.
- Add metadata as fields to log entries for checkpoint processing.

Addresses issue raised in https://github.com/MystenLabs/walrus/pull/1047#discussion_r1798040304.
Addresses issue raised in https://github.com/MystenLabs/walrus/pull/1048#discussion_r1798042910.
Closes #1051