### PR TITLE
fix: Fix order of arguments while catching up using events

### DIFF
--- a/crates/walrus-service/src/node/events/event_processor.rs
+++ b/crates/walrus-service/src/node/events/event_processor.rs
@@ -846,8 +846,8 @@ impl EventProcessor {
 
         let blobs = collect_event_blobs_for_catchup(
             clients.sui_client.clone(),
-            system_objects.system_object_id,
             system_objects.staking_object_id,
+            system_objects.system_object_id,
             Some(system_objects.system_pkg_id),
             next_checkpoint,
             recovery_path,


### PR DESCRIPTION
## Description

Describe the changes or additions included in this PR.

## Test plan

Checked the logs, and found working on private testnet:
```
Jan 07 22:37:59 guest walrus-node[3070204]: {"timestamp":"2025-01-07T22:37:59.525300Z","level":"INFO","fields":{"message":"Starting event catchup using event blobs"},"target":"walrus_service::node::events::event_processor","filename":"crates/walrus-service/src/node/events/event_processor.rs","line_number":835}
Jan 07 22:37:59 guest walrus-node[3070204]: {"timestamp":"2025-01-07T22:37:59.732385Z","level":"INFO","fields":{"message":"Starting downloading event blobs using event blobs from latest blob ID BlobId(iGsPuaznSVkwR82PWbBjj7fsCzDsLpyYUg-egsWsdvM) and going backwards"},"target":"walrus_service::common::event_blob_downloader","filename":"crates/walrus-service/src/common/event_blob_downloader.rs","line_number":50}
Jan 07 22:38:02 guest walrus-node[3070204]: {"timestamp":"2025-01-07T22:38:02.250642Z","level":"INFO","fields":{"message":"finished reading event blob","blob_id":"iGsPuaznSVkwR82PWbBjj7fsCzDsLpyYUg-egsWsdvM"},"target":"walrus_service::common::event_blob_downloader","filename":"crates/walrus-service/src/common/event_blob_downloader.rs","line_number":90}
Jan 07 22:38:02 guest walrus-node[3070204]: {"timestamp":"2025-01-07T22:38:02.250675Z","level":"INFO","fields":{"message":"Storing event blob BlobId(iGsPuaznSVkwR82PWbBjj7fsCzDsLpyYUg-egsWsdvM) with 18000 checkpoints"},"target":"walrus_service::common::event_blob_downloader","filename":"crates/walrus-service/src/common/event_blob_downloader.rs","line_number":103}
Jan 07 22:38:04 guest walrus-node[3070204]: {"timestamp":"2025-01-07T22:38:04.068897Z","level":"INFO","fields":{"message":"finished reading event blob","blob_id":"EMQREHO9tc-C5QNRha6_LxR5GGQ8yfpIWayXW6nTccY"},"target":"walrus_service::common::event_blob_downloader","filename":"crates/walrus-service/src/common/event_blob_downloader.rs","line_number":90}
Jan 07 22:38:04 guest walrus-node[3070204]: {"timestamp":"2025-01-07T22:38:04.068940Z","level":"INFO","fields":{"message":"Storing event blob BlobId(EMQREHO9tc-C5QNRha6_LxR5GGQ8yfpIWayXW6nTccY) with 18000 checkpoints"},"target":"walrus_service::common::event_blob_downloader","filename":"crates/walrus-service/src/common/event_blob_downloader.rs","line_number":103}
Jan 07 22:38:05 guest walrus-node[3070204]: {"timestamp":"2025-01-07T22:38:05.871465Z","level":"INFO","fields":{"message":"finished reading event blob","blob_id":"4QVLtNWIraf7b5ZANaL5YOumgJGjSA3wwLie1cyvEOY"},"target":"walrus_service::common::event_blob_downloader","filename":"crates/walrus-service/src/common/event_blob_downloader.rs","line_number":90}
Jan 07 22:38:05 guest walrus-node[3070204]: {"timestamp":"2025-01-07T22:38:05.871507Z","level":"INFO","fields":{"message":"Storing event blob BlobId(4QVLtNWIraf7b5ZANaL5YOumgJGjSA3wwLie1cyvEOY) with 18000 checkpoints"},"target":"walrus_service::common::event_blob_downloader","filename":"crates/walrus-service/src/common/event_blob_downloader.rs","line_number":103}
Jan 07 22:38:07 guest walrus-node[3070204]: {"timestamp":"2025-01-07T22:38:07.597930Z","level":"INFO","fields":{"message":"finished reading event blob","blob_id":"I762PrknO60a1wGWz56aPuHpVDmIECoWMkv0YjsMJD8"},"target":"walrus_service::common::event_blob_downloader","filename":"crates/walrus-service/src/common/event_blob_downloader.rs","line_number":90}
Jan 07 22:38:07 guest walrus-node[3070204]: {"timestamp":"2025-01-07T22:38:07.597963Z","level":"INFO","fields":{"message":"Storing event blob BlobId(I762PrknO60a1wGWz56aPuHpVDmIECoWMkv0YjsMJD8) with 18000 checkpoints"},"target":"walrus_service::common::event_blob_downloader","filename":"crates/walrus-service/src/common/event_blob_downloader.rs","line_number":103}
Jan 07 22:38:07 guest walrus-node[3070204]: {"timestamp":"2025-01-07T22:38:07.662736Z","level":"INFO","fields":{"message":"Processed event blob BlobId(I762PrknO60a1wGWz56aPuHpVDmIECoWMkv0YjsMJD8) with 6345 events, last event index: 187847"},"target":"walrus_service::node::events::event_processor","filename":"crates/walrus-service/src/node/events/event_processor.rs","line_number":975}
Jan 07 22:38:07 guest walrus-node[3070204]: {"timestamp":"2025-01-07T22:38:07.739422Z","level":"INFO","fields":{"message":"Processed event blob BlobId(4QVLtNWIraf7b5ZANaL5YOumgJGjSA3wwLie1cyvEOY) with 18892 events, last event index: 206739"},"target":"walrus_service::node::events::event_processor","filename":"crates/walrus-service/src/node/events/event_processor.rs","line_number":975}
Jan 07 22:38:07 guest walrus-node[3070204]: {"timestamp":"2025-01-07T22:38:07.788860Z","level":"INFO","fields":{"message":"Processed event blob BlobId(EMQREHO9tc-C5QNRha6_LxR5GGQ8yfpIWayXW6nTccY) with 18896 events, last event index: 225635"},"target":"walrus_service::node::events::event_processor","filename":"crates/walrus-service/src/node/events/event_processor.rs","line_number":975}
Jan 07 22:38:07 guest walrus-node[3070204]: {"timestamp":"2025-01-07T22:38:07.827123Z","level":"INFO","fields":{"message":"Processed event blob BlobId(iGsPuaznSVkwR82PWbBjj7fsCzDsLpyYUg-egsWsdvM) with 18886 events, last event index: 244521"},"target":"walrus_service::node::events::event_processor","filename":"crates/walrus-service/src/node/events/event_processor.rs","line_number":975}
Jan 07 22:38:07 guest walrus-node[3070204]: {"timestamp":"2025-01-07T22:38:07.827165Z","level":"INFO","fields":{"message":"Recovered 63019 events from event blobs"},"target":"walrus_service::node::events::event_processor","filename":"crates/walrus-service/src/node/events/event_processor.rs","line_number":982}
Jan 07 22:38:07 guest walrus-node[3070204]: {"timestamp":"2025-01-07T22:38:07.827173Z","level":"INFO","fields":{"message":"Successfully caught up using event blobs"},"target":"walrus_service::node::events::event_processor","filename":"crates/walrus-service/src/node/events/event_processor.rs","line_number":623}
```
