### PR TITLE
fix(client): wait after registering a new blob

### DIFF
--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -189,9 +189,6 @@ async fn test_inconsistency(failed_shards: &[usize]) -> TestResult {
         )
         .await?;
 
-    // Wait to ensure that the storage nodes received the registration event.
-    tokio::time::sleep(Duration::from_secs(1)).await;
-
     // Certify blob.
     let certificate = client
         .as_ref()
@@ -293,9 +290,6 @@ async fn test_store_with_existing_blob_resource(
         )
         .await?;
 
-    // Wait to ensure that the storage nodes received the registration event.
-    tokio::time::sleep(Duration::from_secs(1)).await;
-
     // Now ask the client to store again.
     let blob_store = client
         .inner
@@ -363,9 +357,6 @@ async fn test_store_with_existing_storage_resource(
         .sui_client()
         .reserve_space(encoded_size, epochs_ahead_registered)
         .await?;
-
-    // Wait to ensure that the storage nodes received the registration event.
-    tokio::time::sleep(Duration::from_secs(1)).await;
 
     // Now ask the client to store again.
 

--- a/crates/walrus-service/client_config_example.yaml
+++ b/crates/walrus-service/client_config_example.yaml
@@ -36,3 +36,6 @@ communication_config:
     base:
       secs: 0
       nanos: 500000000
+  registration_delay:
+    secs: 0
+    nanos: 200000000

--- a/crates/walrus-service/src/client.rs
+++ b/crates/walrus-service/src/client.rs
@@ -410,6 +410,14 @@ impl<T: ContractClient> Client<T> {
             StoreOp::RegisterNew { blob, operation } => (blob, operation),
         };
 
+        if resource_operation.is_registration() {
+            tracing::debug!(
+                delay=?self.config.communication_config.registration_delay,
+                "waiting to ensure that all storage nodes have seen the registration"
+            );
+            tokio::time::sleep(self.config.communication_config.registration_delay).await;
+        }
+
         let (certificate, write_committee_epoch) = {
             let committees = self.committees.read().await;
 

--- a/crates/walrus-service/src/client/config.rs
+++ b/crates/walrus-service/src/client/config.rs
@@ -85,6 +85,9 @@ pub struct ClientCommunicationConfig {
     pub disable_native_certs: bool,
     /// The extra time allowed for sliver writes.
     pub sliver_write_extra_time: SliverWriteExtraTime,
+    /// The delay for which the client waits before storing data to ensure that storage nodes have
+    /// seen the registration event.
+    pub registration_delay: Duration,
 }
 
 impl Default for ClientCommunicationConfig {
@@ -100,6 +103,7 @@ impl Default for ClientCommunicationConfig {
             request_rate_config: Default::default(),
             disable_proxy: Default::default(),
             sliver_write_extra_time: Default::default(),
+            registration_delay: Duration::from_millis(200),
         }
     }
 }

--- a/crates/walrus-service/src/client/resource.rs
+++ b/crates/walrus-service/src/client/resource.rs
@@ -86,6 +86,13 @@ impl RegisterBlobOp {
             | RegisterBlobOp::ReuseRegistration { encoded_length } => *encoded_length,
         }
     }
+
+    /// Returns if the operation involved issuing a new registration.
+    pub fn is_registration(&self) -> bool {
+        matches!(self, RegisterBlobOp::RegisterFromScratch { .. })
+            // Reusing storage also requires a new registration.
+            || matches!(self, RegisterBlobOp::ReuseStorage { .. })
+    }
 }
 
 /// The result of a store operation.


### PR DESCRIPTION
Adds a little delay after executing a blob registration on Sui. This may help reduce the store latency by 2-3 seconds, as the client does not fail immediately and needs to retry after a delay.