### PR TITLE
chore: enable shellcheck linting in walrus repo

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -73,6 +73,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: crate-ci/typos@v1.29.0
 
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run ShellCheck
+        run: find . -type f -name "*.sh" -exec shellcheck --severity=error {} +
+
   license-headers:
     runs-on: ubuntu-latest
     name: Check license headers

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,17 @@ repos:
     hooks:
       - id: editorconfig-checker
         alias: ec
+  - repo: local
+    hooks:
+      - id: shellcheck
+        args: ["--severity=error"]
+        name: shellcheck
+        description: Test shell scripts with shellcheck
+        entry: shellcheck
+        # Note that this relies on https://github.com/shellcheck-py/shellcheck-py.
+        language: python
+        types: [shell]
+        require_serial: true # shellcheck can detect sourcing this way
   - repo: https://github.com/google/yamlfmt
     rev: v0.14.0
     hooks:

--- a/crates/walrus-service/bin/deploy.rs
+++ b/crates/walrus-service/bin/deploy.rs
@@ -154,7 +154,6 @@ fn main() -> anyhow::Result<()> {
 
     match args.command {
         Commands::DeploySystemContract(args) => commands::deploy_system_contract(args)?,
-
         Commands::GenerateDryRunConfigs(args) => commands::generate_dry_run_configs(args)?,
     }
     Ok(())

--- a/scripts/crash_recovery.sh
+++ b/scripts/crash_recovery.sh
@@ -185,7 +185,7 @@ function get_blob_confirmation() {
     blob_id=$1
     host_address=$2
     #/v1/blobs/{blob_id}/confirmations
-    cmd="curl -s -X GET https://${host_address}/v1/blobs/${blob_id}/confirmation" --insecure
+    cmd="curl -s -X GET https://${host_address}/v1/blobs/${blob_id}/confirmation --insecure"
     log "$cmd"
     output=$($cmd)
     log "Blob confirmation: $output"

--- a/scripts/local-testbed.sh
+++ b/scripts/local-testbed.sh
@@ -131,6 +131,7 @@ if ! $existing; then
 fi
 
 i=0
+# shellcheck disable=SC2045
 for config in $( ls $working_dir/dryrun-node-*[0-9].yaml ); do
     node_name=$(basename -- "$config")
     node_name="${node_name%.*}"

--- a/scripts/simtest/cargo-simtest
+++ b/scripts/simtest/cargo-simtest
@@ -109,7 +109,7 @@ export TMPDIR=$(mktemp -d)
 root_dir="$(git rev-parse --show-toplevel)"
 export SIMTEST_STATIC_INIT_MOVE="$root_dir/testnet-contracts/walrus"
 
-cargo ${CARGO_COMMAND[@]} \
+cargo "${CARGO_COMMAND[@]}" \
   --config "build.rustflags = [$RUST_FLAGS]" \
   "${cargo_patch_args[@]}" \
   "$@"


### PR DESCRIPTION
## Description

Enable shellcheck linting on all shell scripts. Working on local testbed, as well.

## Test plan

Tested via CI and manual testing of local-testbed.sh.

No release impact.