### PR TITLE
fix(deps): bump thiserror from 1.0.68 to 2.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ dependencies = [
  "serde_json",
  "socket2 0.5.7",
  "tap",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tokio-util 0.7.12",
  "tower 0.4.13",
@@ -488,7 +488,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror",
+ "thiserror 1.0.68",
  "time",
 ]
 
@@ -1170,7 +1170,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85b6598a2f5d564fb7855dc6b06fd1c38cff5a72bd8b863a4d021938497b440a"
 dependencies = [
  "serde",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -1209,7 +1209,7 @@ dependencies = [
  "byteorder",
  "ff 0.13.0",
  "serde",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -1596,7 +1596,7 @@ dependencies = [
  "instant",
  "lazy_static",
  "once_cell",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
 ]
 
@@ -1920,7 +1920,7 @@ dependencies = [
  "sui-protocol-config",
  "sui-tls",
  "tap",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tokio-rustls 0.26.0",
  "tokio-stream",
@@ -2642,7 +2642,7 @@ checksum = "feadfed35b96a5634e08fc503677ded669549ae2cf7f0b01d5964f09d95487fd"
 dependencies = [
  "documented-macros",
  "phf",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -2744,7 +2744,7 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "sha2 0.9.9",
- "thiserror",
+ "thiserror 1.0.68",
  "zeroize",
 ]
 
@@ -2959,7 +2959,7 @@ dependencies = [
  "sha3 0.10.8",
  "signature 2.2.0",
  "static_assertions",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "typenum",
  "zeroize",
@@ -3009,7 +3009,7 @@ dependencies = [
  "sha3 0.10.8",
  "signature 2.2.0",
  "static_assertions",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "typenum",
  "zeroize",
@@ -4311,7 +4311,7 @@ dependencies = [
  "pin-project",
  "rustls-native-certs 0.6.3",
  "soketto",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tokio-rustls 0.23.4",
  "tokio-util 0.7.12",
@@ -4341,7 +4341,7 @@ dependencies = [
  "serde",
  "serde_json",
  "soketto",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tracing",
 ]
@@ -4359,7 +4359,7 @@ dependencies = [
  "rustc-hash 1.1.0",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tracing",
 ]
@@ -4406,7 +4406,7 @@ dependencies = [
  "beef",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.68",
  "tracing",
 ]
 
@@ -4834,7 +4834,7 @@ dependencies = [
  "rustc_version",
  "smallvec",
  "tagptr",
- "thiserror",
+ "thiserror 1.0.68",
  "triomphe",
  "uuid",
 ]
@@ -5051,7 +5051,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_with",
- "thiserror",
+ "thiserror 1.0.68",
  "uint",
 ]
 
@@ -5666,7 +5666,7 @@ dependencies = [
  "libc",
  "once_cell",
  "parking_lot 0.12.3",
- "thiserror",
+ "thiserror 1.0.68",
  "widestring",
  "winapi",
 ]
@@ -5684,7 +5684,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.68",
  "tracing",
 ]
 
@@ -5760,7 +5760,7 @@ dependencies = [
  "serde",
  "serde_with",
  "sui-protocol-config",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tonic",
  "tonic-build",
@@ -6131,7 +6131,7 @@ dependencies = [
  "js-sys",
  "once_cell",
  "pin-project-lite",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -6147,7 +6147,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tonic",
 ]
@@ -6178,7 +6178,7 @@ dependencies = [
  "js-sys",
  "once_cell",
  "pin-project-lite",
- "thiserror",
+ "thiserror 1.0.68",
  "urlencoding",
 ]
 
@@ -6198,7 +6198,7 @@ dependencies = [
  "percent-encoding",
  "rand 0.8.5",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tokio-stream",
 ]
@@ -6466,7 +6466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 1.0.68",
  "ucd-trie",
 ]
 
@@ -6817,7 +6817,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.68",
  "toml 0.5.11",
 ]
 
@@ -6875,7 +6875,7 @@ dependencies = [
  "memchr",
  "parking_lot 0.12.3",
  "protobuf",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -7046,7 +7046,7 @@ dependencies = [
  "rustc-hash 2.0.0",
  "rustls 0.23.16",
  "socket2 0.5.7",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tracing",
 ]
@@ -7063,7 +7063,7 @@ dependencies = [
  "rustc-hash 2.0.0",
  "rustls 0.23.16",
  "slab",
- "thiserror",
+ "thiserror 1.0.68",
  "tinyvec",
  "tracing",
 ]
@@ -7304,7 +7304,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -7889,7 +7889,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b5b14ebbcc4e4f2b3642fa99c388649da58d1dc3308c7d109f39f565d1710f0"
 dependencies = [
  "serde",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -7900,7 +7900,7 @@ checksum = "f05a5f801ac62a51a49d378fdb3884480041b99aced450b28990673e8ff99895"
 dependencies = [
  "once_cell",
  "serde",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -8760,7 +8760,7 @@ dependencies = [
  "tap",
  "telemetry-subscribers",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tokio-retry",
  "tokio-stream",
@@ -8960,7 +8960,7 @@ dependencies = [
  "tap",
  "telemetry-subscribers",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.12",
@@ -9032,7 +9032,7 @@ dependencies = [
  "sui-transaction-builder",
  "sui-types",
  "tap",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tokio-util 0.7.12",
  "tower 0.4.13",
@@ -9359,7 +9359,7 @@ dependencies = [
  "sui-json-rpc-types",
  "sui-sdk",
  "sui-types",
- "thiserror",
+ "thiserror 1.0.68",
  "tracing",
 ]
 
@@ -9378,7 +9378,7 @@ dependencies = [
  "serde",
  "sui-rest-api",
  "sui-types",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
 ]
 
@@ -9450,7 +9450,7 @@ dependencies = [
  "sui-sdk-types",
  "sui-types",
  "tap",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "url",
 ]
@@ -9483,7 +9483,7 @@ dependencies = [
  "sui-keys",
  "sui-transaction-builder",
  "sui-types",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tracing",
 ]
@@ -9821,7 +9821,7 @@ dependencies = [
  "sui-protocol-config",
  "sui-sdk-types",
  "tap",
- "thiserror",
+ "thiserror 1.0.68",
  "tonic",
  "tracing",
  "typed-store-error",
@@ -10116,7 +10116,16 @@ version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02dd99dc800bbb97186339685293e1cc5d9df1f8fae2d0aecd9ff1c77efea892"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.68",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+dependencies = [
+ "thiserror-impl 2.0.3",
 ]
 
 [[package]]
@@ -10124,6 +10133,17 @@ name = "thiserror-impl"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
+dependencies = [
+ "proc-macro2 1.0.89",
+ "quote 1.0.37",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
@@ -10193,7 +10213,7 @@ dependencies = [
  "rand 0.8.5",
  "rustc-hash 1.1.0",
  "sha2 0.10.8",
- "thiserror",
+ "thiserror 1.0.68",
  "unicode-normalization",
  "wasm-bindgen",
  "zeroize",
@@ -10688,7 +10708,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
 dependencies = [
  "crossbeam-channel",
- "thiserror",
+ "thiserror 1.0.68",
  "time",
  "tracing-subscriber",
 ]
@@ -10828,7 +10848,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "sha1",
- "thiserror",
+ "thiserror 1.0.68",
  "utf-8",
 ]
 
@@ -10865,7 +10885,7 @@ dependencies = [
  "serde",
  "sui-macros",
  "tap",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tracing",
  "typed-store-derive",
@@ -10890,7 +10910,7 @@ version = "0.4.0"
 source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
 dependencies = [
  "serde",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -11232,7 +11252,7 @@ dependencies = [
  "serde",
  "serde_test",
  "serde_with",
- "thiserror",
+ "thiserror 2.0.3",
  "tracing",
  "utoipa",
  "walrus-test-utils",
@@ -11316,7 +11336,7 @@ dependencies = [
  "serde_yaml 0.9.34+deprecated",
  "ssh2",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.3",
  "tokio",
  "walrus-core",
  "walrus-service",
@@ -11352,7 +11372,7 @@ dependencies = [
  "serde",
  "sui-simulator",
  "sui-types",
- "thiserror",
+ "thiserror 2.0.3",
  "tokio",
  "tracing",
  "tracing-opentelemetry",
@@ -11412,7 +11432,7 @@ dependencies = [
  "sui-types",
  "telemetry-subscribers",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.3",
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.12",
@@ -11497,7 +11517,7 @@ dependencies = [
  "sui-types",
  "tempfile",
  "test-cluster",
- "thiserror",
+ "thiserror 2.0.3",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -11977,7 +11997,7 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror",
+ "thiserror 1.0.68",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ syn = "2.0"
 telemetry-subscribers = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.1" }
 tempfile = "3.14.0"
 test-cluster = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.1" }
-thiserror = "1.0.67"
+thiserror = "2.0.3"
 tokio = "=1.38.1"
 tokio-stream = "0.1.16"
 tokio-util = "0.7.12"

--- a/crates/walrus-core/src/encoding/errors.rs
+++ b/crates/walrus-core/src/encoding/errors.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use core::num::NonZeroU16;
-use std;
 
 use thiserror::Error;
 

--- a/crates/walrus-core/src/encoding/mapping.rs
+++ b/crates/walrus-core/src/encoding/mapping.rs
@@ -4,7 +4,6 @@
 //! The mapping between the encoded sliver pairs and shards.
 
 use core::num::NonZeroU16;
-use std;
 
 use thiserror::Error;
 

--- a/crates/walrus-core/src/inconsistency.rs
+++ b/crates/walrus-core/src/inconsistency.rs
@@ -45,7 +45,6 @@
 
 use alloc::vec::Vec;
 use core::marker::PhantomData;
-use std;
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/walrus-core/src/merkle.rs
+++ b/crates/walrus-core/src/merkle.rs
@@ -4,7 +4,6 @@
 //! Merkle tree implementation for Walrus.
 use alloc::{format, vec::Vec};
 use core::{fmt::Debug, marker::PhantomData};
-use std;
 
 use fastcrypto::hash::{Blake2b256, Digest, HashFunction};
 use serde::{Deserialize, Serialize};

--- a/crates/walrus-core/src/metadata.rs
+++ b/crates/walrus-core/src/metadata.rs
@@ -5,7 +5,6 @@
 
 use alloc::vec::Vec;
 use core::num::NonZeroU16;
-use std;
 
 use fastcrypto::hash::{Blake2b256, HashFunction};
 use serde::{Deserialize, Serialize};

--- a/deny.toml
+++ b/deny.toml
@@ -4,17 +4,24 @@
 [advisories]
 version = 2
 ignore = [
-  # We depend on rsa via fastcrypto but don't actually use it.
-  "RUSTSEC-2023-0071",
-  # difference 2.0.0 is unmaintained.
+  # `difference` is unmaintained.
   "RUSTSEC-2020-0095",
-  # rust-yaml is not maintained, but is a dependency in many of our packages.
+  # We depend on `rsa` via `fastcrypto` but don't actually use it.
+  "RUSTSEC-2023-0071",
+  # `rust-yaml` is not maintained, but is a dependency in many of our packages.
   "RUSTSEC-2024-0320",
   # We have a vulnerable version of `rustls` in our dependency tree through the old version of
-  # jsonrpsee used by sui.
+  # `jsonrpsee` used by Sui.
   "RUSTSEC-2024-0336",
-  # proc-macro-error is not maintained, but is a dependency in many of our packages.
+  # `proc-macro-error` is not maintained, but is a dependency in many of our packages.
   "RUSTSEC-2024-0370",
+  # `instance` is unmaintained; consider using `web-time`.
+  "RUSTSEC-2024-0384",
+  # `opentelemetry_api` has been merged into the `opentelemetry` crate; we currently depend on the
+  # old version through Sui.
+  "RUSTSEC-2024-0387",
+  # `derivative` is unmaintained.
+  "RUSTSEC-2024-0388",
 ]
 
 # This section is considered when running `cargo deny check licenses`


### PR DESCRIPTION
With the new version, the proc macros no longer require importing `std`.

Replaces #1160. 