### PR TITLE
chore: add features required in binaries to default features

### DIFF
--- a/crates/walrus-service/Cargo.toml
+++ b/crates/walrus-service/Cargo.toml
@@ -27,6 +27,7 @@ client = [
   "dep:indoc",
   "dep:prettytable",
 ]
+default = ["client", "deploy", "node"]
 deploy = ["client", "node", "walrus-sui/test-utils"]
 mainnet-contracts = ["walrus-sui/mainnet-contracts"]
 node = [

--- a/docker/walrus-service/Dockerfile
+++ b/docker/walrus-service/Dockerfile
@@ -13,7 +13,6 @@ COPY Cargo.toml Cargo.lock ./
 COPY crates crates
 
 RUN cargo build --profile $PROFILE \
-    --features deploy\
     --bin walrus \
     --bin walrus-node \
     --bin walrus-deploy


### PR DESCRIPTION
## Description

This adds the `client`, `deploy`, and `node` features to the default features in the `walrus-service` crate. This makes sure that all binaries can be compiled without having to explicitly enable any features.

## Test plan

Tested building binaries manually, otherwise covered by CI tests.