### PR TITLE
fix: improve output for `burn-blobs` command when there are none

### DIFF
--- a/crates/walrus-service/src/client/cli/args.rs
+++ b/crates/walrus-service/src/client/cli/args.rs
@@ -679,6 +679,10 @@ impl BurnSelection {
             )),
         }
     }
+
+    pub(super) fn is_all_expired(&self) -> bool {
+        self.all_expired
+    }
 }
 
 pub(crate) mod default {

--- a/crates/walrus-service/src/client/cli/runner.rs
+++ b/crates/walrus-service/src/client/cli/runner.rs
@@ -655,6 +655,18 @@ impl ClientCommandRunner {
             .await?;
         let object_ids = burn_selection.get_object_ids(&sui_client).await?;
 
+        if object_ids.is_empty() {
+            println!(
+                "The wallet does not own any {}blob objects.",
+                if burn_selection.is_all_expired() {
+                    "expired "
+                } else {
+                    ""
+                }
+            );
+            return Ok(());
+        }
+
         if confirmation.is_required() {
             let object_list = object_ids.iter().map(|id| id.to_string()).join("\n");
             println!(


### PR DESCRIPTION
## Description

Before:

<img width="519" alt="image" src="https://github.com/user-attachments/assets/71677dba-8e6e-4ba4-94fe-3ee006351f0d">

After:

<img width="425" alt="image" src="https://github.com/user-attachments/assets/3fde358e-7e72-4b08-94b8-a106254b1370">


## Test plan

Run `walrus burn_blobs --all-expired` manually.