### PR TITLE
test: improve logging in simtest

### DIFF
--- a/crates/walrus-sdk/src/client.rs
+++ b/crates/walrus-sdk/src/client.rs
@@ -799,6 +799,7 @@ impl Client {
     ) -> Result<(Response, Span), NodeError> {
         let url = request.url();
         let span = tracing::info_span!(
+            parent: &Span::current(),
             "http_request",
             otel.name = format!("{} {}", request.method().as_str(), url_template),
             otel.kind = "CLIENT",

--- a/crates/walrus-service/src/common/telemetry.rs
+++ b/crates/walrus-service/src/common/telemetry.rs
@@ -55,6 +55,7 @@ impl MakeHttpSpan {
     fn make_span<B>(&mut self, request: &Request<B>) -> Span {
         let route = self.get_route(request);
         let span = tracing::info_span!(
+            parent: &Span::current(),
             "rest_api",
             // Overrides the exported span name to "{http.request.method} {http.route}"
             "otel.name" = format!("{} {}", request.method(), route),

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -24,7 +24,7 @@ use start_epoch_change_finisher::StartEpochChangeFinisher;
 use sui_types::{digests::TransactionDigest, event::EventID};
 use tokio::{select, sync::watch, time::Instant};
 use tokio_util::sync::CancellationToken;
-use tracing::{field, Instrument};
+use tracing::{field, Instrument, Span};
 use typed_store::{rocks::MetricConf, DBMetrics, TypedStoreError};
 use walrus_core::{
     encoding::{EncodingAxis, EncodingConfig, RecoverySymbolError},
@@ -562,7 +562,7 @@ impl StorageNode {
         while let Some((element_index, stream_element)) = indexed_element_stream.next().await {
             let node_status = self.inner.storage.node_status()?;
             let span = tracing::info_span!(
-                parent: None,
+                parent: &Span::current(),
                 "blob_store receive",
                 "otel.kind" = "CONSUMER",
                 "otel.status_code" = field::Empty,


### PR DESCRIPTION
In simtest, every log entry is supported to be sent from a simulated node. There are a few spans that are newly created without preserving the context, which makes it hard to debug which node is the log.

Before
`2022-01-03T02:08:55.131647Z DEBUG blob_store receive{...}`

After:
`2022-01-03T02:08:55.131647Z DEBUG node{id=6 name="mJ+v6CCuD/ewZHrZEpeQra9B83zbrmUWrnaKP7BEtJ9+o0mtuJH5xgA0wiMlNRSg"}:cluster-node{address=10.10.0.10:1314}:blob_store receive{...}`

So that the node information is preserved.