### PR TITLE
fix: fix local testbed

### DIFF
--- a/crates/walrus-service/bin/node.rs
+++ b/crates/walrus-service/bin/node.rs
@@ -745,7 +745,7 @@ impl EventProcessorRuntime {
                             read_client,
                             sui_config.event_polling_interval,
                         )),
-                        tokio::spawn(async { Ok(()) }),
+                        tokio::spawn(async { std::future::pending().await }),
                     )
                 }
             };


### PR DESCRIPTION
The expectation for EventProcessorRuntime is that it should never return. Make LegacyEventProvider also never returns, otherwise, any node uses the LegacyEventProvider exit immediately after start due to immediate return [here](https://github.com/MystenLabs/walrus/blob/924e9cf7b128a8d57b0d01c4166ef86f2b0d1daa/crates/walrus-service/bin/node.rs#L419).