### PR TITLE
fix(test): Use legacy event processor by default in tests

### DIFF
--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -527,7 +527,7 @@ async fn test_repeated_shard_move() -> TestResult {
         test_cluster::default_setup_with_epoch_duration_generic::<StorageNodeHandle>(
             Duration::from_secs(20),
             &[1, 1],
-            false,
+            true,
         )
         .await?;
 

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -1772,7 +1772,7 @@ pub mod test_cluster {
         default_setup_with_epoch_duration_generic::<StorageNodeHandle>(
             epoch_duration,
             &node_weights,
-            false,
+            true,
         )
         .await
     }

--- a/crates/walrus-simtest/tests/simtest.rs
+++ b/crates/walrus-simtest/tests/simtest.rs
@@ -94,7 +94,7 @@ mod tests {
             test_cluster::default_setup_with_epoch_duration_generic::<SimStorageNodeHandle>(
                 Duration::from_secs(60 * 60),
                 &[1, 2, 3, 3, 4],
-                false,
+                true,
             )
             .await
             .unwrap();
@@ -119,7 +119,7 @@ mod tests {
             test_cluster::default_setup_with_epoch_duration_generic::<SimStorageNodeHandle>(
                 Duration::from_secs(60 * 60),
                 &[1, 2, 3, 3, 4],
-                false,
+                true,
             )
             .await
             .unwrap();
@@ -269,7 +269,7 @@ mod tests {
             test_cluster::default_setup_with_epoch_duration_generic::<SimStorageNodeHandle>(
                 Duration::from_secs(30),
                 &[1, 2, 3, 3, 4],
-                false,
+                true,
             )
             .await
             .unwrap();
@@ -431,7 +431,7 @@ mod tests {
             test_cluster::default_setup_with_epoch_duration_generic::<SimStorageNodeHandle>(
                 Duration::from_secs(10),
                 &[1, 2, 3, 3, 4],
-                false,
+                true,
             )
             .await
             .unwrap();


### PR DESCRIPTION
Default to using legacy event processor as checkpoint based processor is sometimes slower causing tests to timeout.