### PR TITLE
fix: use a specific msim version to work around rust 1.83 non-determinism in MacOs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5552,7 +5552,7 @@ dependencies = [
 [[package]]
 name = "msim"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=9c6636c399d5c60a1759f1670b1c07b3d408799a#9c6636c399d5c60a1759f1670b1c07b3d408799a"
+source = "git+https://www.github.com/MystenLabs/mysten-sim.git?rev=2a170f4cd81c5cd10f5e4a5e810068f3045f41b6#2a170f4cd81c5cd10f5e4a5e810068f3045f41b6"
 dependencies = [
  "ahash 0.7.8",
  "async-task",
@@ -5581,7 +5581,7 @@ dependencies = [
 [[package]]
 name = "msim-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=9c6636c399d5c60a1759f1670b1c07b3d408799a#9c6636c399d5c60a1759f1670b1c07b3d408799a"
+source = "git+https://www.github.com/MystenLabs/mysten-sim.git?rev=2a170f4cd81c5cd10f5e4a5e810068f3045f41b6#2a170f4cd81c5cd10f5e4a5e810068f3045f41b6"
 dependencies = [
  "darling 0.14.4",
  "proc-macro2 1.0.92",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,3 +125,8 @@ inherits = "test"
 overflow-checks = true
 # opt-level 1 gives >5x speedup for simulator tests without slowing down build times very much.
 opt-level = 1
+
+# TODO: Remove this once Sui 1.41 is released.
+[patch."https://github.com/MystenLabs/mysten-sim.git"]
+msim = { git = "https://www.github.com/MystenLabs/mysten-sim.git", rev = "2a170f4cd81c5cd10f5e4a5e810068f3045f41b6" }
+msim-macros = { git = "https://www.github.com/MystenLabs/mysten-sim.git", rev = "2a170f4cd81c5cd10f5e4a5e810068f3045f41b6" }

--- a/deny.toml
+++ b/deny.toml
@@ -104,6 +104,7 @@ allow-git = [
   "https://github.com/mystenmark/tokio-madsim-fork",
   "https://github.com/wlmyng/jsonrpsee",
   "https://github.com/zhiburt/tabled",
+  "https://www.github.com/MystenLabs/mysten-sim.git",
 ]
 
 [sources.allow-org]

--- a/scripts/simtest/cargo-simtest
+++ b/scripts/simtest/cargo-simtest
@@ -54,9 +54,9 @@ if [ -n "$LOCAL_MSIM_PATH" ]; then
 else
   cargo_patch_args=(
     --config 'patch.crates-io.tokio.git = "https://github.com/MystenLabs/mysten-sim.git"'
-    --config 'patch.crates-io.tokio.rev = "9c6636c399d5c60a1759f1670b1c07b3d408799a"'
+    --config 'patch.crates-io.tokio.rev = "2a170f4cd81c5cd10f5e4a5e810068f3045f41b6"'
     --config 'patch.crates-io.futures-timer.git = "https://github.com/MystenLabs/mysten-sim.git"'
-    --config 'patch.crates-io.futures-timer.rev = "9c6636c399d5c60a1759f1670b1c07b3d408799a"'
+    --config 'patch.crates-io.futures-timer.rev = "2a170f4cd81c5cd10f5e4a5e810068f3045f41b6"'
   )
 fi
 


### PR DESCRIPTION
## Description

We upgraded to rust 1.83 where MacOs calls a new native function to get random bytes that are no longer determinism. @mystenmark fixed it in the msim repo. Before Sui 1.41 is released, we need to use a custom version of msim to get determinism when running simtest in MacOs.

Linux and CI are not affected.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
