### PR TITLE
chore: repoint licensesnip to updated upstream

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -86,8 +86,7 @@ jobs:
     name: Check license headers
     steps:
       - uses: actions/checkout@v4
-      # TODO: Consider repointing this to the upstream version again when https://github.com/notken12/licensesnip/pull/10 is merged.
-      - run: cargo install --git https://github.com/wbbradley/licensesnip --rev a1037505417d06a3 licensesnip
+      - run: cargo install licensesnip
       - run: licensesnip check
 
   check-all:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,9 +28,8 @@ repos:
     rev: v0.14.0
     hooks:
       - id: yamlfmt
-  # TODO: Consider repointing this to the upstream version again when https://github.com/notken12/licensesnip/pull/10 is merged.
-  - repo: https://github.com/wbbradley/licensesnip
-    rev: a1037505417d06a3d311ec3b2993205127ee9e03
+  - repo: https://github.com/notken12/licensesnip
+    rev: f01f898
     hooks:
       - id: licensesnip
         args: []


### PR DESCRIPTION
## Description

A fix to the upstream implementation of licensesnip was accepted. Repoint our pre-commit hook and CI to that.

## Test plan

Ran manual tests of `licensesnip`.

No release impact.