### PR TITLE
fix: Initialize rocksdb metrics in walrus

### DIFF
--- a/crates/walrus-service/src/common/utils.rs
+++ b/crates/walrus-service/src/common/utils.rs
@@ -50,6 +50,7 @@ use tracing_subscriber::{
     EnvFilter,
     Layer,
 };
+use typed_store::DBMetrics;
 use uuid::Uuid;
 use walrus_core::{PublicKey, ShardIndex};
 use walrus_sui::utils::SuiNetwork;
@@ -286,6 +287,9 @@ impl MetricsAndLoggingRuntime {
             .with_prom_registry(&walrus_registry)
             .with_json()
             .init();
+
+        // Initialize metrics to track db usage before we create any db instances.
+        DBMetrics::init(&walrus_registry);
 
         Ok(Self {
             runtime,

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -25,7 +25,7 @@ use sui_types::{digests::TransactionDigest, event::EventID};
 use tokio::{select, sync::watch, time::Instant};
 use tokio_util::sync::CancellationToken;
 use tracing::{field, Instrument, Span};
-use typed_store::{rocks::MetricConf, DBMetrics, TypedStoreError};
+use typed_store::{rocks::MetricConf, TypedStoreError};
 use walrus_core::{
     encoding::{EncodingAxis, EncodingConfig, RecoverySymbolError},
     ensure,
@@ -286,8 +286,6 @@ impl StorageNodeBuilder {
         config: &StorageNodeConfig,
         metrics_registry: Registry,
     ) -> Result<StorageNode, anyhow::Error> {
-        DBMetrics::init(&metrics_registry);
-
         let protocol_key_pair = config
             .protocol_key_pair
             .get()


### PR DESCRIPTION
The db metrics needs to be initialized before we create any DBMap or else it gets default initialized (which wouldn't push metrics out of the metrics endpoint as it is the case today). With this PR, we can start seeing rocksdb related metrics in Walrus.