### PR TITLE
feat: Store and recover events using event blobs

### DIFF
--- a/crates/walrus-core/src/lib.rs
+++ b/crates/walrus-core/src/lib.rs
@@ -90,6 +90,9 @@ impl BlobId {
     /// The length of a blob ID in bytes.
     pub const LENGTH: usize = 32;
 
+    /// A blob ID with all zeros.
+    pub const ZERO: Self = Self([0u8; Self::LENGTH]);
+
     /// Returns the blob ID as a hash over the Merkle root, encoding type,
     /// and unencoded_length of the blob.
     pub fn from_metadata(merkle_root: Node, encoding: EncodingType, unencoded_length: u64) -> Self {

--- a/crates/walrus-e2e-tests/tests/test_event_blobs.rs
+++ b/crates/walrus-e2e-tests/tests/test_event_blobs.rs
@@ -1,0 +1,78 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end tests for event blobs.
+use std::time::Duration;
+
+use anyhow::Context;
+use walrus_core::{
+    encoding::{Primary, Secondary},
+    BlobId,
+};
+use walrus_service::{
+    client::ClientCommunicationConfig,
+    test_utils::{test_cluster, StorageNodeHandle},
+};
+use walrus_sui::client::ReadClient;
+
+#[tokio::test]
+#[ignore = "ignore E2E tests by default"]
+async fn test_event_blobs() -> anyhow::Result<()> {
+    let (_sui_cluster, _cluster, client) =
+        test_cluster::default_setup_with_num_checkpoints_generic::<StorageNodeHandle>(
+            Duration::from_secs(60 * 60),
+            &[1, 1],
+            false,
+            Some(10),
+            ClientCommunicationConfig::default_for_test(),
+        )
+        .await?;
+
+    let event_blob_id = loop {
+        if let Some(blob) = client
+            .inner
+            .sui_client()
+            .read_client
+            .last_certified_event_blob()
+            .await
+            .unwrap()
+        {
+            break blob.blob_id;
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    };
+
+    tokio::time::sleep(Duration::from_secs(10)).await;
+
+    // Read the blob using primary slivers.
+    let read_blob_primary = client
+        .as_ref()
+        .read_blob::<Primary>(&event_blob_id)
+        .await
+        .context("should be able to read blob we just stored")?;
+
+    // Read using secondary slivers and check the result.
+    let read_blob_secondary = client
+        .as_ref()
+        .read_blob::<Secondary>(&event_blob_id)
+        .await
+        .context("should be able to read blob we just stored")?;
+
+    assert_eq!(read_blob_primary, read_blob_secondary);
+
+    let mut prev_event_blob = event_blob_id;
+    while prev_event_blob != BlobId::ZERO {
+        let read_blob_primary = client
+            .as_ref()
+            .read_blob::<Primary>(&prev_event_blob)
+            .await
+            .context("should be able to read blob we just stored")?;
+        let event_blob =
+            walrus_service::node::events::event_blob::EventBlob::new(&read_blob_primary)?;
+        prev_event_blob = event_blob.prev_blob_id();
+        for i in event_blob {
+            tracing::debug!("element: {:?}", i);
+        }
+    }
+    Ok(())
+}

--- a/crates/walrus-service/src/common.rs
+++ b/crates/walrus-service/src/common.rs
@@ -7,3 +7,6 @@ pub(crate) mod active_committees;
 pub(crate) mod api;
 pub(crate) mod telemetry;
 pub mod utils;
+
+#[cfg(feature = "client")]
+pub mod event_blob_downloader;

--- a/crates/walrus-service/src/common/event_blob_downloader.rs
+++ b/crates/walrus-service/src/common/event_blob_downloader.rs
@@ -1,0 +1,132 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Responsible for downloading and managing event blobs
+
+use std::path::Path;
+
+use anyhow::Result;
+use walrus_core::BlobId;
+use walrus_sui::client::{ReadClient, SuiReadClient};
+
+use crate::{
+    client::{Client as WalrusClient, ClientErrorKind::BlobIdDoesNotExist},
+    node::events::event_blob::EventBlob as LocalEventBlob,
+};
+
+/// Responsible for downloading and managing event blobs
+pub struct EventBlobDownloader {
+    walrus_client: WalrusClient<SuiReadClient>,
+    sui_read_client: SuiReadClient,
+}
+
+impl EventBlobDownloader {
+    pub fn new(walrus_client: WalrusClient<SuiReadClient>, sui_read_client: SuiReadClient) -> Self {
+        Self {
+            walrus_client,
+            sui_read_client,
+        }
+    }
+
+    /// Collects event blobs starting from the given blob ID and going backwards until reaching
+    /// the specified checkpoint or an expired blob.
+    ///
+    /// Returns a vector of blob IDs in reverse chronological order (newest to oldest).
+    pub async fn download(
+        &self,
+        upto_checkpoint: Option<u64>,
+        from_blob: Option<BlobId>,
+        path: &Path,
+    ) -> Result<Vec<BlobId>> {
+        let mut blobs = Vec::new();
+        let mut prev_event_blob = match from_blob {
+            Some(blob) => blob,
+            None => match self.sui_read_client.last_certified_event_blob().await? {
+                Some(blob) => blob.blob_id,
+                None => return Ok(vec![]),
+            },
+        };
+
+        tracing::info!(
+            "Starting downloading event blobs using event blobs from latest blob ID {:?} \
+            and going backwards",
+            prev_event_blob
+        );
+
+        while prev_event_blob != BlobId::ZERO {
+            let result = self
+                .walrus_client
+                .get_blob_status_with_retries(&prev_event_blob, &self.sui_read_client)
+                .await;
+
+            let Ok(blob_status) = result else {
+                let err = result.err().unwrap();
+                if matches!(err.kind(), BlobIdDoesNotExist) {
+                    // We've reached an expired blob, safe to terminate
+                    break;
+                } else {
+                    return Err(err.into());
+                }
+            };
+
+            let blob_path = path.join(prev_event_blob.to_string());
+            let blob = if blob_path.exists() {
+                std::fs::read(path)?
+            } else {
+                let result = self
+                    .walrus_client
+                    .read_blob_with_status::<walrus_core::encoding::Primary>(
+                        &prev_event_blob,
+                        blob_status,
+                    )
+                    .await;
+                let Ok(blob) = result else {
+                    let err = result.err().unwrap();
+                    return Err(err.into());
+                };
+                blob
+            };
+
+            tracing::info!(blob_id = %prev_event_blob, "finished reading event blob");
+            let mut event_blob = LocalEventBlob::new(&blob)?;
+
+            let should_store = match upto_checkpoint {
+                Some(next_cp) => event_blob.end_checkpoint_sequence_number() >= next_cp,
+                None => true,
+            };
+
+            if should_store {
+                blobs.push(prev_event_blob);
+                let num_checkpoints_stored = event_blob.end_checkpoint_sequence_number()
+                    - event_blob.start_checkpoint_sequence_number()
+                    + 1;
+                tracing::info!(
+                    "Storing event blob {:?} with {} checkpoints",
+                    prev_event_blob,
+                    num_checkpoints_stored
+                );
+            } else {
+                tracing::info!(
+                    "Skipping event blob {:?} as it contains events only before the next \
+                    checkpoint",
+                    prev_event_blob
+                );
+                break;
+            }
+
+            if !blob_path.exists() {
+                event_blob.store_as_file(&blob_path)?;
+            }
+
+            if let Some(max_cp) = upto_checkpoint {
+                if event_blob.start_checkpoint_sequence_number() <= max_cp {
+                    break;
+                }
+            }
+
+            prev_event_blob = event_blob.prev_blob_id();
+        }
+
+        Ok(blobs)
+    }
+}

--- a/crates/walrus-service/src/node/contract_service.rs
+++ b/crates/walrus-service/src/node/contract_service.rs
@@ -9,13 +9,19 @@ use std::{
     time::Duration,
 };
 
-use anyhow::Context as _;
+use anyhow::{Context as _, Error};
 use async_trait::async_trait;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use tokio::sync::Mutex as TokioMutex;
 use walrus_core::{messages::InvalidBlobCertificate, Epoch};
 use walrus_sui::{
-    client::{FixedSystemParameters, ReadClient as _, SuiClientError, SuiContractClient},
+    client::{
+        BlobObjectMetadata,
+        FixedSystemParameters,
+        ReadClient as _,
+        SuiClientError,
+        SuiContractClient,
+    },
     types::move_structs::EpochState,
 };
 use walrus_utils::backoff::{self, ExponentialBackoff};
@@ -49,6 +55,14 @@ pub trait SystemContractService: std::fmt::Debug + Sync + Send {
 
     /// Initiates epoch change.
     async fn initiate_epoch_change(&self) -> Result<(), anyhow::Error>;
+
+    /// Certify an event blob to the contract.
+    async fn certify_event_blob(
+        &self,
+        blob_metadata: BlobObjectMetadata,
+        ending_checkpoint_seq_num: u64,
+        epoch: u32,
+    ) -> Result<(), Error>;
 }
 
 /// A [`SystemContractService`] that uses a [`SuiContractClient`] for chain interactions.
@@ -186,6 +200,48 @@ impl SystemContractService for SuiSystemContractService {
     async fn initiate_epoch_change(&self) -> Result<(), anyhow::Error> {
         let client = self.contract_client.lock().await;
         client.initiate_epoch_change().await?;
+        Ok(())
+    }
+
+    async fn certify_event_blob(
+        &self,
+        blob_metadata: BlobObjectMetadata,
+        ending_checkpoint_seq_num: u64,
+        epoch: u32,
+    ) -> Result<(), Error> {
+        let backoff = ExponentialBackoff::new_with_seed(
+            MIN_BACKOFF,
+            MAX_BACKOFF,
+            None,
+            self.rng.lock().unwrap().gen(),
+        );
+        backoff::retry(backoff, || {
+            let blob_metadata = blob_metadata.clone();
+            async move {
+                match self
+                    .contract_client
+                    .lock()
+                    .await
+                    .certify_event_blob(blob_metadata, ending_checkpoint_seq_num, epoch)
+                    .await
+                {
+                    Ok(()) => Some(()),
+                    Err(SuiClientError::TransactionExecutionError(e)) => {
+                        tracing::debug!(
+                            walrus.epoch = epoch,
+                            error = ?e,
+                            "repeatedly submitted certify_event_blob"
+                        );
+                        Some(())
+                    }
+                    Err(error) => {
+                        tracing::warn!(?error, "submitting certify event blob to contract failed");
+                        None
+                    }
+                }
+            }
+        })
+        .await;
         Ok(())
     }
 }

--- a/crates/walrus-service/src/node/events/event_blob.rs
+++ b/crates/walrus-service/src/node/events/event_blob.rs
@@ -7,15 +7,21 @@ use std::{
     fs::File,
     io,
     io::{BufReader, Read, Seek, SeekFrom, Write},
+    path::Path,
 };
 
 use anyhow::{anyhow, Error, Result};
-use byteorder::ReadBytesExt;
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use integer_encoding::{VarInt, VarIntReader};
-use sui_types::messages_checkpoint::CheckpointSequenceNumber;
-use walrus_core::BlobId;
+use sui_types::{
+    digests::TransactionDigest,
+    event::EventID,
+    messages_checkpoint::CheckpointSequenceNumber,
+};
+use walrus_core::{BlobId, Epoch};
 
-use crate::node::events::IndexedStreamElement;
+use crate::node::events::IndexedStreamEvent;
+
 /// The encoding of an entry in the blob file.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum EntryEncoding {
@@ -59,7 +65,7 @@ impl BlobEntry {
     pub const EVENT_ENCODING_BYTES: usize = 1;
 
     /// Encode the given value into a blob entry.
-    pub fn encode(value: &IndexedStreamElement, encoding: EntryEncoding) -> Result<Self> {
+    pub fn encode(value: &IndexedStreamEvent, encoding: EntryEncoding) -> Result<Self> {
         let value_buf = bcs::to_bytes(value)?;
         let (data, encoding) = match encoding {
             EntryEncoding::Bcs => (value_buf, encoding),
@@ -68,7 +74,7 @@ impl BlobEntry {
     }
 
     /// Decode the blob entry into a value.
-    pub fn decode(self) -> Result<IndexedStreamElement> {
+    pub fn decode(self) -> Result<IndexedStreamEvent> {
         let data = match &self.encoding {
             EntryEncoding::Bcs => self.data,
         };
@@ -113,7 +119,7 @@ impl BlobEntry {
 
     /// Decode the blob entry from a byte vector.
     #[allow(dead_code)]
-    pub fn decode_from_bytes(bytes: &[u8]) -> Result<IndexedStreamElement> {
+    pub fn decode_from_bytes(bytes: &[u8]) -> Result<IndexedStreamEvent> {
         let (encoding, data) = bytes.split_first().ok_or(anyhow!("empty bytes"))?;
         BlobEntry {
             data: data.to_vec(),
@@ -123,40 +129,149 @@ impl BlobEntry {
     }
 }
 
+/// A serialized event ID.
+#[derive(Debug, Eq, PartialEq)]
+pub struct SerializedEventID(pub [u8; Self::LENGTH]);
+
+impl SerializedEventID {
+    /// The length of the serialized event ID in bytes.
+    pub const LENGTH: usize = 40;
+
+    /// Create a new serialized event ID with all bytes set to zero.
+    pub const ZERO: Self = Self([0u8; Self::LENGTH]);
+
+    /// Create a new serialized event ID from the given event ID.
+    pub fn encode(id: EventID) -> Self {
+        let mut buf = [0u8; Self::LENGTH];
+        buf[0..32].copy_from_slice(id.tx_digest.inner());
+        buf[32..40].copy_from_slice(&id.event_seq.to_be_bytes());
+        Self(buf)
+    }
+
+    /// Decode the serialized event ID into an event ID.
+    pub fn decode(&self) -> Result<Option<EventID>> {
+        if *self == Self::ZERO {
+            return Ok(None);
+        }
+        let event_id = EventID {
+            tx_digest: TransactionDigest::new(self.0[..32].try_into()?),
+            event_seq: u64::from_be_bytes(self.0[32..40].try_into()?),
+        };
+        Ok(Some(event_id))
+    }
+}
+
 #[allow(dead_code)]
 #[derive(Debug)]
 /// An iterator over events in a blob file.
-pub struct EventBlob {
-    reader: BufReader<File>,
+pub struct EventBlob<'a> {
+    reader: BufReader<io::Cursor<&'a [u8]>>,
     current_pos: u64,
     total_size: u64,
     prev_blob_id: BlobId,
+    prev_event_id: Option<EventID>,
     start: CheckpointSequenceNumber,
     end: CheckpointSequenceNumber,
     blob_format_version: u32,
+    epoch: Epoch,
 }
 
-impl EventBlob {
+/// Represents an Event Blob, which stores a sequence of events in a structured format.
+///
+/// The blob format is as follows:
+///
+/// ```text
+/// +------------------+ --
+/// |  Magic (4 bytes) |   \
+/// +------------------+    \
+/// | Version (4 bytes)|     \
+/// +------------------+     \
+/// |  Epoch (4 bytes) |      \
+/// +------------------+       > Header (84 bytes)
+/// |Prev Blob ID (32B)|      /
+/// +------------------+     /
+/// |Prev EventID (40B)|    /
+/// +------------------+ --
+/// |                  |
+/// |                  |
+/// |   Event Data     |
+/// |    (Variable)    |
+/// |                  |
+/// |                  |
+/// +------------------+ --
+/// | Start Chkpt (8B) |   \
+/// +------------------+    > Trailer (16 bytes)
+/// |  End Chkpt (8B)  |   /
+/// +------------------+ --
+/// ```
+///
+/// - Magic: Identifies the file as an Event Blob (0x005EA1CE)
+/// - Version: Format version of the blob
+/// - Epoch: Epoch of the first event in the blob
+/// - Prev Blob ID: ID of the previous blob in the sequence
+/// - Prev EventID: ID of the last event in the previous blob
+/// - Event Data: Variable-length section containing serialized events
+/// - Start/End Checkpoint: Sequence numbers of the first and last checkpoints in this blob
+impl<'a> EventBlob<'a> {
     /// The magic bytes at the start of the blob file.
-    pub const MAGIC: u32 = 0x0000DEAD;
+    pub const MAGIC: u32 = 0x005EA1CE;
     /// The size of the magic bytes in bytes.
-    pub const MAGIC_BYTES_SIZE: usize = std::mem::size_of::<u32>();
+    pub const MAGIC_BYTES_SIZE: usize = size_of::<u32>();
     /// The format version of the blob file.
     pub const FORMAT_VERSION: u32 = 1;
     /// The size of the format version in bytes.
-    pub const FORMAT_BYTES_SIZE: usize = std::mem::size_of::<u32>();
+    pub const FORMAT_BYTES_SIZE: usize = size_of::<u32>();
+    /// The size of the epoch in bytes.
+    pub const EPOCH_BYTES_SIZE: usize = size_of::<u32>();
     /// The size of the header of the blob file in bytes.
-    pub const HEADER_SIZE: usize = EventBlob::MAGIC_BYTES_SIZE + EventBlob::FORMAT_BYTES_SIZE;
+    pub const HEADER_SIZE: usize = EventBlob::MAGIC_BYTES_SIZE
+        + EventBlob::FORMAT_BYTES_SIZE
+        + EventBlob::EPOCH_BYTES_SIZE
+        + BlobId::LENGTH
+        + SerializedEventID::LENGTH;
+    /// The offset of the blob ID in the blob file in bytes.
+    pub const BLOB_ID_OFFSET: usize =
+        EventBlob::MAGIC_BYTES_SIZE + EventBlob::FORMAT_BYTES_SIZE + EventBlob::EPOCH_BYTES_SIZE;
+    /// The offset of the event ID in the blob file in bytes.
+    pub const EVENT_ID_OFFSET: usize = EventBlob::BLOB_ID_OFFSET + BlobId::LENGTH;
     /// The size of the tail of the blob file in bytes.
-    pub const TRAILER_SIZE: usize = 2 * std::mem::size_of::<u64>() + BlobId::LENGTH;
+    pub const TRAILER_SIZE: usize = 2 * std::mem::size_of::<u64>();
     /// The minimum size of a blob file in bytes.
     pub const MIN_SIZE: usize = EventBlob::HEADER_SIZE + EventBlob::TRAILER_SIZE;
 
-    /// Create a new event blob from the given file.
-    #[allow(dead_code)]
-    pub fn new(file: File) -> Result<Self> {
-        let mut buf_reader = BufReader::new(file);
-        let mut total_size = buf_reader.seek(SeekFrom::End(0))?;
+    /// Create a new event blob from the list of events
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn from_events(
+        epoch: Epoch,
+        prev_blob_id: BlobId,
+        prev_event_id: Option<EventID>,
+        start: CheckpointSequenceNumber,
+        end: CheckpointSequenceNumber,
+        events: impl IntoIterator<Item = &'a IndexedStreamEvent>,
+    ) -> Result<Vec<u8>> {
+        let serialized_event_id = prev_event_id
+            .map(SerializedEventID::encode)
+            .unwrap_or(SerializedEventID::ZERO);
+        let mut buf = Vec::new();
+        buf.write_u32::<BigEndian>(EventBlob::MAGIC)?;
+        buf.write_u32::<BigEndian>(EventBlob::FORMAT_VERSION)?;
+        buf.write_u32::<BigEndian>(epoch)?;
+        buf.write_all(&prev_blob_id.0)?;
+        buf.write_all(&serialized_event_id.0)?;
+        for event in events {
+            let entry = BlobEntry::encode(event, EntryEncoding::Bcs)?;
+            entry.write(&mut buf)?;
+        }
+        buf.write_u64::<BigEndian>(start)?;
+        buf.write_u64::<BigEndian>(end)?;
+        Ok(buf)
+    }
+
+    /// Create a new event blob from the given buffer.
+    pub fn new(buf: &'a [u8]) -> Result<Self> {
+        let cursor = io::Cursor::new(buf);
+        let mut buf_reader = BufReader::new(cursor);
+        let total_size = buf_reader.seek(SeekFrom::End(0))?;
         if total_size < EventBlob::MIN_SIZE as u64 {
             return Err(Error::from(io::Error::new(
                 io::ErrorKind::InvalidData,
@@ -164,37 +279,56 @@ impl EventBlob {
             )));
         }
         buf_reader.seek(SeekFrom::Start(0))?;
-        let magic = buf_reader.read_u32::<byteorder::BigEndian>()?;
+        let magic = buf_reader.read_u32::<BigEndian>()?;
         if magic != EventBlob::MAGIC {
             return Err(Error::from(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "Not an event blob file",
             )));
         }
-        let blob_format_version = buf_reader.read_u32::<byteorder::BigEndian>()?;
+        let blob_format_version = buf_reader.read_u32::<BigEndian>()?;
         if blob_format_version != EventBlob::FORMAT_VERSION {
             return Err(Error::from(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "Unsupported blob format version",
             )));
         }
-        let trailer_size = Self::TRAILER_SIZE as i64;
-        total_size -= trailer_size as u64;
-        buf_reader.seek(SeekFrom::End(-trailer_size))?;
-        let start = buf_reader.read_u64::<byteorder::BigEndian>()?;
-        let end = buf_reader.read_u64::<byteorder::BigEndian>()?;
+        let epoch = buf_reader.read_u32::<BigEndian>()?;
         let mut prev_blob_id = [0u8; BlobId::LENGTH];
         buf_reader.read_exact(&mut prev_blob_id)?;
+        let mut prev_event_id = [0u8; SerializedEventID::LENGTH];
+        buf_reader.read_exact(&mut prev_event_id)?;
+        let trailer_size = Self::TRAILER_SIZE as i64;
+        buf_reader.seek(SeekFrom::End(-trailer_size))?;
+        let start = buf_reader.read_u64::<BigEndian>()?;
+        let end = buf_reader.read_u64::<BigEndian>()?;
         buf_reader.seek(SeekFrom::Start(Self::HEADER_SIZE as u64))?;
         Ok(Self {
             reader: buf_reader,
             current_pos: Self::HEADER_SIZE as u64,
             total_size,
             prev_blob_id: BlobId(prev_blob_id),
+            prev_event_id: SerializedEventID(prev_event_id).decode()?,
             start,
             end,
             blob_format_version,
+            epoch,
         })
+    }
+
+    /// Previous blob ID.
+    pub fn prev_blob_id(&self) -> BlobId {
+        self.prev_blob_id
+    }
+
+    /// Previous event ID.
+    pub fn prev_event_id(&self) -> Option<EventID> {
+        self.prev_event_id
+    }
+
+    /// Epoch of the blob.
+    pub fn epoch(&self) -> Epoch {
+        self.epoch
     }
 
     /// Checkpoint sequence number of first event in the blob.
@@ -209,16 +343,26 @@ impl EventBlob {
         self.end
     }
 
-    /// Return the next event.
-    fn next_event(&mut self) -> Result<IndexedStreamElement> {
+    /// Returns the next event in the blob.
+    fn next_event(&mut self) -> Result<IndexedStreamEvent> {
         let entry = BlobEntry::read(&mut self.reader)?;
         self.current_pos += entry.size() as u64;
         entry.decode()
     }
+
+    /// Store the blob as a file at the given path.
+    pub fn store_as_file(&mut self, path: &Path) -> anyhow::Result<()> {
+        let mut file = File::create(path)?;
+        let mut buf = Vec::new();
+        self.reader.seek(SeekFrom::Start(0))?;
+        self.reader.read_to_end(&mut buf)?;
+        file.write_all(&buf)?;
+        Ok(())
+    }
 }
 
-impl Iterator for EventBlob {
-    type Item = IndexedStreamElement;
+impl Iterator for EventBlob<'_> {
+    type Item = IndexedStreamEvent;
     fn next(&mut self) -> Option<Self::Item> {
         if self.current_pos >= self.total_size {
             return None;

--- a/crates/walrus-service/src/node/events/event_blob_writer.rs
+++ b/crates/walrus-service/src/node/events/event_blob_writer.rs
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 #![allow(dead_code)]
 
-//! Event blob writer module for writing event blobs to Walrus.
+//! Event blob writer.
 
 use std::{
     fs,
     fs::{File, OpenOptions},
-    io::{BufWriter, Read, Seek, SeekFrom, Write},
+    io,
+    io::{BufWriter, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -15,49 +16,400 @@ use std::{
 use anyhow::{Context, Result};
 use byteorder::{BigEndian, WriteBytesExt};
 use futures_util::future::try_join_all;
+use prometheus::{register_int_gauge_with_registry, IntGauge, Registry};
 use rocksdb::Options;
 use serde::{Deserialize, Serialize};
-use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+use sui_types::{event::EventID, messages_checkpoint::CheckpointSequenceNumber};
 use typed_store::{
     rocks,
-    rocks::{errors::typed_store_err_from_rocks_err, DBMap, MetricConf, ReadWriteOptions},
+    rocks::{errors::typed_store_err_from_rocks_err, DBBatch, DBMap, MetricConf, ReadWriteOptions},
     Map,
 };
-use walrus_core::{BlobId, Sliver};
+use walrus_core::{ensure, metadata::VerifiedBlobMetadataWithId, BlobId, Epoch, Sliver};
+use walrus_sui::types::{BlobEvent, ContractEvent, EpochChangeEvent};
 
 use crate::node::{
     errors::StoreSliverError,
     events::{
-        event_blob::{BlobEntry, EntryEncoding, EventBlob},
-        EventSequenceNumber,
-        IndexedStreamElement,
+        event_blob::{BlobEntry, EntryEncoding, EventBlob, SerializedEventID},
+        EventStreamCursor,
+        EventStreamElement,
+        IndexedStreamEvent,
+        InitState,
+        PositionedStreamEvent,
     },
-    ServiceState,
     StorageNodeInner,
 };
 
-const EVENT_BLOB_METADATA_STORE: &str = "event_blob_metadata_store";
-const NUM_CHECKPOINTS_PER_BLOB: u64 = 100;
+const CERTIFIED: &str = "certified_blob_store";
+const ATTESTED: &str = "attested_blob_store";
+const PENDING: &str = "pending_blob_store";
+const MAX_BLOB_SIZE: usize = 100 * 1024 * 1024;
+const NUM_CHECKPOINTS_PER_BLOB: u32 = 18_000;
 
+/// Metadata for event blobs.
 #[derive(Eq, PartialEq, Debug, Clone, Deserialize, Serialize)]
-struct EventBlobMetadata {
-    /// Blob id of the event blob.
-    blob_id: BlobId,
-    /// Starting Sui checkpoint sequence number of the events in the blob (inclusive).
-    start: CheckpointSequenceNumber,
-    /// Ending Sui checkpoint sequence number of the events in the blob (inclusive).
-    end: CheckpointSequenceNumber,
-    /// EventSequenceNumber of the last event in the blob.
-    last_event_sequence_number: EventSequenceNumber,
-    /// index of the last event in the blob.
-    last_event_index: u64,
+pub struct EventBlobMetadata<T, U> {
+    /// The starting Sui checkpoint sequence number of the events in the blob (inclusive).
+    pub start: T,
+    /// The ending Sui checkpoint sequence number of the events in the blob (inclusive).
+    pub end: T,
+    /// The event cursor of the last event in the blob.
+    pub event_cursor: EventStreamCursor,
+    /// The Walrus epoch of the events in the blob.
+    pub epoch: Epoch,
+    /// The blob ID of the blob.
+    pub blob_id: U,
 }
 
-/// EventBlobWriter writes events to event blobs.
+/// Metadata for a blob that is waiting for attestation.
+type PendingEventBlobMetadata = EventBlobMetadata<CheckpointSequenceNumber, ()>;
+
+/// Metadata for a blob that is last attested.
+type AttestedEventBlobMetadata = EventBlobMetadata<CheckpointSequenceNumber, BlobId>;
+
+/// Metadata for a blob that is last certified.
+type CertifiedEventBlobMetadata = EventBlobMetadata<(), BlobId>;
+
+impl PendingEventBlobMetadata {
+    fn new(
+        start: CheckpointSequenceNumber,
+        end: CheckpointSequenceNumber,
+        event_cursor: EventStreamCursor,
+        epoch: Epoch,
+    ) -> Self {
+        Self {
+            start,
+            end,
+            event_cursor,
+            epoch,
+            blob_id: (),
+        }
+    }
+
+    fn to_attested(&self, blob_metadata: VerifiedBlobMetadataWithId) -> AttestedEventBlobMetadata {
+        AttestedEventBlobMetadata {
+            start: self.start,
+            end: self.end,
+            event_cursor: self.event_cursor.clone(),
+            epoch: self.epoch,
+            blob_id: *blob_metadata.blob_id(),
+        }
+    }
+}
+
+impl AttestedEventBlobMetadata {
+    fn to_certified(&self) -> CertifiedEventBlobMetadata {
+        CertifiedEventBlobMetadata {
+            blob_id: self.blob_id,
+            event_cursor: self.event_cursor.clone(),
+            epoch: self.epoch,
+            start: (),
+            end: (),
+        }
+    }
+
+    fn to_pending(&self) -> PendingEventBlobMetadata {
+        PendingEventBlobMetadata {
+            start: self.start,
+            end: self.end,
+            event_cursor: self.event_cursor.clone(),
+            epoch: self.epoch,
+            blob_id: (),
+        }
+    }
+}
+
+impl CertifiedEventBlobMetadata {
+    fn new(blob_id: BlobId, event_cursor: EventStreamCursor, epoch: Epoch) -> Self {
+        Self {
+            blob_id,
+            event_cursor,
+            epoch,
+            start: (),
+            end: (),
+        }
+    }
+}
+
+/// Metrics for the event processor.
+#[derive(Clone, Debug)]
+pub struct EventBlobWriterMetrics {
+    /// The latest event certified in an event blob.
+    pub latest_certified_event_index: IntGauge,
+}
+
+impl EventBlobWriterMetrics {
+    /// Creates new metrics for event blob writer.
+    pub fn new(registry: &Registry) -> Self {
+        Self {
+            latest_certified_event_index: register_int_gauge_with_registry!(
+                "event_blob_writer_latest_certified_event_index",
+                "Latest certified event blob writer index",
+                registry,
+            )
+            .expect("this is a valid metrics registration"),
+        }
+    }
+}
+
+/// Factory for creating and managing Event Blob Writers.
+///
+/// The `EventBlobWriterFactory` is responsible for initializing and maintaining the infrastructure
+/// necessary for writing event blobs. It manages the directory structure, database connections,
+/// and provides methods to create new `EventBlobWriter` instances.
+#[derive(Clone, Debug)]
+pub struct EventBlobWriterFactory {
+    /// Root directory path where the event blobs are stored.
+    root_dir_path: PathBuf,
+    /// Client to store the slivers and metadata of the event blob.
+    node: Arc<StorageNodeInner>,
+    /// Metrics for the event blob writer.
+    metrics: Arc<EventBlobWriterMetrics>,
+    /// Current event cursor.
+    event_cursor: Option<EventStreamCursor>,
+    /// Current epoch.
+    epoch: Option<Epoch>,
+    /// Blob ID of the last certified blob.
+    prev_certified_blob_id: Option<BlobId>,
+    /// Certified blobs metadata.
+    certified: DBMap<(), CertifiedEventBlobMetadata>,
+    /// Attested blobs metadata.
+    attested: DBMap<(), AttestedEventBlobMetadata>,
+    /// Pending blobs metadata.
+    pending: DBMap<u64, PendingEventBlobMetadata>,
+    /// Number of checkpoints per blob.
+    num_checkpoints_per_blob: Option<u32>,
+}
+
+impl EventBlobWriterFactory {
+    /// Create a new event blob writer factory.
+    pub fn new(
+        root_dir_path: &Path,
+        node: Arc<StorageNodeInner>,
+        registry: &Registry,
+        num_checkpoints_per_blob: Option<u32>,
+    ) -> Result<EventBlobWriterFactory> {
+        let dirs = ["db", "blobs"];
+        for dir in dirs.iter() {
+            fs::create_dir_all(root_dir_path.join(dir))?;
+        }
+        let mut db_opts = Options::default();
+        let metric_conf = MetricConf::default();
+        db_opts.create_missing_column_families(true);
+        db_opts.create_if_missing(true);
+        let database = rocks::open_cf_opts(
+            root_dir_path.join("db"),
+            Some(db_opts),
+            metric_conf,
+            &[
+                (PENDING, Options::default()),
+                (ATTESTED, Options::default()),
+                (CERTIFIED, Options::default()),
+            ],
+        )?;
+        if database.cf_handle(CERTIFIED).is_none() {
+            database
+                .create_cf(CERTIFIED, &Options::default())
+                .map_err(typed_store_err_from_rocks_err)?;
+        }
+        if database.cf_handle(ATTESTED).is_none() {
+            database
+                .create_cf(ATTESTED, &Options::default())
+                .map_err(typed_store_err_from_rocks_err)?;
+        }
+        if database.cf_handle(PENDING).is_none() {
+            database
+                .create_cf(PENDING, &Options::default())
+                .map_err(typed_store_err_from_rocks_err)?;
+        }
+        let certified: DBMap<(), CertifiedEventBlobMetadata> = DBMap::reopen(
+            &database,
+            Some(CERTIFIED),
+            &ReadWriteOptions::default(),
+            false,
+        )?;
+        let attested: DBMap<(), AttestedEventBlobMetadata> = DBMap::reopen(
+            &database,
+            Some(ATTESTED),
+            &ReadWriteOptions::default(),
+            false,
+        )?;
+        let pending: DBMap<u64, PendingEventBlobMetadata> = DBMap::reopen(
+            &database,
+            Some(PENDING),
+            &ReadWriteOptions::default(),
+            false,
+        )?;
+        let event_cursor = pending
+            .unbounded_iter()
+            .last()
+            .map(|(_, metadata)| metadata.event_cursor)
+            .or_else(|| {
+                attested
+                    .get(&())
+                    .ok()
+                    .flatten()
+                    .map(|metadata| metadata.event_cursor)
+            })
+            .or_else(|| {
+                certified
+                    .get(&())
+                    .ok()
+                    .flatten()
+                    .map(|metadata| metadata.event_cursor)
+            });
+        let epoch = pending
+            .unbounded_iter()
+            .last()
+            .map(|(_, metadata)| metadata.epoch)
+            .or_else(|| {
+                attested
+                    .get(&())
+                    .ok()
+                    .flatten()
+                    .map(|metadata| metadata.epoch)
+            })
+            .or_else(|| {
+                certified
+                    .get(&())
+                    .ok()
+                    .flatten()
+                    .map(|metadata| metadata.epoch)
+            });
+        let prev_certified_blob_id = certified
+            .get(&())
+            .ok()
+            .flatten()
+            .map(|metadata| metadata.blob_id);
+        Ok(Self {
+            root_dir_path: root_dir_path.to_path_buf(),
+            node,
+            metrics: Arc::new(EventBlobWriterMetrics::new(registry)),
+            event_cursor,
+            epoch,
+            prev_certified_blob_id,
+            certified,
+            attested,
+            pending,
+            num_checkpoints_per_blob,
+        })
+    }
+
+    /// Returns a clone of the current event cursor position.
+    ///
+    /// The event cursor tracks the position of the last processed event in the stream,
+    /// including its event ID and element index. This cursor is used to maintain continuity
+    /// when writing events across multiple blobs.
+    ///
+    /// # Returns
+    /// * `Option<EventStreamCursor>` - The current cursor position if one exists, or None if
+    ///   no events have been processed yet.
+    pub fn event_cursor(&self) -> Option<EventStreamCursor> {
+        self.event_cursor.clone()
+    }
+
+    /// Create a new event blob writer.
+    pub async fn create(&self) -> Result<EventBlobWriter> {
+        let databases = EventBlobDatabases {
+            certified: self.certified.clone(),
+            attested: self.attested.clone(),
+            pending: self.pending.clone(),
+        };
+        let event_cursor = self
+            .event_cursor
+            .clone()
+            .unwrap_or(EventStreamCursor::new(None, 0));
+        let epoch = self.epoch.unwrap_or(0);
+        let prev_certified_blob_id = self.prev_certified_blob_id.unwrap_or(BlobId::ZERO);
+        let config = EventBlobWriterConfig {
+            blob_dir_path: self.root_dir_path.join("blobs").clone().into(),
+            metrics: self.metrics.clone(),
+            event_stream_cursor: event_cursor,
+            current_epoch: epoch,
+            prev_certified_blob_id,
+        };
+        EventBlobWriter::new(
+            config,
+            self.node.clone(),
+            databases,
+            self.num_checkpoints_per_blob
+                .unwrap_or(NUM_CHECKPOINTS_PER_BLOB),
+        )
+        .await
+    }
+}
+
+/// EventBlobWriter manages the creation, storage, and certification of event blobs.
+///                   +-------------------+
+///                   |  EventBlobWriter  |
+///                   +-------------------+
+///                            |
+///                            v
+///   +------------+    +-------------+    +-------------+    +--------------+
+///   |Current Blob|--->| Pending Blob|--->|Attested Blob|--->|Certified Blob|
+///   +------------+    +-------------+    +-------------+    +--------------+
+///         |                 ^                 |                   ^
+///         |                 |                 |                   |
+///         |                 |                 v                   |
+///   +-----------------+    +------------------+             +-----------+
+///   |Filesystem (tmp) |--->| Database Storage |<------------| System    |
+///   +-----------------+    +------------------+             | Contract  |
+///                                                           +-----------+
+///
+/// Flow: Current -> Pending -> Attested -> Certified
+///
+/// Blob Lifecycle:
+///
+/// a. Current:
+/// The events that are being written to is in this active blob.
+/// It's stored as a file named "current_blob" in the filesystem. This blob hasn't been materialized
+/// yet and if the system is restarted, the events in this blob will be lost (and will need to be
+/// reprocessed).
+///
+/// b. Pending:
+/// When a blob is first materialized (once the size of the current blob has reached a threshold, or
+/// we have accumulated events for enough number of checkpoints), it's in a "pending" state.
+/// Metadata about pending blobs is stored in the pending database and the file is renamed from
+/// "current_blob" to its final name (based on event index of last event in the blob).
+///
+/// c. Attested:
+/// If the node isn't waiting for a previous attested blob to get certified, it is ready to attest
+/// the oldest pending blob.
+/// Previous blob id pointer is updated in the blob file.
+/// Metadata is moved from pending to attested database.
+/// We send the blob for attestation to the system contract.
+/// The writer waits for a certification event to mark this blob as certified. Until then, we will
+/// not attest any more blobs (but keep writing events to the current blob and accumulate more
+/// pending blobs).
+///
+/// d. Certified:
+/// Once a blob is certified by the quorum, its metadata moves to the certified database.
+/// The system removes the file for certified blobs from the filesystem to save space.
+/// The system is now ready to attest the next pending blob.
+///
+/// Writing Process:
+///
+/// The system writes events to the active blob using a buffered writer (BufWriter).
+/// The writer keeps track of the blob's size and the number of checkpoints it contains.
+///
+/// Epoch Changes:
+///
+/// The writer handles epoch changes by moving attested blob back to pending state. This is needed
+/// because non-certified blobs are not synced during shard sync across epoch changes.
+/// This ensures previously attested but non-certified blobs are stored on newly assigned shards and
+/// get re-attested in the new epoch.
+///
+/// Storage:
+///
+/// Metadata for blobs in different states (pending, attested, certified) is stored in separate
+/// database tables.
+/// Actual blob data is initially stored as files in the filesystem.
+/// Once certified, blob data is removed from the filesystem, and we only retain the metadata in db.
 #[derive(Debug)]
 pub struct EventBlobWriter {
     /// Root directory path where the event blobs are stored.
-    root_dir_path: PathBuf,
+    blob_dir_path: PathBuf,
     /// Starting Sui checkpoint sequence number of the events in the current blob (inclusive).
     start: Option<CheckpointSequenceNumber>,
     /// Ending Sui checkpoint sequence number of the events in the current blob (inclusive).
@@ -66,205 +418,249 @@ pub struct EventBlobWriter {
     wbuf: BufWriter<File>,
     /// Offset in the current blob file where the next event will be written.
     buf_offset: usize,
-    /// Maximum size of the current blob file before it is committed.
-    number_of_checkpoints_per_blob: u64,
-    /// DBMap from () to the metadata of the previous event blob.
-    prev_blob_id: DBMap<(), EventBlobMetadata>,
+    /// Certified blobs metadata.
+    certified: DBMap<(), CertifiedEventBlobMetadata>,
+    /// Attested blobs metadata.
+    attested: DBMap<(), AttestedEventBlobMetadata>,
+    /// Pending blobs metadata.
+    pending: DBMap<u64, PendingEventBlobMetadata>,
     /// Client to store the slivers and metadata of the event blob.
     node: Arc<StorageNodeInner>,
-    /// The latest event sequence number in the current blob.
-    latest_sequence_number: Option<EventSequenceNumber>,
-    /// The latest event index in the current blob.
-    latest_event_index: Option<u64>,
-    /// The last event sequence number in the prev committed blob.
-    latest_committed_event_sequence_number: Option<EventSequenceNumber>,
-    /// The last event index in the prev committed blob.
-    latest_committed_event_index: Option<u64>,
+    /// Current epoch.
+    current_epoch: Epoch,
+    /// Next event index.
+    event_cursor: EventStreamCursor,
+    /// Blob ID of the last certified blob.
+    prev_certified_blob_id: BlobId,
+    /// Event ID of the last certified event.
+    prev_certified_event_id: Option<EventID>,
+    /// Metrics for the event blob writer.
+    metrics: Arc<EventBlobWriterMetrics>,
+    /// Number of checkpoints per blob.
+    num_checkpoints_per_blob: u32,
+}
+
+/// Struct to group database-related parameters.
+#[derive(Debug)]
+pub struct EventBlobDatabases {
+    certified: DBMap<(), CertifiedEventBlobMetadata>,
+    attested: DBMap<(), AttestedEventBlobMetadata>,
+    pending: DBMap<u64, PendingEventBlobMetadata>,
+}
+
+/// Struct to group configuration-related parameters
+#[derive(Debug)]
+pub struct EventBlobWriterConfig {
+    /// Root directory path where the event blobs are stored.
+    blob_dir_path: Arc<Path>,
+    /// Event stream cursor to initialize the writer.
+    event_stream_cursor: EventStreamCursor,
+    /// Current epoch.
+    current_epoch: Epoch,
+    /// Blob ID of the last certified blob.
+    prev_certified_blob_id: BlobId,
+    /// Metrics for the event blob writer.
+    metrics: Arc<EventBlobWriterMetrics>,
 }
 
 impl EventBlobWriter {
-    /// Create a new EventBlobWriter.
-    pub fn new(root_dir_path: &Path, node: Arc<StorageNodeInner>) -> Result<Self> {
-        if root_dir_path.exists() {
-            fs::remove_dir_all(root_dir_path)?;
-        }
-        fs::create_dir_all(root_dir_path)?;
-        let mut db_opts = Options::default();
-        let metric_conf = MetricConf::default();
-        db_opts.create_missing_column_families(true);
-        db_opts.create_if_missing(true);
-        let database = rocks::open_cf_opts(
-            root_dir_path.join("event_blob_metadata_db"),
-            Some(db_opts),
-            metric_conf,
-            &[(EVENT_BLOB_METADATA_STORE, Options::default())],
-        )?;
-        if database.cf_handle(EVENT_BLOB_METADATA_STORE).is_none() {
-            database
-                .create_cf(EVENT_BLOB_METADATA_STORE, &Options::default())
-                .map_err(typed_store_err_from_rocks_err)?;
-        }
-        let prev_blob_id = DBMap::reopen(
-            &database,
-            Some(EVENT_BLOB_METADATA_STORE),
-            &ReadWriteOptions::default(),
-            false,
-        )?;
-        let file = Self::next_file(root_dir_path, EventBlob::MAGIC, EventBlob::FORMAT_VERSION)?;
-        let latest_committed_event_sequence_number = prev_blob_id
-            .get(&())?
-            .map(|b: EventBlobMetadata| b.last_event_sequence_number);
-        let latest_committed_event_index = prev_blob_id
-            .get(&())?
-            .map(|b: EventBlobMetadata| b.last_event_index);
-        Ok(Self {
-            root_dir_path: root_dir_path.to_path_buf(),
-            start: None,
-            end: None,
-            wbuf: BufWriter::new(file),
-            buf_offset: EventBlob::MAGIC_BYTES_SIZE,
-            // TODO: Read this from system object on epoch change
-            number_of_checkpoints_per_blob: NUM_CHECKPOINTS_PER_BLOB,
-            prev_blob_id,
-            node,
-            latest_sequence_number: None,
-            latest_event_index: None,
-            latest_committed_event_sequence_number,
-            latest_committed_event_index,
-        })
-    }
-
-    /// Create a new file for the next blob.
-    #[cfg(any(test, feature = "test-utils"))]
-    fn new_for_testing(
-        root_dir_path: PathBuf,
-        number_of_checkpoints_per_blob: u64,
+    /// Creates a new EventBlobWriter instance.
+    ///
+    /// This method initializes a new EventBlobWriter with the provided configuration,
+    /// node, system contract service, and databases. It sets up the initial state,
+    /// including the event cursor, current epoch, and previous certified blob ID.
+    pub async fn new(
+        config: EventBlobWriterConfig,
         node: Arc<StorageNodeInner>,
+        databases: EventBlobDatabases,
+        num_checkpoints_per_blob: u32,
     ) -> Result<Self> {
-        if root_dir_path.exists() {
-            fs::remove_dir_all(&root_dir_path)?;
-        }
-        fs::create_dir_all(&root_dir_path)?;
-        let mut db_opts = Options::default();
-        let metric_conf = MetricConf::default();
-        db_opts.create_missing_column_families(true);
-        db_opts.create_if_missing(true);
-        let database = rocks::open_cf_opts(
-            root_dir_path.join("event_blob_metadata_db"),
-            Some(db_opts),
-            metric_conf,
-            &[(EVENT_BLOB_METADATA_STORE, Options::default())],
-        )?;
-        if database.cf_handle(EVENT_BLOB_METADATA_STORE).is_none() {
-            database
-                .create_cf(EVENT_BLOB_METADATA_STORE, &Options::default())
-                .map_err(typed_store_err_from_rocks_err)?;
-        }
-        let prev_blob_id = DBMap::reopen(
-            &database,
-            Some(EVENT_BLOB_METADATA_STORE),
-            &ReadWriteOptions::default(),
-            false,
-        )?;
-        let file = Self::next_file(&root_dir_path, EventBlob::MAGIC, EventBlob::FORMAT_VERSION)?;
-        let latest_committed_event_sequence_number: Option<EventSequenceNumber> = prev_blob_id
-            .get(&())?
-            .map(|b: EventBlobMetadata| b.last_event_sequence_number);
-        let latest_committed_event_index = prev_blob_id
-            .get(&())?
-            .map(|b: EventBlobMetadata| b.last_event_index);
-        Ok(Self {
-            root_dir_path,
+        let file = Self::next_file(&config.blob_dir_path, config.current_epoch)?;
+        let mut blob_writer = Self {
+            blob_dir_path: config.blob_dir_path.to_path_buf(),
             start: None,
             end: None,
             wbuf: BufWriter::new(file),
-            buf_offset: EventBlob::MAGIC_BYTES_SIZE,
-            number_of_checkpoints_per_blob,
-            prev_blob_id,
+            buf_offset: EventBlob::HEADER_SIZE,
+            attested: databases.attested,
+            certified: databases.certified,
+            pending: databases.pending,
             node,
-            latest_sequence_number: None,
-            latest_event_index: None,
-            latest_committed_event_sequence_number,
-            latest_committed_event_index,
-        })
+            current_epoch: config.current_epoch,
+            event_cursor: config.event_stream_cursor.clone(),
+            prev_certified_blob_id: config.prev_certified_blob_id,
+            prev_certified_event_id: config.event_stream_cursor.event_id,
+            metrics: config.metrics,
+            num_checkpoints_per_blob,
+        };
+        // Upon receiving a blob_certified event for an event blob, we may have crashed after making
+        // the db changes but before attesting the next pending blob (since those two events are
+        // not atomic).This invocation is to account for that particular scenario.
+        blob_writer.attest_next_blob().await?;
+        Ok(blob_writer)
     }
 
-    /// Create a new file for the next blob.
-    fn next_file(dir_path: &Path, magic_bytes: u32, blob_format_version: u32) -> Result<File> {
+    /// Update the event blob writer with the initial state.
+    pub async fn update(&mut self, init_state: InitState) -> Result<()> {
+        self.event_cursor = init_state.event_cursor.clone();
+        self.current_epoch = init_state.epoch;
+        self.prev_certified_blob_id = init_state.prev_blob_id;
+        self.prev_certified_event_id = init_state.event_cursor.event_id;
+        let certified_metadata = CertifiedEventBlobMetadata::new(
+            self.prev_certified_blob_id,
+            self.event_cursor.clone(),
+            self.current_epoch,
+        );
+        self.certified.insert(&(), &certified_metadata)?;
+        Ok(())
+    }
+
+    /// Returns the path to the blob directory.
+    fn blob_dir(&self) -> PathBuf {
+        self.blob_dir_path.clone()
+    }
+
+    /// Creates and initializes the next blob file.
+    ///
+    /// This method creates a new file for the next blob, initializes it with the
+    /// necessary header information, and prepares it for writing events.
+    fn next_file(dir_path: &Path, epoch: Epoch) -> Result<File> {
         let next_file_path = dir_path.join("current_blob");
-        let mut file = File::create(&next_file_path)?;
-        file.write_u32::<BigEndian>(magic_bytes)?;
-        file.write_u32::<BigEndian>(blob_format_version)?;
+        let mut file: File = Self::create_and_initialize_file(&next_file_path, epoch)?;
         drop(file);
-
-        // File::set_len requires write, not append access rights on Windows.
-        #[cfg(target_os = "windows")]
-        {
-            file = OpenOptions::new()
-                .read(true)
-                .write(true)
-                .open(next_file_path)?;
-        }
-        #[cfg(not(target_os = "windows"))]
-        {
-            file = OpenOptions::new()
-                .read(true)
-                .append(true)
-                .open(next_file_path)?;
-        }
-
+        file = Self::reopen_file_with_permissions(&next_file_path)?;
         file.seek(SeekFrom::Start(EventBlob::HEADER_SIZE as u64))?;
         Ok(file)
     }
 
-    /// Finalize the current blob.
+    /// Creates and initializes a new blob file.
+    ///
+    /// This method creates a new file at the specified path and writes the initial
+    /// header information, including:
+    /// - Magic bytes for file format identification
+    /// - Format version for compatibility checks
+    /// - Current epoch number
+    /// - Previous blob ID (initialized to zero since it will be set later when blob is attested)
+    /// - Previous event ID (initialized to zero since it will be set later when blob is attested)
+    ///
+    /// The blob ID and event ID are initially set to zero as placeholder values. These will be
+    /// updated with the actual previous blob/event IDs when the blob is attested, creating the
+    /// chain of blob references.
+    fn create_and_initialize_file(path: &Path, epoch: Epoch) -> Result<File> {
+        let mut file = File::create(path)?;
+        file.write_u32::<BigEndian>(EventBlob::MAGIC)?;
+        file.write_u32::<BigEndian>(EventBlob::FORMAT_VERSION)?;
+        file.write_u32::<BigEndian>(epoch)?;
+        let zero_blob_id = BlobId::ZERO;
+        file.write_all(&zero_blob_id.0)?;
+        let zero_event_id = SerializedEventID::ZERO;
+        file.write_all(&zero_event_id.0)?;
+        Ok(file)
+    }
+
+    /// Reopens a file with the necessary permissions.
+    ///
+    /// This method reopens an existing file with read and write permissions,
+    /// which may be necessary after initial creation and writing.
+    fn reopen_file_with_permissions(path: &Path) -> io::Result<File> {
+        OpenOptions::new().read(true).write(true).open(path)
+    }
+
+    /// Renames the current blob file to its final name.
+    ///
+    /// This method renames the 'current_blob' file to a name based on the
+    /// current event cursor's element index.
+    fn rename_blob_file(&self) -> Result<()> {
+        let from = self.current_blob_path();
+        let to = self
+            .blob_dir()
+            .join(self.event_cursor.element_index.to_string());
+        fs::rename(from, to)?;
+        Ok(())
+    }
+
+    /// Finalizes the current blob by writing trailer information.
+    ///
+    /// This method writes the start and end checkpoint sequence numbers to the
+    /// end of the blob file and ensures all data is flushed and synced to disk.
     fn finalize(&mut self) -> Result<()> {
         self.wbuf
             .write_u64::<BigEndian>(self.start.unwrap_or_default())?;
         self.wbuf
             .write_u64::<BigEndian>(self.end.unwrap_or_default())?;
-        self.wbuf.write_all(
-            &self
-                .prev_blob_id
-                .get(&())?
-                .map(|b| b.blob_id.0)
-                .unwrap_or([0; 32])[..],
-        )?;
         self.wbuf.flush()?;
-        self.wbuf.get_ref().sync_data()?;
+        self.wbuf.get_ref().sync_all()?;
         let off = self.wbuf.get_ref().stream_position()?;
         self.wbuf.get_ref().set_len(off)?;
         Ok(())
     }
 
-    /// Reset the writer to start writing a new blob.
+    /// Resets the blob writer state for a new blob.
+    ///
+    /// This method clears the start and end sequence numbers, creates a new file
+    /// for the next blob, and resets the buffer offset.
     fn reset(&mut self) -> Result<()> {
         self.start = None;
         self.end = None;
-        let f = Self::next_file(
-            &self.root_dir_path,
-            EventBlob::MAGIC,
-            EventBlob::FORMAT_VERSION,
-        )?;
-        self.buf_offset = EventBlob::MAGIC_BYTES_SIZE + EventBlob::FORMAT_BYTES_SIZE;
+        let f = Self::next_file(&self.blob_dir(), self.current_epoch)?;
+        self.buf_offset = EventBlob::HEADER_SIZE;
         self.wbuf = BufWriter::new(f);
         Ok(())
     }
 
-    /// Store the slivers of the blob content.
-    async fn store_slivers(&mut self, content: &[u8]) -> Result<BlobId> {
-        let blob_encoder = self.node.encoding_config().get_blob_encoder(content)?;
-        let (sliver_pairs, blob_metadata) = blob_encoder.encode_with_metadata();
+    /// Updates the previous blob ID and previous event ID in a blob file.
+    ///
+    /// This method writes the provided blob ID and event ID to the header of the specified blob
+    /// file.
+    fn update_blob_header(
+        &self,
+        event_index: u64,
+        blob_id: &BlobId,
+        event_id: &Option<EventID>,
+    ) -> Result<()> {
+        let file_path = self.blob_dir().join(event_index.to_string());
+        let mut file = Self::reopen_file_with_permissions(&file_path)?;
+        file.seek(SeekFrom::Start(EventBlob::BLOB_ID_OFFSET as u64))?;
+        file.write_all(&blob_id.0)?;
+        file.seek(SeekFrom::Start(EventBlob::EVENT_ID_OFFSET as u64))?;
+        file.write_all(
+            &event_id
+                .map(SerializedEventID::encode)
+                .unwrap_or(SerializedEventID::ZERO)
+                .0,
+        )?;
+        file.flush()?;
+        file.sync_all()?;
+        Ok(())
+    }
+
+    /// Stores the slivers of the current blob.
+    ///
+    /// This method reads the blob file, encodes it into slivers, and stores these
+    /// slivers along with the blob metadata in the storage node.
+    async fn store_slivers(
+        &mut self,
+        metadata: &PendingEventBlobMetadata,
+    ) -> Result<VerifiedBlobMetadataWithId> {
+        let content = std::fs::read(
+            self.blob_dir()
+                .join(metadata.event_cursor.element_index.to_string()),
+        )?;
+        let (sliver_pairs, blob_metadata) = self
+            .node
+            .encoding_config()
+            .get_blob_encoder(&content)?
+            .encode_with_metadata();
         self.node
             .storage()
-            .put_verified_metadata(&blob_metadata)
+            .put_verified_metadata_without_blob_info(&blob_metadata)
             .context("unable to store metadata")?;
         // TODO: Once shard assignment per storage node will be read from walrus
         // system object at the beginning of the walrus epoch, we can only store the blob for
         // shards that are locally assigned to this node. (#682)
         try_join_all(sliver_pairs.iter().map(|sliver_pair| async {
             self.node
-                .store_sliver(
+                .store_sliver_unchecked(
                     blob_metadata.blob_id(),
                     sliver_pair.index(),
                     &Sliver::Primary(sliver_pair.primary.clone()),
@@ -284,7 +680,7 @@ impl EventBlobWriter {
         .map(|_| ())?;
         try_join_all(sliver_pairs.iter().map(|sliver_pair| async {
             self.node
-                .store_sliver(
+                .store_sliver_unchecked(
                     blob_metadata.blob_id(),
                     sliver_pair.index(),
                     &Sliver::Secondary(sliver_pair.secondary.clone()),
@@ -302,179 +698,488 @@ impl EventBlobWriter {
         }))
         .await
         .map(|_| ())?;
-        Ok(*blob_metadata.blob_id())
+        Ok(blob_metadata)
     }
 
-    /// Write an event to the current blob. If the event is an end of epoch event or the current
-    /// blob reaches the maximum number of processed sui checkpoints, the current blob is committed
-    #[cfg(not(test))]
+    /// Cuts the current blob and prepares for a new one.
+    ///
+    /// This method finalizes the current blob file and renames it to its final name.
     async fn cut(&mut self) -> Result<()> {
         self.finalize()?;
-        let mut file = self.wbuf.get_ref();
-        file.seek(SeekFrom::Start(0))?;
-        let mut file_content = Vec::new();
-        file.read_to_end(&mut file_content)?;
-        let blob_id = self.store_slivers(&file_content).await?;
-        // TODO: Once slivers are stored locally, invoke the new sui contract endpoint to certify
-        // the event blob. (#683)
-        let event_blob_metadata = EventBlobMetadata {
-            blob_id,
-            start: self.start.as_ref().cloned().unwrap_or_default(),
-            end: self.end.as_ref().cloned().unwrap_or_default(),
-            last_event_sequence_number: self.latest_sequence_number.clone().unwrap_or_default(),
-            last_event_index: self.latest_committed_event_index.unwrap_or_default(),
-        };
-        self.prev_blob_id.insert(&(), &event_blob_metadata)?;
-        self.latest_committed_event_sequence_number = self.latest_sequence_number.clone();
-        self.latest_committed_event_index = self.latest_event_index;
+        self.rename_blob_file()?;
         Ok(())
     }
 
-    /// Write an event to the current blob. If the event is an end of epoch event or the current
-    /// blob reaches the maximum number of processed sui checkpoints, the current blob is committed
-    #[cfg(test)]
-    async fn cut(&mut self) -> Result<()> {
-        self.finalize()?;
-        let mut file = self.wbuf.get_ref();
-        file.seek(SeekFrom::Start(0))?;
-        let mut file_content = Vec::new();
-        file.read_to_end(&mut file_content)?;
-        let mut tmp_file = File::create(self.root_dir_path.join("event_blob"))?;
-        tmp_file.write_all(&file_content)?;
-        tmp_file.flush()?;
-        Ok(())
-    }
-
-    /// Write an event to the current blob. If the event is an end of epoch event or the current
-    /// blob reaches the maximum number of processed sui checkpoints, the current blob is committed
-    /// and a new blob is started.
-    pub async fn write(&mut self, element: IndexedStreamElement, element_index: u64) -> Result<()> {
-        if self
-            .latest_committed_event_index()
-            .map_or(false, |i| i >= element_index)
+    /// Attests a blob by calling the system contract.
+    ///
+    /// This method sends a request to the system contract to certify the event blob.
+    async fn attest_blob(
+        &self,
+        metadata: &VerifiedBlobMetadataWithId,
+        checkpoint_sequence_number: CheckpointSequenceNumber,
+    ) -> Result<()> {
+        tracing::debug!("attesting event blob in epoch: {}", self.current_epoch);
+        match self
+            .node
+            .contract_service
+            .certify_event_blob(
+                metadata.try_into()?,
+                checkpoint_sequence_number,
+                self.current_epoch,
+            )
+            .await
         {
-            // It is possible to receive committed events upon restart
+            Ok(_) => {
+                tracing::info!("attested event blob with id: {:?}", metadata.blob_id());
+                Ok(())
+            }
+            Err(e) => {
+                tracing::info!("failed to attest event blob: {:?}", e);
+                Ok(())
+            }
+        }
+    }
+
+    /// Attests the next pending blob.
+    ///
+    /// This method processes the next pending blob by storing its slivers,
+    /// attesting it, and updating the database state.
+    async fn attest_next_blob(&mut self) -> Result<()> {
+        if !self.attested.is_empty() {
             return Ok(());
         }
 
-        self.update_sequence_range(&element, element_index);
-        self.write_event_to_buffer(&element)?;
-        let cut_new_blob = element.is_end_of_epoch_event()
-            || (element.is_end_of_checkpoint_marker()
-                && (element.global_sequence_number.checkpoint_sequence_number + 1)
-                    % self.number_of_checkpoints_per_blob
-                    == 0);
-        if cut_new_blob {
-            self.commit().await?;
-        }
+        let Some((event_index, metadata)) = self.pending.unbounded_iter().seek_to_first().next()
+        else {
+            return Ok(());
+        };
+
+        self.update_blob_header(
+            metadata.event_cursor.element_index,
+            &self.prev_certified_blob_id,
+            &self.prev_certified_event_id,
+        )?;
+
+        let blob_metadata = self.store_slivers(&metadata).await?;
+        let attested_metadata = metadata.to_attested(blob_metadata.clone());
+
+        self.attest_blob(&blob_metadata, metadata.end).await?;
+        let mut batch = self.pending.batch();
+        batch.insert_batch(&self.attested, std::iter::once(((), attested_metadata)))?;
+        batch.delete_batch(&self.pending, std::iter::once(event_index))?;
+        batch.write()?;
 
         Ok(())
     }
 
-    /// Update the sequence range of the current blob.
-    fn update_sequence_range(&mut self, element: &IndexedStreamElement, element_index: u64) {
-        if self.start.is_none() {
-            self.start = Some(element.global_sequence_number.checkpoint_sequence_number);
+    /// Writes an event to the current blob.
+    ///
+    /// This method writes the provided event to the current blob, updates necessary
+    /// metadata, and handles blob cutting and certification if needed.
+    pub async fn write(
+        &mut self,
+        element: PositionedStreamEvent,
+        element_index: u64,
+    ) -> Result<()> {
+        ensure!(
+            element_index == self.event_cursor.element_index,
+            "Invalid event index"
+        );
+        self.event_cursor = EventStreamCursor::new(element.element.event_id(), element_index + 1);
+        self.update_sequence_range(&element);
+        self.write_event_to_buffer(element.clone(), element_index)?;
+
+        let mut batch = self.pending.batch();
+        self.update_epoch(&element, &mut batch)?;
+
+        if self.should_cut_new_blob(&element) {
+            self.cut_and_reset_blob(&mut batch, element_index).await?;
         }
-        self.end = Some(element.global_sequence_number.checkpoint_sequence_number);
-        self.latest_sequence_number = Some(element.global_sequence_number.clone());
-        self.latest_event_index = Some(element_index);
+
+        self.handle_event_blob_certification(&element, element_index, &mut batch)?;
+
+        batch.write()?;
+
+        self.attest_next_blob().await?;
+
+        Ok(())
     }
 
-    /// Write an event to the buffer.
-    fn write_event_to_buffer(&mut self, event: &IndexedStreamElement) -> Result<()> {
-        if event.is_end_of_checkpoint_marker() {
+    fn current_blob_path(&self) -> PathBuf {
+        self.blob_dir().join("current_blob")
+    }
+
+    /// Returns the current size of the blob being written.
+    fn current_blob_size(&self) -> usize {
+        self.buf_offset
+    }
+
+    /// Determines if a new blob should be cut based on the current event.
+    ///
+    /// This method checks if the current event is an end-of-checkpoint marker and
+    /// if either the checkpoint count or blob size threshold has been reached.
+    fn should_cut_new_blob(&self, element: &PositionedStreamEvent) -> bool {
+        element.is_end_of_checkpoint_marker()
+            && (self.current_blob_size() > MAX_BLOB_SIZE
+                || (element.checkpoint_event_position.checkpoint_sequence_number + 1
+                    >= self.start.unwrap_or(0) + self.num_checkpoints_per_blob() as u64))
+    }
+
+    /// Cuts the current blob and resets for a new one.
+    ///
+    /// This method finalizes the current blob, stores its metadata, and prepares
+    /// for writing a new blob.
+    async fn cut_and_reset_blob(&mut self, batch: &mut DBBatch, element_index: u64) -> Result<()> {
+        self.cut().await?;
+        let blob_metadata = PendingEventBlobMetadata::new(
+            self.start.unwrap(),
+            self.end.unwrap(),
+            self.event_cursor.clone(),
+            self.current_epoch,
+        );
+        batch.insert_batch(
+            &self.pending,
+            std::iter::once((element_index, blob_metadata)),
+        )?;
+        self.reset()
+    }
+
+    /// Handles the certification of event blobs.
+    ///
+    /// This method processes blob certification events, updates the database state,
+    /// and manages file cleanup for certified blobs.
+    fn handle_event_blob_certification(
+        &mut self,
+        element: &PositionedStreamEvent,
+        element_index: u64,
+        batch: &mut DBBatch,
+    ) -> Result<()> {
+        let Some(blob_id) = element
+            .element
+            .blob_event()
+            .and_then(|blob_event| self.match_event_blob_is_certified(blob_event))
+        else {
+            return Ok(());
+        };
+        let Some(metadata) = self.attested.get(&())? else {
+            return Ok(());
+        };
+        if metadata.blob_id != blob_id {
             return Ok(());
         }
-        let entry = BlobEntry::encode(event, EntryEncoding::Bcs)?;
+        self.metrics
+            .latest_certified_event_index
+            .set(element_index as i64);
+        batch.delete_batch(&self.attested, std::iter::once(()))?;
+        batch.insert_batch(
+            &self.certified,
+            std::iter::once(((), metadata.to_certified())),
+        )?;
+
+        let file_path = self
+            .blob_dir()
+            .join(metadata.event_cursor.element_index.to_string());
+        if Path::new(&file_path).exists() {
+            fs::remove_file(file_path)?;
+        }
+
+        self.prev_certified_blob_id = blob_id;
+        self.prev_certified_event_id = metadata.event_cursor.event_id;
+        Ok(())
+    }
+
+    /// Updates the current epoch based on epoch change events.
+    ///
+    /// This method checks for epoch change events and updates the current epoch
+    /// and blob states accordingly.
+    fn update_epoch(
+        &mut self,
+        indexed_stream_element: &PositionedStreamEvent,
+        batch: &mut DBBatch,
+    ) -> Result<()> {
+        let EventStreamElement::ContractEvent(ContractEvent::EpochChangeEvent(
+            EpochChangeEvent::EpochChangeStart(new_epoch),
+        )) = &indexed_stream_element.element
+        else {
+            return Ok(());
+        };
+        self.current_epoch = new_epoch.epoch;
+        self.move_attested_blob_to_pending(batch)?;
+        Ok(())
+    }
+
+    /// Moves an attested blob to the pending state during epoch changes.
+    ///
+    /// This method updates the database state to move attested blobs back to
+    /// pending status when an epoch change occurs.
+    fn move_attested_blob_to_pending(&mut self, batch: &mut DBBatch) -> Result<()> {
+        let Some((_, metadata)) = self.attested.unbounded_iter().seek_to_first().next() else {
+            return Ok(());
+        };
+
+        batch.delete_batch(&self.attested, std::iter::once(()))?;
+        batch.insert_batch(
+            &self.pending,
+            std::iter::once((metadata.event_cursor.element_index, metadata.to_pending())),
+        )?;
+
+        Ok(())
+    }
+
+    /// Checks if a blob event indicates a certified blob.
+    ///
+    /// This method examines a BlobEvent to determine if it represents a
+    /// certified blob, returning the blob ID if so.
+    fn match_event_blob_is_certified(&self, blob_event: &BlobEvent) -> Option<BlobId> {
+        match blob_event {
+            BlobEvent::Certified(blob_certified) => Some(blob_certified.blob_id),
+            _ => None,
+        }
+    }
+
+    /// Updates the sequence range for the current blob.
+    ///
+    /// This method updates the start and end checkpoint sequence numbers
+    /// based on the provided event.
+    fn update_sequence_range(&mut self, element: &PositionedStreamEvent) {
+        if self.start.is_none() {
+            self.start = Some(element.checkpoint_event_position.checkpoint_sequence_number);
+        }
+        self.end = Some(element.checkpoint_event_position.checkpoint_sequence_number);
+    }
+
+    /// Writes an event to the internal buffer.
+    ///
+    /// This method encodes the provided event and writes it to the internal
+    /// buffer, updating the buffer offset.
+    fn write_event_to_buffer(
+        &mut self,
+        event: PositionedStreamEvent,
+        element_index: u64,
+    ) -> Result<()> {
+        let event_with_cursor = IndexedStreamEvent::new(event, element_index);
+        let entry = BlobEntry::encode(&event_with_cursor, EntryEncoding::Bcs)?;
         self.buf_offset += entry.write(&mut self.wbuf)?;
         Ok(())
     }
 
-    /// Commit the current blob.
-    pub async fn commit(&mut self) -> Result<()> {
-        self.cut().await?;
-        self.reset()?;
-        Ok(())
+    /// Returns the current event cursor.
+    pub fn event_cursor(&self) -> EventStreamCursor {
+        self.event_cursor.clone()
     }
 
-    /// Get the latest committed event sequence number.
-    pub fn latest_committed_event_sequence_number(&self) -> Option<EventSequenceNumber> {
-        self.latest_committed_event_sequence_number.clone()
-    }
-
-    /// Get the latest committed event index.
-    pub fn latest_committed_event_index(&self) -> Option<u64> {
-        self.latest_committed_event_index
+    /// Returns the number of checkpoints per blob.
+    pub fn num_checkpoints_per_blob(&self) -> u32 {
+        self.num_checkpoints_per_blob
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::{fs, path::PathBuf};
+    use std::{
+        fs::File,
+        io::Read,
+        path::{Path, PathBuf},
+    };
 
+    use anyhow::Result;
+    use typed_store::Map;
     use walrus_core::{BlobId, ShardIndex};
-    use walrus_sui::{test_utils::EventForTesting, types::BlobCertified};
+    use walrus_sui::{
+        test_utils::EventForTesting,
+        types::{BlobCertified, ContractEvent},
+    };
 
     use crate::{
         node::events::{
             event_blob::EventBlob,
-            event_blob_writer::EventBlobWriter,
-            EventSequenceNumber,
-            EventStreamElement,
-            IndexedStreamElement,
+            event_blob_writer::{EventBlobWriter, EventBlobWriterFactory},
+            CheckpointEventPosition,
+            PositionedStreamEvent,
         },
         test_utils::StorageNodeHandle,
     };
 
     #[tokio::test]
-    async fn test_e2e() -> anyhow::Result<()> {
-        let dir: PathBuf = tempfile::tempdir()
-            .expect("Failed to open temporary directory")
-            .into_path();
-        let node = StorageNodeHandle::builder()
+    async fn test_blob_writer_all_events_exist() -> Result<()> {
+        const NUM_BLOBS: u64 = 10;
+        const NUM_EVENTS_PER_CHECKPOINT: u64 = 2;
+
+        let dir: PathBuf = tempfile::tempdir()?.into_path();
+        let node = create_test_node().await?;
+        let blob_writer_factory = EventBlobWriterFactory::new(
+            &dir,
+            node.storage_node.inner().clone(),
+            prometheus::default_registry(),
+            Some(10),
+        )?;
+        let mut blob_writer = blob_writer_factory.create().await?;
+        let num_checkpoints: u64 = NUM_BLOBS * blob_writer.num_checkpoints_per_blob() as u64;
+
+        generate_and_write_events(&mut blob_writer, num_checkpoints, NUM_EVENTS_PER_CHECKPOINT)
+            .await?;
+
+        let pending_blobs = blob_writer.pending.unbounded_iter().collect::<Vec<_>>();
+        assert_eq!(pending_blobs.len() as u64, NUM_BLOBS - 1);
+
+        let mut prev_blob_id = BlobId([0; 32]);
+        while !blob_writer.attested.is_empty() {
+            let attested_blob = blob_writer
+                .attested
+                .get(&())?
+                .expect("Attested blob should exist");
+            let attested_blob_id = attested_blob.blob_id;
+            let f = File::open(
+                dir.join("blobs")
+                    .join(attested_blob.event_cursor.element_index.to_string()),
+            )?;
+            let mut buf = Vec::new();
+            let mut buf_reader = std::io::BufReader::new(f);
+            buf_reader.read_to_end(&mut buf)?;
+            let blob = EventBlob::new(&buf)?;
+            assert_eq!(blob.prev_blob_id(), prev_blob_id);
+            prev_blob_id = attested_blob_id;
+            for entry in blob {
+                tracing::info!("{:?}", entry);
+            }
+            certify_attested_blob(&mut blob_writer, attested_blob_id, num_checkpoints).await?;
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_blob_writer_e2e() -> Result<()> {
+        const NUM_BLOBS: u64 = 10;
+        const NUM_EVENTS_PER_CHECKPOINT: u64 = 1;
+
+        let dir: PathBuf = tempfile::tempdir()?.into_path();
+        let node = create_test_node().await?;
+        let blob_writer_factory = EventBlobWriterFactory::new(
+            &dir,
+            node.storage_node.inner().clone(),
+            prometheus::default_registry(),
+            Some(10),
+        )?;
+        let mut blob_writer = blob_writer_factory.create().await?;
+        let num_checkpoints: u64 = NUM_BLOBS * blob_writer.num_checkpoints_per_blob() as u64;
+
+        generate_and_write_events(&mut blob_writer, num_checkpoints, NUM_EVENTS_PER_CHECKPOINT)
+            .await?;
+
+        let attested_blob = blob_writer
+            .attested
+            .get(&())?
+            .expect("Attested blob should exist");
+        let attested_blob_id = attested_blob.blob_id;
+
+        let pending_blobs: Vec<_> = blob_writer.pending.unbounded_iter().collect();
+        assert_eq!(pending_blobs.len() as u64, NUM_BLOBS - 1);
+        let first_pending_blob_event_index = pending_blobs[0].0;
+
+        certify_attested_blob(&mut blob_writer, attested_blob_id, num_checkpoints).await?;
+
+        verify_certified_blob(&blob_writer, attested_blob_id)?;
+        verify_next_attested_blob(
+            &blob_writer,
+            &dir,
+            first_pending_blob_event_index + 1,
+            attested_blob_id,
+        )?;
+
+        assert_eq!(
+            blob_writer.pending.unbounded_iter().count() as u64,
+            NUM_BLOBS - 2
+        );
+
+        Ok(())
+    }
+
+    async fn create_test_node() -> Result<StorageNodeHandle> {
+        StorageNodeHandle::builder()
             .with_system_event_provider(vec![])
             .with_shard_assignment(&[ShardIndex(0)])
             .with_node_started(true)
             .build()
-            .await?;
-        let mut blob_writer =
-            EventBlobWriter::new_for_testing(dir.clone(), 100, node.storage_node.inner().clone())?;
-        let event_blob_file_path = dir.join("event_blob");
-        if event_blob_file_path.exists() {
-            fs::remove_file(event_blob_file_path.clone())?;
+            .await
+    }
+
+    async fn generate_and_write_events(
+        blob_writer: &mut EventBlobWriter,
+        num_checkpoints: u64,
+        num_events_per_checkpoint: u64,
+    ) -> Result<()> {
+        for i in 0..num_checkpoints {
+            for j in 0..num_events_per_checkpoint {
+                let event = if j == num_events_per_checkpoint - 1 {
+                    PositionedStreamEvent::new_checkpoint_boundary(i, num_events_per_checkpoint - 1)
+                } else {
+                    PositionedStreamEvent::new(
+                        ContractEvent::BlobEvent(
+                            BlobCertified::for_testing(BlobId([7; 32])).into(),
+                        ),
+                        CheckpointEventPosition::new(i, j),
+                    )
+                };
+                blob_writer
+                    .write(event, i * num_events_per_checkpoint + j)
+                    .await?;
+            }
         }
-        let mut counter = 0;
-        // Write events into the blob
-        for i in 0..100 {
-            let event = IndexedStreamElement {
-                global_sequence_number: EventSequenceNumber::new(i as u64, 0),
-                element: EventStreamElement::ContractEvent(
-                    BlobCertified::for_testing(BlobId([7; 32])).into(),
-                ),
-            };
-            blob_writer.write(event, counter).await?;
-            counter += 1;
-            let end_of_checkpoint_marker_event =
-                IndexedStreamElement::new_checkpoint_boundary(i as u64, 1);
-            blob_writer
-                .write(end_of_checkpoint_marker_event, counter)
-                .await?;
-            counter += 1;
-        }
-        // Read back the events from the blob
-        let file = std::fs::File::open(event_blob_file_path)?;
-        let event_blob = EventBlob::new(file)?;
-        assert_eq!(event_blob.start_checkpoint_sequence_number(), 0);
-        assert_eq!(event_blob.end_checkpoint_sequence_number(), 99);
-        let events: Vec<_> = event_blob.collect();
-        assert_eq!(events.len(), 100);
-        for (i, event) in events.iter().enumerate() {
-            assert_eq!(
-                event.global_sequence_number.checkpoint_sequence_number,
-                i as u64
-            );
-        }
+        Ok(())
+    }
+
+    async fn certify_attested_blob(
+        blob_writer: &mut EventBlobWriter,
+        attested_blob_id: BlobId,
+        num_checkpoints: u64,
+    ) -> Result<()> {
+        let certified_event = PositionedStreamEvent::new(
+            ContractEvent::BlobEvent(BlobCertified::for_testing(attested_blob_id).into()),
+            CheckpointEventPosition::new(num_checkpoints, 0),
+        );
+        blob_writer
+            .write(certified_event, blob_writer.event_cursor.element_index)
+            .await
+    }
+
+    fn verify_certified_blob(
+        blob_writer: &EventBlobWriter,
+        expected_blob_id: BlobId,
+    ) -> Result<()> {
+        let certified_blob = blob_writer
+            .certified
+            .get(&())?
+            .expect("Certified blob should exist");
+        assert_eq!(certified_blob.blob_id, expected_blob_id);
+        Ok(())
+    }
+
+    fn verify_next_attested_blob(
+        blob_writer: &EventBlobWriter,
+        dir: &Path,
+        expected_event_index: u64,
+        expected_prev_blob_id: BlobId,
+    ) -> Result<()> {
+        let next_attested_blob = blob_writer
+            .attested
+            .get(&())?
+            .expect("Next attested blob should exist");
+        assert_eq!(
+            next_attested_blob.event_cursor.element_index,
+            expected_event_index
+        );
+
+        let path = dir
+            .join("blobs")
+            .join(next_attested_blob.event_cursor.element_index.to_string());
+        let f = File::open(&path)?;
+        let mut buf_reader = std::io::BufReader::new(f);
+        let mut buf = Vec::new();
+        buf_reader.read_to_end(&mut buf)?;
+        let blob = EventBlob::new(&buf)?;
+        assert_eq!(blob.epoch(), 0);
+        assert_eq!(blob.prev_blob_id(), expected_prev_blob_id);
+
         Ok(())
     }
 }

--- a/crates/walrus-service/src/node/events/event_processor.rs
+++ b/crates/walrus-service/src/node/events/event_processor.rs
@@ -3,9 +3,16 @@
 
 //! Event processor for processing events from the full node.
 
-use std::{collections::HashMap, fmt::Debug, path::Path, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    fmt::Debug,
+    fs,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use async_trait::async_trait;
 use futures_util::future::try_join_all;
 use move_core_types::{
@@ -27,8 +34,11 @@ use sui_package_resolver::{
     PackageStoreWithLruCache,
     Resolver,
 };
-use sui_rpc_api::Client;
-use sui_sdk::{rpc_types::SuiEvent, SuiClientBuilder};
+use sui_sdk::{
+    rpc_types::{SuiEvent, SuiObjectDataOptions, SuiTransactionBlockResponseOptions},
+    SuiClient,
+    SuiClientBuilder,
+};
 use sui_storage::verify_checkpoint_with_committee;
 use sui_types::{
     base_types::ObjectID,
@@ -38,6 +48,7 @@ use sui_types::{
     message_envelope::Message,
     messages_checkpoint::{TrustedCheckpoint, VerifiedCheckpoint},
     object::{Data, Object},
+    sui_serde::BigInt,
     SYSTEM_PACKAGE_ADDRESSES,
 };
 use tokio::{
@@ -48,34 +59,43 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 use typed_store::{
     rocks,
-    rocks::{errors::typed_store_err_from_rocks_err, DBMap, MetricConf, ReadWriteOptions},
+    rocks::{errors::typed_store_err_from_rocks_err, DBMap, MetricConf, ReadWriteOptions, RocksDB},
     Map,
     TypedStoreError,
 };
-use walrus_core::ensure;
-use walrus_sui::types::ContractEvent;
-use walrus_utils::checkpoint_downloader::ParallelCheckpointDownloader;
+use walrus_core::{ensure, BlobId};
+use walrus_sui::{client::retry_client::RetriableSuiClient, types::ContractEvent};
+use walrus_utils::{
+    backoff::ExponentialBackoffConfig,
+    checkpoint_downloader::ParallelCheckpointDownloader,
+};
 
-use crate::node::events::{
-    ensure_experimental_rest_endpoint_exists,
-    get_bootstrap_committee_and_checkpoint,
-    EventProcessorConfig,
-    EventSequenceNumber,
-    IndexedStreamElement,
+use crate::{
+    node::events::{
+        ensure_experimental_rest_endpoint_exists,
+        event_blob::EventBlob,
+        CheckpointEventPosition,
+        EventProcessorConfig,
+        IndexedStreamEvent,
+        InitState,
+        PositionedStreamEvent,
+        StreamEventWithInitState,
+    },
+    utils::collect_event_blobs_for_catchup,
 };
 
 /// The name of the checkpoint store.
-#[allow(dead_code)]
 const CHECKPOINT_STORE: &str = "checkpoint_store";
 /// The name of the Walrus package store.
-#[allow(dead_code)]
 const WALRUS_PACKAGE_STORE: &str = "walrus_package_store";
 /// The name of the committee store.
-#[allow(dead_code)]
 const COMMITTEE_STORE: &str = "committee_store";
 /// The name of the event store.
-#[allow(dead_code)]
 const EVENT_STORE: &str = "event_store";
+/// Event blob state to consider before the first event is processed.
+const INIT_STATE: &str = "init_state";
+/// Max events per stream poll
+const MAX_EVENTS_PER_POLL: usize = 1000;
 
 pub(crate) type PackageCache = PackageStoreWithLruCache<LocalDBPackageStore>;
 
@@ -88,7 +108,7 @@ pub struct LocalDBPackageStore {
     /// The table which stores the package objects.
     package_store_table: DBMap<ObjectID, Object>,
     /// The full node REST client.
-    fallback_client: Client,
+    fallback_client: sui_rpc_api::Client,
     /// Cache for original package ids.
     original_id_cache: Arc<RwLock<HashMap<AccountAddress, ObjectID>>>,
 }
@@ -102,11 +122,27 @@ pub struct EventProcessorMetrics {
     pub total_downloaded_checkpoints: IntCounter,
 }
 
+/// Stores for the event processor.
+#[derive(Clone, Debug)]
+pub struct EventProcessorStores {
+    /// The checkpoint store.
+    pub checkpoint_store: DBMap<(), TrustedCheckpoint>,
+    /// The Walrus package store.
+    pub walrus_package_store: DBMap<ObjectID, Object>,
+    /// The committee store.
+    pub committee_store: DBMap<(), Committee>,
+    /// The event store.
+    pub event_store: DBMap<u64, PositionedStreamEvent>,
+    /// The init state store. Key is the event index
+    /// of the first event in an event blob.
+    pub init_state: DBMap<u64, InitState>,
+}
+
 /// Event processor for processing checkpoint and extract Walrus events from the full node.
 #[derive(Clone)]
 pub struct EventProcessor {
     /// Full node REST client.
-    pub client: Client,
+    pub client: sui_rpc_api::Client,
     /// Event polling interval.
     pub event_polling_interval: Duration,
     /// The address of the Walrus system package.
@@ -116,13 +152,7 @@ pub struct EventProcessor {
     /// Event store pruning interval.
     pub pruning_interval: Duration,
     /// Store which only stores the latest checkpoint.
-    pub checkpoint_store: DBMap<(), TrustedCheckpoint>,
-    /// Store which only stores the latest Walrus package.
-    pub walrus_package_store: DBMap<ObjectID, Object>,
-    /// Store which only stores the latest Sui committee.
-    pub committee_store: DBMap<(), Committee>,
-    /// Store which only stores all event stream elements.
-    pub event_store: DBMap<u64, IndexedStreamElement>,
+    pub stores: EventProcessorStores,
     /// Package resolver.
     pub package_resolver: Arc<Resolver<PackageCache>>,
     /// Event processor metrics.
@@ -165,25 +195,80 @@ impl Debug for EventProcessor {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("EventProcessor")
             .field("system_pkg_id", &self.system_pkg_id)
-            .field("checkpoint_store", &self.checkpoint_store)
-            .field("walrus_package_store", &self.walrus_package_store)
-            .field("committee_store", &self.committee_store)
-            .field("event_store", &self.event_store)
+            .field("checkpoint_store", &self.stores.checkpoint_store)
+            .field("walrus_package_store", &self.stores.walrus_package_store)
+            .field("committee_store", &self.stores.committee_store)
+            .field("event_store", &self.stores.event_store)
             .finish()
+    }
+}
+
+/// Struct to group system-related parameters.
+#[derive(Debug, Clone)]
+pub struct SystemConfig {
+    /// The package ID of the system package.
+    pub system_pkg_id: ObjectID,
+    /// The object ID of the system object.
+    pub system_object_id: ObjectID,
+    /// The object ID of the staking object.
+    pub staking_object_id: ObjectID,
+}
+
+/// Struct to group general configuration parameters.
+#[derive(Debug)]
+pub struct EventProcessorRuntimeConfig {
+    /// The address of the RPC server.
+    pub rpc_address: String,
+    /// The event polling interval.
+    pub event_polling_interval: Duration,
+    /// The path to the database.
+    pub db_path: PathBuf,
+}
+
+/// Struct to group client-related parameters.
+pub struct SuiClientSet {
+    /// Sui client.
+    sui_client: RetriableSuiClient,
+    /// Rest client for the full node.
+    client: sui_rpc_api::Client,
+}
+
+impl Debug for SuiClientSet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClientConfig").finish()
     }
 }
 
 #[allow(dead_code)]
 impl EventProcessor {
+    /// Returns the initialization state for the given event index. If the event index is not found,
+    /// it will return `None`. This method is used to recover the state of the event blob writer.
+    pub fn get_init_state(&self, from: u64) -> Result<Option<InitState>> {
+        let res = self.stores.init_state.get(&from)?;
+        Ok(res)
+    }
+
     /// Polls the event store for new events starting from the given sequence number.
-    pub async fn poll(&self, from: u64) -> Result<Vec<IndexedStreamElement>> {
-        let mut elements = vec![];
-        let mut iter = self.event_store.unbounded_iter();
+    pub fn poll(&self, from: u64) -> Result<Vec<PositionedStreamEvent>> {
+        let iter = self.stores.event_store.unbounded_iter();
+        Ok(iter
+            .skip_to(&from)?
+            .take(MAX_EVENTS_PER_POLL)
+            .map(|(_, event)| event)
+            .collect())
+    }
+
+    /// Polls the event store for the next event starting from the given sequence number,
+    /// and returns the event along with any InitState that exists at that index.
+    pub fn poll_next(&self, from: u64) -> Result<Option<StreamEventWithInitState>> {
+        let mut iter = self.stores.event_store.unbounded_iter();
         iter = iter.skip_to(&from)?;
-        for (_, event) in iter {
-            elements.push(event.clone());
-        }
-        Ok(elements)
+        let Some((index, event)) = iter.next() else {
+            return Ok(None);
+        };
+        let init_state = self.get_init_state(index)?;
+        let event_with_cursor = StreamEventWithInitState::new(event, init_state);
+        Ok(Some(event_with_cursor))
     }
 
     /// Starts the event processor. This method will run until the cancellation token is cancelled.
@@ -204,7 +289,7 @@ impl EventProcessor {
 
     /// Updates the package store with the given objects.
     fn update_package_store(&self, objects: &[Object]) -> Result<(), TypedStoreError> {
-        let mut write_batch = self.walrus_package_store.batch();
+        let mut write_batch = self.stores.walrus_package_store.batch();
         for object in objects.iter() {
             // Update the package store with the given object.We want to track not just the
             // walrus package but all its transitive dependencies as well. While it is possible
@@ -214,7 +299,7 @@ impl EventProcessor {
                 continue;
             }
             write_batch.insert_batch(
-                &self.walrus_package_store,
+                &self.stores.walrus_package_store,
                 std::iter::once((object.id(), object)),
             )?;
         }
@@ -232,12 +317,13 @@ impl EventProcessor {
                     if commit_index == 0 {
                         continue;
                     }
-                    let mut write_batch = self.event_store.batch();
-                    write_batch.schedule_delete_range(&self.event_store, &0, &commit_index)?;
+                    let mut write_batch = self.stores.event_store.batch();
+                    write_batch.schedule_delete_range(&self.stores.event_store, &0, &commit_index)?;
+                    write_batch.schedule_delete_range(&self.stores.init_state, &0, &commit_index)?;
                     write_batch.write()?;
                     // This will prune the event store by deleting all the sst files relevant to the
                     // events before the commit index
-                    self.event_store.delete_file_in_range(&0, &commit_index)?;
+                    self.stores.event_store.delete_file_in_range(&0, &commit_index)?;
                 }
                 _ = cancel_token.cancelled() => {
                     return Ok(());
@@ -254,7 +340,7 @@ impl EventProcessor {
         checkpoint: &CheckpointData,
         prev_checkpoint: VerifiedCheckpoint,
     ) -> Result<VerifiedCheckpoint> {
-        let Some(committee) = self.committee_store.get(&())? else {
+        let Some(committee) = self.stores.committee_store.get(&())? else {
             bail!("No committee found in the committee store");
         };
 
@@ -312,13 +398,14 @@ impl EventProcessor {
     /// will read events from the event blobs so it can catch up.
     pub async fn start_tailing_checkpoints(&self, cancel_token: CancellationToken) -> Result<()> {
         let mut next_event_index = self
+            .stores
             .event_store
             .unbounded_iter()
             .skip_to_last()
             .next()
             .map(|(k, _)| k + 1)
             .unwrap_or(0);
-        let Some(prev_checkpoint) = self.checkpoint_store.get(&())? else {
+        let Some(prev_checkpoint) = self.stores.checkpoint_store.get(&())? else {
             bail!("No checkpoint found in the checkpoint store");
         };
         let mut next_checkpoint = prev_checkpoint.inner().sequence_number().saturating_add(1);
@@ -349,7 +436,7 @@ impl EventProcessor {
             self.metrics.total_downloaded_checkpoints.inc();
             let verified_checkpoint =
                 self.verify_checkpoint(&checkpoint, prev_verified_checkpoint)?;
-            let mut write_batch = self.event_store.batch();
+            let mut write_batch = self.stores.event_store.batch();
             let mut counter = 0;
             for tx in checkpoint.transactions.into_iter() {
                 self.update_package_store(&tx.output_objects)
@@ -390,15 +477,15 @@ impl EventProcessor {
                         move_datatype_layout,
                     )?;
                     let contract_event: ContractEvent = sui_event.try_into()?;
-                    let event_sequence_number = EventSequenceNumber::new(
+                    let event_sequence_number = CheckpointEventPosition::new(
                         *checkpoint.checkpoint_summary.sequence_number(),
                         counter,
                     );
                     let walrus_event =
-                        IndexedStreamElement::new(contract_event, event_sequence_number.clone());
+                        PositionedStreamEvent::new(contract_event, event_sequence_number.clone());
                     write_batch
                         .insert_batch(
-                            &self.event_store,
+                            &self.stores.event_store,
                             std::iter::once((next_event_index, walrus_event)),
                         )
                         .map_err(|e| anyhow!("Failed to insert event into event store: {}", e))?;
@@ -406,12 +493,12 @@ impl EventProcessor {
                     next_event_index += 1;
                 }
             }
-            let end_of_checkpoint = IndexedStreamElement::new_checkpoint_boundary(
+            let end_of_checkpoint = PositionedStreamEvent::new_checkpoint_boundary(
                 checkpoint.checkpoint_summary.sequence_number,
                 counter,
             );
             write_batch.insert_batch(
-                &self.event_store,
+                &self.stores.event_store,
                 std::iter::once((next_event_index, end_of_checkpoint)),
             )?;
             next_event_index += 1;
@@ -426,7 +513,10 @@ impl EventProcessor {
                     next_committee,
                 );
                 write_batch
-                    .insert_batch(&self.committee_store, std::iter::once(((), committee)))
+                    .insert_batch(
+                        &self.stores.committee_store,
+                        std::iter::once(((), committee)),
+                    )
                     .map_err(|e| {
                         anyhow!("Failed to insert committee into committee store: {}", e)
                     })?;
@@ -436,7 +526,7 @@ impl EventProcessor {
             }
             write_batch
                 .insert_batch(
-                    &self.checkpoint_store,
+                    &self.stores.checkpoint_store,
                     std::iter::once(((), verified_checkpoint.serializable_ref())),
                 )
                 .map_err(|e| anyhow!("Failed to insert checkpoint into checkpoint store: {}", e))?;
@@ -447,31 +537,131 @@ impl EventProcessor {
         Ok(())
     }
 
+    /// Clears all stores by scheduling deletion of all entries.
+    fn clear_stores(&self) -> Result<(), TypedStoreError> {
+        self.stores.committee_store.schedule_delete_all()?;
+        self.stores.event_store.schedule_delete_all()?;
+        self.stores.walrus_package_store.schedule_delete_all()?;
+        Ok(())
+    }
+
     /// Creates a new checkpoint processor with the given configuration. The processor will use the
     /// given configuration to connect to the full node and the checkpoint store. If the checkpoint
     /// store is not found, it will be created. If the checkpoint store is found, the processor will
     /// resume from the last checkpoint.
     pub async fn new(
         config: &EventProcessorConfig,
-        rpc_address: String,
-        system_pkg_id: ObjectID,
-        event_polling_interval: Duration,
-        db_path: &Path,
+        runtime_config: EventProcessorRuntimeConfig,
+        system_config: SystemConfig,
         registry: &Registry,
     ) -> Result<Self, anyhow::Error> {
-        // return a new CheckpointProcessor
-        let client = Client::new(&config.rest_url)?;
+        let client = Self::create_and_validate_client(&runtime_config.rpc_address).await?;
+        let database = Self::initialize_database(&runtime_config)?;
+        let stores = Self::open_stores(&database)?;
+        let package_store =
+            LocalDBPackageStore::new(stores.walrus_package_store.clone(), client.clone());
+        let original_system_package_id = package_store
+            .get_original_package_id(system_config.system_pkg_id.into())
+            .await?;
+        let checkpoint_downloader = ParallelCheckpointDownloader::new(
+            client.clone(),
+            stores.checkpoint_store.clone(),
+            config.adaptive_downloader_config(),
+            registry,
+        )?;
+        let metrics = EventProcessorMetrics::new(registry);
+        let event_processor = EventProcessor {
+            client: client.clone(),
+            stores: stores.clone(),
+            system_pkg_id: original_system_package_id,
+            event_polling_interval: runtime_config.event_polling_interval,
+            event_store_commit_index: Arc::new(Mutex::new(0)),
+            pruning_interval: config.pruning_interval,
+            package_resolver: Arc::new(Resolver::new(PackageCache::new(package_store.clone()))),
+            metrics,
+            checkpoint_downloader,
+            package_store,
+        };
 
-        // Fail with an error if experimental rest endpoint does not exist
-        // as we need it to get the full checkpoint
+        if event_processor.stores.checkpoint_store.is_empty() {
+            event_processor.clear_stores()?;
+        }
+
+        let current_checkpoint = event_processor
+            .stores
+            .checkpoint_store
+            .get(&())?
+            .map(|t| *t.inner().sequence_number())
+            .unwrap_or(0);
+
+        let latest_checkpoint = client.get_latest_checkpoint().await?;
+        let current_lag = latest_checkpoint.sequence_number - current_checkpoint;
+
+        let url = config.rest_url.clone();
+        let sui_client = SuiClientBuilder::default()
+            .build(&url)
+            .await
+            .context(format!("cannot connect to Sui RPC node at {url}"))?;
+        let retriable_sui_client =
+            RetriableSuiClient::new(sui_client.clone(), ExponentialBackoffConfig::default());
+        if current_lag > config.event_stream_catchup_min_checkpoint_lag {
+            let clients = SuiClientSet {
+                sui_client: retriable_sui_client,
+                client: client.clone(),
+            };
+            let recovery_path = runtime_config.db_path.join("recovery");
+            if let Err(e) = Self::catchup_using_event_blobs(
+                clients,
+                system_config.clone(),
+                stores.clone(),
+                &recovery_path,
+            )
+            .await
+            {
+                tracing::error!(?e, "Failed to catch up using event blobs");
+            } else {
+                tracing::info!("Successfully caught up using event blobs");
+            }
+        }
+
+        if event_processor.stores.checkpoint_store.is_empty() {
+            let sui_client = SuiClientBuilder::default()
+                .build(runtime_config.rpc_address)
+                .await?;
+            let (committee, verified_checkpoint) = Self::get_bootstrap_committee_and_checkpoint(
+                &sui_client,
+                event_processor.client.clone(),
+                event_processor.system_pkg_id,
+            )
+            .await?;
+            event_processor
+                .stores
+                .committee_store
+                .insert(&(), &committee)?;
+            event_processor
+                .stores
+                .checkpoint_store
+                .insert(&(), verified_checkpoint.serializable_ref())?;
+        }
+
+        Ok(event_processor)
+    }
+
+    async fn create_and_validate_client(
+        rest_url: &str,
+    ) -> Result<sui_rpc_api::Client, anyhow::Error> {
+        let client = sui_rpc_api::Client::new(rest_url)?;
         ensure_experimental_rest_endpoint_exists(client.clone()).await?;
+        Ok(client)
+    }
 
+    fn initialize_database(processor_config: &EventProcessorRuntimeConfig) -> Result<Arc<RocksDB>> {
         let metric_conf = MetricConf::default();
         let mut db_opts = Options::default();
         db_opts.create_missing_column_families(true);
         db_opts.create_if_missing(true);
         let database = rocks::open_cf_opts(
-            db_path,
+            processor_config.db_path.clone(),
             Some(db_opts),
             metric_conf,
             &[
@@ -479,106 +669,356 @@ impl EventProcessor {
                 (WALRUS_PACKAGE_STORE, Options::default()),
                 (COMMITTEE_STORE, Options::default()),
                 (EVENT_STORE, Options::default()),
+                (INIT_STATE, Options::default()),
             ],
         )?;
+
         if database.cf_handle(CHECKPOINT_STORE).is_none() {
             database
-                .create_cf(CHECKPOINT_STORE, &rocksdb::Options::default())
+                .create_cf(CHECKPOINT_STORE, &Options::default())
                 .map_err(typed_store_err_from_rocks_err)?;
         }
         if database.cf_handle(WALRUS_PACKAGE_STORE).is_none() {
             database
-                .create_cf(WALRUS_PACKAGE_STORE, &rocksdb::Options::default())
+                .create_cf(WALRUS_PACKAGE_STORE, &Options::default())
                 .map_err(typed_store_err_from_rocks_err)?;
         }
         if database.cf_handle(COMMITTEE_STORE).is_none() {
             database
-                .create_cf(COMMITTEE_STORE, &rocksdb::Options::default())
+                .create_cf(COMMITTEE_STORE, &Options::default())
                 .map_err(typed_store_err_from_rocks_err)?;
         }
         if database.cf_handle(EVENT_STORE).is_none() {
             database
-                .create_cf(EVENT_STORE, &rocksdb::Options::default())
+                .create_cf(EVENT_STORE, &Options::default())
                 .map_err(typed_store_err_from_rocks_err)?;
         }
+        if database.cf_handle(INIT_STATE).is_none() {
+            database
+                .create_cf(INIT_STATE, &Options::default())
+                .map_err(typed_store_err_from_rocks_err)?;
+        }
+        Ok(database)
+    }
+
+    fn open_stores(database: &Arc<RocksDB>) -> Result<EventProcessorStores, anyhow::Error> {
         let checkpoint_store = DBMap::reopen(
-            &database,
+            database,
             Some(CHECKPOINT_STORE),
             &ReadWriteOptions::default(),
             false,
         )?;
         let walrus_package_store = DBMap::reopen(
-            &database,
+            database,
             Some(WALRUS_PACKAGE_STORE),
             &ReadWriteOptions::default(),
             false,
         )?;
         let committee_store = DBMap::reopen(
-            &database,
+            database,
             Some(COMMITTEE_STORE),
             &ReadWriteOptions::default(),
             false,
         )?;
         let event_store = DBMap::reopen(
-            &database,
+            database,
             Some(EVENT_STORE),
             &ReadWriteOptions::default().set_ignore_range_deletions(true),
             false,
         )?;
-
-        let package_store = LocalDBPackageStore::new(walrus_package_store.clone(), client.clone());
-        let original_system_package_id = package_store
-            .get_original_package_id(system_pkg_id.into())
-            .await?;
-
-        let checkpoint_downloader = ParallelCheckpointDownloader::new(
-            client.clone(),
-            checkpoint_store.clone(),
-            config.adaptive_downloader_config(),
-            registry,
+        let init_state = DBMap::reopen(
+            database,
+            Some(INIT_STATE),
+            &ReadWriteOptions::default().set_ignore_range_deletions(true),
+            false,
         )?;
 
-        let event_processor = EventProcessor {
-            client,
-            walrus_package_store,
+        let event_processor_stores = EventProcessorStores {
             checkpoint_store,
+            walrus_package_store,
             committee_store,
             event_store,
-            system_pkg_id: original_system_package_id,
-            event_polling_interval,
-            event_store_commit_index: Arc::new(Mutex::new(0)),
-            pruning_interval: config.pruning_interval,
-            package_resolver: Arc::new(Resolver::new(PackageCache::new(package_store.clone()))),
-            metrics: EventProcessorMetrics::new(registry),
-            checkpoint_downloader,
-            package_store,
+            init_state,
         };
 
-        if event_processor.checkpoint_store.is_empty() {
-            // This is a fresh start as there is no prev disk state
-            event_processor.committee_store.schedule_delete_all()?;
-            event_processor.event_store.schedule_delete_all()?;
-            event_processor.walrus_package_store.schedule_delete_all()?;
-            let sui_client = SuiClientBuilder::default().build(rpc_address).await?;
-            let (committee, verified_checkpoint) = get_bootstrap_committee_and_checkpoint(
-                &sui_client,
-                event_processor.client.clone(),
-                event_processor.system_pkg_id,
+        Ok(event_processor_stores)
+    }
+
+    /// Gets the initial committee and checkpoint information by:
+    /// 1. Fetching the system package object
+    /// 2. Getting its previous transaction
+    /// 3. Using that transaction's checkpoint to get the committee and checkpoint data
+    ///
+    /// Returns a tuple containing:
+    /// - The committee for the current or next epoch
+    /// - The verified checkpoint containing the system package deployment
+    pub async fn get_bootstrap_committee_and_checkpoint(
+        sui_client: &SuiClient,
+        client: sui_rpc_api::Client,
+        system_pkg_id: ObjectID,
+    ) -> anyhow::Result<(Committee, VerifiedCheckpoint)> {
+        let object = sui_client
+            .read_api()
+            .get_object_with_options(
+                system_pkg_id,
+                SuiObjectDataOptions::new()
+                    .with_bcs()
+                    .with_type()
+                    .with_previous_transaction(),
             )
             .await?;
-            event_processor.committee_store.insert(&(), &committee)?;
-            event_processor
-                .checkpoint_store
-                .insert(&(), verified_checkpoint.serializable_ref())?;
+        let txn = sui_client
+            .read_api()
+            .get_transaction_with_options(
+                object
+                    .data
+                    .ok_or(anyhow!("No object data"))?
+                    .previous_transaction
+                    .ok_or(anyhow!("No transaction data"))?,
+                SuiTransactionBlockResponseOptions::new(),
+            )
+            .await?;
+        let checkpoint_data = client
+            .get_full_checkpoint(txn.checkpoint.ok_or(anyhow!("No checkpoint data"))?)
+            .await?;
+        let epoch = checkpoint_data.checkpoint_summary.epoch;
+        let checkpoint_summary = checkpoint_data.checkpoint_summary.clone();
+        let committee = if let Some(end_of_epoch_data) = &checkpoint_summary.end_of_epoch_data {
+            Committee::new(
+                epoch + 1,
+                end_of_epoch_data
+                    .next_epoch_committee
+                    .iter()
+                    .cloned()
+                    .collect(),
+            )
+        } else {
+            let committee_info = sui_client
+                .governance_api()
+                .get_committee_info(Some(BigInt::from(epoch)))
+                .await?;
+            Committee::new(
+                committee_info.epoch,
+                committee_info.validators.into_iter().collect(),
+            )
+        };
+        let verified_checkpoint = VerifiedCheckpoint::new_unchecked(checkpoint_summary);
+        Ok((committee, verified_checkpoint))
+    }
+
+    /// Catch up the local event store using certified event blobs stored on Walrus nodes.
+    ///
+    /// This function performs the following steps:
+    /// 1. Initializes Sui and Walrus clients for network communication.
+    /// 2. Retrieves the last certified event blob from the network.
+    /// 3. Iteratively fetches event blobs backwards from the latest, storing relevant ones locally:
+    ///    - Stops when it reaches a blob containing events earlier than the local store's next
+    ///      checkpoint.
+    ///    - Temporarily stores relevant blobs in a local directory.
+    /// 4. Processes stored blobs in reverse order (oldest to newest):
+    ///    - Extracts events and inserts them into the local event database.
+    ///    - Skips events that are already present in the local store.
+    ///    - Updates checkpoints and committee information.
+    ///    - Maintains initialization state for continuity.
+    ///
+    /// This catch-up mechanism ensures that it never introduces any gaps in stored events (i.e., if
+    /// the last stored event index in local store is `N`, the catch-up will only store events
+    /// starting from `N+1`). If however, the local store is empty, the catch-up will store all
+    /// events from the earliest available event blob (in which case the first stored event index
+    /// could be greater than `0`).
+    pub async fn catchup_using_event_blobs(
+        clients: SuiClientSet,
+        system_objects: SystemConfig,
+        stores: EventProcessorStores,
+        recovery_path: &Path,
+    ) -> Result<()> {
+        tracing::info!("Starting event catchup using event blobs");
+        let next_checkpoint = stores
+            .checkpoint_store
+            .unbounded_iter()
+            .skip_to_last()
+            .next()
+            .map(|(_, checkpoint)| checkpoint.inner().sequence_number + 1);
+
+        if !recovery_path.exists() {
+            fs::create_dir_all(recovery_path)?;
         }
 
-        Ok(event_processor)
+        let blobs = collect_event_blobs_for_catchup(
+            clients.sui_client.clone(),
+            system_objects.system_object_id,
+            system_objects.staking_object_id,
+            Some(system_objects.system_pkg_id),
+            next_checkpoint,
+            recovery_path,
+        )
+        .await?;
+
+        let next_event_index = stores
+            .event_store
+            .unbounded_iter()
+            .skip_to_last()
+            .next()
+            .map(|(i, _)| i + 1);
+
+        Self::process_event_blobs(blobs, &stores, recovery_path, &clients, next_event_index)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn process_event_blobs(
+        blobs: Vec<BlobId>,
+        stores: &EventProcessorStores,
+        recovery_path: &Path,
+        clients: &SuiClientSet,
+        next_event_index: Option<u64>,
+    ) -> Result<()> {
+        let mut num_events_recovered = 0;
+        let mut next_event_index = next_event_index;
+        for blob_id in blobs.iter().rev() {
+            let blob_path = recovery_path.join(blob_id.to_string());
+            let buf = std::fs::read(&blob_path)?;
+            let event_blob = EventBlob::new(&buf)?;
+            let prev_blob_id = event_blob.prev_blob_id();
+            let prev_event_id = event_blob.prev_event_id();
+            let epoch = event_blob.epoch();
+            let last_checkpoint = event_blob.end_checkpoint_sequence_number();
+
+            let (first_event, events) = Self::collect_relevant_events(event_blob, next_event_index);
+
+            if events.is_empty() {
+                // We break (rather than continue) because empty events indicates we've hit our
+                // first "gap" in the sequence, and all future blobs will also have gaps. Here's
+                // why:
+                // We process blobs from oldest to newest (in chronological order)
+                // For each blob, we only collect events that maintain a continuous sequence (no
+                // gaps) with what's already in our database. If our last stored event in the DB has
+                // index N, we only accept events starting at index N+1.
+                // If a blob returns empty events, it means none of its events could maintain this
+                // continuous sequence - there's a gap between our DB's last event and this blob's
+                // first event. Since we're going forward in time, all future blobs will have even
+                // larger gaps so there's no point in processing them.
+                //
+                // For example:
+                // If our DB's last event has index 100
+                // And we find a blob with events [200,201,202], it will return empty events
+                // All future blobs will have indices > 200, making gaps even larger
+                // So we can safely break the loop
+                tracing::info!(
+                    event_blob_id = %blob_id,
+                    next_event_index = ?next_event_index,
+                    "no relevant events found in event blob; breaking the loop"
+                );
+                break;
+            }
+
+            num_events_recovered += events.len();
+
+            let first_event_index = first_event.expect("Event list is not empty").index;
+            let last_event_index = events.last().expect("Event list is not empty").index;
+
+            let mut batch = stores.event_store.batch();
+            batch.insert_batch(
+                &stores.event_store,
+                events
+                    .iter()
+                    .map(|event| (event.index, event.element.clone())),
+            )?;
+
+            let checkpoint_summary = clients
+                .client
+                .get_checkpoint_summary(last_checkpoint)
+                .await?;
+            let verified_checkpoint = VerifiedCheckpoint::new_unchecked(checkpoint_summary.clone());
+            batch.insert_batch(
+                &stores.checkpoint_store,
+                [((), verified_checkpoint.serializable_ref())],
+            )?;
+
+            let next_committee =
+                if let Some(end_of_epoch_data) = &checkpoint_summary.end_of_epoch_data {
+                    Committee::new(
+                        checkpoint_summary.epoch + 1,
+                        end_of_epoch_data
+                            .next_epoch_committee
+                            .iter()
+                            .cloned()
+                            .collect(),
+                    )
+                } else {
+                    let committee_info = clients
+                        .sui_client
+                        .governance_api()
+                        .get_committee_info(Some(BigInt::from(checkpoint_summary.epoch)))
+                        .await?;
+                    Committee::new(
+                        committee_info.epoch,
+                        committee_info.validators.into_iter().collect(),
+                    )
+                };
+
+            batch.insert_batch(
+                &stores.committee_store,
+                std::iter::once(((), next_committee)),
+            )?;
+
+            let state = InitState::new(prev_blob_id, prev_event_id, first_event_index, epoch);
+            batch.insert_batch(
+                &stores.init_state,
+                std::iter::once((first_event_index, state)),
+            )?;
+
+            batch.write()?;
+            fs::remove_file(blob_path)?;
+            next_event_index = Some(last_event_index + 1);
+            tracing::info!(
+                "Processed event blob {:?} with {} events, last event index: {}",
+                blob_id,
+                events.len(),
+                last_event_index
+            );
+        }
+        tracing::info!("Recovered {} events from event blobs", num_events_recovered);
+        Ok(())
+    }
+
+    /// Processes an event blob and returns relevant events that maintain a continuous sequence with
+    /// the local store.
+    ///
+    /// Returns a tuple containing:
+    /// - The first event in the blob (regardless of relevance)
+    /// - A vector of relevant events paired with their indices
+    ///
+    /// Events are considered relevant if they either:
+    /// - Start at the next expected index (when next_event_index is Some)
+    /// - Or all events in the blob (when next_event_index is None)
+    ///
+    /// The function stops collecting events as soon as it encounters a gap in the sequence.
+    fn collect_relevant_events(
+        event_blob: EventBlob,
+        next_event_index: Option<u64>,
+    ) -> (Option<IndexedStreamEvent>, Vec<IndexedStreamEvent>) {
+        let mut iterator = event_blob.peekable();
+        let first_event = iterator.peek().cloned();
+        let relevant_events: Vec<IndexedStreamEvent> = iterator
+            .skip_while(|event| next_event_index.map_or(false, |index| event.index < index))
+            .scan(next_event_index, |state, event| match state {
+                Some(expected_index) if event.index == *expected_index => {
+                    *state = Some(*expected_index + 1);
+                    Some(event)
+                }
+                None => Some(event),
+                _ => None,
+            })
+            .collect();
+        (first_event, relevant_events)
     }
 }
 
 impl LocalDBPackageStore {
     /// Creates a new instance of the local package store.
-    pub fn new(package_store_table: DBMap<ObjectID, Object>, client: Client) -> Self {
+    pub fn new(package_store_table: DBMap<ObjectID, Object>, client: sui_rpc_api::Client) -> Self {
         Self {
             package_store_table,
             fallback_client: client,
@@ -683,6 +1123,7 @@ mod tests {
                     (WALRUS_PACKAGE_STORE, Options::default()),
                     (COMMITTEE_STORE, Options::default()),
                     (EVENT_STORE, Options::default()),
+                    (INIT_STATE, Options::default()),
                 ],
             )?
         };
@@ -724,13 +1165,19 @@ mod tests {
             &ReadWriteOptions::default(),
             false,
         )?;
-        let event_store = DBMap::<u64, IndexedStreamElement>::reopen(
+        let event_store = DBMap::<u64, PositionedStreamEvent>::reopen(
             &database,
             Some(EVENT_STORE),
             &ReadWriteOptions::default(),
             false,
         )?;
-        let client = Client::new("http://localhost:8080")?;
+        let init_state = DBMap::<u64, InitState>::reopen(
+            &database,
+            Some(INIT_STATE),
+            &ReadWriteOptions::default(),
+            false,
+        )?;
+        let client = sui_rpc_api::Client::new("http://localhost:8080")?;
         let package_store = LocalDBPackageStore::new(walrus_package_store.clone(), client.clone());
         let checkpoint_downloader = ParallelCheckpointDownloader::new(
             client.clone(),
@@ -738,12 +1185,16 @@ mod tests {
             AdaptiveDownloaderConfig::default(),
             &Registry::default(),
         )?;
-        Ok(EventProcessor {
-            client,
-            walrus_package_store,
+        let stores = EventProcessorStores {
             checkpoint_store,
+            walrus_package_store,
             committee_store,
             event_store,
+            init_state,
+        };
+        Ok(EventProcessor {
+            client,
+            stores,
             system_pkg_id: ObjectID::random(),
             event_store_commit_index: Arc::new(Mutex::new(0)),
             pruning_interval: Duration::from_secs(10),
@@ -758,10 +1209,10 @@ mod tests {
     fn default_event_for_testing(
         checkpoint_sequence_number: CheckpointSequenceNumber,
         counter: u64,
-    ) -> IndexedStreamElement {
-        IndexedStreamElement::new(
+    ) -> PositionedStreamEvent {
+        PositionedStreamEvent::new(
             BlobCertified::for_testing(BlobId([7; 32])).into(),
-            EventSequenceNumber::new(checkpoint_sequence_number, counter),
+            CheckpointEventPosition::new(checkpoint_sequence_number, counter),
         )
     }
     #[tokio::test]
@@ -772,11 +1223,11 @@ mod tests {
         for i in 0..100 {
             let event = default_event_for_testing(0, i);
             expected_events.push(event.clone());
-            processor.event_store.insert(&i, &event).unwrap();
+            processor.stores.event_store.insert(&i, &event).unwrap();
         }
 
         // poll events from beginning
-        let events = processor.poll(0).await.unwrap();
+        let events = processor.poll(0).unwrap();
         assert_eq!(events.len(), 100);
         // assert events are the same
         for (expected, actual) in expected_events.iter().zip(events.iter()) {
@@ -792,11 +1243,11 @@ mod tests {
         for i in 0..100 {
             let event = default_event_for_testing(0, i);
             expected_events1.push(event.clone());
-            processor.event_store.insert(&i, &event).unwrap();
+            processor.stores.event_store.insert(&i, &event).unwrap();
         }
 
         // poll events
-        let events = processor.poll(0).await.unwrap();
+        let events = processor.poll(0).unwrap();
         assert_eq!(events.len(), 100);
         // assert events are the same
         for (expected, actual) in expected_events1.iter().zip(events.iter()) {
@@ -806,13 +1257,55 @@ mod tests {
         for i in 100..200 {
             let event = default_event_for_testing(0, i);
             expected_events2.push(event.clone());
-            processor.event_store.insert(&i, &event).unwrap();
+            processor.stores.event_store.insert(&i, &event).unwrap();
         }
-        let events = processor.poll(100).await.unwrap();
+        let events = processor.poll(100).unwrap();
         assert_eq!(events.len(), 100);
         // assert events are the same
         for (expected, actual) in expected_events2.iter().zip(events.iter()) {
             assert_eq!(expected, actual);
         }
+    }
+
+    #[test]
+    fn test_collect_relevant_events() {
+        // Helper function to create dummy events
+        fn create_event(index: u64) -> IndexedStreamEvent {
+            IndexedStreamEvent {
+                index,
+                element: PositionedStreamEvent::new_checkpoint_boundary(index, 0),
+            }
+        }
+
+        // Create a mock EventBlob
+        let events = vec![
+            create_event(0),
+            create_event(1),
+            create_event(2),
+            create_event(3),
+            create_event(4),
+        ];
+        let buf = EventBlob::from_events(0, BlobId::ZERO, None, 2, 10, events.iter()).unwrap();
+        let event_blob = EventBlob::new(&buf).unwrap();
+
+        // Test case 1: Collect all events (next_event_index = None)
+        let (_first_event, result) = EventProcessor::collect_relevant_events(event_blob, None);
+        assert_eq!(result.len(), 5);
+        assert_eq!(result[0].index, 0);
+        assert_eq!(result[4].index, 4);
+
+        // Test case 2: Collect events starting from index 2
+        let buf = EventBlob::from_events(0, BlobId::ZERO, None, 2, 10, events.iter()).unwrap();
+        let event_blob = EventBlob::new(&buf).unwrap();
+        let (_first_event, result) = EventProcessor::collect_relevant_events(event_blob, Some(2));
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0].index, 2);
+        assert_eq!(result[2].index, 4);
+
+        // Test case 3: Collect events starting from an index beyond the blob's range
+        let buf = EventBlob::from_events(0, BlobId::ZERO, None, 2, 10, events.iter()).unwrap();
+        let event_blob = EventBlob::new(&buf).unwrap();
+        let (_first_event, result) = EventProcessor::collect_relevant_events(event_blob, Some(10));
+        assert!(result.is_empty());
     }
 }

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -325,6 +325,18 @@ impl Storage {
         Ok(status_list)
     }
 
+    /// Store the verified metadata without updating blob info. This is only
+    /// used during storing metadata for event blobs which are stored without getting registered
+    /// first.
+    #[tracing::instrument(skip_all)]
+    pub fn put_verified_metadata_without_blob_info(
+        &self,
+        metadata: &VerifiedBlobMetadataWithId,
+    ) -> Result<(), TypedStoreError> {
+        self.metadata
+            .insert(metadata.blob_id(), metadata.metadata())
+    }
+
     /// Store the verified metadata.
     #[tracing::instrument(skip_all)]
     pub fn put_verified_metadata(
@@ -372,6 +384,16 @@ impl Storage {
         event: &BlobEvent,
     ) -> Result<(), TypedStoreError> {
         self.blob_info.update_blob_info(event_index, event)
+    }
+
+    /// Repositions the event cursor to the specified event index.
+    pub(crate) fn reposition_event_cursor(
+        &self,
+        event_index: usize,
+        cursor: EventID,
+    ) -> Result<(), TypedStoreError> {
+        self.event_cursor
+            .reposition_event_cursor(cursor, event_index as u64)
     }
 
     /// Advances the event cursor to the most recent, sequential event observed.

--- a/crates/walrus-sui/src/client/retry_client.rs
+++ b/crates/walrus-sui/src/client/retry_client.rs
@@ -13,7 +13,7 @@ use rand::{
 };
 use serde::{de::DeserializeOwned, Serialize};
 use sui_sdk::{
-    apis::EventApi,
+    apis::{EventApi, GovernanceApi},
     error::SuiRpcResult,
     rpc_types::{
         Balance,
@@ -274,6 +274,14 @@ impl RetriableSuiClient {
     /// implemented for this function.
     pub fn event_api(&self) -> &EventApi {
         self.sui_client.event_api()
+    }
+
+    /// Returns a reference to the [`GovernanceApi`].
+    ///
+    /// Internally calls the [`SuiClient::governance_api`] function. Note that no retries are
+    /// implemented for this function.
+    pub fn governance_api(&self) -> &GovernanceApi {
+        self.sui_client.governance_api()
     }
 
     // Other wrapper methods.

--- a/crates/walrus-sui/src/client/transaction_builder.rs
+++ b/crates/walrus-sui/src/client/transaction_builder.rs
@@ -296,6 +296,29 @@ impl WalrusPtbBuilder {
         bitmap
     }
 
+    /// Adds a call to `certify_event_blob` to the `pt_builder`.
+    pub async fn certify_event_blob(
+        &mut self,
+        blob_metadata: BlobObjectMetadata,
+        storage_node_cap: ArgumentOrOwnedObject,
+        ending_checkpoint_seq_num: u64,
+        epoch: u32,
+    ) -> SuiClientResult<()> {
+        let arguments = vec![
+            self.system_arg(Mutability::Mutable).await?,
+            self.argument_from_arg_or_obj(storage_node_cap).await?,
+            self.pt_builder.pure(blob_metadata.blob_id)?,
+            self.pt_builder.pure(blob_metadata.root_hash.bytes())?,
+            self.pt_builder.pure(blob_metadata.unencoded_size)?,
+            self.pt_builder
+                .pure(u8::from(blob_metadata.encoding_type))?,
+            self.pt_builder.pure(ending_checkpoint_seq_num)?,
+            self.pt_builder.pure(epoch)?,
+        ];
+        self.move_call(contracts::system::certify_event_blob, arguments)?;
+        Ok(())
+    }
+
     /// Adds a call to `delete_blob` to the `pt_builder` and returns the result [`Argument`].
     pub async fn delete_blob(
         &mut self,

--- a/crates/walrus-sui/src/contracts.rs
+++ b/crates/walrus-sui/src/contracts.rs
@@ -213,6 +213,7 @@ pub mod system {
     contract_ident!(fn system::certify_blob);
     contract_ident!(fn system::invalidate_blob_id);
     contract_ident!(fn system::delete_blob, 1);
+    contract_ident!(fn system::certify_event_blob);
 }
 
 /// Module for tags corresponding to the Move module `system_state_inner`.

--- a/crates/walrus-utils/src/checkpoint_downloader.rs
+++ b/crates/walrus-utils/src/checkpoint_downloader.rs
@@ -352,7 +352,7 @@ impl ParallelCheckpointDownloaderInner {
         client: &Client,
     ) -> Result<u64> {
         let Ok(Some(current_checkpoint)) = checkpoint_store.get(&()) else {
-            return Err(anyhow!("Failed to fetch current checkpoint"));
+            return Err(anyhow!("Failed to get current checkpoint"));
         };
         let latest_checkpoint = client.get_latest_checkpoint().await?;
         let current_lag =


### PR DESCRIPTION
This PR adds the functionality to start storing event blobs and recovering from event blobs. I deployed it to ptn and blobs are being stored every hour without any issues so far.
<img width="1277" alt="Screenshot 2024-11-08 at 8 43 51 AM" src="https://github.com/user-attachments/assets/9d89daa5-3bc2-4410-9fb5-56df38f088c3">

Closes WAL-190
Contributes to WAL-348