### PR TITLE
test: speed up simtest in CI; fix simtest db load issue

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -43,13 +43,14 @@ jobs:
       isMove: ${{ steps.diff.outputs.isMove }}
       isDenyConfig: ${{ steps.diff.outputs.isDenyConfig }}
       isTestConfig: ${{ steps.diff.outputs.isTestConfig }}
-      isRelevantForRustTests: ${{ steps.diff.outputs.isRust == 'true' || steps.diff.outputs.isMove == 'true' || steps.diff.outputs.isTestConfig
+      isRelevantForRustTests:
+        ${{ steps.diff.outputs.isRust == 'true' || steps.diff.outputs.isMove == 'true' || steps.diff.outputs.isTestConfig
         == 'true' }}
       isTestnetContracts: ${{ steps.diff.outputs.isTestnetContracts }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # Pin v4.1.1
       - name: Detect Changes
-        uses: './.github/actions/diffs'
+        uses: "./.github/actions/diffs"
         id: diff
 
   dependencies:
@@ -158,7 +159,7 @@ jobs:
     runs-on: ubuntu-ghcloud
     continue-on-error: true
     env:
-      MSIM_TEST_NUM: 10
+      MSIM_TEST_NUM: 5
       RUST_LOG: error
     steps:
       - uses: taiki-e/install-action@v2.46.6

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -21,6 +21,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use futures::{stream::FuturesUnordered, StreamExt};
 use prometheus::Registry;
+use sui_macros::nondeterministic;
 use sui_types::base_types::ObjectID;
 use tempfile::TempDir;
 use tokio::{task::JoinHandle, time::Duration};
@@ -381,10 +382,10 @@ impl SimStorageNodeHandle {
                     crate::node::events::event_processor::EventProcessorRuntimeConfig {
                         rpc_address: sui_config.rpc.clone(),
                         event_polling_interval: Duration::from_millis(100),
-                        db_path: tempfile::tempdir()
+                        db_path: nondeterministic!(tempfile::tempdir()
                             .expect("temporary directory creation must succeed")
                             .path()
-                            .to_path_buf(),
+                            .to_path_buf()),
                     };
                 let system_config = crate::node::events::event_processor::SystemConfig {
                     system_object_id: sui_config.system_object,
@@ -1637,7 +1638,9 @@ impl TestClusterBuilder {
                     builder,
                     self.sui_cluster_handle.clone(),
                     self.system_context.clone(),
-                    tempfile::tempdir().expect("temporary directory creation must succeed"),
+                    nondeterministic!(
+                        tempfile::tempdir().expect("temporary directory creation must succeed")
+                    ),
                     start_node_from_beginning,
                 )
                 .await?,
@@ -2148,10 +2151,10 @@ pub mod test_cluster {
             let processor_config = EventProcessorRuntimeConfig {
                 rpc_address: event_processor_config.rest_url.clone(),
                 event_polling_interval: Duration::from_millis(100),
-                db_path: tempfile::tempdir()
+                db_path: nondeterministic!(tempfile::tempdir()
                     .expect("temporary directory creation must succeed")
                     .path()
-                    .to_path_buf(),
+                    .to_path_buf()),
             };
             let system_config = SystemConfig {
                 system_pkg_id: sui_read_client.get_system_package_id(),
@@ -2193,7 +2196,7 @@ pub mod test_cluster {
 
 /// Creates a new [`StorageNodeConfig`] object for testing.
 pub fn storage_node_config() -> WithTempDir<StorageNodeConfig> {
-    let temp_dir = TempDir::new().expect("able to create a temporary directory");
+    let temp_dir = nondeterministic!(TempDir::new().expect("able to create a temporary directory"));
     let rest_api_address = unused_socket_address(false);
     WithTempDir {
         inner: StorageNodeConfig {
@@ -2247,7 +2250,8 @@ async fn wait_for_event_processor_to_start(
 
 /// Returns an empty storage, with the column families for the specified shards already created.
 pub fn empty_storage_with_shards(shards: &[ShardIndex]) -> WithTempDir<Storage> {
-    let temp_dir = tempfile::tempdir().expect("temporary directory creation must succeed");
+    let temp_dir =
+        nondeterministic!(tempfile::tempdir().expect("temporary directory creation must succeed"));
     let db_config = DatabaseConfig::default();
     let storage = Storage::open(temp_dir.path(), db_config, MetricConf::default())
         .expect("storage creation must succeed");


### PR DESCRIPTION
## Description

Reduce the iteration per test from 10 to 5. It currently occasionally times out the tests.

Also make temp dir creation in a separate thread so that it won't interfere with simtest determinisim.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
