### PR TITLE
chore: add CI profile for nextest and use it in CI

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -14,6 +14,7 @@ fail-fast = false # do not stop at first failure
 slow-timeout = { period = "60s", terminate-after = 5 } # Timeout tests after 5 minutes
 retries = 2 # retry twice for a total of 3 attempts
 
-[[profile.ci.overrides]]
-filter = 'package(walrus-e2e-tests)'
-threads-required = 4
+[profile.simtest]
+fail-fast = false # do not stop at first failure
+slow-timeout = { period = "5m", terminate-after = 3 } # Timeout tests after 15 minutes
+test-threads = "num-cpus"

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -162,7 +162,7 @@ jobs:
           tool: cargo-nextest
       - uses: actions/checkout@v4
       - run: ./scripts/simtest/install.sh
-      - run: cargo simtest
+      - run: cargo simtest simtest --profile simtest
 
   test-move:
     name: Test Move code

--- a/.github/workflows/scheduled_reports.yml
+++ b/.github/workflows/scheduled_reports.yml
@@ -53,7 +53,7 @@ jobs:
           tool: cargo-nextest
       - uses: actions/checkout@v4
       - run: ./scripts/simtest/install.sh
-      - run: cargo simtest
+      - run: cargo simtest simtest --profile simtest
 
   dependencies:
     name: Check dependencies (including vulnerabilities)

--- a/scripts/simtest/cargo-simtest
+++ b/scripts/simtest/cargo-simtest
@@ -87,12 +87,12 @@ if ! cargo nextest --help > /dev/null 2>&1; then
   exit 1
 fi
 
-# Adding `simtest` after `run` since all walrus simtest is prefixed with `simtest`.
 if [ -n "$1" ]; then
   echo "Running test $1"
   CARGO_COMMAND=(nextest run "$1" --cargo-profile simulator --run-ignored all)
 else
   echo "Running all simtest"
+  # Adding `simtest` after `run` since all walrus simtest is prefixed with `simtest`.
   CARGO_COMMAND=(nextest run simtest --cargo-profile simulator --run-ignored all)
 fi
 


### PR DESCRIPTION
2 main motivations:
- don't need `retries = 2` when running tests locally
- add a timeout for tests running in CI so that it won't run indefinitely for abnormal tests