### PR TITLE
fix(node): do not crash nodes that are far behind

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -565,13 +565,11 @@ impl StorageNode {
 
                     // if event.event_epoch() < starting_epoch - 1
                     if event.event_epoch() + 1 < epoch_at_start {
-                        let error = anyhow!(
+                        tracing::warn!(
                             "the current epoch ({}) is too far ahead of the event epoch: {}",
                             epoch_at_start,
-                            event.event_epoch(),
+                            event.event_epoch()
                         );
-                        tracing::error!(%error);
-                        return Err(error);
                     }
                 }
             }


### PR DESCRIPTION
With this PR, nodes that are far behind no longer crash completely, but log a warning and attempt catching up. This does not change any other behavior, so this might actually cause issues later.