### PR TITLE
chore: set_node_status should only be called from StorageNodeInner::set_node_status

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -882,7 +882,7 @@ impl StorageNode {
             tracing::info!(
                 "node is not in the current committee, set node status to Standby status"
             );
-            self.inner.storage.set_node_status(NodeStatus::Standby)?;
+            self.inner.set_node_status(NodeStatus::Standby)?;
             event_handle.mark_as_complete();
             return Ok(());
         }
@@ -947,7 +947,7 @@ impl StorageNode {
                 // current committee, and therefore from this epoch, it won't sync any blob
                 // metadata. In the case it becomes committee member again, it needs to sync blob
                 // metadata again.
-                self.inner.storage.set_node_status(NodeStatus::Standby)?;
+                self.inner.set_node_status(NodeStatus::Standby)?;
             }
             self.process_shard_changes_in_new_epoch(event_handle, event, false)
                 .await
@@ -1113,9 +1113,7 @@ impl StorageNode {
                 // It's also important to set RecoverMetadata status after creating storage for
                 // the new shards. Restarting seeing RecoverMetadata status will assume all the
                 // shards are created.
-                self.inner
-                    .storage
-                    .set_node_status(NodeStatus::RecoverMetadata)?;
+                self.inner.set_node_status(NodeStatus::RecoverMetadata)?;
             }
 
             // There shouldn't be an epoch change event for the genesis epoch.
@@ -3662,9 +3660,7 @@ mod tests {
 
         if wipe_metadata_before_transfer_in_dst {
             node_inner.storage.clear_metadata_in_test()?;
-            node_inner
-                .storage
-                .set_node_status(NodeStatus::RecoverMetadata)?;
+            node_inner.set_node_status(NodeStatus::RecoverMetadata)?;
         }
 
         cluster.nodes[1]
@@ -3728,9 +3724,7 @@ mod tests {
 
         if wipe_metadata_before_transfer_in_dst {
             node_inner.storage.clear_metadata_in_test()?;
-            node_inner
-                .storage
-                .set_node_status(NodeStatus::RecoverMetadata)?;
+            node_inner.set_node_status(NodeStatus::RecoverMetadata)?;
         }
 
         cluster.nodes[1]

--- a/crates/walrus-service/src/node/shard_sync.rs
+++ b/crates/walrus-service/src/node/shard_sync.rs
@@ -104,7 +104,6 @@ impl ShardSyncHandler {
             == NodeStatus::RecoverMetadata
         {
             self.node
-                .storage
                 .set_node_status(NodeStatus::Active)
                 .expect("setting node status should not fail");
         }


### PR DESCRIPTION
## Description

Directly calling Storage::set_node_status() won't update the `current_node_status` metrics.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
