### PR TITLE
fix: fix walrus info command

### DIFF
--- a/crates/walrus-sui/src/client/read_client.rs
+++ b/crates/walrus-sui/src/client/read_client.rs
@@ -54,7 +54,6 @@ use crate::{
         move_structs::{
             EpochState,
             EventBlob,
-            Key,
             StakingInnerV1,
             StakingObjectForDeserialization,
             StakingPool,
@@ -862,15 +861,11 @@ impl ReadClient for SuiReadClient {
 
         let staking_object = self.get_staking_object().await?;
         let active_set_id = staking_object.inner.active_set;
-        let key_tag = contracts::extended_field::Key
-            .to_move_struct_tag_with_type_map(&self.type_origin_map(), &[])?;
+        let type_map = self.type_origin_map().clone();
+
         let active_set = self
             .sui_client
-            .get_dynamic_field::<Key, ActiveSet>(
-                active_set_id,
-                key_tag.into(),
-                Key { dummy_field: false },
-            )
+            .get_extended_field::<ActiveSet>(active_set_id, &type_map)
             .await?;
         Ok(active_set.nodes.into_iter().collect())
     }

--- a/crates/walrus-sui/src/client/retry_client.rs
+++ b/crates/walrus-sui/src/client/retry_client.rs
@@ -41,8 +41,8 @@ use walrus_utils::backoff::{BackoffStrategy, ExponentialBackoff, ExponentialBack
 
 use super::{SuiClientError, SuiClientResult};
 use crate::{
-    contracts::{AssociatedContractStruct, TypeOriginMap},
-    types::move_structs::{SuiDynamicField, SystemObjectForDeserialization},
+    contracts::{self, AssociatedContractStruct, TypeOriginMap},
+    types::move_structs::{Key, SuiDynamicField, SystemObjectForDeserialization},
     utils::get_sui_object_from_object_response,
 };
 
@@ -351,6 +351,20 @@ impl RetriableSuiClient {
                 .collect::<Result<Vec<_>, _>>()
         })
         .await
+    }
+
+    pub(crate) async fn get_extended_field<V>(
+        &self,
+        object_id: ObjectID,
+        type_origin_map: &TypeOriginMap,
+    ) -> SuiClientResult<V>
+    where
+        V: DeserializeOwned,
+    {
+        let key_tag = contracts::extended_field::Key
+            .to_move_struct_tag_with_type_map(type_origin_map, &[])?;
+        self.get_dynamic_field::<Key, V>(object_id, key_tag.into(), Key { dummy_field: false })
+            .await
     }
 
     #[allow(unused)]

--- a/crates/walrus-sui/src/types/move_structs.rs
+++ b/crates/walrus-sui/src/types/move_structs.rs
@@ -640,8 +640,9 @@ impl AssociatedContractStruct for SharedBlob {
 }
 
 /// Sui type for the key of an extended field.
+// TODO(WAL-513): investigate why this is needed.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
-pub struct Key {
+pub(crate) struct Key {
     /// To match empty struct in Move.
     pub dummy_field: bool,
 }


### PR DESCRIPTION
## Description

It was reporting object not found when getting `active_set`.

(absolutely not sure if this is the right fix...)

Contribute to WAL-513

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
