### PR TITLE
fix: add error type

### DIFF
--- a/crates/walrus-sui/build.rs
+++ b/crates/walrus-sui/build.rs
@@ -197,7 +197,7 @@ fn generate_move_error_from_impl(module_error_defs: &[ModuleErrorDefs]) -> Strin
     code.push_str("            _ => Ok(Self::OtherMoveModule(error)),\n");
 
     code.push_str("        }\n");
-    code.push_str("        .unwrap_or_else(|e| Self::OtherMoveModule(e.0))\n");
+    code.push_str("        .unwrap_or_else(|e: ConversionError| Self::OtherMoveModule(e.0))\n");
     code.push_str("    }\n");
     code.push_str("}\n\n");
 


### PR DESCRIPTION
## Description

Add error type for walrus-sui crate, otherwise `cargo build` is failing within the Docker build.

## Test plan

```
docker build -f docker/walrus-service/Dockerfile . --target walrus-deploy
```