### PR TITLE
feat(staking): no more `New` state of the pool

### DIFF
--- a/crates/walrus-sui/src/types/move_structs.rs
+++ b/crates/walrus-sui/src/types/move_structs.rs
@@ -156,6 +156,7 @@ impl Display for StorageNodeCap {
 
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize)]
 enum PoolState {
+    #[cfg(not(feature = "mainnet-contracts"))]
     // The pool is new and awaits the stake to be added.
     New,
     // The pool is active and can accept stakes.


### PR DESCRIPTION
replace: #1191 to avoid rebase conflicts