### PR TITLE
fix: deflake test_lagging_node_recovery test

### DIFF
--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -17,6 +17,7 @@ use walrus_sdk::api::BlobStatus;
 use walrus_service::{
     client::{
         responses::BlobStoreResult,
+        ClientCommunicationConfig,
         ClientError,
         ClientErrorKind::{
             self,
@@ -528,6 +529,7 @@ async fn test_repeated_shard_move() -> TestResult {
             Duration::from_secs(20),
             &[1, 1],
             true,
+            ClientCommunicationConfig::default_for_test(),
         )
         .await?;
 

--- a/crates/walrus-service/src/client/communication/node.rs
+++ b/crates/walrus-service/src/client/communication/node.rs
@@ -300,19 +300,22 @@ impl<'a> NodeWriteCommunication<'a> {
                 .store_metadata_with_retries(metadata)
                 .await
                 .map_err(StoreError::Metadata)?;
-            tracing::debug!(?metadata_status, "finished storing metadata on node");
+            tracing::debug!(node = %self.node.public_key, ?metadata_status,
+                "finished storing metadata on node");
 
             let n_stored_slivers = self
                 .store_pairs(metadata.blob_id(), &metadata_status, pairs)
                 .await?;
-            tracing::debug!(n_stored_slivers, "finished storing slivers on node");
+            tracing::debug!(node = %self.node.public_key, n_stored_slivers,
+                "finished storing slivers on node");
 
             self.get_confirmation_with_retries_inner(metadata.blob_id(), self.committee_epoch)
                 .await
                 .map_err(StoreError::Confirmation)
         }
         .await;
-        tracing::debug!("successfully stored metadata and sliver pairs");
+        tracing::debug!(node = %self.node.public_key, ?result,
+            "storing metadata and sliver pairs finished");
         self.to_node_result_with_n_shards(result)
     }
 

--- a/crates/walrus-service/src/client/config.rs
+++ b/crates/walrus-service/src/client/config.rs
@@ -123,7 +123,7 @@ impl ClientCommunicationConfig {
     #[cfg(any(test, feature = "test-utils"))]
     pub fn default_for_test() -> Self {
         #[cfg(msim)]
-        let max_retries = Some(5);
+        let max_retries = Some(3);
         #[cfg(not(msim))]
         let max_retries = Some(1);
         ClientCommunicationConfig {
@@ -137,6 +137,15 @@ impl ClientCommunicationConfig {
             },
             ..Default::default()
         }
+    }
+
+    /// Provides a config with lower number of retries and a custom timeout to speed up integration
+    /// testing.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn default_for_test_with_reqwest_timeout(timeout: Duration) -> Self {
+        let mut config = Self::default_for_test();
+        config.reqwest_config.total_timeout = timeout;
+        config
     }
 }
 

--- a/crates/walrus-service/src/node/blob_sync.rs
+++ b/crates/walrus-service/src/node/blob_sync.rs
@@ -187,7 +187,7 @@ impl BlobSyncHandler {
         match in_progress.entry(blob_id) {
             Entry::Vacant(entry) => {
                 let spawned_trace = info_span!(
-                    parent: None,
+                    parent: &Span::current(),
                     "blob_sync",
                     "otel.kind" = "CONSUMER",
                     "otel.status_code" = field::Empty,

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -1772,6 +1772,7 @@ pub mod test_cluster {
             epoch_duration,
             &node_weights,
             true,
+            ClientCommunicationConfig::default_for_test(),
         )
         .await
     }
@@ -1782,6 +1783,7 @@ pub mod test_cluster {
         epoch_duration: Duration,
         node_weights: &[u16],
         use_legacy_event_processor: bool,
+        communication_config: ClientCommunicationConfig,
     ) -> anyhow::Result<(
         Arc<TestClusterHandle>,
         TestCluster<T>,
@@ -1930,7 +1932,7 @@ pub mod test_cluster {
             staking_object: system_ctx.staking_object,
             exchange_object: None,
             wallet_config: None,
-            communication_config: ClientCommunicationConfig::default_for_test(),
+            communication_config,
         };
 
         let client = sui_contract_client

--- a/crates/walrus-simtest/tests/simtest.rs
+++ b/crates/walrus-simtest/tests/simtest.rs
@@ -19,7 +19,7 @@ mod tests {
     use walrus_proc_macros::walrus_simtest;
     use walrus_sdk::api::{ServiceHealthInfo, ShardStatus};
     use walrus_service::{
-        client::{responses::BlobStoreResult, Client, StoreWhen},
+        client::{responses::BlobStoreResult, Client, ClientCommunicationConfig, StoreWhen},
         test_utils::{test_cluster, SimStorageNodeHandle},
     };
     use walrus_sui::client::{BlobPersistence, SuiContractClient};
@@ -129,6 +129,7 @@ mod tests {
                 Duration::from_secs(60 * 60),
                 &[1, 2, 3, 3, 4],
                 true,
+                ClientCommunicationConfig::default_for_test(),
             )
             .await
             .unwrap();
@@ -154,6 +155,7 @@ mod tests {
                 Duration::from_secs(60 * 60),
                 &[1, 2, 3, 3, 4],
                 true,
+                ClientCommunicationConfig::default_for_test(),
             )
             .await
             .unwrap();
@@ -294,6 +296,9 @@ mod tests {
                 Duration::from_secs(30),
                 &[1, 2, 3, 3, 4],
                 true,
+                ClientCommunicationConfig::default_for_test_with_reqwest_timeout(
+                    Duration::from_secs(2),
+                ),
             )
             .await
             .unwrap();
@@ -431,6 +436,9 @@ mod tests {
                 Duration::from_secs(10),
                 &[1, 2, 3, 3, 4],
                 true,
+                ClientCommunicationConfig::default_for_test_with_reqwest_timeout(
+                    Duration::from_secs(1),
+                ),
             )
             .await
             .unwrap();
@@ -545,6 +553,9 @@ mod tests {
                 Duration::from_secs(60),
                 &[1, 2, 3, 3, 4],
                 true,
+                ClientCommunicationConfig::default_for_test_with_reqwest_timeout(
+                    Duration::from_secs(5),
+                ),
             )
             .await
             .unwrap();


### PR DESCRIPTION
The main reason for the test failure that happens pretty often is due to that after the node crashes, it takes more than 30 seconds (reqwest timeout) for the client to get an error from the crashed node. However, 30 seconds is also the epoch length in the simtest, so by the time it retries the request, another epoch passed, so we have two consecutive upload blob fails, which caused the test to fail.

Although the ultimate fix would be to address #1218 , this PR deflake the test by reducing reqwest timeout in simtest, so that it can return error early without waiting for 30 seconds.

100 seeds passed.

Contributes to #1172 