### PR TITLE
fix: wal_balance_at_epoch should take pre_active_withdrawals into account

### DIFF
--- a/contracts/walrus/sources/staking/staking_pool.move
+++ b/contracts/walrus/sources/staking/staking_pool.move
@@ -551,7 +551,9 @@ public(package) fun wal_balance_at_epoch(pool: &StakingPool, epoch: u32): u64 {
     pre_active_withdrawals.keys().do_ref!(|old_epoch| if (*old_epoch <= epoch) {
         let wal_value = pre_active_withdrawals.get(old_epoch);
         // recall that pre_active_withdrawals contains stakes that were
-        // active for exactly 1 epoch.
+        // active for exactly 1 epoch. since the node might have been
+        // inactive, this list may contain more than one value
+        // (although exchange_rate_at_epoch will return the same value).
         let activation_epoch = *old_epoch - 1;
         let token_value_for_epoch = pool
             .exchange_rate_at_epoch(activation_epoch)


### PR DESCRIPTION
## Description

wal_balance_at_epoch should take pre_active_withdrawals into account

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
