### PR TITLE
chore: bump sui to 1.37.3

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -30,7 +30,7 @@ env:
   # Don't emit giant backtraces in the CI logs.
   RUST_BACKTRACE: short
   RUSTDOCFLAGS: -D warnings
-  SUI_TAG: testnet-v1.37.1
+  SUI_TAG: testnet-v1.37.3
 
 jobs:
   diff:

--- a/.github/workflows/scheduled_reports.yml
+++ b/.github/workflows/scheduled_reports.yml
@@ -30,7 +30,7 @@ env:
   # Don't emit giant backtraces in the CI logs.
   RUST_BACKTRACE: short
   RUSTDOCFLAGS: -D warnings
-  SUI_TAG: testnet-v1.37.1
+  SUI_TAG: testnet-v1.37.3
 
 jobs:
   test-coverage:

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
       pull-requests: write
     env:
-      SUI_TAG: testnet-v1.37.1
+      SUI_TAG: testnet-v1.37.3
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1234,8 +1234,8 @@ dependencies = [
 
 [[package]]
 name = "bin-version"
-version = "1.37.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+version = "1.37.3"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "const-str",
  "git-version",
@@ -1868,7 +1868,7 @@ dependencies = [
 [[package]]
 name = "consensus-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=2f502fd8570fe4e9cff36eea5bbd6fef22002898)",
  "mysten-network",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "consensus-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -2473,6 +2473,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2 1.0.89",
+ "quote 1.0.37",
+ "syn 2.0.87",
+ "unicode-xid 0.2.6",
+]
+
+[[package]]
 name = "diesel"
 version = "2.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2808,7 +2829,7 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -2932,7 +2953,7 @@ dependencies = [
  "cbc",
  "ctr",
  "curve25519-dalek-ng",
- "derive_more",
+ "derive_more 0.99.18",
  "digest 0.10.7",
  "ecdsa 0.16.9",
  "ed25519-consensus",
@@ -2982,7 +3003,7 @@ dependencies = [
  "blst",
  "bs58 0.4.0",
  "curve25519-dalek-ng",
- "derive_more",
+ "derive_more 0.99.18",
  "digest 0.10.7",
  "ecdsa 0.16.9",
  "ed25519-consensus",
@@ -3083,7 +3104,7 @@ dependencies = [
  "ark-snark",
  "bcs",
  "byte-slice-cast",
- "derive_more",
+ "derive_more 0.99.18",
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=2f502fd8570fe4e9cff36eea5bbd6fef22002898)",
  "ff 0.13.0",
  "im",
@@ -4842,7 +4863,7 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "move-binary-format",
  "move-bytecode-verifier-meter",
@@ -4851,7 +4872,7 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "move-binary-format",
 ]
@@ -4859,12 +4880,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "enum-compat-util",
@@ -4878,12 +4899,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4899,7 +4920,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "indexmap 2.6.0",
@@ -4912,7 +4933,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -4927,7 +4948,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -4937,7 +4958,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
@@ -4952,7 +4973,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
@@ -4967,7 +4988,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
@@ -4982,7 +5003,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5001,7 +5022,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5034,7 +5055,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5058,7 +5079,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5078,7 +5099,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5098,7 +5119,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "codespan",
@@ -5116,7 +5137,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -5134,7 +5155,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "hex",
@@ -5147,7 +5168,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -5160,7 +5181,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "codespan",
@@ -5184,7 +5205,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "clap",
@@ -5218,7 +5239,7 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "enum-compat-util",
  "quote 1.0.37",
@@ -5228,7 +5249,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -5243,7 +5264,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v0"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -5258,7 +5279,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v1"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -5273,7 +5294,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v2"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -5288,7 +5309,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "once_cell",
  "phf",
@@ -5298,7 +5319,7 @@ dependencies = [
 [[package]]
 name = "move-trace-format"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "enum-compat-util",
@@ -5314,7 +5335,7 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "move-binary-format",
  "once_cell",
@@ -5323,7 +5344,7 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "move-vm-config",
  "once_cell",
@@ -5335,7 +5356,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "better_any",
  "fail",
@@ -5355,7 +5376,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "better_any",
  "fail",
@@ -5374,7 +5395,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "better_any",
  "fail",
@@ -5393,7 +5414,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "better_any",
  "fail",
@@ -5412,7 +5433,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5426,7 +5447,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -5540,7 +5561,7 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 [[package]]
 name = "mysten-common"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=2f502fd8570fe4e9cff36eea5bbd6fef22002898)",
@@ -5559,7 +5580,7 @@ dependencies = [
 [[package]]
 name = "mysten-metrics"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "async-trait",
  "axum",
@@ -5580,16 +5601,14 @@ dependencies = [
 [[package]]
 name = "mysten-network"
 version = "0.2.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anemo",
- "async-stream",
  "bcs",
  "bytes",
  "eyre",
  "futures",
  "http 1.1.0",
- "hyper-rustls 0.27.3",
  "hyper-util",
  "multiaddr",
  "once_cell",
@@ -5597,7 +5616,6 @@ dependencies = [
  "serde",
  "snap",
  "tokio",
- "tokio-rustls 0.26.0",
  "tokio-stream",
  "tonic",
  "tonic-health",
@@ -5609,7 +5627,7 @@ dependencies = [
 [[package]]
 name = "mysten-service"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "axum",
@@ -5625,7 +5643,7 @@ dependencies = [
 [[package]]
 name = "mysten-util-mem"
 version = "0.11.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "cfg-if",
  "ed25519-consensus",
@@ -5644,7 +5662,7 @@ dependencies = [
 [[package]]
 name = "mysten-util-mem-derive"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "proc-macro2 1.0.89",
  "syn 1.0.109",
@@ -5674,7 +5692,7 @@ dependencies = [
 [[package]]
 name = "narwhal-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=2f502fd8570fe4e9cff36eea5bbd6fef22002898)",
  "match_opt",
@@ -5691,7 +5709,7 @@ dependencies = [
 [[package]]
 name = "narwhal-crypto"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "bcs",
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=2f502fd8570fe4e9cff36eea5bbd6fef22002898)",
@@ -5702,7 +5720,7 @@ dependencies = [
 [[package]]
 name = "narwhal-network"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -5730,7 +5748,7 @@ dependencies = [
 [[package]]
 name = "narwhal-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -6164,22 +6182,6 @@ dependencies = [
  "prost",
  "serde",
  "tonic",
-]
-
-[[package]]
-name = "opentelemetry_api"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a81f725323db1b1206ca3da8bb19874bbd3f57c3bcd59471bfb04525b265b9b"
-dependencies = [
- "futures-channel",
- "futures-util",
- "indexmap 1.9.3",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror 1.0.69",
- "urlencoding",
 ]
 
 [[package]]
@@ -6881,7 +6883,7 @@ dependencies = [
 [[package]]
 name = "prometheus-closure-metric"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -8135,7 +8137,7 @@ dependencies = [
 [[package]]
 name = "shared-crypto"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "bcs",
  "eyre",
@@ -8216,7 +8218,7 @@ checksum = "16e78919e05c9b8e123d435a4ad104b488ad1585631830e413830985c214086e"
 [[package]]
 name = "simulacrum"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8508,7 +8510,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 [[package]]
 name = "sui-adapter-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8536,7 +8538,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8564,7 +8566,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8591,7 +8593,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8617,8 +8619,8 @@ dependencies = [
 
 [[package]]
 name = "sui-archival"
-version = "1.37.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+version = "1.37.3"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -8643,7 +8645,7 @@ dependencies = [
 [[package]]
 name = "sui-authority-aggregation"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "futures",
  "mysten-metrics",
@@ -8655,7 +8657,7 @@ dependencies = [
 [[package]]
 name = "sui-config"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anemo",
  "anyhow",
@@ -8685,7 +8687,7 @@ dependencies = [
 [[package]]
 name = "sui-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anemo",
  "anyhow",
@@ -8754,7 +8756,6 @@ dependencies = [
  "sui-simulator",
  "sui-storage",
  "sui-swarm-config",
- "sui-tls",
  "sui-transaction-checks",
  "sui-types",
  "tap",
@@ -8773,7 +8774,7 @@ dependencies = [
 [[package]]
 name = "sui-data-ingestion-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8802,7 +8803,7 @@ dependencies = [
 [[package]]
 name = "sui-enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -8810,7 +8811,7 @@ dependencies = [
 [[package]]
 name = "sui-execution"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-interpreter-v2",
@@ -8844,7 +8845,7 @@ dependencies = [
 [[package]]
 name = "sui-framework"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -8857,8 +8858,8 @@ dependencies = [
 
 [[package]]
 name = "sui-framework-snapshot"
-version = "1.37.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+version = "1.37.3"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8873,7 +8874,7 @@ dependencies = [
 [[package]]
 name = "sui-genesis-builder"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8900,8 +8901,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer"
-version = "1.37.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+version = "1.37.3"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8972,7 +8973,7 @@ dependencies = [
 [[package]]
 name = "sui-json"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "bcs",
@@ -8989,7 +8990,7 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -9044,7 +9045,7 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc-api"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=2f502fd8570fe4e9cff36eea5bbd6fef22002898)",
@@ -9064,7 +9065,7 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc-types"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9094,7 +9095,7 @@ dependencies = [
 [[package]]
 name = "sui-keys"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "bip32",
@@ -9113,7 +9114,7 @@ dependencies = [
 [[package]]
 name = "sui-macros"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "futures",
  "once_cell",
@@ -9123,8 +9124,8 @@ dependencies = [
 
 [[package]]
 name = "sui-move-build"
-version = "1.37.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+version = "1.37.3"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=2f502fd8570fe4e9cff36eea5bbd6fef22002898)",
@@ -9148,7 +9149,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "bcs",
  "better_any",
@@ -9171,7 +9172,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "bcs",
  "better_any",
@@ -9192,7 +9193,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "bcs",
  "better_any",
@@ -9213,7 +9214,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "bcs",
  "better_any",
@@ -9234,7 +9235,7 @@ dependencies = [
 [[package]]
 name = "sui-network"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -9271,8 +9272,8 @@ dependencies = [
 
 [[package]]
 name = "sui-node"
-version = "1.37.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+version = "1.37.3"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -9324,8 +9325,8 @@ dependencies = [
 
 [[package]]
 name = "sui-open-rpc"
-version = "1.37.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+version = "1.37.3"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "bcs",
  "schemars",
@@ -9337,7 +9338,7 @@ dependencies = [
 [[package]]
 name = "sui-open-rpc-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -9349,8 +9350,8 @@ dependencies = [
 
 [[package]]
 name = "sui-package-management"
-version = "1.37.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+version = "1.37.3"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -9366,7 +9367,7 @@ dependencies = [
 [[package]]
 name = "sui-package-resolver"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "async-trait",
  "bcs",
@@ -9385,7 +9386,7 @@ dependencies = [
 [[package]]
 name = "sui-proc-macros"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "msim-macros",
  "proc-macro2 1.0.89",
@@ -9397,7 +9398,7 @@ dependencies = [
 [[package]]
 name = "sui-protocol-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "clap",
  "insta",
@@ -9413,7 +9414,7 @@ dependencies = [
 [[package]]
 name = "sui-protocol-config-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "proc-macro2 1.0.89",
  "quote 1.0.37",
@@ -9423,7 +9424,7 @@ dependencies = [
 [[package]]
 name = "sui-rest-api"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9457,8 +9458,8 @@ dependencies = [
 
 [[package]]
 name = "sui-sdk"
-version = "1.37.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+version = "1.37.3"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9511,7 +9512,7 @@ dependencies = [
 [[package]]
 name = "sui-simulator"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -9535,7 +9536,7 @@ dependencies = [
 [[package]]
 name = "sui-snapshot"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9563,7 +9564,7 @@ dependencies = [
 [[package]]
 name = "sui-storage"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9613,7 +9614,7 @@ dependencies = [
 [[package]]
 name = "sui-swarm"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "futures",
@@ -9627,7 +9628,6 @@ dependencies = [
  "sui-protocol-config",
  "sui-simulator",
  "sui-swarm-config",
- "sui-tls",
  "sui-types",
  "tap",
  "telemetry-subscribers",
@@ -9640,7 +9640,7 @@ dependencies = [
 [[package]]
 name = "sui-swarm-config"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anemo",
  "anyhow",
@@ -9668,7 +9668,7 @@ dependencies = [
 [[package]]
 name = "sui-synthetic-ingestion"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "async-trait",
  "simulacrum",
@@ -9681,7 +9681,7 @@ dependencies = [
 [[package]]
 name = "sui-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "reqwest",
  "serde",
@@ -9692,7 +9692,7 @@ dependencies = [
 [[package]]
 name = "sui-test-transaction-builder"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "bcs",
  "move-core-types",
@@ -9706,7 +9706,7 @@ dependencies = [
 [[package]]
 name = "sui-tls"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -9728,7 +9728,7 @@ dependencies = [
 [[package]]
 name = "sui-transaction-builder"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9745,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "sui-transaction-checks"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "fastcrypto-zkp",
  "once_cell",
@@ -9760,7 +9760,7 @@ dependencies = [
 [[package]]
 name = "sui-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anemo",
  "anyhow",
@@ -9771,8 +9771,7 @@ dependencies = [
  "byteorder",
  "chrono",
  "consensus-config",
- "derivative",
- "derive_more",
+ "derive_more 1.0.0",
  "enum_dispatch",
  "eyre",
  "fastcrypto 0.1.8 (git+https://github.com/MystenLabs/fastcrypto?rev=2f502fd8570fe4e9cff36eea5bbd6fef22002898)",
@@ -9830,7 +9829,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -9847,7 +9846,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -9863,7 +9862,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -9878,7 +9877,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -10001,7 +10000,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "telemetry-subscribers"
 version = "0.2.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -10013,7 +10012,6 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-proto",
- "opentelemetry_api",
  "opentelemetry_sdk",
  "prometheus",
  "prost",
@@ -10077,7 +10075,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 [[package]]
 name = "test-cluster"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "anyhow",
  "bcs",
@@ -10866,7 +10864,7 @@ dependencies = [
 [[package]]
 name = "typed-store"
 version = "0.4.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "async-trait",
  "bcs",
@@ -10896,7 +10894,7 @@ dependencies = [
 [[package]]
 name = "typed-store-derive"
 version = "0.3.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2 1.0.89",
@@ -10907,7 +10905,7 @@ dependencies = [
 [[package]]
 name = "typed-store-error"
 version = "0.4.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "serde",
  "thiserror 1.0.69",
@@ -10916,7 +10914,7 @@ dependencies = [
 [[package]]
 name = "typed-store-workspace-hack"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.1#7839b9501066108cb2322ba9039120a41781a1b0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.37.3#b8eb8920aeca592d0cf15fbddc7f64ed4aad7202"
 dependencies = [
  "cc",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ integer-encoding = "4.0.2"
 itertools = "0.13.0"
 mime = "0.3.17"
 mockall = "0.12.1"
-move-core-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.1" }
-mysten-metrics = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.1" }
+move-core-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.3" }
+mysten-metrics = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.3" }
 num-bigint = { version = "0.4.5", default-features = false }
 opentelemetry = { version = "=0.25.0", default-features = false, features = ["trace"] }
 p256 = "0.13.2"
@@ -56,22 +56,22 @@ serde_json = "1.0.132"
 serde_test = "1.0.177"
 serde_with = { version = "3.11", features = ["base64"] }
 serde_yaml = "0.9"
-sui-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.1" }
-sui-json-rpc-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.1" }
-sui-keys = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.1" }
-sui-macros = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.1" }
-sui-move-build = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.1" }
-sui-package-resolver = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.1" }
-sui-protocol-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.1" }
-sui-rest-api = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.1" }
-sui-sdk = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.1" }
-sui-simulator = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.1" }
-sui-storage = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.1" }
-sui-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.1" }
+sui-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.3" }
+sui-json-rpc-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.3" }
+sui-keys = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.3" }
+sui-macros = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.3" }
+sui-move-build = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.3" }
+sui-package-resolver = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.3" }
+sui-protocol-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.3" }
+sui-rest-api = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.3" }
+sui-sdk = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.3" }
+sui-simulator = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.3" }
+sui-storage = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.3" }
+sui-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.3" }
 syn = "2.0"
-telemetry-subscribers = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.1" }
+telemetry-subscribers = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.3" }
 tempfile = "3.14.0"
-test-cluster = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.1" }
+test-cluster = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.3" }
 thiserror = "2.0.3"
 tokio = "=1.38.1"
 tokio-stream = "0.1.16"
@@ -81,7 +81,7 @@ tower-http = { version = "0.5.2", features = ["trace"] }
 tracing = "0.1.40"
 tracing-opentelemetry = { version = "0.26", default-features = false }
 tracing-subscriber = { version = "0.3.18", default-features = false }
-typed-store = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.1" }
+typed-store = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.37.3" }
 url = "2.5.2"
 utoipa = { version = "4.2.3" }
 utoipa-redoc = { version = "4.0.0", features = ["axum"] }

--- a/contracts/wal/Move.lock
+++ b/contracts/wal/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "444A445EC9CBD8DA26D5F0DE87B2BCD95F2C0FE4F58A6E3465658E7F777698C5"
+manifest_digest = "54853461F55CB3DA4177F438A5E8DB412AEA71DD53B4A954B4952746D6D7BFF6"
 deps_digest = "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -10,17 +10,17 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.37.1", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.37.3", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.37.1", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.37.3", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
 ]
 
 [move.toolchain-version]
-compiler-version = "1.37.1"
+compiler-version = "1.37.3"
 edition = "2024.beta"
 flavor = "sui"

--- a/contracts/wal/Move.toml
+++ b/contracts/wal/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.37.1" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.37.3" }
 
 # For remote import, use the `{ git = "...", subdir = "...", rev = "..." }`.
 # Revision can be a branch, a tag, and a commit hash.

--- a/contracts/wal_exchange/Move.lock
+++ b/contracts/wal_exchange/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "F34BDFC5425559EB00A2E5459EFB3E2FDC910AA59AB2941D6655FC2C90A0A93D"
+manifest_digest = "79DC1C0394F74C978D5E9AD62463475129999120EFDC5CDA66E9A19B8C913DA4"
 deps_digest = "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -11,11 +11,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.37.1", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.37.3", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.37.1", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.37.3", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -30,6 +30,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.37.1"
+compiler-version = "1.37.3"
 edition = "2024.beta"
 flavor = "sui"

--- a/contracts/wal_exchange/Move.toml
+++ b/contracts/wal_exchange/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.37.1" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.37.3" }
 WAL = { local = "../wal" }
 
 # For remote import, use the `{ git = "...", subdir = "...", rev = "..." }`.

--- a/contracts/walrus/Move.lock
+++ b/contracts/walrus/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "422E54244C5582DFA5A6590B5CFDB97609B2ADF5863B6E2BB043800EFF09FB8C"
+manifest_digest = "242029C730FAEA77E0C9FE45D5863AFA346E200D1210ABBB3D73750FC3368A24"
 deps_digest = "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -12,11 +12,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.37.1", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.37.3", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.37.1", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.37.3", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -40,6 +40,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.37.1"
+compiler-version = "1.37.3"
 edition = "2024.beta"
 flavor = "sui"

--- a/contracts/walrus/Move.toml
+++ b/contracts/walrus/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.37.1" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.37.3" }
 WAL = { local = "../wal" }
 # TODO: Remove this after we publish contracts separately (#909).
 WAL_exchange = { local = "../wal_exchange" }


### PR DESCRIPTION
simtest `test_repeated_node_crash` is consistently failing, and the sympton is that epoch sync done transactions all submitted by storage nodes, but `EpochChangeDone` event is never emitted. I was betting this is related to the recent fullnode bug in 1.37. But it's not...

I think I have an idea why the test is failing now (testing it at the moment), but since I already have the version updated, might as well just send it.