### PR TITLE
chore: add a subsection for owned shard status in shard summary

### DIFF
--- a/crates/walrus-sdk/src/api.rs
+++ b/crates/walrus-sdk/src/api.rs
@@ -234,6 +234,20 @@ pub struct ServiceHealthInfo {
     pub shard_detail: Option<ShardStatusDetail>,
 }
 
+/// The status of the shards for which the node is responsible.
+#[derive(Debug, Default, Clone, Deserialize, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct OwnedShardStatus {
+    /// The number of owned shards in an unknown state.
+    pub unknown: usize,
+    /// The number of owned shards that are up-to-date for the epoch.
+    pub ready: usize,
+    /// The number of owned shards that are being transferred to the node.
+    pub in_transfer: usize,
+    /// The number of owned shards that are being recovered.
+    pub in_recovery: usize,
+}
+
 /// Summary of the shard statuses.
 ///
 /// Summarises the number of nodes for which this node is responsible, as well as those that are
@@ -243,16 +257,10 @@ pub struct ServiceHealthInfo {
 pub struct ShardStatusSummary {
     /// The number of shards, for which this node is responsible.
     ///
-    /// Their statuses are summarized in `unknown`, `ready`, `in_transfer`, and `in_recovery`.
+    /// Their statuses are summarized in `owned_shard_status`.
     pub owned: usize,
-    /// The number of owned shards in an unknown state.
-    pub unknown: usize,
-    /// The number of owned shards that are up-to-date for the epoch.
-    pub ready: usize,
-    /// The number of owned shards that are being transferred to the node.
-    pub in_transfer: usize,
-    /// The number of owned shards that are being recovered.
-    pub in_recovery: usize,
+    /// The statuses of the shards for which this node is responsible.
+    pub owned_shard_status: OwnedShardStatus,
     /// The number of shards, no longer owned by the node, that are read only,
     /// i.e., only serving reads from this node.
     pub read_only: usize,

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -1675,10 +1675,10 @@ fn increment_shard_summary(
     debug_assert!(is_owned);
     summary.owned += 1;
     match status {
-        ApiShardStatus::Unknown => summary.unknown += 1,
-        ApiShardStatus::Ready => summary.ready += 1,
-        ApiShardStatus::InTransfer => summary.in_transfer += 1,
-        ApiShardStatus::InRecovery => summary.in_recovery += 1,
+        ApiShardStatus::Unknown => summary.owned_shard_status.unknown += 1,
+        ApiShardStatus::Ready => summary.owned_shard_status.ready += 1,
+        ApiShardStatus::InTransfer => summary.owned_shard_status.in_transfer += 1,
+        ApiShardStatus::InRecovery => summary.owned_shard_status.in_recovery += 1,
         // We do not expect owned shards to be read-only.
         _ => (),
     }

--- a/crates/walrus-sui/src/client/retry_client.rs
+++ b/crates/walrus-sui/src/client/retry_client.rs
@@ -37,8 +37,6 @@ use tracing::Level;
 use walrus_utils::backoff::{BackoffStrategy, ExponentialBackoff, ExponentialBackoffConfig};
 
 use super::{SuiClientError, SuiClientResult};
-#[cfg(not(feature = "walrus-mainnet"))]
-use crate::utils::get_package_id_from_object_response;
 use crate::{
     contracts::{AssociatedContractStruct, TypeOriginMap},
     types::move_structs::{SuiDynamicField, SystemObjectForDeserialization},


### PR DESCRIPTION
## Description

In today's shard summary when querying the health endpoint, we output:

"shardSummary": {
  "owned": 3,
  "ready": 3,
  ...
}

which is a bit confusing because the user doesn't know whether the node has 3 or 6 shards.

After the change, the shard summary section looks like this, which is clearer that the node has 3 shards, they are all in ready state.

      "shardSummary": {
        "owned": 3,
        "ownedShardStatus": {
          "unknown": 0,
          "ready": 3,
          "inTransfer": 0,
          "inRecovery": 0
        },
        "readOnly": 0
      },

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
