### PR TITLE
fix: build.sh should include all binaries

### DIFF
--- a/docker/walrus-service/build.sh
+++ b/docker/walrus-service/build.sh
@@ -32,7 +32,5 @@ docker build -f "$DOCKERFILE" "$REPO_ROOT" \
   --build-arg GIT_REVISION="$GIT_REVISION" \
   --build-arg BUILD_DATE="$BUILD_DATE" \
   --build-arg PROFILE="$PROFILE" \
-  --target walrus-cli \
-  --target walrus-node \
-  --target walrus-deploy \
+  --target walrus-service \
   "$@"


### PR DESCRIPTION
## Description

build.sh is problematic, docker will only take the last target. so changing the script to use the image with all binaries

## Test plan

tested locally

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
