### PR TITLE
fix(node): expose metrics only on localhost by default

### DIFF
--- a/crates/walrus-service/node_config_example.yaml
+++ b/crates/walrus-service/node_config_example.yaml
@@ -18,7 +18,7 @@ voting_params:
   storage_price: 5
   write_price: 1
   node_capacity: 250000000000
-# metrics_address: 0.0.0.0:9184
+# metrics_address: 127.0.0.1:9184
 # rest_api_address: 0.0.0.0:9185
 # blob_recovery:
 #   max_concurrent_blob_syncs: 10

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -401,7 +401,7 @@ pub mod defaults {
 
     /// Returns the default metrics address.
     pub fn metrics_address() -> SocketAddr {
-        (Ipv4Addr::UNSPECIFIED, METRICS_PORT).into()
+        (Ipv4Addr::LOCALHOST, METRICS_PORT).into()
     }
 
     /// Returns the default REST API address.


### PR DESCRIPTION
Currently, storage-node metrics are publicly accessible by default (unless a firewall is set up). For example, try running `curl http://mia-tnt-sto-00.walrus-testnet.walrus.space:9184/metrics`. I don't think this should be the default behavior.

This PR changes the default metrics address from `0.0.0.0` to `127.0.0.1`.