### PR TITLE
chore: refactor EventProcessorRuntime into its own crate

### DIFF
--- a/crates/walrus-service/bin/node.rs
+++ b/crates/walrus-service/bin/node.rs
@@ -34,12 +34,9 @@ use walrus_core::{
 use walrus_service::{
     node::{
         config::{self, defaults::REST_API_PORT, StorageNodeConfig, SuiConfig},
-        events::{
-            event_processor::{EventProcessor, EventProcessorRuntimeConfig, SystemConfig},
-            EventProcessorConfig,
-        },
+        events::event_processor_runtime::EventProcessorRuntime,
         server::{RestApiConfig, RestApiServer},
-        system_events::{EventManager, SuiSystemEventProvider},
+        system_events::EventManager,
         StorageNode,
     },
     utils::{
@@ -815,102 +812,6 @@ async fn get_contract_client_from_node_config(
         bail!("storage config does not contain Sui wallet configuration");
     };
     Ok(node_wallet_config.new_contract_client().await?)
-}
-
-struct EventProcessorRuntime {
-    event_processor_handle: JoinHandle<anyhow::Result<()>>,
-    // INV: Runtime must be dropped last.
-    runtime: Runtime,
-}
-
-impl EventProcessorRuntime {
-    async fn build_event_processor(
-        sui_config: SuiConfig,
-        event_processor_config: &EventProcessorConfig,
-        db_path: &Path,
-        metrics_registry: &Registry,
-    ) -> anyhow::Result<Arc<EventProcessor>> {
-        let runtime_config = EventProcessorRuntimeConfig {
-            rpc_address: sui_config.rpc.clone(),
-            event_polling_interval: sui_config.event_polling_interval,
-            db_path: db_path.join("events"),
-        };
-        let system_config = SystemConfig {
-            system_pkg_id: sui_config.new_read_client().await?.get_system_package_id(),
-            system_object_id: sui_config.contract_config.system_object,
-            staking_object_id: sui_config.contract_config.staking_object,
-        };
-        Ok(Arc::new(
-            EventProcessor::new(
-                event_processor_config,
-                runtime_config,
-                system_config,
-                metrics_registry,
-            )
-            .await?,
-        ))
-    }
-
-    fn start(
-        sui_config: SuiConfig,
-        event_processor_config: EventProcessorConfig,
-        use_legacy_event_provider: bool,
-        db_path: &Path,
-        metrics_registry: &Registry,
-        cancel_token: CancellationToken,
-    ) -> anyhow::Result<(Box<dyn EventManager>, Self)> {
-        let runtime = runtime::Builder::new_multi_thread()
-            .thread_name("event-manager-runtime")
-            .worker_threads(2)
-            .enable_all()
-            .build()
-            .context("event manager runtime creation failed")?;
-        let _guard = runtime.enter();
-
-        let (event_manager, event_processor_handle): (Box<dyn EventManager>, _) =
-            if use_legacy_event_provider {
-                let read_client = runtime.block_on(async { sui_config.new_read_client().await })?;
-                (
-                    Box::new(SuiSystemEventProvider::new(
-                        read_client,
-                        sui_config.event_polling_interval,
-                    )),
-                    tokio::spawn(async { std::future::pending().await }),
-                )
-            } else {
-                let event_processor = runtime.block_on(async {
-                    Self::build_event_processor(
-                        sui_config.clone(),
-                        &event_processor_config,
-                        db_path,
-                        metrics_registry,
-                    )
-                    .await
-                })?;
-                let cloned_event_processor = event_processor.clone();
-                let event_processor_handle = tokio::spawn(async move {
-                    let result = cloned_event_processor.start(cancel_token).await;
-                    if let Err(ref error) = result {
-                        tracing::error!(?error, "event manager exited with an error");
-                    }
-                    result
-                });
-                (Box::new(event_processor), event_processor_handle)
-            };
-
-        Ok((
-            event_manager,
-            Self {
-                runtime,
-                event_processor_handle,
-            },
-        ))
-    }
-
-    fn join(&mut self) -> Result<(), anyhow::Error> {
-        tracing::debug!("waiting for the event processor to shutdown...");
-        self.runtime.block_on(&mut self.event_processor_handle)?
-    }
 }
 
 struct StorageNodeRuntime {

--- a/crates/walrus-service/src/node/events.rs
+++ b/crates/walrus-service/src/node/events.rs
@@ -24,6 +24,7 @@ use walrus_utils::checkpoint_downloader::AdaptiveDownloaderConfig;
 pub mod event_blob;
 pub mod event_blob_writer;
 pub mod event_processor;
+pub mod event_processor_runtime;
 
 /// Configuration for event processing.
 #[serde_as]


### PR DESCRIPTION
## Description

Code organization: pull EventProcessorRuntime into its own crate.

## Test plan

Tested with local tests and CI pipeline.

No release impact.