### PR TITLE
fix(node): don't start blob sync for already expired blobs

### DIFF
--- a/crates/walrus-service/src/node/blob_sync.rs
+++ b/crates/walrus-service/src/node/blob_sync.rs
@@ -205,8 +205,9 @@ impl BlobSyncHandler {
         output
     }
 
+    /// Cancels all blob syncs and returns the number of canceled syncs.
     #[tracing::instrument(skip_all)]
-    pub async fn cancel_all(&self) -> anyhow::Result<()> {
+    pub async fn cancel_all(&self) -> anyhow::Result<usize> {
         let join_handles: Vec<_> = self
             .blob_syncs_in_progress
             .lock()
@@ -214,12 +215,13 @@ impl BlobSyncHandler {
             .iter_mut()
             .filter_map(|(_, sync)| sync.cancel())
             .collect();
+        let count = join_handles.len();
 
         try_join_all(join_handles)
             .await?
             .into_iter()
             .collect::<Result<Vec<_>, _>>()?;
-        Ok(())
+        Ok(count)
     }
 }
 


### PR DESCRIPTION
This does not directly solve #1095, but at least makes sure that no blob syncs are started for already expired blobs. This also offers a manual recovery path: Just restart the recovering node after the epoch change.