### PR TITLE
test: make nodes_drive_epoch_change more robust

### DIFF
--- a/crates/walrus-proc-macros/src/lib.rs
+++ b/crates/walrus-proc-macros/src/lib.rs
@@ -25,12 +25,12 @@ pub fn walrus_simtest(args: TokenStream, item: TokenStream) -> TokenStream {
         let fn_name = &input.sig.ident;
         input.sig.ident = syn::Ident::new(&format!("simtest_{}", fn_name), fn_name.span());
         quote! {
-            #[sui_macros::sim_test(#(#args)*)]
+            #[sui_macros::sim_test(#(#args),*)]
             #input
         }
     } else {
         quote! {
-            #[tokio::test(#(#args)*)]
+            #[tokio::test(#(#args),*)]
             #input
         }
     };

--- a/crates/walrus-service/tests/epoch_change.rs
+++ b/crates/walrus-service/tests/epoch_change.rs
@@ -7,20 +7,30 @@ use std::time::Duration;
 
 use tokio::time;
 use walrus_core::Epoch;
-use walrus_service::test_utils::test_cluster;
+use walrus_proc_macros::walrus_simtest;
+use walrus_service::{
+    client::ClientCommunicationConfig,
+    test_utils::{test_cluster, StorageNodeHandle},
+};
 use walrus_test_utils::Result as TestResult;
 
 #[ignore = "ignore E2E tests by default"]
-#[tokio::test(flavor = "multi_thread", worker_threads = 5)]
+#[walrus_simtest]
 async fn nodes_drive_epoch_change() -> TestResult {
     let _ = tracing_subscriber::fmt::try_init();
-    let epoch_duration = Duration::from_secs(10);
+    let epoch_duration = Duration::from_secs(5);
     let (_sui, storage_nodes, _) =
-        test_cluster::default_setup_with_epoch_duration(epoch_duration).await?;
+        test_cluster::default_setup_with_epoch_duration_generic::<StorageNodeHandle>(
+            epoch_duration,
+            &[1, 1],
+            true,
+            ClientCommunicationConfig::default_for_test(),
+        )
+        .await?;
 
-    let target_epoch: Epoch = 4;
-    // Allow time to reach the desired epoch, with an additional 50% for the jitter.
-    let time_to_reach_epoch = epoch_duration * target_epoch * 15 / 10;
+    let target_epoch: Epoch = 3;
+    // Allow twice the expected time to reach the desired epoch.
+    let time_to_reach_epoch = epoch_duration * target_epoch * 2;
 
     time::timeout(
         time_to_reach_epoch,


### PR DESCRIPTION
## Description

- decrease the cluster size
- decrease number of epochs and epoch duration
- add more slack for the timeout
- make the test also a simtest
- add missing commas to the `walrus_simtest` proc macro (this also requires https://github.com/MystenLabs/sui/pull/20643)

Closes WAL-322.

## Test plan

Automatic tests.