### PR TITLE
fix(contracts): source_symbols_primary/secondary fn match Rust code

### DIFF
--- a/contracts/walrus/sources/system/redstuff.move
+++ b/contracts/walrus/sources/system/redstuff.move
@@ -25,12 +25,12 @@ public(package) fun encoded_blob_length(unencoded_length: u64, n_shards: u16): u
 
 /// The number of primary source symbols per sliver given `n_shards`.
 fun source_symbols_primary(n_shards: u16): u16 {
-    n_shards - max_byzantine(n_shards) - decoding_safety_limit(n_shards)
+    n_shards - 2 * max_byzantine(n_shards) - decoding_safety_limit(n_shards)
 }
 
 /// The number of secondary source symbols per sliver given `n_shards`.
 fun source_symbols_secondary(n_shards: u16): u16 {
-    n_shards - 2 * max_byzantine(n_shards) - decoding_safety_limit(n_shards)
+    n_shards - max_byzantine(n_shards) - decoding_safety_limit(n_shards)
 }
 
 /// The total number of source symbols given `n_shards`.
@@ -101,4 +101,21 @@ fun test_symbol_too_large() {
     let unencoded_length = (0xffff + 1) * n_source_symbols(n_shards);
     // Test should fail here
     let _ = symbol_size(unencoded_length, n_shards);
+}
+
+#[test_only]
+fun assert_primary_secondary_source_symbols(n_shards: u16, primary: u16, secondary: u16) {
+    assert!(source_symbols_primary(n_shards) == primary, 0);
+    assert!(source_symbols_secondary(n_shards) == secondary, 0);
+}
+
+#[test]
+fun test_source_symbols_number() {
+    // These values are taken from the RedStuff docs.
+    assert_primary_secondary_source_symbols(7, 3, 5);
+    assert_primary_secondary_source_symbols(10, 4, 7);
+    assert_primary_secondary_source_symbols(31, 9, 19);
+    assert_primary_secondary_source_symbols(100, 29, 62);
+    assert_primary_secondary_source_symbols(300, 97, 196);
+    assert_primary_secondary_source_symbols(1000, 329, 662);
 }


### PR DESCRIPTION
## Description

There was a naming inversion between the contracts and the Rust code.
This PR ensures the naming is consistent.

No issues arose from this inversion because in the contracts the two values are always considered in their aggregate (sum or product), and therefore the result is independent of the order in which they are considered.

## Test plan

Added a test to ensure `source_symbols_primary/secondary` match what is specified in the docs.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
