### PR TITLE
fix(publisher): improve response formats

### DIFF
--- a/crates/walrus-service/src/client/resource.rs
+++ b/crates/walrus-service/src/client/resource.rs
@@ -64,6 +64,7 @@ impl PriceComputation {
 
 /// The operation performed on blob and storage resources to register a blob.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase", rename_all_fields = "camelCase")]
 pub enum RegisterBlobOp {
     /// The storage and blob resources are purchased from scratch.
     RegisterFromScratch {

--- a/crates/walrus-service/src/client/responses.rs
+++ b/crates/walrus-service/src/client/responses.rs
@@ -50,6 +50,7 @@ use crate::client::cli::{format_event_id, HumanReadableFrost};
 
 /// Either an event ID or an object ID.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub enum EventOrObjectId {
     /// The variant representing an event ID.
     Event(EventID),
@@ -85,6 +86,7 @@ pub enum BlobStoreResult {
         ///
         /// The object ID of the registered blob is used in place of the event ID when the blob is
         /// deletable, already certified, and owned by the client.
+        #[serde(flatten)]
         event_or_object: EventOrObjectId,
         /// The epoch until which the blob is stored (exclusive).
         #[schema(value_type = u64)]


### PR DESCRIPTION
## Description

Currently the publisher's responses contain fields that are not camelCased. Also, the response for an already existing blob is overly complicated.

Closes WAL-484.

## Test plan

Run a publisher and look at its OpenAPI specification.

---

## Release notes

- [x] Publisher: Minor modifications to the response format when storing blobs.
