### PR TITLE
fix: fix repeated_node_crash flakiness; make simtest deterministic when using different log level

### DIFF
--- a/crates/walrus-simtest/tests/simtest.rs
+++ b/crates/walrus-simtest/tests/simtest.rs
@@ -525,7 +525,7 @@ mod tests {
             );
             if last_persist_event_index == node_health_info[0].event_progress.persisted {
                 // We expect that there shouldn't be any stuck event progress.
-                assert!(last_persisted_event_time.elapsed() < Duration::from_secs(10));
+                assert!(last_persisted_event_time.elapsed() < Duration::from_secs(15));
             } else {
                 last_persist_event_index = node_health_info[0].event_progress.persisted;
                 last_persisted_event_time = Instant::now();

--- a/crates/walrus-sui/src/test_utils/system_setup.rs
+++ b/crates/walrus-sui/src/test_utils/system_setup.rs
@@ -247,17 +247,16 @@ pub async fn end_epoch_zero(contract_client: &SuiContractClient) -> Result<()> {
     // call vote end
     contract_client.voting_end().await?;
 
-    tracing::info!(
-        "Epoch state after voting end: {:?}",
-        contract_client.current_committee().await?
-    );
+    let voting_end_epoch_state = contract_client.current_committee().await?;
+    tracing::info!("Epoch state after voting end: {:?}", voting_end_epoch_state);
 
     // call epoch change
     contract_client.initiate_epoch_change().await?;
 
+    let initiate_epoch_state = contract_client.current_committee().await?;
     tracing::info!(
         "Epoch state after initiating epoch change: {:?}",
-        contract_client.current_committee().await?
+        initiate_epoch_state
     );
 
     Ok(())


### PR DESCRIPTION
In `repeated_node_crash` test, we check event handling liveness by checking that the event cursor must move within 10 seconds. However, given that the epoch length is 10 seconds, after EpochParameterSelected event, there will be 5 seconds idle time, and also we observed that sending `epoch_sync_done` message can take more than 5 seconds:

```
2022-11-18T21:58:24.616866Z  INFO node{id=6 name="qcmK6lnJwF10GVISqyJmLje/QoflasJsC2ZbigZ83PpPAKDqlpmL0s4asgvK3aTY"}: walrus_service::node::start_epoch_change_finisher: crates/walrus-service/src/node/start_epoch_change_finisher.rs:69: sending epoch sync done
2022-11-18T21:58:30.295905Z  INFO node{id=6 name="qcmK6lnJwF10GVISqyJmLje/QoflasJsC2ZbigZ83PpPAKDqlpmL0s4asgvK3aTY"}: walrus_service::node::start_epoch_change_finisher: crates/walrus-service/src/node/start_epoch_change_finisher.rs:73: epoch sync done complete
```

Therefore, the 10 seconds timeout is a bit too short (currently I'm seeing 10% test failure due to this error). Increasing it to 15 seconds and 100/100 seeds passed.

This PR also fixes that RUST_LOG=warn and RUST_LOG=info produce different execution result, by moving async function out of the logging function.

Contribute to #1172 
