### PR TITLE
ci: make simtests blocking for PRs

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -229,6 +229,7 @@ jobs:
       - build
       - test
       - test-mainnet
+      - simtests
       - test-move
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Now that our simtests are succeeding consistently, let's make them mandatory for PRs.
