### PR TITLE
fix: shebang treatment in pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,8 +17,8 @@ repos:
     rev: v0.14.0
     hooks:
       - id: yamlfmt
-  - repo: https://github.com/notken12/licensesnip
-    rev: 19b1186
+  - repo: https://github.com/wbbradley/licensesnip
+    rev: a1037505417d06a3d311ec3b2993205127ee9e03
     hooks:
       - id: licensesnip
         args: []

--- a/docker/local-testbed/build-local-image.sh
+++ b/docker/local-testbed/build-local-image.sh
@@ -1,6 +1,6 @@
+#!/bin/bash
 # Copyright (c) Mysten Labs, Inc.
 # SPDX-License-Identifier: Apache-2.0
-#!/bin/bash
 
 PLATFORM=linux/arm64
 GIT_REVISION=$(git rev-parse HEAD)

--- a/docker/local-testbed/files/deploy-walrus.sh
+++ b/docker/local-testbed/files/deploy-walrus.sh
@@ -1,6 +1,6 @@
+#!/bin/bash
 # Copyright (c) Mysten Labs, Inc.
 # SPDX-License-Identifier: Apache-2.0
-#!/bin/bash
 
 # use EPOCH_DURATION to set the epoch duration, default is 1h
 EPOCH_DURATION=${EPOCH_DURATION:-1h}

--- a/docker/local-testbed/files/run-walrus.sh
+++ b/docker/local-testbed/files/run-walrus.sh
@@ -1,6 +1,6 @@
+#!/bin/bash
 # Copyright (c) Mysten Labs, Inc.
 # SPDX-License-Identifier: Apache-2.0
-#!/bin/bash
 
 ## -----------------------------------------------------------------------------
 ## Prepare the environment

--- a/scripts/crash_recovery.sh
+++ b/scripts/crash_recovery.sh
@@ -1,6 +1,6 @@
+#!/bin/bash
 # Copyright (c) Mysten Labs, Inc.
 # SPDX-License-Identifier: Apache-2.0
-#!/bin/bash
 
 set -euo pipefail
 

--- a/scripts/local-testbed.sh
+++ b/scripts/local-testbed.sh
@@ -1,6 +1,6 @@
+#!/bin/bash
 # Copyright (c) Mysten Labs, Inc.
 # SPDX-License-Identifier: Apache-2.0
-#!/bin/bash
 
 set -euo pipefail
 

--- a/scripts/simtest/install.sh
+++ b/scripts/simtest/install.sh
@@ -1,6 +1,6 @@
+#!/bin/bash
 # Copyright (c) Mysten Labs, Inc.
 # SPDX-License-Identifier: Apache-2.0
-#!/bin/bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 


### PR DESCRIPTION
## Description

The pre-commit tool licensesnip is deficient when it comes to treatment of shell files. I've forked it, fixed it in my fork, and redirected our dependency to my fork. We can repoint the walrus repo to the original repo at some point although it looks like it's not being maintained. This change also fixes the shell files in our repo to have functional shebang lines.

## Test plan

Manual testing. licensesnip entirely lacks tests and I wanted to limit the time spent on this maintenance task for now.

No release notes impact.