### PR TITLE
fix: Increase gas budget when deploying system contracts

### DIFF
--- a/crates/walrus-service/bin/deploy.rs
+++ b/crates/walrus-service/bin/deploy.rs
@@ -65,7 +65,7 @@ struct DeploySystemContractArgs {
     #[clap(long, default_value = "./testnet-contracts/walrus")]
     contract_path: PathBuf,
     /// Gas budget for sui transactions to publish the contracts and set up the system.
-    #[arg(long, default_value_t = 500_000_000)]
+    #[arg(long, default_value_t = 1_000_000_000)]
     gas_budget: u64,
     /// The total number of shards. The shards are distributed evenly among the storage nodes.
     // TODO: accept non-even shard distributions #377


### PR DESCRIPTION
## Description

The default of 0.5 SUI is failing to deploy contracts with insufficient gas.
