### PR TITLE
fix: storage lag check should only be performed on being processed events

### DIFF
--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -161,7 +161,6 @@ pub trait StorageNodeHandleTrait {
         system_context: Option<SystemContext>,
         storage_dir: TempDir,
         start_node: bool,
-        disable_event_blob_writer: bool,
     ) -> impl std::future::Future<Output = anyhow::Result<Self>> + Send
     where
         Self: Sized;
@@ -226,7 +225,6 @@ impl StorageNodeHandleTrait for StorageNodeHandle {
         _system_context: Option<SystemContext>,
         _storage_dir: TempDir,
         _start_node: bool,
-        _disable_event_blob_writer: bool,
     ) -> anyhow::Result<Self> {
         builder.build().await
     }
@@ -485,7 +483,6 @@ impl StorageNodeHandleTrait for SimStorageNodeHandle {
         system_context: Option<SystemContext>,
         storage_dir: TempDir,
         start_node: bool,
-        disable_event_blob_writer: bool,
     ) -> anyhow::Result<Self>
     where
         Self: Sized,
@@ -1691,7 +1688,6 @@ impl TestClusterBuilder {
                         tempfile::tempdir().expect("temporary directory creation must succeed")
                     ),
                     start_node_from_beginning,
-                    disable_event_blob_writer,
                 )
                 .await?,
             );


### PR DESCRIPTION
## Description

When blob writer is catching up, the node may writing events that are already processed. These events may be old from the processed event and should not be used to check event lagging.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
