### PR TITLE
feat(test): Add event blob check to simtests

### DIFF
--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -551,6 +551,7 @@ async fn test_blocklist() -> TestResult {
             true,
             ClientCommunicationConfig::default_for_test(),
             Some(blocklist_dir.path().to_path_buf()),
+            None,
         )
         .await?;
     let client = client.as_ref();
@@ -693,6 +694,7 @@ async fn test_repeated_shard_move() -> TestResult {
             &[1, 1],
             true,
             ClientCommunicationConfig::default_for_test(),
+            None,
             None,
         )
         .await?;

--- a/crates/walrus-service/src/node/events/event_blob_writer.rs
+++ b/crates/walrus-service/src/node/events/event_blob_writer.rs
@@ -867,6 +867,11 @@ impl EventBlobWriter {
         if metadata.blob_id != blob_id {
             return Ok(());
         }
+        self.node
+            .storage()
+            .update_blob_info_with_metadata(&blob_id)
+            .context("unable to update metadata")?;
+
         self.metrics
             .latest_certified_event_index
             .set(element_index as i64);

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -342,6 +342,16 @@ impl Storage {
             .insert(metadata.blob_id(), metadata.metadata())
     }
 
+    /// Store the metadata without updating blob info. This is only used during storing metadata for
+    /// event blobs which are stored without getting registered first.
+    #[tracing::instrument(skip_all)]
+    pub fn update_blob_info_with_metadata(&self, blob_id: &BlobId) -> Result<(), TypedStoreError> {
+        let mut batch = self.metadata.batch();
+        self.blob_info
+            .set_metadata_stored(&mut batch, blob_id, true)?;
+        batch.write()
+    }
+
     /// Store the verified metadata.
     #[tracing::instrument(skip_all)]
     pub fn put_verified_metadata(

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -161,6 +161,7 @@ pub trait StorageNodeHandleTrait {
         system_context: Option<SystemContext>,
         storage_dir: TempDir,
         start_node: bool,
+        disable_event_blob_writer: bool,
     ) -> impl std::future::Future<Output = anyhow::Result<Self>> + Send
     where
         Self: Sized;
@@ -225,6 +226,7 @@ impl StorageNodeHandleTrait for StorageNodeHandle {
         _system_context: Option<SystemContext>,
         _storage_dir: TempDir,
         _start_node: bool,
+        _disable_event_blob_writer: bool,
     ) -> anyhow::Result<Self> {
         builder.build().await
     }
@@ -280,6 +282,7 @@ impl SimStorageNodeHandle {
     /// node.
     pub async fn spawn_node(
         config: StorageNodeConfig,
+        num_checkpoints_per_blob: Option<u32>,
         cancel_token: CancellationToken,
     ) -> sui_simulator::runtime::NodeHandle {
         let (startup_sender, mut startup_receiver) = tokio::sync::watch::channel(false);
@@ -314,9 +317,13 @@ impl SimStorageNodeHandle {
 
                 async move {
                     let (rest_api_handle, node_handle, event_processor_handle) =
-                        Self::build_and_run_node(config, cancel_token.clone())
-                            .await
-                            .expect("Should start node successfully");
+                        Self::build_and_run_node(
+                            config,
+                            num_checkpoints_per_blob,
+                            cancel_token.clone(),
+                        )
+                        .await
+                        .expect("Should start node successfully");
 
                     startup_sender.send(true).ok();
 
@@ -353,6 +360,7 @@ impl SimStorageNodeHandle {
     /// REST API, the node, and the event processor.
     async fn build_and_run_node(
         config: StorageNodeConfig,
+        num_checkpoints_per_blob: Option<u32>,
         cancel_token: CancellationToken,
     ) -> anyhow::Result<(
         tokio::task::JoinHandle<Result<(), std::io::Error>>,
@@ -428,7 +436,11 @@ impl SimStorageNodeHandle {
         };
 
         // Build storage node with the current configuration and event manager.
-        let node = StorageNode::builder()
+        let mut builder = StorageNode::builder();
+        if let Some(num_checkpoints_per_blob) = num_checkpoints_per_blob {
+            builder = builder.with_num_checkpoints_per_blob(num_checkpoints_per_blob);
+        };
+        let node = builder
             .with_system_event_manager(event_provider)
             .build(&config, metrics_registry.clone())
             .await?;
@@ -483,17 +495,20 @@ impl StorageNodeHandleTrait for SimStorageNodeHandle {
         system_context: Option<SystemContext>,
         storage_dir: TempDir,
         start_node: bool,
+        disable_event_blob_writer: bool,
     ) -> anyhow::Result<Self>
     where
         Self: Sized,
     {
+        let num_checkpoints_per_blob = builder.num_checkpoints_per_blob.as_ref().cloned();
         builder
             .start_node(
                 sui_cluster_handle.expect("SUI cluster handle must be provided in simtest"),
                 system_context.expect("System context must be provided"),
                 storage_dir,
                 start_node,
-                false,
+                disable_event_blob_writer,
+                num_checkpoints_per_blob,
             )
             .await
     }
@@ -845,6 +860,7 @@ impl StorageNodeHandleBuilder {
         storage_dir: TempDir,
         start_node: bool,
         disable_event_blob_writer: bool,
+        num_checkpoints_per_blob: Option<u32>,
     ) -> anyhow::Result<SimStorageNodeHandle> {
         use walrus_sui::client::contract_config::ContractConfig;
 
@@ -879,9 +895,13 @@ impl StorageNodeHandleBuilder {
 
         let node_id = if start_node {
             Some(
-                SimStorageNodeHandle::spawn_node(storage_node_config.clone(), cancel_token.clone())
-                    .await
-                    .id(),
+                SimStorageNodeHandle::spawn_node(
+                    storage_node_config.clone(),
+                    num_checkpoints_per_blob,
+                    cancel_token.clone(),
+                )
+                .await
+                .id(),
             )
         } else {
             None
@@ -1691,6 +1711,7 @@ impl TestClusterBuilder {
                         tempfile::tempdir().expect("temporary directory creation must succeed")
                     ),
                     start_node_from_beginning,
+                    disable_event_blob_writer,
                 )
                 .await?,
             );
@@ -1971,6 +1992,7 @@ pub mod test_cluster {
             true,
             ClientCommunicationConfig::default_for_test(),
             None,
+            Some(10),
         )
         .await
     }
@@ -1983,6 +2005,7 @@ pub mod test_cluster {
         use_legacy_event_processor: bool,
         communication_config: ClientCommunicationConfig,
         blocklist_dir: Option<PathBuf>,
+        num_checkpoints_per_blob: Option<u32>,
     ) -> anyhow::Result<(
         Arc<TestClusterHandle>,
         TestCluster<T>,
@@ -1993,7 +2016,7 @@ pub mod test_cluster {
             node_weights,
             use_legacy_event_processor,
             false,
-            None,
+            num_checkpoints_per_blob,
             communication_config,
             blocklist_dir,
         )

--- a/crates/walrus-service/tests/epoch_change.rs
+++ b/crates/walrus-service/tests/epoch_change.rs
@@ -26,6 +26,7 @@ async fn nodes_drive_epoch_change() -> TestResult {
             true,
             ClientCommunicationConfig::default_for_test(),
             None,
+            None,
         )
         .await?;
 


### PR DESCRIPTION
## Description

This PR adds a check that event blobs are being created. And enabling it in couple sim tests for now. Intentionally not enabling it for every simtest as the tests slow down a lot (due to single threaded runtime) and fail abruptly due to timeouts and delays in different places. So, this might require some work on individual tests before enabling it every where.

## Test plan

Running locally works.
