### PR TITLE
test: create a test that reproduce the issue that extending blob doesn't extend blob registration

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -3983,7 +3983,7 @@ mod tests {
             .inner
             .is_blob_certified(blob_details.blob_id())?);
 
-        // TODO: fix that blob registration is not extended when extending blob life time.
+        // TODO: fix that blob registration is not extended when extending blob life time (#1163).
         assert!(!cluster.nodes[0]
             .storage_node
             .inner


### PR DESCRIPTION
Syncing extended certified blob currently is blocked due to that `is_blob_registered` returns false after the original end_epoch is passed, even though the blob is extended.

Related issue: #1163 