### PR TITLE
fix: fetch dynamic fields directly based on key

### DIFF
--- a/crates/walrus-sui/src/client/read_client.rs
+++ b/crates/walrus-sui/src/client/read_client.rs
@@ -49,9 +49,11 @@ use crate::{
     types::{
         move_structs::{
             EpochState,
+            StakingInnerV1,
             StakingObjectForDeserialization,
             StakingPool,
             SystemObjectForDeserialization,
+            SystemStateInnerV1,
         },
         BlobEvent,
         Committee,
@@ -62,6 +64,7 @@ use crate::{
         SystemObject,
     },
     utils::{
+        get_dynamic_field_object,
         get_package_id_from_object_response,
         get_sui_object,
         get_sui_object_from_object_response,
@@ -509,38 +512,28 @@ impl SuiReadClient {
     async fn get_system_object(&self) -> SuiClientResult<SystemObject> {
         let SystemObjectForDeserialization { id, version } =
             get_sui_object(&self.sui_client, self.system_object_id).await?;
-        let Some(dynamic_field_info) = self
-            .sui_client
-            .read_api()
-            .get_dynamic_fields(self.system_object_id, None, None)
-            .await?
-            .data
-            .into_iter()
-            .next()
-        else {
-            return Err(anyhow!("system object does not have a dynamic field").into());
-        };
+        let inner = get_dynamic_field_object::<u64, SystemStateInnerV1>(
+            &self.sui_client,
+            self.system_object_id,
+            TypeTag::U64,
+            version,
+        )
+        .await?;
 
-        let inner = get_sui_object(&self.sui_client, dynamic_field_info.object_id).await?;
         Ok(SystemObject { id, version, inner })
     }
 
     async fn get_staking_object(&self) -> SuiClientResult<StakingObject> {
         let StakingObjectForDeserialization { id, version } =
             get_sui_object(&self.sui_client, self.staking_object_id).await?;
-        let Some(dynamic_field_info) = self
-            .sui_client
-            .read_api()
-            .get_dynamic_fields(self.staking_object_id, None, None)
-            .await?
-            .data
-            .into_iter()
-            .next()
-        else {
-            return Err(anyhow!("staking object does not have a dynamic field").into());
-        };
 
-        let inner = get_sui_object(&self.sui_client, dynamic_field_info.object_id).await?;
+        let inner = get_dynamic_field_object::<u64, StakingInnerV1>(
+            &self.sui_client,
+            self.staking_object_id,
+            TypeTag::U64,
+            version,
+        )
+        .await?;
         Ok(StakingObject { id, version, inner })
     }
 

--- a/crates/walrus-sui/src/contracts.rs
+++ b/crates/walrus-sui/src/contracts.rs
@@ -323,3 +323,10 @@ pub mod wal_exchange {
     contract_ident!(fn wal_exchange::exchange_all_for_sui, 1);
     contract_ident!(fn wal_exchange::exchange_for_sui, 1);
 }
+
+/// Module for tags corresponding to the Move module `dynamic_field` from the `sui` package.
+pub mod dynamic_field {
+    use super::*;
+
+    contract_ident!(struct dynamic_field::Field);
+}

--- a/crates/walrus-sui/src/types/move_structs.rs
+++ b/crates/walrus-sui/src/types/move_structs.rs
@@ -6,7 +6,13 @@
 use std::{fmt::Display, num::NonZeroU16};
 
 use fastcrypto::traits::ToFromBytes;
-use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{
+    de::{DeserializeOwned, Error},
+    Deserialize,
+    Deserializer,
+    Serialize,
+    Serializer,
+};
 use sui_types::{base_types::ObjectID, messages_checkpoint::CheckpointSequenceNumber};
 use walrus_core::{BlobId, EncodingType, Epoch, NetworkPublicKey, PublicKey, ShardIndex};
 
@@ -579,4 +585,23 @@ impl ExchangeRate {
     pub fn sui_to_wal(&self, amount: u64) -> u64 {
         amount * self.wal / self.sui
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+/// Sui type for a dynamic field.
+pub struct SuiDynamicField<N, V> {
+    /// The object ID of the dynamic field.
+    pub id: ObjectID,
+    /// The name of the dynamic field.
+    pub name: N,
+    /// The value of the dynamic field.
+    pub value: V,
+}
+
+impl<N, V> AssociatedContractStruct for SuiDynamicField<N, V>
+where
+    N: DeserializeOwned,
+    V: DeserializeOwned,
+{
+    const CONTRACT_STRUCT: StructTag<'static> = contracts::dynamic_field::Field;
 }


### PR DESCRIPTION
## Description

- fetches the dynamic field objects for `StakingInner` and `SystemStateInner` directly instead of fetching the list of dynamic fields
- prevents the deserialization issue when deserializing `DynamicFieldInfo`

## Test plan

Existing tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
