### PR TITLE
feat: add initial custom upgrade policy

### DIFF
--- a/contracts/wal/Move.lock
+++ b/contracts/wal/Move.lock
@@ -21,6 +21,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.39.2"
+compiler-version = "1.39.3"
 edition = "2024.beta"
 flavor = "sui"

--- a/contracts/walrus/sources/init.move
+++ b/contracts/walrus/sources/init.move
@@ -3,8 +3,14 @@
 
 module walrus::init;
 
-use sui::clock::Clock;
-use walrus::{staking, system};
+use std::type_name;
+use sui::{clock::Clock, package::UpgradeCap};
+use walrus::{events, staking::{Self, Staking}, system::{Self, System}, upgrade};
+
+// Error codes
+// Error types in `walrus-sui/types/move_errors.rs` are auto-generated from the Move error codes.
+const EInvalidMigration: u64 = 0;
+const EInvalidUpgradeCap: u64 = 1;
 
 /// Must only be created by `init`.
 public struct InitCap has key, store {
@@ -24,17 +30,44 @@ fun init(ctx: &mut TxContext) {
 /// This can only be called once, after which the `InitCap` is destroyed.
 /// TODO: decide what to add as system parameters instead of constants.
 public fun initialize_walrus(
-    cap: InitCap,
+    init_cap: InitCap,
+    upgrade_cap: UpgradeCap,
     epoch_zero_duration: u64,
     epoch_duration: u64,
     n_shards: u16,
     max_epochs_ahead: u32,
     clock: &Clock,
     ctx: &mut TxContext,
-) {
-    system::create_empty(max_epochs_ahead, ctx);
-    staking::create(epoch_zero_duration, epoch_duration, n_shards, clock, ctx);
-    cap.destroy();
+): upgrade::EmergencyUpgradeCap {
+    let package_id = upgrade_cap.package();
+    assert!(
+        type_name::get<InitCap>().get_address() == package_id.to_address().to_ascii_string(),
+        EInvalidUpgradeCap,
+    );
+    system::create_empty(max_epochs_ahead, package_id, ctx);
+    staking::create(epoch_zero_duration, epoch_duration, n_shards, package_id, clock, ctx);
+    let emergency_upgrade_cap = upgrade::new(upgrade_cap, ctx);
+    init_cap.destroy();
+    emergency_upgrade_cap
+}
+
+/// Migrate the staking and system objects to the new package id.
+///
+/// This must be called in the new package after an upgrade is committed
+/// to emit an event that informs all storage nodes and prevent previous package
+/// versions from being used.
+public fun migrate(staking: &mut Staking, system: &mut System) {
+    staking.migrate();
+    system.migrate();
+    // Check that the package id and version are the same.
+    assert!(staking.package_id() == system.package_id(), EInvalidMigration);
+    assert!(staking.version() == system.version(), EInvalidMigration);
+    // Emit an event to inform storage nodes of the upgrade.
+    events::emit_contract_upgraded(
+        staking.epoch(),
+        staking.package_id(),
+        staking.version(),
+    );
 }
 
 fun destroy(cap: InitCap) {
@@ -47,4 +80,27 @@ fun destroy(cap: InitCap) {
 #[test_only]
 public fun init_for_testing(ctx: &mut TxContext) {
     init(ctx);
+}
+
+#[test_only]
+/// Does the same as `initialize_walrus` but does not check the package id of the upgrade cap.
+///
+/// This is needed for testing, since the package ID of all types will be zero, which cannot be used
+/// as the package ID for an upgrade cap.
+public fun initialize_for_testing(
+    init_cap: InitCap,
+    upgrade_cap: UpgradeCap,
+    epoch_zero_duration: u64,
+    epoch_duration: u64,
+    n_shards: u16,
+    max_epochs_ahead: u32,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): upgrade::EmergencyUpgradeCap {
+    let package_id = upgrade_cap.package();
+    system::create_empty(max_epochs_ahead, package_id, ctx);
+    staking::create(epoch_zero_duration, epoch_duration, n_shards, package_id, clock, ctx);
+    let emergency_upgrade_cap = upgrade::new(upgrade_cap, ctx);
+    init_cap.destroy();
+    emergency_upgrade_cap
 }

--- a/contracts/walrus/sources/system.move
+++ b/contracts/walrus/sources/system.move
@@ -16,6 +16,10 @@ use walrus::{
     system_state_inner::{Self, SystemStateInnerV1}
 };
 
+// Error codes
+// Error types in `walrus-sui/types/move_errors.rs` are auto-generated from the Move error codes.
+const EInvalidMigration: u64 = 0;
+
 /// Flag to indicate the version of the system.
 const VERSION: u64 = 0;
 
@@ -23,12 +27,19 @@ const VERSION: u64 = 0;
 public struct System has key {
     id: UID,
     version: u64,
+    package_id: ID,
+    new_package_id: Option<ID>,
 }
 
 /// Creates and shares an empty system object.
 /// Must only be called by the initialization function.
-public(package) fun create_empty(max_epochs_ahead: u32, ctx: &mut TxContext) {
-    let mut system = System { id: object::new(ctx), version: VERSION };
+public(package) fun create_empty(max_epochs_ahead: u32, package_id: ID, ctx: &mut TxContext) {
+    let mut system = System {
+        id: object::new(ctx),
+        version: VERSION,
+        package_id,
+        new_package_id: option::none(),
+    };
     let system_state_inner = system_state_inner::create_empty(max_epochs_ahead, ctx);
     dynamic_object_field::add(&mut system.id, VERSION, system_state_inner);
     transfer::share_object(system);
@@ -196,6 +207,42 @@ public(package) fun advance_epoch(
     self.inner_mut().advance_epoch(new_committee, new_epoch_params)
 }
 
+// === Accessors ===
+
+public(package) fun package_id(system: &System): ID {
+    system.package_id
+}
+
+public(package) fun version(system: &System): u64 {
+    system.version
+}
+
+// === Upgrade ===
+
+public(package) fun set_new_package_id(system: &mut System, new_package_id: ID) {
+    system.new_package_id = option::some(new_package_id);
+}
+
+/// Migrate the system object to the new package id.
+///
+/// This function sets the new package id and version and can be modified in future versions
+/// to migrate changes in the `system_state_inner` object if needed.
+public(package) fun migrate(system: &mut System) {
+    assert!(system.version < VERSION, EInvalidMigration);
+
+    // Move the old system state inner to the new version.
+    let system_state_inner: SystemStateInnerV1 = dynamic_object_field::remove(
+        &mut system.id,
+        system.version,
+    );
+    dynamic_object_field::add(&mut system.id, VERSION, system_state_inner);
+    system.version = VERSION;
+
+    // Set the new package id.
+    assert!(system.new_package_id.is_some(), EInvalidMigration);
+    system.package_id = system.new_package_id.extract();
+}
+
 // === Internals ===
 
 /// Get a mutable reference to `SystemStateInner` from the `System`.
@@ -215,7 +262,12 @@ public(package) fun inner(system: &System): &SystemStateInnerV1 {
 #[test_only]
 public(package) fun new_for_testing(): System {
     let ctx = &mut tx_context::dummy();
-    let mut system = System { id: object::new(ctx), version: VERSION };
+    let mut system = System {
+        id: object::new(ctx),
+        version: VERSION,
+        package_id: new_id(ctx),
+        new_package_id: option::none(),
+    };
     let system_state_inner = system_state_inner::new_for_testing();
     dynamic_object_field::add(&mut system.id, VERSION, system_state_inner);
     system
@@ -223,8 +275,23 @@ public(package) fun new_for_testing(): System {
 
 #[test_only]
 public(package) fun new_for_testing_with_multiple_members(ctx: &mut TxContext): System {
-    let mut system = System { id: object::new(ctx), version: VERSION };
+    let mut system = System {
+        id: object::new(ctx),
+        version: VERSION,
+        package_id: new_id(ctx),
+        new_package_id: option::none(),
+    };
     let system_state_inner = system_state_inner::new_for_testing_with_multiple_members(ctx);
     dynamic_object_field::add(&mut system.id, VERSION, system_state_inner);
     system
+}
+
+#[test_only]
+fun new_id(ctx: &mut TxContext): ID {
+    ctx.fresh_object_address().to_id()
+}
+
+#[test_only]
+public(package) fun new_package_id(system: &System): Option<ID> {
+    system.new_package_id
 }

--- a/contracts/walrus/sources/system/events.move
+++ b/contracts/walrus/sources/system/events.move
@@ -79,6 +79,13 @@ public struct ShardRecoveryStart has copy, drop {
     shards: vector<u16>,
 }
 
+/// Signals that the contract has been upgraded and migrated.
+public struct ContractUpgraded has copy, drop {
+    epoch: u32,
+    package_id: ID,
+    version: u64,
+}
+
 // === Functions to emit the events from other modules ===
 
 public(package) fun emit_blob_registered(
@@ -144,4 +151,8 @@ public(package) fun emit_epoch_parameters_selected(next_epoch: u32) {
 
 public(package) fun emit_shard_recovery_start(epoch: u32, shards: vector<u16>) {
     event::emit(ShardRecoveryStart { epoch, shards })
+}
+
+public(package) fun emit_contract_upgraded(epoch: u32, package_id: ID, version: u64) {
+    event::emit(ContractUpgraded { epoch, package_id, version })
 }

--- a/contracts/walrus/sources/upgrade.move
+++ b/contracts/walrus/sources/upgrade.move
@@ -1,0 +1,73 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Module: upgrade
+module walrus::upgrade;
+
+use sui::package::{UpgradeCap, UpgradeTicket, UpgradeReceipt};
+use walrus::{staking::Staking, system::System};
+
+const EInvalidUpgradeManager: u64 = 0;
+
+public struct UpgradeManager has key {
+    id: UID,
+    cap: UpgradeCap,
+}
+
+public struct EmergencyUpgradeCap has key, store {
+    id: UID,
+    upgrade_manager_id: ID,
+}
+
+public(package) fun new(cap: UpgradeCap, ctx: &mut TxContext): EmergencyUpgradeCap {
+    let upgrade_manager = UpgradeManager { id: object::new(ctx), cap };
+    let emergency_upgrade_cap = EmergencyUpgradeCap {
+        id: object::new(ctx),
+        upgrade_manager_id: object::id(&upgrade_manager),
+    };
+    transfer::share_object(upgrade_manager);
+    emergency_upgrade_cap
+}
+
+/// Authorize an upgrade using the emergency upgrade cap.
+///
+/// This should be used sparingly and once walrus has a healthy community and governance,
+/// the EmergencyUpgradeCap should be burned.
+public fun authorize_emergency_upgrade(
+    upgrade_manager: &mut UpgradeManager,
+    emergency_upgrade_cap: &EmergencyUpgradeCap,
+    digest: vector<u8>,
+): UpgradeTicket {
+    assert!(
+        emergency_upgrade_cap.upgrade_manager_id == object::id(upgrade_manager),
+        EInvalidUpgradeManager,
+    );
+    let policy = upgrade_manager.cap.policy();
+    upgrade_manager.cap.authorize(policy, digest)
+}
+
+/// Commits an upgrade and sets the new package id in the staking and system objects.
+///
+/// After committing an upgrade, the staking and system objects should be migrated
+/// using the [`package::migrate`] function to emit an event that informs all storage nodes
+/// and prevent previous package versions from being used.
+public fun commit_upgrade(
+    upgrade_manager: &mut UpgradeManager,
+    staking: &mut Staking,
+    system: &mut System,
+    receipt: UpgradeReceipt,
+) {
+    let new_package_id = receipt.package();
+    staking.set_new_package_id(new_package_id);
+    system.set_new_package_id(new_package_id);
+    upgrade_manager.cap.commit(receipt)
+}
+
+/// Burn the emergency upgrade cap.
+///
+/// This will prevent any further upgrades using the `EmergencyUpgradeCap` and will
+/// make upgrades fully reliant on quorum-based governance.
+public fun burn_emergency_upgrade_cap(emergency_upgrade_cap: EmergencyUpgradeCap) {
+    let EmergencyUpgradeCap { id, .. } = emergency_upgrade_cap;
+    id.delete();
+}

--- a/crates/walrus-service/src/node/contract_service.rs
+++ b/crates/walrus-service/src/node/contract_service.rs
@@ -63,6 +63,9 @@ pub trait SystemContractService: std::fmt::Debug + Sync + Send {
         ending_checkpoint_seq_num: u64,
         epoch: u32,
     ) -> Result<(), Error>;
+
+    /// Refreshes the contract package that the service is using.
+    async fn refresh_contract_package(&self) -> Result<(), anyhow::Error>;
 }
 
 /// A [`SystemContractService`] that uses a [`SuiContractClient`] for chain interactions.
@@ -242,6 +245,12 @@ impl SystemContractService for SuiSystemContractService {
             }
         })
         .await;
+        Ok(())
+    }
+
+    async fn refresh_contract_package(&self) -> Result<(), anyhow::Error> {
+        let client = self.contract_client.lock().await;
+        client.refresh_package_id().await?;
         Ok(())
     }
 }

--- a/crates/walrus-service/src/node/metrics.rs
+++ b/crates/walrus-service/src/node/metrics.rs
@@ -13,7 +13,7 @@ use prometheus::{
     Registry,
 };
 pub(crate) use telemetry::with_label;
-use walrus_sui::types::{BlobCertified, BlobEvent, ContractEvent, EpochChangeEvent};
+use walrus_sui::types::{BlobCertified, BlobEvent, ContractEvent, EpochChangeEvent, PackageEvent};
 
 use crate::{
     common::telemetry::{self, CurrentEpochMetric, CurrentEpochStateMetric},
@@ -156,11 +156,21 @@ impl TelemetryLabel for EpochChangeEvent {
     }
 }
 
+impl TelemetryLabel for PackageEvent {
+    fn label(&self) -> &'static str {
+        match self {
+            PackageEvent::ContractUpgraded(_) => "contract-upgraded",
+            _ => "unknown-package-event",
+        }
+    }
+}
+
 impl TelemetryLabel for ContractEvent {
     fn label(&self) -> &'static str {
         match self {
             ContractEvent::BlobEvent(event) => event.label(),
             ContractEvent::EpochChangeEvent(event) => event.label(),
+            ContractEvent::PackageEvent(event) => event.label(),
         }
     }
 }

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -1238,6 +1238,10 @@ impl SystemContractService for StubContractService {
     ) -> Result<(), Error> {
         anyhow::bail!("stub service cannot certify event blob")
     }
+
+    async fn refresh_contract_package(&self) -> Result<(), anyhow::Error> {
+        anyhow::bail!("stub service cannot refresh contract package")
+    }
 }
 
 /// Returns a socket address that is not currently in use on the system.
@@ -1804,6 +1808,10 @@ where
             .inner
             .certify_event_blob(blob_metadata, ending_checkpoint_seq_num, epoch)
             .await
+    }
+
+    async fn refresh_contract_package(&self) -> Result<(), anyhow::Error> {
+        self.as_ref().inner.refresh_contract_package().await
     }
 }
 

--- a/crates/walrus-sui/src/client.rs
+++ b/crates/walrus-sui/src/client.rs
@@ -322,7 +322,7 @@ impl SuiContractClient {
         let storage_id = get_created_sui_object_ids_by_type(
             &res,
             &contracts::storage_resource::Storage
-                .to_move_struct_tag_with_type_map(&self.read_client.type_origin_map, &[])?,
+                .to_move_struct_tag_with_type_map(&self.read_client.type_origin_map(), &[])?,
         )?;
 
         ensure!(
@@ -359,7 +359,7 @@ impl SuiContractClient {
         let blob_obj_ids = get_created_sui_object_ids_by_type(
             &res,
             &contracts::blob::Blob
-                .to_move_struct_tag_with_type_map(&self.read_client.type_origin_map, &[])?,
+                .to_move_struct_tag_with_type_map(&self.read_client.type_origin_map(), &[])?,
         )?;
         ensure!(
             blob_obj_ids.len() == expected_num_blobs,
@@ -407,7 +407,7 @@ impl SuiContractClient {
         let blob_obj_ids = get_created_sui_object_ids_by_type(
             &res,
             &contracts::blob::Blob
-                .to_move_struct_tag_with_type_map(&self.read_client.type_origin_map, &[])?,
+                .to_move_struct_tag_with_type_map(&self.read_client.type_origin_map(), &[])?,
         )?;
 
         ensure!(
@@ -550,7 +550,7 @@ impl SuiContractClient {
         let cap_id = get_created_sui_object_ids_by_type(
             &res,
             &contracts::storage_node::StorageNodeCap
-                .to_move_struct_tag_with_type_map(&self.read_client.type_origin_map, &[])?,
+                .to_move_struct_tag_with_type_map(&self.read_client.type_origin_map(), &[])?,
         )?;
         ensure!(
             cap_id.len() == 1,
@@ -578,7 +578,7 @@ impl SuiContractClient {
         let staked_wal = get_created_sui_object_ids_by_type(
             &res,
             &contracts::staked_wal::StakedWal
-                .to_move_struct_tag_with_type_map(&self.read_client.type_origin_map, &[])?,
+                .to_move_struct_tag_with_type_map(&self.read_client.type_origin_map(), &[])?,
         )?;
         ensure!(
             staked_wal.len() == 1,
@@ -660,7 +660,7 @@ impl SuiContractClient {
         let exchange_id = get_created_sui_object_ids_by_type(
             &res,
             &contracts::wal_exchange::Exchange
-                .to_move_struct_tag_with_type_map(&self.read_client.type_origin_map, &[])?,
+                .to_move_struct_tag_with_type_map(&self.read_client.type_origin_map(), &[])?,
         )?;
         ensure!(
             exchange_id.len() == 1,
@@ -953,6 +953,10 @@ impl ReadClient for SuiContractClient {
 
     async fn last_certified_event_blob(&self) -> SuiClientResult<Option<EventBlob>> {
         self.read_client.last_certified_event_blob().await
+    }
+
+    async fn refresh_package_id(&self) -> SuiClientResult<()> {
+        self.read_client.refresh_package_id().await
     }
 }
 

--- a/crates/walrus-sui/src/client/read_client.rs
+++ b/crates/walrus-sui/src/client/read_client.rs
@@ -9,6 +9,7 @@ use std::{
     future::Future,
     num::NonZeroU16,
     ops::ControlFlow,
+    sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard},
     time::Duration,
 };
 
@@ -182,6 +183,11 @@ pub trait ReadClient: Send + Sync {
     fn last_certified_event_blob(
         &self,
     ) -> impl Future<Output = SuiClientResult<Option<EventBlob>>> + Send;
+
+    /// Refreshes the Walrus package ID.
+    ///
+    /// Should be called after the contract is upgraded.
+    fn refresh_package_id(&self) -> impl Future<Output = SuiClientResult<()>> + Send;
 }
 
 /// The mutability of a shared object.
@@ -212,11 +218,11 @@ impl From<Mutability> for bool {
 /// Client implementation for interacting with the Walrus smart contracts.
 #[derive(Clone)]
 pub struct SuiReadClient {
-    pub(crate) walrus_package_id: ObjectID,
+    walrus_package_id: Arc<RwLock<ObjectID>>,
     pub(crate) sui_client: RetriableSuiClient,
     pub(crate) system_object_id: ObjectID,
     pub(crate) staking_object_id: ObjectID,
-    pub(crate) type_origin_map: TypeOriginMap,
+    type_origin_map: Arc<RwLock<TypeOriginMap>>,
     sys_obj_initial_version: OnceCell<SequenceNumber>,
     staking_obj_initial_version: OnceCell<SequenceNumber>,
 }
@@ -230,8 +236,10 @@ impl SuiReadClient {
         sui_client: RetriableSuiClient,
         system_object_id: ObjectID,
         staking_object_id: ObjectID,
+        // TODO(WAL-474): remove this when removing the `walrus-mainnet` feature flag.
         package_id: Option<ObjectID>,
     ) -> SuiClientResult<Self> {
+        #[cfg(not(feature = "walrus-mainnet"))]
         let walrus_package_id = package_id.unwrap_or(
             // We use `unwrap_or` here because we want to call the function even if the package ID
             // is provided to check if the system and staking objects exist.
@@ -239,15 +247,21 @@ impl SuiReadClient {
                 .get_system_package_id_from_system_object(system_object_id)
                 .await?,
         );
+        #[cfg(feature = "walrus-mainnet")]
+        let walrus_package_id = sui_client
+            .get_system_package_id_from_system_object(system_object_id)
+            .await?;
+        #[cfg(feature = "walrus-mainnet")]
+        let _ = package_id; // Drop to avoid unused variable warning.
         let type_origin_map = sui_client
             .type_origin_map_for_package(walrus_package_id)
             .await?;
         Ok(Self {
-            walrus_package_id,
+            walrus_package_id: Arc::new(RwLock::new(walrus_package_id)),
             sui_client,
             system_object_id,
             staking_object_id,
-            type_origin_map,
+            type_origin_map: Arc::new(RwLock::new(type_origin_map)),
             sys_obj_initial_version: OnceCell::new(),
             staking_obj_initial_version: OnceCell::new(),
         })
@@ -338,7 +352,7 @@ impl SuiReadClient {
 
     /// Returns the system package ID.
     pub fn get_system_package_id(&self) -> ObjectID {
-        self.walrus_package_id
+        *self.walrus_package_id()
     }
 
     /// Returns the system object ID.
@@ -349,6 +363,30 @@ impl SuiReadClient {
     /// Returns the staking object ID.
     pub fn get_staking_object_id(&self) -> ObjectID {
         self.staking_object_id
+    }
+
+    fn walrus_package_id(&self) -> RwLockReadGuard<ObjectID> {
+        self.walrus_package_id
+            .read()
+            .expect("lock should not be poisoned")
+    }
+
+    fn walrus_package_id_mut(&self) -> RwLockWriteGuard<ObjectID> {
+        self.walrus_package_id
+            .write()
+            .expect("lock should not be poisoned")
+    }
+
+    pub(crate) fn type_origin_map(&self) -> RwLockReadGuard<TypeOriginMap> {
+        self.type_origin_map
+            .read()
+            .expect("lock should not be poisoned")
+    }
+
+    fn type_origin_map_mut(&self) -> RwLockWriteGuard<TypeOriginMap> {
+        self.type_origin_map
+            .write()
+            .expect("lock should not be poisoned")
     }
 
     /// Returns the balance of the owner for the given coin type.
@@ -462,7 +500,7 @@ impl SuiReadClient {
         object_type: contracts::StructTag<'a>,
     ) -> Result<impl Iterator<Item = Result<SuiObjectData>> + 'a> {
         let struct_tag =
-            object_type.to_move_struct_tag_with_type_map(&self.type_origin_map, type_args)?;
+            object_type.to_move_struct_tag_with_type_map(&self.type_origin_map(), type_args)?;
         Ok(handle_pagination(move |cursor| {
             self.sui_client.get_owned_objects(
                 owner,
@@ -507,13 +545,49 @@ impl SuiReadClient {
     pub fn wal_coin_type(&self) -> String {
         // TODO: WAL-425
         let type_name = ("wal".to_string(), "WAL".to_string());
-        let package_id = self
-            .type_origin_map
-            .get(&type_name)
-            .expect("WAL type origin not found");
-        format!("{}::{}::{}", package_id, type_name.0, type_name.1)
+        format!(
+            "{}::{}::{}",
+            self.type_origin_map()
+                .get(&type_name)
+                .expect("WAL type origin not found"),
+            type_name.0,
+            type_name.1
+        )
     }
 
+    #[cfg(feature = "walrus-mainnet")]
+    async fn get_system_object(&self) -> SuiClientResult<SystemObject> {
+        let SystemObjectForDeserialization {
+            id,
+            version,
+            package_id,
+            new_package_id,
+        } = self
+            .sui_client
+            .get_sui_object(self.system_object_id)
+            .await?;
+        // Refresh the package ID if it is different from the current package ID.
+        if package_id != *self.walrus_package_id() {
+            self.refresh_package_id_with_id(package_id).await?;
+        }
+        let inner = self
+            .sui_client
+            .get_dynamic_field_object::<u64, SystemStateInnerV1>(
+                self.system_object_id,
+                TypeTag::U64,
+                version,
+            )
+            .await?;
+        Ok(SystemObject {
+            id,
+            version,
+            package_id,
+            new_package_id,
+            inner,
+        })
+    }
+
+    #[cfg(not(feature = "walrus-mainnet"))]
     async fn get_system_object(&self) -> SuiClientResult<SystemObject> {
         let SystemObjectForDeserialization { id, version } = self
             .sui_client
@@ -527,16 +601,25 @@ impl SuiReadClient {
                 version,
             )
             .await?;
-
-        Ok(SystemObject { id, version, inner })
+        let system_object = SystemObject { id, version, inner };
+        Ok(system_object)
     }
 
+    #[cfg(feature = "walrus-mainnet")]
     async fn get_staking_object(&self) -> SuiClientResult<StakingObject> {
-        let StakingObjectForDeserialization { id, version } = self
+        let StakingObjectForDeserialization {
+            id,
+            version,
+            package_id,
+            new_package_id,
+        } = self
             .sui_client
             .get_sui_object(self.staking_object_id)
             .await?;
-
+        // Refresh the package ID if it is different from the current package ID.
+        if package_id != *self.walrus_package_id() {
+            self.refresh_package_id_with_id(package_id).await?;
+        }
         let inner = self
             .sui_client
             .get_dynamic_field_object::<u64, StakingInnerV1>(
@@ -545,7 +628,42 @@ impl SuiReadClient {
                 version,
             )
             .await?;
-        Ok(StakingObject { id, version, inner })
+        let staking_object = StakingObject {
+            id,
+            version,
+            package_id,
+            new_package_id,
+            inner,
+        };
+        Ok(staking_object)
+    }
+
+    #[cfg(not(feature = "walrus-mainnet"))]
+    async fn get_staking_object(&self) -> SuiClientResult<StakingObject> {
+        let StakingObjectForDeserialization { id, version } = self
+            .sui_client
+            .get_sui_object(self.staking_object_id)
+            .await?;
+        let inner = self
+            .sui_client
+            .get_dynamic_field_object::<u64, StakingInnerV1>(
+                self.staking_object_id,
+                TypeTag::U64,
+                version,
+            )
+            .await?;
+        let staking_object = StakingObject { id, version, inner };
+        Ok(staking_object)
+    }
+
+    async fn refresh_package_id_with_id(&self, walrus_package_id: ObjectID) -> SuiClientResult<()> {
+        let type_origin_map = self
+            .sui_client
+            .type_origin_map_for_package(walrus_package_id)
+            .await?;
+        *self.walrus_package_id_mut() = walrus_package_id;
+        *self.type_origin_map_mut() = type_origin_map;
+        Ok(())
     }
 
     async fn shard_assignment_to_committee(
@@ -659,7 +777,10 @@ impl ReadClient for SuiReadClient {
         let event_api = self.sui_client.event_api().clone();
 
         let event_filter = EventFilter::MoveEventModule {
-            package: self.walrus_package_id,
+            package: *self
+                .walrus_package_id
+                .read()
+                .expect("lock should not be poisoned"),
             module: Identifier::new(EVENT_MODULE)?,
         };
         tokio::spawn(async move {
@@ -792,12 +913,23 @@ impl ReadClient for SuiReadClient {
         let staking_object = self.get_staking_object().await?;
         let active_set_id = staking_object.inner.active_set;
         let key_tag = contracts::extended_field::Key
-            .to_move_struct_tag_with_type_map(&self.type_origin_map, &[])?;
+            .to_move_struct_tag_with_type_map(&self.type_origin_map(), &[])?;
         let active_set: ActiveSet = self
             .sui_client
             .get_dynamic_field(active_set_id, key_tag.into(), ())
             .await?;
         Ok(active_set.nodes.into_iter().collect())
+    }
+
+    async fn refresh_package_id(&self) -> SuiClientResult<()> {
+        if cfg!(feature = "walrus-mainnet") {
+            let walrus_package_id = self
+                .sui_client
+                .get_system_package_id_from_system_object(self.system_object_id)
+                .await?;
+            self.refresh_package_id_with_id(walrus_package_id).await?;
+        }
+        Ok(())
     }
 }
 

--- a/crates/walrus-sui/src/client/transaction_builder.rs
+++ b/crates/walrus-sui/src/client/transaction_builder.rs
@@ -195,7 +195,7 @@ impl WalrusPtbBuilder {
         arguments: Vec<Argument>,
     ) -> SuiClientResult<Argument> {
         Ok(self.pt_builder.programmable_move_call(
-            self.read_client.walrus_package_id,
+            self.read_client.get_system_package_id(),
             Identifier::from_str(function.module)?,
             Identifier::from_str(function.name)?,
             function.type_params,

--- a/crates/walrus-sui/src/contracts.rs
+++ b/crates/walrus-sui/src/contracts.rs
@@ -300,6 +300,7 @@ pub mod events {
     contract_ident!(struct events::EpochChangeDone);
     contract_ident!(struct events::ShardsReceived);
     contract_ident!(struct events::ShardRecoveryStart);
+    contract_ident!(struct events::ContractUpgraded);
 }
 
 /// Module for tags corresponding to the Move module `extended_field`.
@@ -344,4 +345,11 @@ pub mod dynamic_field {
     use super::*;
 
     contract_ident!(struct dynamic_field::Field);
+}
+
+/// Module for tags corresponding to the Move module `package` from the `sui` package.
+pub mod package {
+    use super::*;
+
+    contract_ident!(struct package::UpgradeCap);
 }

--- a/crates/walrus-sui/src/test_utils.rs
+++ b/crates/walrus-sui/src/test_utils.rs
@@ -367,7 +367,7 @@ pub async fn new_contract_client_on_sui_test_cluster(
 ) -> anyhow::Result<WithTempDir<SuiContractClient>> {
     let system_object = existing_client.read_client().get_system_object_id();
     let staking_object = existing_client.read_client().get_staking_object_id();
-    let package_id = existing_client.read_client().walrus_package_id;
+    let package_id = existing_client.read_client().get_system_package_id();
     let walrus_client = new_wallet_on_sui_test_cluster(sui_cluster_handle)
         .await?
         .and_then_async(|wallet| {

--- a/crates/walrus-sui/src/test_utils/system_setup.rs
+++ b/crates/walrus-sui/src/test_utils/system_setup.rs
@@ -30,7 +30,7 @@ use walrus_utils::backoff::ExponentialBackoffConfig;
 use super::{default_protocol_keypair, DEFAULT_GAS_BUDGET};
 use crate::{
     client::{ReadClient, SuiClientError, SuiContractClient},
-    system_setup::{self, InitSystemParams},
+    system_setup::{self, InitSystemParams, PublishSystemPackageResult},
     types::{NodeRegistrationParams, StorageNodeCap},
 };
 
@@ -176,7 +176,12 @@ pub async fn create_and_init_system(
     gas_budget: u64,
     for_test: bool,
 ) -> Result<SystemContext> {
-    let (package_id, cap_id, treasury_cap) = system_setup::publish_coin_and_system_package(
+    let PublishSystemPackageResult {
+        walrus_pkg_id,
+        init_cap_id,
+        upgrade_cap_id,
+        treasury_cap_id,
+    } = system_setup::publish_coin_and_system_package(
         admin_wallet,
         contract_path,
         gas_budget,
@@ -186,18 +191,19 @@ pub async fn create_and_init_system(
 
     let (system_object, staking_object) = system_setup::create_system_and_staking_objects(
         admin_wallet,
-        package_id,
-        cap_id,
+        walrus_pkg_id,
+        init_cap_id,
+        upgrade_cap_id,
         init_system_params,
         gas_budget,
     )
     .await?;
 
     Ok(SystemContext {
-        package_id,
+        package_id: walrus_pkg_id,
         system_object,
         staking_object,
-        treasury_cap,
+        treasury_cap: treasury_cap_id,
     })
 }
 

--- a/crates/walrus-sui/src/types.rs
+++ b/crates/walrus-sui/src/types.rs
@@ -19,11 +19,13 @@ pub use events::{
     BlobEvent,
     BlobRegistered,
     ContractEvent,
+    ContractUpgradedEvent,
     EpochChangeDone,
     EpochChangeEvent,
     EpochChangeStart,
     EpochParametersSelected,
     InvalidBlobId,
+    PackageEvent,
 };
 
 pub mod move_structs;

--- a/crates/walrus-sui/src/types/move_structs.rs
+++ b/crates/walrus-sui/src/types/move_structs.rs
@@ -314,6 +314,12 @@ pub struct StakingObject {
     pub id: ObjectID,
     /// The version of the system object.
     pub version: u64,
+    #[cfg(feature = "walrus-mainnet")]
+    /// The package ID of the staking object.
+    pub package_id: ObjectID,
+    #[cfg(feature = "walrus-mainnet")]
+    /// The new package ID of the staking object.
+    pub(crate) new_package_id: Option<ObjectID>,
     /// The inner system state.
     pub(crate) inner: StakingInnerV1,
 }
@@ -323,6 +329,10 @@ pub struct StakingObject {
 pub(crate) struct StakingObjectForDeserialization {
     pub(crate) id: ObjectID,
     pub(crate) version: u64,
+    #[cfg(feature = "walrus-mainnet")]
+    pub(crate) package_id: ObjectID,
+    #[cfg(feature = "walrus-mainnet")]
+    pub(crate) new_package_id: Option<ObjectID>,
 }
 
 impl AssociatedContractStruct for StakingObjectForDeserialization {
@@ -453,6 +463,12 @@ pub struct SystemObject {
     pub id: ObjectID,
     /// The version of the system object.
     pub version: u64,
+    #[cfg(feature = "walrus-mainnet")]
+    /// The package ID of the system object.
+    pub package_id: ObjectID,
+    #[cfg(feature = "walrus-mainnet")]
+    /// The new package ID of the system object.
+    pub(crate) new_package_id: Option<ObjectID>,
     /// The inner system state.
     pub(crate) inner: SystemStateInnerV1,
 }
@@ -462,6 +478,10 @@ pub struct SystemObject {
 pub(crate) struct SystemObjectForDeserialization {
     pub(crate) id: ObjectID,
     pub(crate) version: u64,
+    #[cfg(feature = "walrus-mainnet")]
+    pub(crate) package_id: ObjectID,
+    #[cfg(feature = "walrus-mainnet")]
+    pub(crate) new_package_id: Option<ObjectID>,
 }
 impl AssociatedContractStruct for SystemObjectForDeserialization {
     const CONTRACT_STRUCT: StructTag<'static> = contracts::system::System;

--- a/crates/walrus-sui/src/utils.rs
+++ b/crates/walrus-sui/src/utils.rs
@@ -12,7 +12,7 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, Result};
 use move_core_types::language_storage::StructTag as MoveStructTag;
 use serde::{Deserialize, Serialize};
 use sui_config::{sui_config_dir, Config, SUI_CLIENT_CONFIG, SUI_KEYSTORE_FILENAME};
@@ -25,7 +25,7 @@ use sui_sdk::{
     SuiClient,
 };
 use sui_types::{
-    base_types::{ObjectRef, ObjectType, SuiAddress},
+    base_types::{ObjectRef, SuiAddress},
     crypto::SignatureScheme,
     transaction::{ProgrammableTransaction, TransactionData},
 };
@@ -82,11 +82,14 @@ pub fn write_price_for_encoded_length(encoded_length: u64, price_per_unit_size: 
     storage_units_from_size(encoded_length) * price_per_unit_size
 }
 
+#[cfg(not(feature = "walrus-mainnet"))]
 pub(crate) fn get_package_id_from_object_response(
     object_response: &SuiObjectResponse,
 ) -> Result<ObjectID> {
-    let ObjectType::Struct(move_object_type) = object_response.object()?.object_type()? else {
-        bail!("response does not contain a move struct object");
+    let sui_types::base_types::ObjectType::Struct(move_object_type) =
+        object_response.object()?.object_type()?
+    else {
+        anyhow::bail!("response does not contain a move struct object");
     };
     Ok(move_object_type.address().into())
 }


### PR DESCRIPTION
## Description

contributes to WAL-357

Follow-up:
- Quorum-based upgrades

## Test plan

- unit test in move for custom upgrade policy
- existing tests
- will work on adding integration tests for upgrades with WAL-481

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
