### PR TITLE
fix(node): don't serialize default backoff config

### DIFF
--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -367,7 +367,7 @@ pub struct SuiConfig {
     #[serde(deserialize_with = "utils::resolve_home_dir")]
     pub wallet_config: PathBuf,
     /// The configuration for the backoff strategy used for retries.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "defaults::is_default")]
     pub backoff_config: ExponentialBackoffConfig,
     /// Gas budget for transactions.
     #[serde(default = "defaults::gas_budget")]

--- a/crates/walrus-utils/src/backoff.rs
+++ b/crates/walrus-utils/src/backoff.rs
@@ -7,7 +7,7 @@ use rand::{rngs::StdRng, Rng, SeedableRng};
 use serde::{Deserialize, Serialize};
 
 /// Wrapper for the configuration for the exponential backoff strategy.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ExponentialBackoffConfig {
     /// The minimum backoff duration.
     pub min_backoff: Duration,


### PR DESCRIPTION
## Description

We have commands to generate storage-node configs, which is supposed to skip default values (so that those can be adjusted later). With this PR, the backoff config is also skipped if it is the default value.

## Test plan

Run `walrus-node generate-config` and check that the backoff config is not contained in the resulting config file.
