### PR TITLE
chore: fix Move formatting checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Use Node.js
         uses: actions/setup-node@v4
-      - run: npm i @mysten/prettier-plugin-move
+      - run: npm install @mysten/prettier-plugin-move@0.2.2
       - run: npx prettier-move -c **/*.move
 
   typos:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,5 +93,5 @@ repos:
         language: node
         additional_dependencies:
           - "prettier@3.4.1"
-          - "@mysten/prettier-plugin-move@0.2.1"
+          - "@mysten/prettier-plugin-move@0.2.2"
         files: "^contracts/.*\\.move"

--- a/contracts/walrus/sources/staking/staked_wal.move
+++ b/contracts/walrus/sources/staking/staked_wal.move
@@ -182,7 +182,7 @@ public fun join(sw: &mut StakedWal, other: StakedWal) {
             StakedWalState::Withdrawing { pool_token_amount: current_pool_token_amount, .. } => {
                 current_pool_token_amount.do_mut!(|current| *current = *current + amount);
             },
-            _ => abort , // unreachable
+            _ => abort, // unreachable
         }
     });
 }


### PR DESCRIPTION
## Description

- Update `prettier-plugin-move` to 0.2.2
- Pin version in CI to use the same version as pre-commit.
- Run `prettier-move` to fix formatting in `staked_wal.move`.

## Test plan

CI.