### PR TITLE
chore: ignore protobuf with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,7 @@ updates:
       - dependency-name: futures-timer
       - dependency-name: move-core-types
       - dependency-name: mysten-metrics
+      - dependency-name: protobuf # TODO: remove after fixing WAL-458
       - dependency-name: sui-*
       - dependency-name: telemetry-subscribers
       - dependency-name: test-cluster


### PR DESCRIPTION
## Description

Adds `protobuf` to the ignore list of Dependabot. See https://github.com/MystenLabs/walrus/pull/1242#issuecomment-2529388517 for context.

## Test plan

No test required.
