### PR TITLE
fix: use correct type for WAL coins

### DIFF
--- a/crates/walrus-sui/src/client/read_client.rs
+++ b/crates/walrus-sui/src/client/read_client.rs
@@ -506,7 +506,13 @@ impl SuiReadClient {
 
     /// Returns the type of the WAL coin.
     pub fn wal_coin_type(&self) -> String {
-        format!("{}::wal::WAL", self.walrus_package_id)
+        // TODO: WAL-425
+        let type_name = ("wal".to_string(), "WAL".to_string());
+        let package_id = self
+            .type_origin_map
+            .get(&type_name)
+            .expect("WAL type origin not found");
+        format!("{}::{}::{}", package_id, type_name.0, type_name.1)
     }
 
     async fn get_system_object(&self) -> SuiClientResult<SystemObject> {


### PR DESCRIPTION
## Description

Ensures that we use the correct package ID for the `wal::WAL` coin type even if we specify the upgraded walrus package in the config.

Note: This is temporary, since we anyway need to handle the different packages separately (WAL-425).

## Test plan

Tested manually with the updated contract on testnet.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
