### PR TITLE
chore: use forked upstream licensesnip tool to fix shebang treatment

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -78,7 +78,8 @@ jobs:
     name: Check license headers
     steps:
       - uses: actions/checkout@v4
-      - run: cargo install licensesnip@1.5.0
+      # TODO: Consider repointing this to the upstream version again when https://github.com/notken12/licensesnip/pull/10 is merged.
+      - run: cargo install --git https://github.com/wbbradley/licensesnip --rev a1037505417d06a3 licensesnip
       - run: licensesnip check
 
   check-all:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,8 +17,9 @@ repos:
     rev: v0.14.0
     hooks:
       - id: yamlfmt
-  - repo: https://github.com/notken12/licensesnip
-    rev: 19b1186
+  # TODO: Consider repointing this to the upstream version again when https://github.com/notken12/licensesnip/pull/10 is merged.
+  - repo: https://github.com/wbbradley/licensesnip
+    rev: a1037505417d06a3d311ec3b2993205127ee9e03
     hooks:
       - id: licensesnip
         args: []

--- a/docker/local-testbed/build-local-image.sh
+++ b/docker/local-testbed/build-local-image.sh
@@ -1,6 +1,6 @@
+#!/bin/bash
 # Copyright (c) Mysten Labs, Inc.
 # SPDX-License-Identifier: Apache-2.0
-#!/bin/bash
 
 PLATFORM=linux/arm64
 GIT_REVISION=$(git rev-parse HEAD)

--- a/docker/local-testbed/files/deploy-walrus.sh
+++ b/docker/local-testbed/files/deploy-walrus.sh
@@ -1,6 +1,6 @@
+#!/bin/bash
 # Copyright (c) Mysten Labs, Inc.
 # SPDX-License-Identifier: Apache-2.0
-#!/bin/bash
 
 # use EPOCH_DURATION to set the epoch duration, default is 1h
 EPOCH_DURATION=${EPOCH_DURATION:-1h}

--- a/docker/local-testbed/files/run-walrus.sh
+++ b/docker/local-testbed/files/run-walrus.sh
@@ -1,6 +1,6 @@
+#!/bin/bash
 # Copyright (c) Mysten Labs, Inc.
 # SPDX-License-Identifier: Apache-2.0
-#!/bin/bash
 
 ## -----------------------------------------------------------------------------
 ## Prepare the environment

--- a/docker/walrus-orchestrator/build.sh
+++ b/docker/walrus-orchestrator/build.sh
@@ -1,6 +1,6 @@
+#!/bin/sh
 # Copyright (c) Mysten Labs, Inc.
 # SPDX-License-Identifier: Apache-2.0
-#!/bin/sh
 
 # fast fail.
 set -e

--- a/docker/walrus-service/build.sh
+++ b/docker/walrus-service/build.sh
@@ -1,6 +1,6 @@
+#!/bin/sh
 # Copyright (c) Mysten Labs, Inc.
 # SPDX-License-Identifier: Apache-2.0
-#!/bin/sh
 
 # fast fail.
 set -e

--- a/docker/walrus-stress/build.sh
+++ b/docker/walrus-stress/build.sh
@@ -1,6 +1,6 @@
+#!/bin/sh
 # Copyright (c) Mysten Labs, Inc.
 # SPDX-License-Identifier: Apache-2.0
-#!/bin/sh
 
 # fast fail.
 set -e

--- a/scripts/crash_recovery.sh
+++ b/scripts/crash_recovery.sh
@@ -1,6 +1,6 @@
+#!/bin/bash
 # Copyright (c) Mysten Labs, Inc.
 # SPDX-License-Identifier: Apache-2.0
-#!/bin/bash
 
 set -euo pipefail
 

--- a/scripts/local-testbed.sh
+++ b/scripts/local-testbed.sh
@@ -1,6 +1,6 @@
+#!/bin/bash
 # Copyright (c) Mysten Labs, Inc.
 # SPDX-License-Identifier: Apache-2.0
-#!/bin/bash
 
 set -euo pipefail
 

--- a/scripts/simtest/install.sh
+++ b/scripts/simtest/install.sh
@@ -1,6 +1,6 @@
+#!/bin/bash
 # Copyright (c) Mysten Labs, Inc.
 # SPDX-License-Identifier: Apache-2.0
-#!/bin/bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 


### PR DESCRIPTION
## Description

The pre-commit tool licensesnip is deficient when it comes to treatment of shell files. I've forked it, fixed it in my fork, and redirected our dependency to my fork. We can repoint the walrus repo to the original repo at some point although it looks like it's not being maintained. This change includes a fix for the shell files in our repo to have functional shebang lines.

Related upstream issue: https://github.com/notken12/licensesnip/issues/7

## Test plan

Performed manual testing. `licensesnip` itself entirely lacks tests and I wanted to limit the time spent on this maintenance task for now.

No release notes impact.