### PR TITLE
fix: secondary sliver column family should be created last

### DIFF
--- a/crates/walrus-simtest/tests/simtest.rs
+++ b/crates/walrus-simtest/tests/simtest.rs
@@ -33,6 +33,7 @@ mod tests {
         "put-cf-after",
         "delete-cf-before",
         "delete-cf-after",
+        "create-cf-before",
     ];
 
     fn latency_config() -> sui_simulator::SimConfig {


### PR DESCRIPTION
## Description

The issue was found in simtest that when a node crashes in the middle of shard storage initialization, restarting only checks if secondary sliver column family exists or not. After adding status/shard_sync/recovery column families in the shard, this is no longer correct.

To make the change simple, I just move secondary shard creation to the last.

Also rename `ShardStorage::existing_shards` to `ShardStorage::existing_cf_shard_ids` to differentiate from `Storage::existing_shards`

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
