### PR TITLE
chore: various minor fixes for the linter setup

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,4 +18,3 @@ a user might notice and any actions they must take to implement updates. (Add re
 - [ ] Aggregator:
 - [ ] Publisher:
 - [ ] CLI:
-

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Check formatting of all YAML files
         run: ./yamlfmt -lint
 
-  move_formatting:
+  move-formatting:
     name: Check Move formatting
     runs-on: ubuntu-latest
     defaults:
@@ -87,6 +87,7 @@ jobs:
     needs:
       - pr-title
       - formatting
+      - move-formatting
       - typos
       - license-headers
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,7 +89,9 @@ repos:
         pass_filenames: false
       - id: move-format
         name: move-format
-        entry: prettier-move -w contracts/*/sources/**/*.move
+        entry: prettier-move -w
         language: node
-        files: "contracts/.*"
-        additional_dependencies: ["prettier@3.4.1", "@mysten/prettier-plugin-move@0.2.1"]
+        additional_dependencies:
+          - "prettier@3.4.1"
+          - "@mysten/prettier-plugin-move@0.2.1"
+        files: "^contracts/.*\\.move"

--- a/.yamlfmt.yml
+++ b/.yamlfmt.yml
@@ -5,3 +5,4 @@ formatter:
   retain_line_breaks_single: true
   scan_folded_as_literal: true
   max_line_length: 120
+  drop_merge_tag: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,9 @@ You can also use a custom pre-commit configuration if you wish:
 1. Create a file `.custom-pre-commit-config.yaml` (this is set to be ignored by Git).
 1. Run `pre-commit install -c .custom-pre-commit-config.yaml`.
 
-## Code formatting
+## Formatting
+
+### Rust code formatting
 
 We use a few unstable formatting options of Rustfmt. Unfortunately, these can only be used with a
 stable toolchain when specified via the `--config` command-line option. This is done in
@@ -62,17 +64,18 @@ Also make sure you use the correct version of Rustfmt. See
 [rust-toolchain.toml](rust-toolchain.toml) for the current version. This also impacts other checks,
 for example Clippy.
 
-## Move code formatting
+### Move code formatting
 
-We use the `@mysten/prettier-plugin-move` npm package to format Move code.
-If you're using VSCode, you can install the [Move Formatter](https://marketplace.visualstudio.com/items?itemName=mysten.prettier-move) extension.
-The formatter is also run automatically in the [pre-commit hooks](#pre-commit-hooks).
+We use the `@mysten/prettier-plugin-move` npm package to format Move code. If you're using VSCode,
+you can install the [Move Formatter](https://marketplace.visualstudio.com/items?itemName=mysten.prettier-move)
+extension. The formatter is also run automatically in the [pre-commit hooks](#pre-commit-hooks).
 
 To use it as a stand-alone tool, we recommend installing it globally (requires NodeJS and npm):
 
 ```sh
-npm i -g @mysten/prettier-plugin-move
+npm i -g prettier @mysten/prettier-plugin-move
 ```
+
 The Move formatter can then be run manually by executing:
 
 ```sh

--- a/contracts/wal/Move.lock
+++ b/contracts/wal/Move.lock
@@ -21,6 +21,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.38.2"
+compiler-version = "1.38.3"
 edition = "2024.beta"
 flavor = "sui"

--- a/contracts/wal_exchange/Move.lock
+++ b/contracts/wal_exchange/Move.lock
@@ -30,6 +30,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.38.2"
+compiler-version = "1.38.3"
 edition = "2024.beta"
 flavor = "sui"

--- a/contracts/walrus/Move.lock
+++ b/contracts/walrus/Move.lock
@@ -40,6 +40,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.38.2"
+compiler-version = "1.38.3"
 edition = "2024.beta"
 flavor = "sui"

--- a/crates/walrus-proxy/src/fixtures/config.yaml
+++ b/crates/walrus-proxy/src/fixtures/config.yaml
@@ -1,4 +1,3 @@
----
 network: joenet
 listen-address: 127.0.0.1:8080
 remote-write:

--- a/docker/local-testbed/docker-compose.yaml
+++ b/docker/local-testbed/docker-compose.yaml
@@ -99,4 +99,4 @@ networks:
     driver: bridge
     ipam:
       config:
-      - subnet: 10.0.0.0/24
+        - subnet: 10.0.0.0/24

--- a/scripts/move_coverage.sh
+++ b/scripts/move_coverage.sh
@@ -42,7 +42,7 @@ if [ $error -ne 0 ]; then
     exit $error
 fi
 
-if ! [ $COVERAGE ]; then
+if ! $COVERAGE; then
     exit 0
 fi
 


### PR DESCRIPTION
## Description

- make the move-formatting pre-commit hook consistent with the CI job
- fix the yamlfmt config
- include the move-formatting CI job in the list of required jobs
- fix an if condition in the `move_coverage.sh` script
- run all linters/formatters with `pre-commit run --all-files`
- minor changes to the CONTRIBUTING.md file

## Test plan

Run the pre-commit tool and check CI output.
