### PR TITLE
chore: fix shellcheck pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,17 +13,6 @@ repos:
     hooks:
       - id: editorconfig-checker
         alias: ec
-  - repo: local
-    hooks:
-      - id: shellcheck
-        args: ["--severity=error"]
-        name: shellcheck
-        description: Test shell scripts with shellcheck
-        entry: shellcheck
-        # Note that this relies on https://github.com/shellcheck-py/shellcheck-py.
-        language: python
-        types: [shell]
-        require_serial: true # shellcheck can detect sourcing this way
   - repo: https://github.com/google/yamlfmt
     rev: v0.14.0
     hooks:
@@ -55,6 +44,16 @@ repos:
         types: [toml]
         args: []
         additional_dependencies: ["taplo==0.9.3"]
+      - id: shellcheck
+        args: ["--severity=error"]
+        name: shellcheck
+        description: Test shell scripts with shellcheck
+        entry: shellcheck
+        # Note that this relies on https://github.com/shellcheck-py/shellcheck-py.
+        language: python
+        types: [shell]
+        require_serial: true # shellcheck can detect sourcing this way
+        additional_dependencies: ["shellcheck-py==0.10.0.1"]
       - id: cargo-fmt
         name: cargo-fmt
         entry: cargo fmt


### PR DESCRIPTION
## Description

This ensures that `shellcheck` is automatically installed by pre-commit and moves the hook to the already existing list of `local` hooks.
