### PR TITLE
fix: temporary fix for imcompatible node status

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -625,6 +625,11 @@ impl StorageNode {
                         );
                         self.inner.set_node_status(NodeStatus::RecoveryCatchUp)?;
                     }
+
+                    // If the node is not lagging behind, see if we need to fix the node status.
+                    // TODO(WAL-490): remove this once all the nodes are using 1.7.3 or later
+                    // version.
+                    self.fix_standby_node_status()?;
                 }
             }
 
@@ -639,6 +644,32 @@ impl StorageNode {
         }
 
         bail!("event stream for blob events stopped")
+    }
+
+    // In 1.7, we introduced an incompatible change to the node status, where the old active
+    // status before 1.7 is mapped to the new Standby status in 1.7. This function
+    // is a temporary fix to map the old active status to the new Active status if we see that
+    // a node is in Standby status and is in both the current and previous committees.
+    fn fix_standby_node_status(&self) -> anyhow::Result<()> {
+        tracing::info!("checking standby node status");
+        // Do a DB read here to make sure we read the on disk status.
+        if self.inner.storage.node_status()? == NodeStatus::Standby {
+            let active_committees = self.inner.committee_service.active_committees();
+            let node_public_key = self.inner.public_key();
+            if active_committees
+                .current_committee()
+                .contains(node_public_key)
+                && active_committees
+                    .previous_committee()
+                    .is_some_and(|c| c.contains(node_public_key))
+            {
+                tracing::info!(
+                    "node is in Standby status and is up-to-date, set node status to Active"
+                );
+                self.inner.set_node_status(NodeStatus::Active)?;
+            }
+        }
+        Ok(())
     }
 
     #[tracing::instrument(skip_all)]

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -59,6 +59,9 @@ pub struct WouldBlockError;
 //          \          /            \      |
 //           v        v              \     v
 //          RecoverMetadata  -------> Active
+//
+// Important: this enum is committed to database. Do not modify the existing fields. Only add new
+// fields at the end.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum NodeStatus {
     /// The node is in recovery mode and syncing metadata.

--- a/crates/walrus-service/src/node/storage/shard.rs
+++ b/crates/walrus-service/src/node/storage/shard.rs
@@ -54,6 +54,8 @@ use crate::node::{
     StorageNodeInner,
 };
 
+// Important: this enum is committed to database. Do not modify the existing fields. Only add new
+// fields at the end.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum ShardStatus {
     /// Initial status of the shard when just created.


### PR DESCRIPTION
## Description

In this [PR](https://github.com/MystenLabs/walrus/pull/1295), I introduced an careless incompatible change where I updated the NodeStatus enum in place, that caused the old Active status is mapped to the new Standby status. Now, all the existing nodes who were in active status are in standby status. This has no bad consequences since standby status does not affect normal node operation, but we need to fix this.

This PR is a temporary fix that upon starting the node, after checking if the node is lagging or not, it checks if the node is in both previous and current committee and also in Standby status. If so, we change the node status to Active. This should be a safe change since if the node is not lagging, it must have already processed the EpochChangeStart event. Any new nodes who are in Standby status should have been updated. The only left ones are those who were in Active status.

We need to revert this change once all nodes passed the version (1.7.3) that includes this change.

Contribute WAL-490

## Test plan

Deployment to PTN.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [x] Storage node: Fixes an incorrectly set `Standby` status on existing storage nodes and sets it to `Active`.
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
