### PR TITLE
test: only add 'simtest_' prefix if running simtests

### DIFF
--- a/crates/walrus-proc-macros/src/lib.rs
+++ b/crates/walrus-proc-macros/src/lib.rs
@@ -14,21 +14,25 @@ use syn::{parse::Parser, parse_macro_input, punctuated::Punctuated, ItemFn, Toke
 #[proc_macro_attribute]
 pub fn walrus_simtest(args: TokenStream, item: TokenStream) -> TokenStream {
     // Parse the input tokens into a syntax tree
-    let mut input = parse_macro_input!(item as ItemFn);
+    let input = parse_macro_input!(item as ItemFn);
 
     let arg_parser = Punctuated::<syn::Meta, Token![,]>::parse_terminated;
     let args = arg_parser.parse(args).unwrap().into_iter();
 
-    // Extract the function name
-    let fn_name = &input.sig.ident;
-
-    // Create the new name by adding "simtest_" prefix
-    let new_fn_name = syn::Ident::new(&format!("simtest_{}", fn_name), fn_name.span());
-
-    input.sig.ident = new_fn_name;
-    let output = quote! {
-        #[sui_macros::sim_test(#(#args)*)]
-        #input
+    // If running simtests, add a "simtest_" prefix to the function name.
+    let output = if cfg!(msim) {
+        let mut input = input;
+        let fn_name = &input.sig.ident;
+        input.sig.ident = syn::Ident::new(&format!("simtest_{}", fn_name), fn_name.span());
+        quote! {
+            #[sui_macros::sim_test(#(#args)*)]
+            #input
+        }
+    } else {
+        quote! {
+            #[tokio::test(#(#args)*)]
+            #input
+        }
     };
 
     // Return the final tokens


### PR DESCRIPTION
I find it confusing to have the `simtest_` prefix for all function names when running normal tests.