### PR TITLE
feat(test): Use checkpoint based event processor in tests wherever possible

### DIFF
--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -527,6 +527,7 @@ async fn test_repeated_shard_move() -> TestResult {
         test_cluster::default_setup_with_epoch_duration_generic::<StorageNodeHandle>(
             Duration::from_secs(20),
             &[1, 1],
+            false,
         )
         .await?;
 

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -1098,6 +1098,14 @@ impl StorageNode {
 }
 
 impl StorageNodeInner {
+    pub(crate) fn encoding_config(&self) -> &EncodingConfig {
+        &self.encoding_config
+    }
+
+    pub(crate) fn storage(&self) -> &Storage {
+        &self.storage
+    }
+
     fn current_epoch(&self) -> Epoch {
         self.committee_service.get_epoch()
     }

--- a/crates/walrus-service/src/node/events/event_blob.rs
+++ b/crates/walrus-service/src/node/events/event_blob.rs
@@ -16,7 +16,6 @@ use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use walrus_core::BlobId;
 
 use crate::node::events::IndexedStreamElement;
-
 /// The encoding of an entry in the blob file.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum EntryEncoding {

--- a/crates/walrus-service/src/node/events/event_blob_writer.rs
+++ b/crates/walrus-service/src/node/events/event_blob_writer.rs
@@ -253,10 +253,10 @@ impl EventBlobWriter {
 
     /// Store the slivers of the blob content.
     async fn store_slivers(&mut self, content: &[u8]) -> Result<BlobId> {
-        let blob_encoder = self.node.encoding_config.get_blob_encoder(content)?;
+        let blob_encoder = self.node.encoding_config().get_blob_encoder(content)?;
         let (sliver_pairs, blob_metadata) = blob_encoder.encode_with_metadata();
         self.node
-            .storage
+            .storage()
             .put_verified_metadata(&blob_metadata)
             .context("unable to store metadata")?;
         // TODO: Once shard assignment per storage node will be read from walrus

--- a/crates/walrus-simtest/tests/simtest.rs
+++ b/crates/walrus-simtest/tests/simtest.rs
@@ -94,6 +94,7 @@ mod tests {
             test_cluster::default_setup_with_epoch_duration_generic::<SimStorageNodeHandle>(
                 Duration::from_secs(60 * 60),
                 &[1, 2, 3, 3, 4],
+                false,
             )
             .await
             .unwrap();
@@ -118,6 +119,7 @@ mod tests {
             test_cluster::default_setup_with_epoch_duration_generic::<SimStorageNodeHandle>(
                 Duration::from_secs(60 * 60),
                 &[1, 2, 3, 3, 4],
+                false,
             )
             .await
             .unwrap();
@@ -267,6 +269,7 @@ mod tests {
             test_cluster::default_setup_with_epoch_duration_generic::<SimStorageNodeHandle>(
                 Duration::from_secs(30),
                 &[1, 2, 3, 3, 4],
+                false,
             )
             .await
             .unwrap();
@@ -428,6 +431,7 @@ mod tests {
             test_cluster::default_setup_with_epoch_duration_generic::<SimStorageNodeHandle>(
                 Duration::from_secs(10),
                 &[1, 2, 3, 3, 4],
+                false,
             )
             .await
             .unwrap();


### PR DESCRIPTION
We start using the checkpoint based event processor everywhere in tests with this PR. Requires running event processor in a seperate runtime in tokio runtime environment for tests to not timeout.