### PR TITLE
chore: rename `mainnet-contracts` feature to `walrus-mainnet`

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -113,7 +113,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
           shared-key: v0-rust-test
       - name: Run tests
-        run: cargo nextest run --workspace --profile ci --run-ignored all --features mainnet-contracts
+        run: cargo nextest run --workspace --profile ci --run-ignored all --features walrus-mainnet
 
   test:
     name: Test Rust code with testnet contracts

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
         pass_filenames: false
       - id: cargo-test
         name: cargo-test
-        entry: cargo nextest run --features mainnet-contracts
+        entry: cargo nextest run --features walrus-mainnet
         language: rust
         files: (^crates/|Cargo\.(toml|lock)$|nextest\.toml$)
         pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,14 +82,15 @@ The Move formatter can then be run manually by executing:
 prettier-move --write <path-to-move-file-or-folder>
 ```
 
-## Contract Versions
+## Testnet/Mainnet Versions
 
-To allow breaking changes in the contracts, while keeping compatibility with the deployed testnet
-version in the Rust codebase, we gate any incompatible changes in the Rust bindings for the
-contracts behind the `mainnet-contracts` feature.
+To allow breaking changes in the contracts, CLI options, APIs, DB tables, and configuration files,
+while keeping the binaries built and deployed for Testnet backwards-compatible, we gate any
+incompatible changes in the Rust code behind the `walrus-mainnet` feature.
 
 If you make any changes to the contracts that necessitates corresponding changes in Rust, make sure
-to gate these changes behind the feature, e.g. by adding the `#[cfg(feature = "mainnet-contracts")]` attribute.
+to gate these changes behind the feature, e.g. by adding the `#[cfg(feature = "walrus-mainnet")]`
+attribute. The same applies to breaking changes in the CLI, APIs, DB tables, and configuration files.
 
 ## Tests
 
@@ -104,7 +105,7 @@ contracts as deployed on testnet, for which the contracts are located in `testne
 For the first option, you can run these tests as follows:
 
 ```sh
-cargo nextest run --run-ignored ignored-only --features mainnet-contracts
+cargo nextest run --run-ignored ignored-only --features walrus-mainnet
 ```
 
 For the second option, simply run:
@@ -131,11 +132,11 @@ For running tests, start the external cluster with `sui start`, set the environm
 CLUSTER_CONFIG_DIR="$PWD/target/sui-start"
 SUI_CONFIG_DIR="$CLUSTER_CONFIG_DIR" sui start&
 SUI_PID=$!
-SUI_TEST_CONFIG_DIR="$CLUSTER_CONFIG_DIR" cargo test -- --ignored --features mainnet-contracts
+SUI_TEST_CONFIG_DIR="$CLUSTER_CONFIG_DIR" cargo test -- --ignored --features walrus-mainnet
 ```
 
 This runs the tests with the newest contract version. To run them with the testnet version,
-run them without the `--features mainnet-contracts` flag.
+run them without the `--features walrus-mainnet` flag.
 
 After the tests have completed, you can stop the cluster:
 
@@ -180,7 +181,7 @@ To run simulation tests, first install the `cargo simtest` tool:
 You can then run all simtests with
 
 ```sh
-cargo simtest --features mainnet-contracts
+cargo simtest --features walrus-mainnet
 ```
 
 Further information about the simtest framework is available

--- a/crates/walrus-orchestrator/Cargo.toml
+++ b/crates/walrus-orchestrator/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 
 
 [features]
-mainnet-contracts = ["walrus-sui/mainnet-contracts"]
+walrus-mainnet = ["walrus-sui/walrus-mainnet"]
 
 [dependencies]
 aws-config = "1.5.10"

--- a/crates/walrus-orchestrator/src/protocol/target.rs
+++ b/crates/walrus-orchestrator/src/protocol/target.rs
@@ -94,7 +94,7 @@ mod default_node_parameters {
     }
 
     pub fn default_contract_path() -> PathBuf {
-        if cfg!(feature = "mainnet-contracts") {
+        if cfg!(feature = "walrus-mainnet") {
             PathBuf::from("./contracts/walrus")
         } else {
             PathBuf::from("./testnet-contracts/walrus")

--- a/crates/walrus-service/Cargo.toml
+++ b/crates/walrus-service/Cargo.toml
@@ -29,7 +29,6 @@ client = [
 ]
 default = ["client", "deploy", "node"]
 deploy = ["client", "node", "walrus-sui/test-utils"]
-mainnet-contracts = ["walrus-sui/mainnet-contracts"]
 node = [
   "dep:async-trait",
   "dep:enum_dispatch",
@@ -48,6 +47,7 @@ test-utils = [
   "walrus-core/test-utils",
   "walrus-sui/test-utils",
 ]
+walrus-mainnet = ["walrus-sui/walrus-mainnet"]
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/walrus-service/bin/deploy.rs
+++ b/crates/walrus-service/bin/deploy.rs
@@ -56,11 +56,11 @@ struct DeploySystemContractArgs {
     /// specify a custom Sui network, pass a string of the format `<RPC_URL>;<FAUCET_URL>`.
     #[clap(long, default_value = "testnet")]
     sui_network: SuiNetwork,
-    #[cfg(feature = "mainnet-contracts")]
+    #[cfg(feature = "walrus-mainnet")]
     /// The directory in which the contracts are located.
     #[clap(long, default_value = "./contracts/walrus")]
     contract_path: PathBuf,
-    #[cfg(not(feature = "mainnet-contracts"))]
+    #[cfg(not(feature = "walrus-mainnet"))]
     /// The directory in which the contracts are located.
     #[clap(long, default_value = "./testnet-contracts/walrus")]
     contract_path: PathBuf,

--- a/crates/walrus-service/bin/node.rs
+++ b/crates/walrus-service/bin/node.rs
@@ -244,11 +244,11 @@ struct ConfigArgs {
     #[clap(long, default_value_t = config::defaults::write_price())]
     /// Initial vote for the write price in FROST per MiB.
     write_price: u64,
-    #[cfg(not(feature = "mainnet-contracts"))]
+    #[cfg(not(feature = "walrus-mainnet"))]
     #[clap(long, default_value_t = 0)]
     /// The commission rate of the storage node, in basis points.
     commission_rate: u64,
-    #[cfg(feature = "mainnet-contracts")]
+    #[cfg(feature = "walrus-mainnet")]
     #[clap(long, default_value_t = 0)]
     /// The commission rate of the storage node, in basis points.
     commission_rate: u16,

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -99,11 +99,11 @@ pub struct StorageNodeConfig {
     #[serde(default, skip_serializing_if = "defaults::is_default")]
     pub event_provider_config: EventProviderConfig,
     /// The commission rate of the storage node, in basis points.
-    #[cfg(not(feature = "mainnet-contracts"))]
+    #[cfg(not(feature = "walrus-mainnet"))]
     #[serde(default)]
     pub commission_rate: u64,
     /// The commission rate of the storage node, in basis points.
-    #[cfg(feature = "mainnet-contracts")]
+    #[cfg(feature = "walrus-mainnet")]
     #[serde(default)]
     pub commission_rate: u16,
     /// The parameters for the staking pool.

--- a/crates/walrus-service/src/testbed.rs
+++ b/crates/walrus-service/src/testbed.rs
@@ -70,10 +70,10 @@ pub struct TestbedNodeConfig {
     /// The network key of the node.
     #[serde_as(as = "Base64")]
     pub network_keypair: NetworkKeyPair,
-    #[cfg(feature = "mainnet-contracts")]
+    #[cfg(feature = "walrus-mainnet")]
     /// The commission rate of the storage node.
     pub commission_rate: u16,
-    #[cfg(not(feature = "mainnet-contracts"))]
+    #[cfg(not(feature = "walrus-mainnet"))]
     /// The commission rate of the storage node.
     pub commission_rate: u64,
     /// The vote for the storage price per unit.

--- a/crates/walrus-sui/Cargo.toml
+++ b/crates/walrus-sui/Cargo.toml
@@ -8,13 +8,13 @@ license.workspace = true
 
 [features]
 default = []
-mainnet-contracts = []
 test-utils = [
   "dep:tempfile",
   "dep:test-cluster",
   "dep:walrus-test-utils",
   "walrus-core/test-utils",
 ]
+walrus-mainnet = []
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/walrus-sui/src/client/transaction_builder.rs
+++ b/crates/walrus-sui/src/client/transaction_builder.rs
@@ -265,14 +265,14 @@ impl WalrusPtbBuilder {
         blob_object: ArgumentOrOwnedObject,
         certificate: &ConfirmationCertificate,
     ) -> SuiClientResult<()> {
-        #[cfg(not(feature = "mainnet-contracts"))]
+        #[cfg(not(feature = "walrus-mainnet"))]
         let signers = {
             let mut signers = certificate.signers.clone();
             signers.sort_unstable();
             signers
         };
 
-        #[cfg(feature = "mainnet-contracts")]
+        #[cfg(feature = "walrus-mainnet")]
         let signers = Self::signers_to_bitmap(&certificate.signers);
 
         let certify_args = vec![
@@ -286,7 +286,7 @@ impl WalrusPtbBuilder {
         Ok(())
     }
 
-    #[cfg(feature = "mainnet-contracts")]
+    #[cfg(feature = "walrus-mainnet")]
     fn signers_to_bitmap(signers: &[u16]) -> Vec<u8> {
         let mut bitmap = vec![0; signers.len().div_ceil(8)];
         for signer in signers {
@@ -404,14 +404,14 @@ impl WalrusPtbBuilder {
         &mut self,
         certificate: &InvalidBlobCertificate,
     ) -> SuiClientResult<()> {
-        #[cfg(not(feature = "mainnet-contracts"))]
+        #[cfg(not(feature = "walrus-mainnet"))]
         let signers = {
             let mut signers = certificate.signers.clone();
             signers.sort_unstable();
             signers
         };
 
-        #[cfg(feature = "mainnet-contracts")]
+        #[cfg(feature = "walrus-mainnet")]
         let signers = Self::signers_to_bitmap(&certificate.signers);
 
         let invalidate_args = vec![

--- a/crates/walrus-sui/src/test_utils/system_setup.rs
+++ b/crates/walrus-sui/src/test_utils/system_setup.rs
@@ -37,7 +37,7 @@ const DEFAULT_MAX_EPOCHS_AHEAD: EpochCount = 104;
 
 /// Provides the default contract path for testing for the package with name `package`.
 pub fn contract_path_for_testing(package: &str) -> anyhow::Result<PathBuf> {
-    let contract_dir = if cfg!(feature = "mainnet-contracts") {
+    let contract_dir = if cfg!(feature = "walrus-mainnet") {
         "contracts"
     } else {
         "testnet-contracts"

--- a/crates/walrus-sui/src/types.rs
+++ b/crates/walrus-sui/src/types.rs
@@ -95,10 +95,10 @@ pub struct NodeRegistrationParams {
     pub public_key: PublicKey,
     /// The network key of the storage node.
     pub network_public_key: NetworkPublicKey,
-    #[cfg(not(feature = "mainnet-contracts"))]
+    #[cfg(not(feature = "walrus-mainnet"))]
     /// The commission rate of the storage node.
     pub commission_rate: u64,
-    #[cfg(feature = "mainnet-contracts")]
+    #[cfg(feature = "walrus-mainnet")]
     /// The commission rate of the storage node.
     pub commission_rate: u16,
     /// The vote for the storage price per unit.

--- a/crates/walrus-sui/src/types/move_errors.rs
+++ b/crates/walrus-sui/src/types/move_errors.rs
@@ -134,9 +134,9 @@ impl FromStr for RawMoveError {
 }
 
 // Include the auto-generated error definitions based on the Move source code.
-#[cfg(feature = "mainnet-contracts")]
+#[cfg(feature = "walrus-mainnet")]
 include!(concat!(env!("OUT_DIR"), "/contracts_error_defs.rs"));
-#[cfg(not(feature = "mainnet-contracts"))]
+#[cfg(not(feature = "walrus-mainnet"))]
 include!(concat!(env!("OUT_DIR"), "/testnet-contracts_error_defs.rs"));
 
 impl From<&str> for MoveExecutionError {

--- a/crates/walrus-sui/src/types/move_structs.rs
+++ b/crates/walrus-sui/src/types/move_structs.rs
@@ -161,7 +161,7 @@ impl Display for StorageNodeCap {
 
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize)]
 enum PoolState {
-    #[cfg(not(feature = "mainnet-contracts"))]
+    #[cfg(not(feature = "walrus-mainnet"))]
     // The pool is new and awaits the stake to be added.
     New,
     // The pool is active and can accept stakes.
@@ -184,7 +184,7 @@ pub struct VotingParams {
     pub node_capacity: u64,
 }
 
-#[cfg(feature = "mainnet-contracts")]
+#[cfg(feature = "walrus-mainnet")]
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize)]
 /// The receiver of the commission.
 enum CommissionReceiver {
@@ -214,16 +214,16 @@ pub(crate) struct StakingPool {
     pool_token_balance: u64,
     /// Pending withdrawals from the pool token balance indexed by epoch.
     pending_pool_token_withdraw: Vec<(Epoch, u64)>,
-    #[cfg(feature = "mainnet-contracts")]
+    #[cfg(feature = "walrus-mainnet")]
     /// Pending early withdrawals for which we cannot calculate the pool tokens.
     pending_early_withdrawals: Vec<(Epoch, u64)>,
-    #[cfg(feature = "mainnet-contracts")]
+    #[cfg(feature = "walrus-mainnet")]
     /// Pending commission rate changes indexed by epoch.
     pending_commission_rate: Vec<(Epoch, u64)>,
-    #[cfg(not(feature = "mainnet-contracts"))]
+    #[cfg(not(feature = "walrus-mainnet"))]
     /// The commission rate for the pool.
     commission_rate: u64,
-    #[cfg(feature = "mainnet-contracts")]
+    #[cfg(feature = "walrus-mainnet")]
     /// The commission rate for the pool.
     commission_rate: u16,
     /// Exchange rates table ID.
@@ -233,13 +233,13 @@ pub(crate) struct StakingPool {
     pending_stake: Vec<(Epoch, u64)>,
     /// The rewards that the pool has received.
     rewards: u64,
-    #[cfg(feature = "mainnet-contracts")]
+    #[cfg(feature = "walrus-mainnet")]
     /// Collected commission.
     commission: u64,
-    #[cfg(feature = "mainnet-contracts")]
+    #[cfg(feature = "walrus-mainnet")]
     /// The receiver of the commission.
     commission_receiver: CommissionReceiver,
-    #[cfg(feature = "mainnet-contracts")]
+    #[cfg(feature = "walrus-mainnet")]
     #[serde(deserialize_with = "deserialize_bag_or_table")]
     extra_fields: ObjectID,
 }
@@ -296,7 +296,7 @@ pub struct EventBlob {
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize)]
 pub struct EventBlobCertificationState {
     /// The object ID of the inner object.
-    #[cfg(not(feature = "mainnet-contracts"))]
+    #[cfg(not(feature = "walrus-mainnet"))]
     pub id: ObjectID,
     /// Latest certified blob
     pub latest_certified_blob: Option<EventBlob>,
@@ -432,7 +432,7 @@ pub(crate) struct BlsCommittee {
     n_shards: u16,
     /// The current epoch
     epoch: Epoch,
-    #[cfg(feature = "mainnet-contracts")]
+    #[cfg(feature = "walrus-mainnet")]
     /// Aggregated key for all committee members
     #[serde(deserialize_with = "deserialize_public_key")]
     aggregated_keys: PublicKey,
@@ -498,10 +498,10 @@ where
 pub enum StakedWalState {
     /// The WAL is staked.
     Staked,
-    #[cfg(not(feature = "mainnet-contracts"))]
+    #[cfg(not(feature = "walrus-mainnet"))]
     /// The WAL is unstaked and can be withdrawn.
     Withdrawing(Epoch, u64),
-    #[cfg(feature = "mainnet-contracts")]
+    #[cfg(feature = "walrus-mainnet")]
     /// The WAL is unstaked and can be withdrawn.
     Withdrawing(Epoch, Option<u64>),
 }
@@ -510,11 +510,11 @@ impl Display for StakedWalState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             StakedWalState::Staked => write!(f, "Staked"),
-            #[cfg(not(feature = "mainnet-contracts"))]
+            #[cfg(not(feature = "walrus-mainnet"))]
             StakedWalState::Withdrawing(epoch, amount) => {
                 write!(f, "Withdrawing: epoch={}, amount={}", epoch, amount)
             }
-            #[cfg(feature = "mainnet-contracts")]
+            #[cfg(feature = "walrus-mainnet")]
             StakedWalState::Withdrawing(epoch, Some(amount)) => {
                 write!(
                     f,
@@ -522,7 +522,7 @@ impl Display for StakedWalState {
                     epoch, amount
                 )
             }
-            #[cfg(feature = "mainnet-contracts")]
+            #[cfg(feature = "walrus-mainnet")]
             StakedWalState::Withdrawing(epoch, None) => {
                 write!(f, "Withdrawing: epoch={}, pool token amount=Unknown", epoch)
             }

--- a/scripts/local-testbed.sh
+++ b/scripts/local-testbed.sh
@@ -90,10 +90,10 @@ fi
 echo Building walrus, walrus-node, and walrus-deploy binaries...
 features="deploy"
 if $testnet_contracts; then
-    echo "Using testnet contracts."
+    echo "Using testnet version."
 else
-    echo "Using mainnet contracts."
-    features="$features,mainnet-contracts"
+    echo "Using mainnet version."
+    features="$features,walrus-mainnet"
 fi
 cargo build --release --bin walrus --bin walrus --bin walrus-node --bin walrus-deploy --features "$features"
 


### PR DESCRIPTION
## Description

We were using `mainnet-contracts` to feature-gate breaking changes. However, this now applies to parts of the code that are unrelated to contracts, so it makes sense to make the name more general.

I'm not aware of any other repo that uses this feature (I checked `walrus-sites` and `sui-operations`), so this doesn't require any additional changes.

## Test plan

Existing automatic tests.