### PR TITLE
refactor: move events into walrus-service and create walrus-utils crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,9 +124,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.18"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+checksum = "45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9"
 
 [[package]]
 name = "android-tzdata"
@@ -170,7 +170,7 @@ dependencies = [
  "serde_json",
  "socket2 0.5.7",
  "tap",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-util 0.7.12",
  "tower 0.4.13",
@@ -488,7 +488,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "time",
 ]
 
@@ -1170,7 +1170,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85b6598a2f5d564fb7855dc6b06fd1c38cff5a72bd8b863a4d021938497b440a"
 dependencies = [
  "serde",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1209,7 +1209,7 @@ dependencies = [
  "byteorder",
  "ff 0.13.0",
  "serde",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1596,7 +1596,7 @@ dependencies = [
  "instant",
  "lazy_static",
  "once_cell",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -1642,9 +1642,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.34"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b9470d453346108f93a59222a9a1a5724db32d0a4727b7ab7ace4b4d822dc9"
+checksum = "1aeb932158bd710538c73702db6945cb68a8fb08c519e6e12706b94263b36db8"
 dependencies = [
  "jobserver",
  "libc",
@@ -1794,7 +1794,7 @@ checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -1920,7 +1920,7 @@ dependencies = [
  "sui-protocol-config",
  "sui-tls",
  "tap",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-rustls 0.26.0",
  "tokio-stream",
@@ -1943,7 +1943,7 @@ dependencies = [
  "encode_unicode 0.3.6",
  "lazy_static",
  "libc",
- "unicode-width",
+ "unicode-width 0.1.14",
  "windows-sys 0.52.0",
 ]
 
@@ -2027,9 +2027,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
 dependencies = [
  "libc",
 ]
@@ -2197,9 +2197,9 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
+checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
 dependencies = [
  "csv-core",
  "itoa",
@@ -2642,7 +2642,7 @@ checksum = "feadfed35b96a5634e08fc503677ded669549ae2cf7f0b01d5964f09d95487fd"
 dependencies = [
  "documented-macros",
  "phf",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2744,7 +2744,7 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "sha2 0.9.9",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "zeroize",
 ]
 
@@ -2959,7 +2959,7 @@ dependencies = [
  "sha3 0.10.8",
  "signature 2.2.0",
  "static_assertions",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tokio",
  "typenum",
  "zeroize",
@@ -3009,7 +3009,7 @@ dependencies = [
  "sha3 0.10.8",
  "signature 2.2.0",
  "static_assertions",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tokio",
  "typenum",
  "zeroize",
@@ -3102,9 +3102,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
 
 [[package]]
 name = "fdlimit"
@@ -3443,7 +3443,7 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata 0.4.8",
+ "regex-automata 0.4.9",
  "regex-syntax 0.8.5",
 ]
 
@@ -4109,15 +4109,15 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.8"
+version = "0.17.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3"
+checksum = "cbf675b85ed934d3c67b5c5469701eec7db22689d0a2139d856e0925fa28b281"
 dependencies = [
  "console",
- "instant",
  "number_prefix",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.0",
+ "web-time",
 ]
 
 [[package]]
@@ -4311,7 +4311,7 @@ dependencies = [
  "pin-project",
  "rustls-native-certs 0.6.3",
  "soketto",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-rustls 0.23.4",
  "tokio-util 0.7.12",
@@ -4341,7 +4341,7 @@ dependencies = [
  "serde",
  "serde_json",
  "soketto",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
@@ -4359,7 +4359,7 @@ dependencies = [
  "rustc-hash 1.1.0",
  "serde",
  "serde_json",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
@@ -4406,7 +4406,7 @@ dependencies = [
  "beef",
  "serde",
  "serde_json",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -4486,9 +4486,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
 
 [[package]]
 name = "libloading"
@@ -4834,7 +4834,7 @@ dependencies = [
  "rustc_version",
  "smallvec",
  "tagptr",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "triomphe",
  "uuid",
 ]
@@ -5051,7 +5051,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_with",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "uint",
 ]
 
@@ -5666,7 +5666,7 @@ dependencies = [
  "libc",
  "once_cell",
  "parking_lot 0.12.3",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "widestring",
  "winapi",
 ]
@@ -5684,7 +5684,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -5760,7 +5760,7 @@ dependencies = [
  "serde",
  "serde_with",
  "sui-protocol-config",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tokio",
  "tonic",
  "tonic-build",
@@ -6131,7 +6131,7 @@ dependencies = [
  "js-sys",
  "once_cell",
  "pin-project-lite",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6147,7 +6147,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tokio",
  "tonic",
 ]
@@ -6178,7 +6178,7 @@ dependencies = [
  "js-sys",
  "once_cell",
  "pin-project-lite",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "urlencoding",
 ]
 
@@ -6198,7 +6198,7 @@ dependencies = [
  "percent-encoding",
  "rand 0.8.5",
  "serde_json",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
 ]
@@ -6285,7 +6285,7 @@ checksum = "ae7891b22598926e4398790c8fe6447930c72a67d36d983a49d6ce682ce83290"
 dependencies = [
  "bytecount",
  "fnv",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -6466,7 +6466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
 dependencies = [
  "memchr",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "ucd-trie",
 ]
 
@@ -6787,7 +6787,7 @@ dependencies = [
  "is-terminal",
  "lazy_static",
  "term",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -6817,7 +6817,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
 dependencies = [
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "toml 0.5.11",
 ]
 
@@ -6875,7 +6875,7 @@ dependencies = [
  "memchr",
  "parking_lot 0.12.3",
  "protobuf",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7046,7 +7046,7 @@ dependencies = [
  "rustc-hash 2.0.0",
  "rustls 0.23.16",
  "socket2 0.5.7",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
@@ -7063,16 +7063,16 @@ dependencies = [
  "rustc-hash 2.0.0",
  "rustls 0.23.16",
  "slab",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tinyvec",
  "tracing",
 ]
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e346e016eacfff12233c243718197ca12f148c84e1e84268a896699b41c71780"
+checksum = "7d5a626c6807713b15cac82a6acaccd6043c9a5408c24baae07611fec3f243da"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -7304,7 +7304,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7335,7 +7335,7 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.8",
+ "regex-automata 0.4.9",
  "regex-syntax 0.8.5",
 ]
 
@@ -7350,9 +7350,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -7575,9 +7575,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.39"
+version = "0.38.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375116bee2be9ed569afe2154ea6a99dfdffd257f533f187498c2a8f5feaf4ee"
+checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -7849,9 +7849,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
+checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -7865,9 +7865,9 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
@@ -7889,7 +7889,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b5b14ebbcc4e4f2b3642fa99c388649da58d1dc3308c7d109f39f565d1710f0"
 dependencies = [
  "serde",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7900,7 +7900,7 @@ checksum = "f05a5f801ac62a51a49d378fdb3884480041b99aced450b28990673e8ff99895"
 dependencies = [
  "once_cell",
  "serde",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7914,9 +7914,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
@@ -8760,7 +8760,7 @@ dependencies = [
  "tap",
  "telemetry-subscribers",
  "tempfile",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-retry",
  "tokio-stream",
@@ -8960,7 +8960,7 @@ dependencies = [
  "tap",
  "telemetry-subscribers",
  "tempfile",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.12",
@@ -9032,7 +9032,7 @@ dependencies = [
  "sui-transaction-builder",
  "sui-types",
  "tap",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-util 0.7.12",
  "tower 0.4.13",
@@ -9359,7 +9359,7 @@ dependencies = [
  "sui-json-rpc-types",
  "sui-sdk",
  "sui-types",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -9378,7 +9378,7 @@ dependencies = [
  "serde",
  "sui-rest-api",
  "sui-types",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -9450,7 +9450,7 @@ dependencies = [
  "sui-sdk-types",
  "sui-types",
  "tap",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tokio",
  "url",
 ]
@@ -9483,7 +9483,7 @@ dependencies = [
  "sui-keys",
  "sui-transaction-builder",
  "sui-types",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
@@ -9821,7 +9821,7 @@ dependencies = [
  "sui-protocol-config",
  "sui-sdk-types",
  "tap",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tonic",
  "tracing",
  "typed-store-error",
@@ -9970,7 +9970,7 @@ checksum = "0ce69a5028cd9576063ec1f48edb2c75339fd835e6094ef3e05b3a079bf594a6"
 dependencies = [
  "papergrid",
  "tabled_derive",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -10112,11 +10112,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02dd99dc800bbb97186339685293e1cc5d9df1f8fae2d0aecd9ff1c77efea892"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.68",
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -10130,9 +10130,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
@@ -10213,7 +10213,7 @@ dependencies = [
  "rand 0.8.5",
  "rustc-hash 1.1.0",
  "sha2 0.10.8",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "unicode-normalization",
  "wasm-bindgen",
  "zeroize",
@@ -10708,7 +10708,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
 dependencies = [
  "crossbeam-channel",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "time",
  "tracing-subscriber",
 ]
@@ -10848,7 +10848,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "sha1",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "utf-8",
 ]
 
@@ -10885,7 +10885,7 @@ dependencies = [
  "serde",
  "sui-macros",
  "tap",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "typed-store-derive",
@@ -10910,7 +10910,7 @@ version = "0.4.0"
 source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
 dependencies = [
  "serde",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -11033,6 +11033,12 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
@@ -11281,41 +11287,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "walrus-event"
-version = "1.4.0"
-dependencies = [
- "anyhow",
- "async-channel",
- "async-trait",
- "bcs",
- "byteorder",
- "futures-util",
- "integer-encoding 4.0.2",
- "move-core-types",
- "prometheus",
- "reqwest",
- "rocksdb",
- "serde",
- "serde_json",
- "serde_yaml 0.9.34+deprecated",
- "sui-config",
- "sui-package-resolver",
- "sui-rest-api",
- "sui-sdk",
- "sui-storage",
- "sui-types",
- "tempfile",
- "tokio",
- "tokio-util 0.7.12",
- "tracing",
- "typed-store",
- "url",
- "walrus-core",
- "walrus-sdk",
- "walrus-sui",
-]
-
-[[package]]
 name = "walrus-orchestrator"
 version = "1.4.0"
 dependencies = [
@@ -11407,6 +11378,7 @@ dependencies = [
  "itertools 0.13.0",
  "mime",
  "mockall 0.12.1",
+ "move-core-types",
  "mysten-metrics",
  "num-bigint 0.4.6",
  "opentelemetry",
@@ -11426,9 +11398,12 @@ dependencies = [
  "serde_yaml 0.9.34+deprecated",
  "sui-config",
  "sui-macros",
+ "sui-package-resolver",
  "sui-protocol-config",
+ "sui-rest-api",
  "sui-sdk",
  "sui-simulator",
+ "sui-storage",
  "sui-types",
  "telemetry-subscribers",
  "tempfile",
@@ -11445,11 +11420,11 @@ dependencies = [
  "utoipa",
  "utoipa-redoc",
  "walrus-core",
- "walrus-event",
  "walrus-proc-macros",
  "walrus-sdk",
  "walrus-sui",
  "walrus-test-utils",
+ "walrus-utils",
 ]
 
 [[package]]
@@ -11534,6 +11509,27 @@ dependencies = [
  "rand 0.8.5",
  "tempfile",
  "tokio",
+]
+
+[[package]]
+name = "walrus-utils"
+version = "1.4.0"
+dependencies = [
+ "anyhow",
+ "async-channel",
+ "prometheus",
+ "rand 0.8.5",
+ "reqwest",
+ "rocksdb",
+ "serde",
+ "serde_json",
+ "sui-rest-api",
+ "sui-types",
+ "tempfile",
+ "tokio",
+ "tokio-util 0.7.12",
+ "tracing",
+ "typed-store",
 ]
 
 [[package]]
@@ -11997,7 +11993,7 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,12 +86,12 @@ url = "2.5.2"
 utoipa = { version = "4.2.3" }
 utoipa-redoc = { version = "4.0.0", features = ["axum"] }
 walrus-core = { path = "crates/walrus-core" }
-walrus-event = { path = "crates/walrus-event" }
 walrus-proc-macros = { path = "crates/walrus-proc-macros" }
 walrus-sdk = { path = "crates/walrus-sdk" }
 walrus-service = { path = "crates/walrus-service" }
 walrus-sui = { path = "crates/walrus-sui" }
 walrus-test-utils = { path = "crates/walrus-test-utils" }
+walrus-utils = { path = "crates/walrus-utils" }
 x509-cert = "0.2.5"
 
 [workspace.lints.rust]

--- a/crates/walrus-service/Cargo.toml
+++ b/crates/walrus-service/Cargo.toml
@@ -76,6 +76,7 @@ indoc = { workspace = true, optional = true }
 integer-encoding.workspace = true
 itertools = { workspace = true, optional = true }
 mime = { workspace = true, optional = true }
+move-core-types.workspace = true
 mysten-metrics = { workspace = true, optional = true }
 num-bigint.workspace = true
 opentelemetry.workspace = true
@@ -95,8 +96,11 @@ serde_with.workspace = true
 serde_yaml.workspace = true
 sui-config.workspace = true
 sui-macros.workspace = true
+sui-package-resolver.workspace = true
 sui-protocol-config.workspace = true
+sui-rest-api.workspace = true
 sui-sdk.workspace = true
+sui-storage.workspace = true
 sui-types.workspace = true
 telemetry-subscribers.workspace = true
 tempfile = { workspace = true, optional = true }
@@ -113,10 +117,10 @@ typed-store = { workspace = true, optional = true }
 utoipa = { workspace = true, features = ["axum_extras"] }
 utoipa-redoc.workspace = true
 walrus-core = { workspace = true, features = ["utoipa"] }
-walrus-event.workspace = true
 walrus-sdk.workspace = true
 walrus-sui = { workspace = true, features = ["utoipa"] }
 walrus-test-utils = { workspace = true, optional = true }
+walrus-utils.workspace = true
 
 [dev-dependencies]
 mockall.workspace = true

--- a/crates/walrus-service/bin/node.rs
+++ b/crates/walrus-service/bin/node.rs
@@ -29,7 +29,6 @@ use tokio::{
 };
 use tokio_util::sync::CancellationToken;
 use walrus_core::keys::{NetworkKeyPair, ProtocolKeyPair};
-use walrus_event::{event_processor::EventProcessor, EventProcessorConfig};
 use walrus_service::{
     node::{
         config::{
@@ -39,6 +38,7 @@ use walrus_service::{
             StorageNodeConfig,
             SuiConfig,
         },
+        events::{event_processor::EventProcessor, EventProcessorConfig},
         server::{UserServer, UserServerConfig},
         system_events::{EventManager, SuiSystemEventProvider},
         StorageNode,

--- a/crates/walrus-service/src/client.rs
+++ b/crates/walrus-service/src/client.rs
@@ -40,7 +40,7 @@ use self::{
     responses::BlobStoreResult,
     utils::{CompletedReasonWeight, WeightedFutures},
 };
-use crate::{common::active_committees::ActiveCommittees, utils::ExponentialBackoff};
+use crate::common::active_committees::ActiveCommittees;
 
 pub mod cli;
 pub mod responses;
@@ -68,6 +68,7 @@ mod resource;
 
 mod utils;
 pub use utils::string_prefix;
+use walrus_utils::backoff::ExponentialBackoff;
 
 pub mod metrics;
 

--- a/crates/walrus-service/src/common/utils.rs
+++ b/crates/walrus-service/src/common/utils.rs
@@ -9,7 +9,6 @@ use std::{
     fmt::Debug,
     future::Future,
     net::{IpAddr, Ipv4Addr, SocketAddr},
-    num::Saturating,
     path::{Path, PathBuf},
     pin::Pin,
     str::FromStr,
@@ -22,7 +21,6 @@ use anyhow::{anyhow, Context as _, Result};
 use futures::future::FusedFuture;
 use pin_project::pin_project;
 use prometheus::{HistogramVec, Registry};
-use rand::{rngs::StdRng, Rng, SeedableRng};
 use serde::{
     de::{DeserializeOwned, Error},
     Deserialize,
@@ -88,164 +86,6 @@ pub trait LoadConfig: DeserializeOwned {
             .with_context(|| format!("Unable to load config from {}", path.display()))?;
 
         Ok(serde_yaml::from_reader(reader)?)
-    }
-}
-
-/// The representation of a backoff strategy.
-pub(crate) trait BackoffStrategy {
-    /// Steps the backoff iterator, returning the next delay and advances the backoff.
-    ///
-    /// Returns `None` if the strategy mandates that the consumer should stop backing off.
-    fn next_delay(&mut self) -> Option<Duration>;
-}
-
-#[derive(Debug)]
-pub(crate) struct ExponentialBackoffState {
-    min_backoff: Duration,
-    max_backoff: Duration,
-    sequence_index: u32,
-    max_retries: Option<u32>,
-}
-
-impl ExponentialBackoffState {
-    /// Creates new state with the provided minimum and maximum bounds.
-    ///
-    /// If `max_retries` is `None`, this backoff strategy will keep retrying indefinitely.
-    pub fn new(min_backoff: Duration, max_backoff: Duration, max_retries: Option<u32>) -> Self {
-        Self {
-            min_backoff,
-            max_backoff,
-            sequence_index: 0,
-            max_retries,
-        }
-    }
-
-    /// Creates a new `ExponentialBackoffTracker` that yields an infinite sequence of backoffs
-    /// between the min and max specified.
-    pub fn new_infinite(min_backoff: Duration, max_backoff: Duration) -> Self {
-        Self::new(min_backoff, max_backoff, None)
-    }
-
-    pub fn next_delay<R: Rng + ?Sized>(&mut self, rng: &mut R) -> Option<Duration> {
-        if let Some(max_retries) = self.max_retries {
-            if self.sequence_index >= max_retries {
-                return None;
-            }
-        }
-
-        let next_delay_value = self
-            .min_backoff
-            .saturating_mul(Saturating(2u32).pow(self.sequence_index).0)
-            .saturating_add(Self::random_offset(rng))
-            .min(self.max_backoff);
-
-        self.sequence_index = self.sequence_index.saturating_add(1);
-
-        Some(next_delay_value)
-    }
-
-    fn random_offset<R: Rng + ?Sized>(rng: &mut R) -> Duration {
-        let millis = rng.gen_range(0..=ExponentialBackoff::MAX_RAND_OFFSET_MS);
-        Duration::from_millis(millis)
-    }
-}
-
-/// An iterator over exponential wait durations.
-///
-/// Returns the wait duration for an exponential backoff with a multiplicative factor of 2, and
-/// where each duration includes a random positive offset.
-///
-/// For the `i`-th iterator element and bounds `min_backoff` and `max_backoff`, this returns the
-/// sequence `min(max_backoff, 2^i * min_backoff + rand_i)`.
-#[derive(Debug)]
-pub(crate) struct ExponentialBackoff<R> {
-    state: ExponentialBackoffState,
-    rng: R,
-}
-
-impl ExponentialBackoff<StdRng> {
-    /// Maximum number of milliseconds to randomly add to the delay time.
-    const MAX_RAND_OFFSET_MS: u64 = 1000;
-
-    /// Creates a new iterator with the provided minimum and maximum bounds,
-    /// and seeded with the provided value.
-    ///
-    /// If `max_retries` is `None`, this backoff strategy will keep retrying indefinitely.
-    pub fn new_with_seed(
-        min_backoff: Duration,
-        max_backoff: Duration,
-        max_retries: Option<u32>,
-        seed: u64,
-    ) -> ExponentialBackoff<StdRng> {
-        ExponentialBackoff::<StdRng>::new_with_rng(
-            min_backoff,
-            max_backoff,
-            max_retries,
-            StdRng::seed_from_u64(seed),
-        )
-    }
-}
-
-impl<R: Rng> ExponentialBackoff<R> {
-    /// Creates a new iterator with the provided minimum and maximum bounds, with the provided
-    /// iterator.
-    ///
-    /// If `max_retries` is `None`, this backoff strategy will keep retrying indefinitely.
-    pub fn new_with_rng(
-        min_backoff: Duration,
-        max_backoff: Duration,
-        max_retries: Option<u32>,
-        rng: R,
-    ) -> Self {
-        Self {
-            state: ExponentialBackoffState::new(min_backoff, max_backoff, max_retries),
-            rng,
-        }
-    }
-
-    fn next_delay(&mut self) -> Option<Duration> {
-        self.state.next_delay(&mut self.rng)
-    }
-}
-
-impl<R: Rng> Iterator for ExponentialBackoff<R> {
-    type Item = Duration;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.next_delay()
-    }
-}
-
-impl<I> BackoffStrategy for I
-where
-    I: Iterator<Item = Duration>,
-{
-    fn next_delay(&mut self) -> Option<Duration> {
-        self.next()
-    }
-}
-
-/// Trait to unify checking for success on `Result` and `Option` types.
-pub(crate) trait SuccessOrFailure {
-    /// Returns true iff the value is considered successful.
-    fn is_success(&self) -> bool;
-}
-
-impl<T, E> SuccessOrFailure for Result<T, E> {
-    fn is_success(&self) -> bool {
-        self.is_ok()
-    }
-}
-
-impl<T> SuccessOrFailure for Option<T> {
-    fn is_success(&self) -> bool {
-        self.is_some()
-    }
-}
-
-impl SuccessOrFailure for bool {
-    fn is_success(&self) -> bool {
-        *self
     }
 }
 
@@ -364,32 +204,6 @@ where
     fn drop(self: Pin<&mut Self>) {
         if !self.is_terminated() {
             self.observe(None);
-        }
-    }
-}
-
-/// Repeatedly calls the provided function with the provided backoff strategy until it returns
-/// successfully.
-pub(crate) async fn retry<S, F, T, Fut>(mut strategy: S, mut func: F) -> T
-where
-    S: BackoffStrategy,
-    F: FnMut() -> Fut,
-    T: SuccessOrFailure,
-    Fut: Future<Output = T>,
-{
-    loop {
-        let value = func().await;
-
-        if value.is_success() {
-            return value;
-        }
-
-        if let Some(delay) = strategy.next_delay() {
-            tracing::debug!(?delay, "attempt failed, waiting before retrying");
-            tokio::time::sleep(delay).await;
-        } else {
-            tracing::debug!("last attempt failed, returning last failure value");
-            return value;
         }
     }
 }
@@ -737,54 +551,6 @@ mod tests {
     use walrus_test_utils::{assert_unordered_eq, param_test};
 
     use super::*;
-
-    mod exponential_backoff {
-        use super::*;
-
-        #[test]
-        fn backoff_is_exponential() {
-            let min = Duration::from_millis(500);
-            let max = Duration::from_secs(3600);
-
-            let expected: Vec<_> = (0u32..)
-                .map(|i| min * 2u32.pow(i))
-                .take_while(|d| *d < max)
-                .chain([max; 2])
-                .collect();
-
-            let actual: Vec<_> = ExponentialBackoff::new_with_seed(min, max, None, 42)
-                .take(expected.len())
-                .collect();
-
-            assert_eq!(expected.len(), actual.len());
-            assert_ne!(expected, actual, "retries must have a random component");
-
-            for (expected, actual) in expected.iter().zip(actual) {
-                let expected_min = *expected;
-                let expected_max =
-                    *expected + Duration::from_millis(ExponentialBackoff::MAX_RAND_OFFSET_MS);
-
-                assert!(actual >= expected_min, "{actual:?} >= {expected_min:?}");
-                assert!(actual <= expected_max);
-            }
-        }
-
-        #[test]
-        fn backoff_stops_after_max_retries() {
-            let retries = 5;
-            let mut strategy = ExponentialBackoff::new_with_seed(
-                Duration::from_millis(1),
-                Duration::from_millis(5),
-                Some(retries),
-                42,
-            );
-            let mut actual = 0;
-            while let Some(_d) = strategy.next_delay() {
-                actual += 1;
-            }
-            assert_eq!(retries, actual);
-        }
-    }
 
     mod byte_count {
         use super::*;

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -52,7 +52,6 @@ use walrus_core::{
     SliverPairIndex,
     SliverType,
 };
-use walrus_event::{event_processor::EventProcessor, EventProcessorConfig, IndexedStreamElement};
 use walrus_sdk::api::{
     BlobStatus,
     EventProgress,
@@ -91,6 +90,7 @@ use self::{
 pub mod committee;
 pub mod config;
 pub mod contract_service;
+pub mod events;
 pub mod server;
 pub mod system_events;
 
@@ -116,10 +116,16 @@ use errors::{
     StoreSliverError,
     SyncShardServiceError,
 };
+use events::{
+    event_processor::EventProcessor,
+    EventProcessorConfig,
+    EventStreamCursor,
+    EventStreamElement,
+    IndexedStreamElement,
+};
 
 mod storage;
 pub use storage::{DatabaseConfig, NodeStatus, Storage};
-use walrus_event::{EventStreamCursor, EventStreamElement};
 
 use crate::{
     common::utils::ShardDiff,
@@ -1082,6 +1088,10 @@ impl StorageNode {
         );
 
         Ok(())
+    }
+
+    pub(crate) fn inner(&self) -> &Arc<StorageNodeInner> {
+        &self.inner
     }
 }
 

--- a/crates/walrus-service/src/node/committee/request_futures.rs
+++ b/crates/walrus-service/src/node/committee/request_futures.rs
@@ -46,12 +46,13 @@ use walrus_core::{
     SliverType,
 };
 use walrus_sui::types::Committee;
+use walrus_utils::backoff::ExponentialBackoffState;
 
 use super::{
     committee_service::NodeCommitteeServiceInner,
     node_service::{NodeService, NodeServiceError, Request, Response},
 };
-use crate::{common::active_committees::CommitteeTracker, utils::ExponentialBackoffState};
+use crate::common::active_committees::CommitteeTracker;
 
 pub(super) struct GetAndVerifyMetadata<'a, T> {
     blob_id: BlobId,

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -29,14 +29,16 @@ use walrus_core::keys::{
     SupportedKeyPair,
     TaggedKeyPair,
 };
-use walrus_event::EventProcessorConfig;
 use walrus_sui::{
     client::{SuiClientError, SuiContractClient, SuiReadClient},
     types::{move_structs::VotingParams, NetworkAddress, NodeRegistrationParams},
 };
 
 use super::storage::DatabaseConfig;
-use crate::common::utils::{self, LoadConfig};
+use crate::{
+    common::utils::{self, LoadConfig},
+    node::events::EventProcessorConfig,
+};
 
 /// Configuration of a Walrus storage node.
 #[serde_as]

--- a/crates/walrus-service/src/node/contract_service.rs
+++ b/crates/walrus-service/src/node/contract_service.rs
@@ -18,9 +18,9 @@ use walrus_sui::{
     client::{ContractClient, FixedSystemParameters, SuiClientError, SuiContractClient},
     types::move_structs::EpochState,
 };
+use walrus_utils::backoff::{self, ExponentialBackoff};
 
 use super::config::SuiConfig;
-use crate::common::utils::{self, ExponentialBackoff};
 
 const MIN_BACKOFF: Duration = Duration::from_secs(1);
 const MAX_BACKOFF: Duration = Duration::from_secs(3600);
@@ -116,7 +116,7 @@ where
             None,
             self.rng.lock().unwrap().gen(),
         );
-        utils::retry(backoff, || async {
+        backoff::retry(backoff, || async {
             self.contract_client
                 .lock()
                 .await
@@ -141,7 +141,7 @@ where
             self.rng.lock().unwrap().gen(),
         );
 
-        utils::retry(backoff, || async {
+        backoff::retry(backoff, || async {
             match self
                 .contract_client
                 .lock()

--- a/crates/walrus-service/src/node/epoch_change_driver.rs
+++ b/crates/walrus-service/src/node/epoch_change_driver.rs
@@ -21,9 +21,9 @@ use walrus_sui::{
     client::FixedSystemParameters,
     types::{move_structs::EpochState, GENESIS_EPOCH},
 };
+use walrus_utils::backoff::ExponentialBackoffState;
 
 use super::contract_service::SystemContractService;
-use crate::utils::ExponentialBackoffState;
 
 /// Maximum number of seconds that an operation can be randomly delayed by.
 const MAX_SCHEDULE_JITTER: Duration = Duration::from_secs(180);

--- a/crates/walrus-service/src/node/metrics.rs
+++ b/crates/walrus-service/src/node/metrics.rs
@@ -13,10 +13,12 @@ use prometheus::{
     Registry,
 };
 pub(crate) use telemetry::with_label;
-use walrus_event::EventStreamElement;
 use walrus_sui::types::{BlobCertified, BlobEvent, ContractEvent, EpochChangeEvent};
 
-use crate::common::telemetry::{self, CurrentEpochMetric, CurrentEpochStateMetric};
+use crate::{
+    common::telemetry::{self, CurrentEpochMetric, CurrentEpochStateMetric},
+    node::events::EventStreamElement,
+};
 
 pub(crate) const STATUS_FAILURE: &str = "failure";
 pub(crate) const STATUS_SUCCESS: &str = "success";

--- a/crates/walrus-service/src/node/start_epoch_change_finisher.rs
+++ b/crates/walrus-service/src/node/start_epoch_change_finisher.rs
@@ -10,12 +10,10 @@ use sui_macros::fail_point_async;
 use typed_store::TypedStoreError;
 use walrus_core::ShardIndex;
 use walrus_sui::types::EpochChangeStart;
+use walrus_utils::backoff::{self, ExponentialBackoff};
 
 use super::StorageNodeInner;
-use crate::{
-    common::active_committees::ActiveCommittees,
-    utils::{self, ExponentialBackoff},
-};
+use crate::common::active_committees::ActiveCommittees;
 
 #[derive(Debug, Clone)]
 pub struct StartEpochChangeFinisher {
@@ -66,7 +64,7 @@ impl StartEpochChangeFinisher {
 
             fail_point_async!("blocking_finishing_epoch_change_start");
 
-            let result = utils::retry(backoff, || async {
+            let result = backoff::retry(backoff, || async {
                 if !ongoing_shard_sync {
                     self_clone
                         .epoch_sync_done(&committees_clone, &event_clone)

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -44,9 +44,6 @@ pub use database_config::DatabaseConfig;
 mod event_cursor_table;
 
 mod event_sequencer;
-
-pub mod event_blob;
-pub mod event_blob_writer;
 mod shard;
 
 pub(crate) use shard::{ShardStatus, ShardStorage};

--- a/crates/walrus-service/src/node/system_events.rs
+++ b/crates/walrus-service/src/node/system_events.rs
@@ -11,15 +11,15 @@ use futures::StreamExt;
 use futures_util::stream;
 use tokio::time::MissedTickBehavior;
 use tokio_stream::Stream;
-use walrus_event::{
+use walrus_sui::client::{ReadClient, SuiReadClient};
+
+use super::config::SuiConfig;
+use crate::node::events::{
     event_processor::EventProcessor,
     EventSequenceNumber,
     EventStreamCursor,
     IndexedStreamElement,
 };
-use walrus_sui::client::{ReadClient, SuiReadClient};
-
-use super::config::SuiConfig;
 
 /// The capacity of the event channel.
 pub const EVENT_CHANNEL_CAPACITY: usize = 1024;
@@ -53,7 +53,7 @@ impl SuiSystemEventProvider {
 /// A provider of system events to a storage node.
 #[async_trait]
 pub trait SystemEventProvider: std::fmt::Debug + Sync + Send {
-    /// Return a new stream over [`walrus_event::IndexedStreamElement`]s starting from those
+    /// Return a new stream over [`IndexedStreamElement`]s starting from those
     /// specified by `from`.
     async fn events(
         &self,

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -43,12 +43,6 @@ use walrus_core::{
     SliverPairIndex,
     SliverType,
 };
-use walrus_event::{
-    event_processor::EventProcessor,
-    EventSequenceNumber,
-    EventStreamCursor,
-    IndexedStreamElement,
-};
 use walrus_sdk::client::Client;
 use walrus_sui::{
     client::FixedSystemParameters,
@@ -82,6 +76,12 @@ use crate::{
         config::{EventProviderConfig, StorageNodeConfig},
         contract_service::SystemContractService,
         errors::SyncShardClientError,
+        events::{
+            event_processor::EventProcessor,
+            EventSequenceNumber,
+            EventStreamCursor,
+            IndexedStreamElement,
+        },
         server::{UserServer, UserServerConfig},
         system_events::{EventManager, EventRetentionManager, SystemEventProvider},
         DatabaseConfig,
@@ -357,7 +357,7 @@ impl SimStorageNodeHandle {
         let event_provider: Box<dyn EventManager> = match &config.event_provider_config {
             EventProviderConfig::CheckpointBasedEventProcessor(event_processor_config) => {
                 let event_processor_config = event_processor_config.clone().unwrap_or_else(|| {
-                    walrus_event::EventProcessorConfig::new_with_default_pruning_interval(
+                    crate::node::events::EventProcessorConfig::new_with_default_pruning_interval(
                         sui_config.rpc.clone(),
                     )
                 });
@@ -1664,7 +1664,6 @@ pub mod test_cluster {
     use std::sync::OnceLock;
 
     use tokio::sync::Mutex;
-    use walrus_event::EventProcessorConfig;
     use walrus_sui::{
         client::{SuiContractClient, SuiReadClient},
         test_utils::{
@@ -1682,7 +1681,11 @@ pub mod test_cluster {
     use super::*;
     use crate::{
         client::{self, ClientCommunicationConfig, Config},
-        node::{committee::DefaultNodeServiceFactory, contract_service::SuiSystemContractService},
+        node::{
+            committee::DefaultNodeServiceFactory,
+            contract_service::SuiSystemContractService,
+            events::EventProcessorConfig,
+        },
     };
 
     /// The weight of each storage node in the test cluster.

--- a/crates/walrus-utils/Cargo.toml
+++ b/crates/walrus-utils/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "walrus-event"
+name = "walrus-utils"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
@@ -8,33 +8,19 @@ license.workspace = true
 [dependencies]
 anyhow.workspace = true
 async-channel.workspace = true
-async-trait.workspace = true
-bcs.workspace = true
-byteorder.workspace = true
-futures-util.workspace = true
-integer-encoding.workspace = true
-move-core-types.workspace = true
 prometheus.workspace = true
+rand.workspace = true
 reqwest.workspace = true
 rocksdb.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-serde_yaml.workspace = true
-sui-config.workspace = true
-sui-package-resolver.workspace = true
 sui-rest-api.workspace = true
-sui-sdk.workspace = true
-sui-storage.workspace = true
 sui-types = { workspace = true, features = ["test-utils"] }
 tempfile = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tokio-util.workspace = true
 tracing.workspace = true
 typed-store.workspace = true
-url.workspace = true
-walrus-core.workspace = true
-walrus-sdk.workspace = true
-walrus-sui.workspace = true
 
 [features]
 default = ["test-utils"]

--- a/crates/walrus-utils/src/backoff.rs
+++ b/crates/walrus-utils/src/backoff.rs
@@ -1,0 +1,241 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{future::Future, num::Saturating, time::Duration};
+
+use rand::{rngs::StdRng, Rng, SeedableRng};
+
+#[derive(Debug)]
+pub struct ExponentialBackoffState {
+    min_backoff: Duration,
+    max_backoff: Duration,
+    sequence_index: u32,
+    max_retries: Option<u32>,
+}
+
+/// The representation of a backoff strategy.
+pub trait BackoffStrategy {
+    /// Steps the backoff iterator, returning the next delay and advances the backoff.
+    ///
+    /// Returns `None` if the strategy mandates that the consumer should stop backing off.
+    fn next_delay(&mut self) -> Option<Duration>;
+}
+
+impl ExponentialBackoffState {
+    /// Creates new state with the provided minimum and maximum bounds.
+    ///
+    /// If `max_retries` is `None`, this backoff strategy will keep retrying indefinitely.
+    pub fn new(min_backoff: Duration, max_backoff: Duration, max_retries: Option<u32>) -> Self {
+        Self {
+            min_backoff,
+            max_backoff,
+            sequence_index: 0,
+            max_retries,
+        }
+    }
+
+    /// Creates a new `ExponentialBackoffTracker` that yields an infinite sequence of backoffs
+    /// between the min and max specified.
+    pub fn new_infinite(min_backoff: Duration, max_backoff: Duration) -> Self {
+        Self::new(min_backoff, max_backoff, None)
+    }
+
+    pub fn next_delay<R: Rng + ?Sized>(&mut self, rng: &mut R) -> Option<Duration> {
+        if let Some(max_retries) = self.max_retries {
+            if self.sequence_index >= max_retries {
+                return None;
+            }
+        }
+
+        let next_delay_value = self
+            .min_backoff
+            .saturating_mul(Saturating(2u32).pow(self.sequence_index).0)
+            .saturating_add(Self::random_offset(rng))
+            .min(self.max_backoff);
+
+        self.sequence_index = self.sequence_index.saturating_add(1);
+
+        Some(next_delay_value)
+    }
+
+    fn random_offset<R: Rng + ?Sized>(rng: &mut R) -> Duration {
+        let millis = rng.gen_range(0..=ExponentialBackoff::MAX_RAND_OFFSET_MS);
+        Duration::from_millis(millis)
+    }
+}
+
+/// An iterator over exponential wait durations.
+///
+/// Returns the wait duration for an exponential backoff with a multiplicative factor of 2, and
+/// where each duration includes a random positive offset.
+///
+/// For the `i`-th iterator element and bounds `min_backoff` and `max_backoff`, this returns the
+/// sequence `min(max_backoff, 2^i * min_backoff + rand_i)`.
+#[derive(Debug)]
+pub struct ExponentialBackoff<R> {
+    state: ExponentialBackoffState,
+    rng: R,
+}
+
+impl ExponentialBackoff<StdRng> {
+    /// Maximum number of milliseconds to randomly add to the delay time.
+    const MAX_RAND_OFFSET_MS: u64 = 1000;
+
+    /// Creates a new iterator with the provided minimum and maximum bounds,
+    /// and seeded with the provided value.
+    ///
+    /// If `max_retries` is `None`, this backoff strategy will keep retrying indefinitely.
+    pub fn new_with_seed(
+        min_backoff: Duration,
+        max_backoff: Duration,
+        max_retries: Option<u32>,
+        seed: u64,
+    ) -> ExponentialBackoff<StdRng> {
+        ExponentialBackoff::<StdRng>::new_with_rng(
+            min_backoff,
+            max_backoff,
+            max_retries,
+            StdRng::seed_from_u64(seed),
+        )
+    }
+}
+
+impl<R: Rng> ExponentialBackoff<R> {
+    /// Creates a new iterator with the provided minimum and maximum bounds, with the provided
+    /// iterator.
+    ///
+    /// If `max_retries` is `None`, this backoff strategy will keep retrying indefinitely.
+    pub fn new_with_rng(
+        min_backoff: Duration,
+        max_backoff: Duration,
+        max_retries: Option<u32>,
+        rng: R,
+    ) -> Self {
+        Self {
+            state: ExponentialBackoffState::new(min_backoff, max_backoff, max_retries),
+            rng,
+        }
+    }
+
+    fn next_delay(&mut self) -> Option<Duration> {
+        self.state.next_delay(&mut self.rng)
+    }
+}
+
+impl<R: Rng> Iterator for ExponentialBackoff<R> {
+    type Item = Duration;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next_delay()
+    }
+}
+
+impl<I> BackoffStrategy for I
+where
+    I: Iterator<Item = Duration>,
+{
+    fn next_delay(&mut self) -> Option<Duration> {
+        self.next()
+    }
+}
+
+/// Trait to unify checking for success on `Result` and `Option` types.
+pub trait SuccessOrFailure {
+    /// Returns true iff the value is considered successful.
+    fn is_success(&self) -> bool;
+}
+
+impl<T, E> SuccessOrFailure for anyhow::Result<T, E> {
+    fn is_success(&self) -> bool {
+        self.is_ok()
+    }
+}
+
+impl<T> SuccessOrFailure for Option<T> {
+    fn is_success(&self) -> bool {
+        self.is_some()
+    }
+}
+
+impl SuccessOrFailure for bool {
+    fn is_success(&self) -> bool {
+        *self
+    }
+}
+
+/// Repeatedly calls the provided function with the provided backoff strategy until it returns
+/// successfully.
+pub async fn retry<S, F, T, Fut>(mut strategy: S, mut func: F) -> T
+where
+    S: BackoffStrategy,
+    F: FnMut() -> Fut,
+    T: SuccessOrFailure,
+    Fut: Future<Output = T>,
+{
+    loop {
+        let value = func().await;
+
+        if value.is_success() {
+            return value;
+        }
+
+        if let Some(delay) = strategy.next_delay() {
+            tracing::debug!(?delay, "attempt failed, waiting before retrying");
+            tokio::time::sleep(delay).await;
+        } else {
+            tracing::debug!("last attempt failed, returning last failure value");
+            return value;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use crate::backoff::ExponentialBackoff;
+
+    #[test]
+    fn backoff_is_exponential() {
+        let min = Duration::from_millis(500);
+        let max = Duration::from_secs(3600);
+
+        let expected: Vec<_> = (0u32..)
+            .map(|i| min * 2u32.pow(i))
+            .take_while(|d| *d < max)
+            .chain([max; 2])
+            .collect();
+
+        let actual: Vec<_> = ExponentialBackoff::new_with_seed(min, max, None, 42)
+            .take(expected.len())
+            .collect();
+
+        assert_eq!(expected.len(), actual.len());
+        assert_ne!(expected, actual, "retries must have a random component");
+
+        for (expected, actual) in expected.iter().zip(actual) {
+            let expected_min = *expected;
+            let expected_max =
+                *expected + Duration::from_millis(ExponentialBackoff::MAX_RAND_OFFSET_MS);
+
+            assert!(actual >= expected_min, "{actual:?} >= {expected_min:?}");
+            assert!(actual <= expected_max);
+        }
+    }
+
+    #[test]
+    fn backoff_stops_after_max_retries() {
+        let retries = 5;
+        let mut strategy = ExponentialBackoff::new_with_seed(
+            Duration::from_millis(1),
+            Duration::from_millis(5),
+            Some(retries),
+            42,
+        );
+        let mut actual = 0;
+        while let Some(_d) = strategy.next_delay() {
+            actual += 1;
+        }
+        assert_eq!(retries, actual);
+    }
+}

--- a/crates/walrus-utils/src/checkpoint_downloader.rs
+++ b/crates/walrus-utils/src/checkpoint_downloader.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+//! Checkpoint downloader util.
+
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt::Debug,
@@ -74,8 +76,8 @@ pub struct ChannelConfig {
     pub result_queue_buffer_factor: usize,
 }
 
-impl ChannelConfig {
-    pub fn default() -> Self {
+impl Default for ChannelConfig {
+    fn default() -> Self {
         Self {
             work_queue_buffer_factor: 3,
             result_queue_buffer_factor: 3,

--- a/crates/walrus-utils/src/lib.rs
+++ b/crates/walrus-utils/src/lib.rs
@@ -1,0 +1,17 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod backoff;
+pub mod checkpoint_downloader;
+
+pub mod tests {
+    use std::sync::OnceLock;
+
+    use tokio::sync::Mutex;
+
+    // Prevent tests running simultaneously to avoid interferences or race conditions.
+    pub fn global_test_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(Mutex::default)
+    }
+}


### PR DESCRIPTION
Today, `EventProcessor` is susceptible to Sui FullNode failures and would crash the binary on failure to download checkpoints and events after sometime. But, as we recently saw the full nodes can go down for short periods causing a Walrus outage. But, we shouldn't crash storage nodes because:
1. Walrus can still serve reads
2. Storage nodes which are lagging have potentially already downloaded events to their local db and can safely continue with event recovery even if newer events are not being fetched

This PR does a couple things:
1. Moves `event_processor.rs` into `walrus_service` crate so we can use `ExponentialBackoff`. `EventProcessor` needs to access `EventBlobs` for a future PR, so this cyclic dependency needs to be broken
2. Uses exponential backoff to retry checkpoint failures 