### PR TITLE
fix(node): don't call epoch-change functions if they already happened

### DIFF
--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -1166,6 +1166,10 @@ impl SystemContractService for StubContractService {
         anyhow::bail!("stub service does not store the epoch or state")
     }
 
+    fn current_epoch(&self) -> Epoch {
+        unimplemented!("stub service does not store the epoch")
+    }
+
     async fn fixed_system_parameters(&self) -> Result<FixedSystemParameters, anyhow::Error> {
         Ok(self.system_parameters.clone())
     }
@@ -1672,6 +1676,10 @@ where
 
     async fn get_epoch_and_state(&self) -> Result<(Epoch, EpochState), anyhow::Error> {
         self.as_ref().inner.get_epoch_and_state().await
+    }
+
+    fn current_epoch(&self) -> Epoch {
+        self.as_ref().inner.current_epoch()
     }
 
     async fn fixed_system_parameters(&self) -> Result<FixedSystemParameters, anyhow::Error> {


### PR DESCRIPTION
## Description

Currently, storage nodes call `initiate_epoch_change` and `end_voting` even if they were successfully called by a different node already.

With this change, they first check if calling the function is even necessary. It can still happen that between this check and the call it is triggered by another node, but it is much less likely.

## Test plan

Automatic tests and deployment to PTN.
