### PR TITLE
chore: update client default gas budget to 1 Sui

### DIFF
--- a/crates/walrus-sui/src/test_utils.rs
+++ b/crates/walrus-sui/src/test_utils.rs
@@ -51,7 +51,7 @@ use crate::{
 };
 
 /// Default gas budget for transactions in tests and benchmarks.
-pub const DEFAULT_GAS_BUDGET: u64 = 500_000_000;
+pub const DEFAULT_GAS_BUDGET: u64 = 1_000_000_000;
 const DEFAULT_FUNDING_PER_COIN: u64 = 10_000_000_000;
 
 /// Returns a random `EventID` for testing.


### PR DESCRIPTION
## Description

When setting up 100 node cluster, initiate epoch change fails with insufficient gas. [Sample transaction](https://devnet.suivision.xyz/txblock/BfD4h3yek73C9yb1SXxu9DSVbJ4Vw5dGQjJPv13WhNnu) revealed that 0.5 Sui gas budget is not enough.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
