### PR TITLE
feat: use dynamice field for inner staking/system objects

### DIFF
--- a/contracts/walrus/sources/staking.move
+++ b/contracts/walrus/sources/staking.move
@@ -6,7 +6,7 @@
 module walrus::staking;
 
 use std::string::String;
-use sui::{clock::Clock, coin::Coin, dynamic_object_field as df};
+use sui::{clock::Clock, coin::Coin, dynamic_field as df};
 use wal::wal::WAL;
 use walrus::{
     auth::{Self, Authenticated, Authorized},

--- a/contracts/walrus/sources/staking/staking_inner.move
+++ b/contracts/walrus/sources/staking/staking_inner.move
@@ -70,9 +70,7 @@ public enum EpochState has copy, drop, store {
 }
 
 /// The inner object for the staking part of the system.
-public struct StakingInnerV1 has key, store {
-    /// The object ID
-    id: UID,
+public struct StakingInnerV1 has store {
     /// The number of shards in the system.
     n_shards: u16,
     /// The duration of an epoch in ms. Does not affect the first (zero) epoch.
@@ -116,7 +114,6 @@ public(package) fun new(
     ctx: &mut TxContext,
 ): StakingInnerV1 {
     StakingInnerV1 {
-        id: object::new(ctx),
         n_shards,
         epoch_duration,
         first_epoch_start: epoch_zero_duration + clock.timestamp_ms(),

--- a/contracts/walrus/sources/system.move
+++ b/contracts/walrus/sources/system.move
@@ -5,7 +5,7 @@
 /// Module: system
 module walrus::system;
 
-use sui::{balance::Balance, coin::Coin, dynamic_object_field, vec_map::VecMap};
+use sui::{balance::Balance, coin::Coin, dynamic_field, vec_map::VecMap};
 use wal::wal::WAL;
 use walrus::{
     blob::Blob,
@@ -41,7 +41,7 @@ public(package) fun create_empty(max_epochs_ahead: u32, package_id: ID, ctx: &mu
         new_package_id: option::none(),
     };
     let system_state_inner = system_state_inner::create_empty(max_epochs_ahead, ctx);
-    dynamic_object_field::add(&mut system.id, VERSION, system_state_inner);
+    dynamic_field::add(&mut system.id, VERSION, system_state_inner);
     transfer::share_object(system);
 }
 
@@ -264,11 +264,11 @@ public(package) fun migrate(system: &mut System) {
     assert!(system.version < VERSION, EInvalidMigration);
 
     // Move the old system state inner to the new version.
-    let system_state_inner: SystemStateInnerV1 = dynamic_object_field::remove(
+    let system_state_inner: SystemStateInnerV1 = dynamic_field::remove(
         &mut system.id,
         system.version,
     );
-    dynamic_object_field::add(&mut system.id, VERSION, system_state_inner);
+    dynamic_field::add(&mut system.id, VERSION, system_state_inner);
     system.version = VERSION;
 
     // Set the new package id.
@@ -281,13 +281,13 @@ public(package) fun migrate(system: &mut System) {
 /// Get a mutable reference to `SystemStateInner` from the `System`.
 fun inner_mut(system: &mut System): &mut SystemStateInnerV1 {
     assert!(system.version == VERSION);
-    dynamic_object_field::borrow_mut(&mut system.id, VERSION)
+    dynamic_field::borrow_mut(&mut system.id, VERSION)
 }
 
 /// Get an immutable reference to `SystemStateInner` from the `System`.
 public(package) fun inner(system: &System): &SystemStateInnerV1 {
     assert!(system.version == VERSION);
-    dynamic_object_field::borrow(&system.id, VERSION)
+    dynamic_field::borrow(&system.id, VERSION)
 }
 
 // === Testing ===
@@ -302,7 +302,7 @@ public fun new_for_testing(): System {
         new_package_id: option::none(),
     };
     let system_state_inner = system_state_inner::new_for_testing();
-    dynamic_object_field::add(&mut system.id, VERSION, system_state_inner);
+    dynamic_field::add(&mut system.id, VERSION, system_state_inner);
     system
 }
 
@@ -315,7 +315,7 @@ public(package) fun new_for_testing_with_multiple_members(ctx: &mut TxContext): 
         new_package_id: option::none(),
     };
     let system_state_inner = system_state_inner::new_for_testing_with_multiple_members(ctx);
-    dynamic_object_field::add(&mut system.id, VERSION, system_state_inner);
+    dynamic_field::add(&mut system.id, VERSION, system_state_inner);
     system
 }
 

--- a/contracts/walrus/sources/system/system_state_inner.move
+++ b/contracts/walrus/sources/system/system_state_inner.move
@@ -43,8 +43,7 @@ const EIncorrectDenyListNode: u64 = 10;
 
 /// The inner object that is not present in signatures and can be versioned.
 #[allow(unused_field)]
-public struct SystemStateInnerV1 has key, store {
-    id: UID,
+public struct SystemStateInnerV1 has store {
     /// The current committee, with the current epoch.
     committee: BlsCommittee,
     // Some accounting
@@ -74,9 +73,7 @@ public(package) fun create_empty(max_epochs_ahead: u32, ctx: &mut TxContext): Sy
     assert!(max_epochs_ahead <= MAX_MAX_EPOCHS_AHEAD, EInvalidMaxEpochsAhead);
     let future_accounting = storage_accounting::ring_new(max_epochs_ahead);
     let event_blob_certification_state = event_blob::create_with_empty_state();
-    let id = object::new(ctx);
     SystemStateInnerV1 {
-        id,
         committee,
         total_capacity_size: 0,
         used_capacity_size: 0,
@@ -658,9 +655,7 @@ use walrus::test_utils;
 public(package) fun new_for_testing(): SystemStateInnerV1 {
     let committee = test_utils::new_bls_committee_for_testing(0);
     let ctx = &mut tx_context::dummy();
-    let id = object::new(ctx);
     SystemStateInnerV1 {
-        id,
         committee,
         total_capacity_size: 1_000_000_000,
         used_capacity_size: 0,
@@ -675,9 +670,7 @@ public(package) fun new_for_testing(): SystemStateInnerV1 {
 #[test_only]
 public(package) fun new_for_testing_with_multiple_members(ctx: &mut TxContext): SystemStateInnerV1 {
     let committee = test_utils::new_bls_committee_with_multiple_members_for_testing(0, ctx);
-    let id = object::new(ctx);
     SystemStateInnerV1 {
-        id,
         committee,
         total_capacity_size: 1_000_000_000,
         used_capacity_size: 0,

--- a/crates/walrus-sui/src/client/read_client.rs
+++ b/crates/walrus-sui/src/client/read_client.rs
@@ -572,7 +572,7 @@ impl SuiReadClient {
         }
         let inner = self
             .sui_client
-            .get_dynamic_field_object::<u64, SystemStateInnerV1>(
+            .get_dynamic_field::<u64, SystemStateInnerV1>(
                 self.system_object_id,
                 TypeTag::U64,
                 version,
@@ -622,11 +622,7 @@ impl SuiReadClient {
         }
         let inner = self
             .sui_client
-            .get_dynamic_field_object::<u64, StakingInnerV1>(
-                self.staking_object_id,
-                TypeTag::U64,
-                version,
-            )
+            .get_dynamic_field::<u64, StakingInnerV1>(self.staking_object_id, TypeTag::U64, version)
             .await?;
         let staking_object = StakingObject {
             id,

--- a/crates/walrus-sui/src/client/retry_client.rs
+++ b/crates/walrus-sui/src/client/retry_client.rs
@@ -330,6 +330,7 @@ impl RetriableSuiClient {
         .await
     }
 
+    #[allow(unused)]
     pub(crate) async fn get_dynamic_field_object<K, V>(
         &self,
         parent: ObjectID,

--- a/crates/walrus-sui/src/types/move_structs.rs
+++ b/crates/walrus-sui/src/types/move_structs.rs
@@ -405,6 +405,7 @@ type CommitteeShardAssignment = Vec<(ObjectID, Vec<u16>)>;
 /// Sui type for inner staking object
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize)]
 pub(crate) struct StakingInnerV1 {
+    #[cfg(not(feature = "walrus-mainnet"))]
     /// The object ID
     pub(crate) id: ObjectID,
     /// The number of shards in the system.
@@ -506,6 +507,7 @@ impl AssociatedContractStruct for SystemObjectForDeserialization {
 /// Sui type for inner system object.
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize)]
 pub(crate) struct SystemStateInnerV1 {
+    #[cfg(not(feature = "walrus-mainnet"))]
     /// The object ID of the inner object.
     pub id: ObjectID,
     /// The current committee of the Walrus instance.


### PR DESCRIPTION
## Description

Change from dynamic object fields to dynamic fields for the inner objects.
Damir (currently on PTO) and I had discussed this a while ago, because there is no benefit to having dynamic object fields here. As a nice side effect, this saves one RPC request any time we request the system or staking object.

## Test plan

Covered by existing tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
