### PR TITLE
feat(staking): temporarily disable withdrawing functionality

### DIFF
--- a/contracts/walrus/sources/staking.move
+++ b/contracts/walrus/sources/staking.move
@@ -90,13 +90,14 @@ public fun register_candidate(
     cap
 }
 
+#[allow(unused_function)]
 /// Blocks staking for the nodes staking pool
 /// Marks node as "withdrawing",
 /// - excludes it from the next committee selection
 /// - still has to remain active while it is part of the committee and until all shards have
 ///     been transferred to its successor
 /// - The staking pool is deleted once the last funds have been withdrawn from it by its stakers
-public fun withdraw_node(staking: &mut Staking, cap: &mut StorageNodeCap) {
+fun withdraw_node(staking: &mut Staking, cap: &mut StorageNodeCap) {
     staking.inner_mut().set_withdrawing(cap.node_id());
     staking.inner_mut().withdraw_node(cap);
 }


### PR DESCRIPTION
## Description

Removes public visibility on the `withdraw_node` function. Leaves the rest as is.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:

