### PR TITLE
feat: boilerplate for the backup node

### DIFF
--- a/crates/walrus-service/Cargo.toml
+++ b/crates/walrus-service/Cargo.toml
@@ -21,12 +21,27 @@ name = "walrus-deploy"
 path = "bin/deploy.rs"
 required-features = ["deploy"]
 
+[[bin]]
+name = "walrus-backup"
+path = "bin/backup.rs"
+required-features = ["backup"]
+
 [features]
+backup = [
+  "dep:async-trait",
+  "dep:enum_dispatch",
+  "dep:mime",
+  "dep:mysten-metrics",
+  "dep:rocksdb",
+  "dep:tokio-stream",
+  "dep:tokio-util",
+  "dep:typed-store",
+]
 client = [
   "dep:colored",
   "dep:prettytable",
 ]
-default = ["client", "deploy", "node"]
+default = ["backup", "client", "deploy", "node"]
 deploy = ["client", "node", "walrus-sui/test-utils"]
 node = [
   "dep:async-trait",

--- a/crates/walrus-service/bin/backup.rs
+++ b/crates/walrus-service/bin/backup.rs
@@ -1,0 +1,161 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Walrus Backup Node entry point.
+
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+use tokio::{runtime::Runtime, sync::oneshot};
+use tokio_util::sync::CancellationToken;
+use walrus_service::{
+    backup::{BackupNodeConfig, BackupNodeRuntime},
+    node::events::event_processor_runtime::EventProcessorRuntime,
+    utils::{self, version, wait_until_terminated, LoadConfig as _, MetricsAndLoggingRuntime},
+};
+
+const VERSION: &str = version!();
+
+/// Manage and run a Walrus backup node.
+#[derive(Parser)]
+#[clap(rename_all = "kebab-case")]
+#[clap(name = env!("CARGO_BIN_NAME"))]
+#[clap(version = VERSION)]
+#[derive(Debug)]
+struct Args {
+    #[command(subcommand)]
+    command: BackupCommands,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+#[clap(rename_all = "kebab-case")]
+enum BackupCommands {
+    /// Run a backup node with the provided configuration.
+    Run { config_path: PathBuf },
+}
+
+fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+
+    if !matches!(args.command, BackupCommands::Run { .. }) {
+        utils::init_tracing_subscriber()?;
+    }
+
+    match args.command {
+        BackupCommands::Run { config_path } => {
+            let config = BackupNodeConfig::load(config_path)?;
+            commands::run_backup_node(config)?
+        }
+    };
+    Ok(())
+}
+
+mod commands {
+    #[cfg(not(msim))]
+    use tokio::task::JoinSet;
+    use walrus_service::utils;
+
+    use super::*;
+
+    pub(super) fn run_backup_node(config: BackupNodeConfig) -> anyhow::Result<()> {
+        let metrics_runtime = MetricsAndLoggingRuntime::start(config.metrics_address)?;
+        let registry_clone = metrics_runtime.registry.clone();
+        metrics_runtime.runtime.spawn(async move {
+            registry_clone
+                .register(mysten_metrics::uptime_metric(
+                    "walrus_backup_node",
+                    VERSION,
+                    "walrus",
+                ))
+                .unwrap();
+        });
+
+        tracing::info!(version = VERSION, "Walrus backup binary version");
+        tracing::info!(
+            metrics_address = %config.metrics_address, "started Prometheus HTTP endpoint",
+        );
+
+        utils::export_build_info(&metrics_runtime.registry, VERSION);
+
+        let cancel_token = CancellationToken::new();
+        let (exit_notifier, exit_listener) = oneshot::channel::<()>();
+
+        let (event_manager, event_processor_runtime) = EventProcessorRuntime::start(
+            config.sui,
+            config.event_processor_config.clone(),
+            config.use_legacy_event_provider,
+            &config.backup_storage_path,
+            &metrics_runtime.registry,
+            cancel_token.child_token(),
+        )?;
+
+        let node_runtime = BackupNodeRuntime::start(
+            metrics_runtime.registry.clone(),
+            exit_notifier,
+            event_manager,
+            cancel_token.child_token(),
+        )?;
+
+        monitor_runtimes(
+            node_runtime,
+            event_processor_runtime,
+            exit_listener,
+            cancel_token,
+        )?;
+
+        Ok(())
+    }
+
+    #[cfg(not(msim))]
+    fn monitor_runtimes(
+        mut node_runtime: BackupNodeRuntime,
+        mut event_processor_runtime: EventProcessorRuntime,
+        exit_listener: oneshot::Receiver<()>,
+        cancel_token: CancellationToken,
+    ) -> anyhow::Result<()> {
+        let monitor_runtime = Runtime::new()?;
+        monitor_runtime.block_on(async {
+            tokio::spawn(async move {
+                let mut set = JoinSet::new();
+                set.spawn_blocking(move || node_runtime.join());
+                set.spawn_blocking(move || event_processor_runtime.join());
+                tokio::select! {
+                    _ = wait_until_terminated(exit_listener) => {
+                        tracing::info!("received termination signal, shutting down...");
+                    }
+                    _ = set.join_next() => {
+                        tracing::info!("backup runtime stopped successfully");
+                    }
+                }
+                cancel_token.cancel();
+                tracing::info!("cancellation token triggered, waiting for tasks to shut down...");
+
+                // Drain remaining runtimes
+                while set.join_next().await.is_some() {}
+                tracing::info!("all runtimes have shut down");
+            })
+            .await
+        })?;
+        Ok(())
+    }
+
+    #[cfg(msim)]
+    fn monitor_runtimes(
+        mut node_runtime: BackupNodeRuntime,
+        mut event_processor_runtime: EventProcessorRuntime,
+        exit_listener: oneshot::Receiver<()>,
+        cancel_token: CancellationToken,
+    ) -> anyhow::Result<()> {
+        let monitor_runtime = Runtime::new()?;
+        monitor_runtime.block_on(async {
+            tokio::spawn(async move { wait_until_terminated(exit_listener).await }).await
+        })?;
+        // Cancel the node runtime, if it is still executing.
+        cancel_token.cancel();
+        event_processor_runtime.join()?;
+        // Wait for the node runtime to complete, may take a moment as
+        // the REST-API waits for open connections to close before exiting.
+        node_runtime.join()?;
+        Ok(())
+    }
+}

--- a/crates/walrus-service/bin/node.rs
+++ b/crates/walrus-service/bin/node.rs
@@ -32,8 +32,9 @@ use walrus_core::{
     Epoch,
 };
 use walrus_service::{
+    common::config::SuiConfig,
     node::{
-        config::{self, defaults::REST_API_PORT, StorageNodeConfig, SuiConfig},
+        config::{self, defaults::REST_API_PORT, StorageNodeConfig},
         events::event_processor_runtime::EventProcessorRuntime,
         server::{RestApiConfig, RestApiServer},
         system_events::EventManager,
@@ -42,6 +43,7 @@ use walrus_service::{
     utils::{
         self,
         version,
+        wait_until_terminated,
         ByteCount,
         EnableMetricsPush,
         LoadConfig as _,
@@ -411,7 +413,8 @@ mod commands {
         let (event_manager, event_processor_runtime) = EventProcessorRuntime::start(
             config
                 .sui
-                .clone()
+                .as_ref()
+                .map(|config| config.into())
                 .expect("SUI configuration must be present"),
             config.event_processor_config.clone(),
             config.use_legacy_event_provider,
@@ -897,37 +900,6 @@ impl StorageNodeRuntime {
         let _ = self.runtime.block_on(&mut self.rest_api_handle)?;
         tracing::debug!("waiting for the storage node to shutdown...");
         self.runtime.block_on(&mut self.walrus_node_handle)?
-    }
-}
-
-/// Wait for SIGINT and SIGTERM (unix only).
-#[tracing::instrument(skip_all)]
-async fn wait_until_terminated(mut exit_listener: oneshot::Receiver<()>) {
-    #[cfg(not(unix))]
-    async fn wait_for_other_signals() {
-        // Disables this branch in the select statement.
-        std::future::pending().await
-    }
-
-    #[cfg(unix)]
-    async fn wait_for_other_signals() {
-        use tokio::signal::unix;
-
-        unix::signal(unix::SignalKind::terminate())
-            .expect("unable to register for SIGTERM signals")
-            .recv()
-            .await;
-        tracing::info!("received SIGTERM")
-    }
-
-    tokio::select! {
-        biased;
-        _ = wait_for_other_signals() => (),
-        _ = tokio::signal::ctrl_c() => tracing::info!("received SIGINT"),
-        exit_or_dropped = &mut exit_listener => match exit_or_dropped {
-            Err(_) => tracing::info!("exit notification sender was dropped"),
-            Ok(_) => tracing::info!("exit notification received"),
-        }
     }
 }
 

--- a/crates/walrus-service/src/backup.rs
+++ b/crates/walrus-service/src/backup.rs
@@ -1,0 +1,183 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Walrus Backup node.
+///
+/// Walrus Backup Node.
+///
+use std::{net::SocketAddr, path::PathBuf, pin::Pin, sync::Arc};
+
+use anyhow::bail;
+use futures::{stream, StreamExt};
+use prometheus::Registry;
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+use tokio::{
+    runtime::{self, Runtime},
+    select,
+    sync::oneshot,
+    task::JoinHandle,
+};
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    common::{
+        config::SuiReaderConfig,
+        utils::{self, LoadConfig},
+    },
+    node::{
+        events::{EventProcessorConfig, EventStreamCursor},
+        system_events::EventManager,
+    },
+};
+
+/// Configuration of a Walrus backup node.
+#[serde_as]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct BackupNodeConfig {
+    /// Directory in which to persist the database
+    #[serde(deserialize_with = "utils::resolve_home_dir")]
+    pub backup_storage_path: PathBuf,
+    /// Socket address on which the Prometheus server should export its metrics.
+    #[serde(default = "defaults::metrics_address")]
+    pub metrics_address: SocketAddr,
+    /// Sui config for the node
+    pub sui: SuiReaderConfig,
+    /// Configuration for the event processor.
+    ///
+    /// This is ignored if `use_legacy_event_provider` is set to `true`.
+    #[serde(default, skip_serializing_if = "defaults::is_default")]
+    pub event_processor_config: EventProcessorConfig,
+    /// Use the legacy event provider.
+    ///
+    /// This is deprecated and will be removed in the future.
+    #[serde(default, skip_serializing_if = "defaults::is_default")]
+    pub use_legacy_event_provider: bool,
+}
+
+impl LoadConfig for BackupNodeConfig {}
+
+/// The Backup node.
+#[derive(Debug)]
+pub struct BackupNode {
+    #[allow(dead_code)]
+    metrics_registry: Registry,
+    event_manager: Box<dyn EventManager>,
+}
+
+impl BackupNode {
+    /// Creates a new [`BackupNode`].
+    pub fn new(event_manager: Box<dyn EventManager>, metrics_registry: Registry) -> Self {
+        Self {
+            metrics_registry,
+            event_manager,
+        }
+    }
+    /// Runs the backup node.
+    pub async fn run(&self, cancel_token: CancellationToken) -> anyhow::Result<()> {
+        select! {
+            result = self.process_events() => match result {
+                Ok(()) => unreachable!("process_events should never return successfully"),
+                Err(err) => return Err(err),
+            },
+            _ = cancel_token.cancelled() => {
+            },
+        }
+        Ok(())
+    }
+
+    fn get_storage_node_cursor(&self) -> anyhow::Result<EventStreamCursor> {
+        // TODO: restart from a saved cursor. Tracked in WAL-532.
+        tracing::warn!("cursor state not yet implemented, starting from the beginning");
+        Ok(EventStreamCursor::new(None, 0))
+    }
+
+    async fn process_events(&self) -> anyhow::Result<()> {
+        let event_cursor = self.get_storage_node_cursor()?;
+        let event_stream = Pin::from(self.event_manager.events(event_cursor).await?);
+        let next_event_index = event_cursor.element_index;
+        let index_stream = stream::iter(next_event_index..);
+        let mut indexed_element_stream = index_stream.zip(event_stream);
+        while let Some((_element_index, stream_element)) = indexed_element_stream.next().await {
+            println!("{}", serde_json::to_string(&stream_element).unwrap());
+        }
+
+        bail!("event stream for blob events stopped")
+    }
+}
+
+/// Backup node runtime lifecycle object.
+#[derive(Debug)]
+pub struct BackupNodeRuntime {
+    backup_node_handle: JoinHandle<anyhow::Result<()>>,
+    // INV: Runtime must be dropped last
+    runtime: Runtime,
+}
+
+impl BackupNodeRuntime {
+    /// Starts a new backup node runtime.
+    pub fn start(
+        metrics_registry: Registry,
+        exit_notifier: oneshot::Sender<()>,
+        event_manager: Box<dyn EventManager>,
+        cancel_token: CancellationToken,
+    ) -> anyhow::Result<Self> {
+        let runtime = runtime::Builder::new_multi_thread()
+            .thread_name("walrus-backup-runtime")
+            .enable_all()
+            .build()
+            .expect("walrus-node runtime creation must succeed");
+        let _guard = runtime.enter();
+
+        let backup_node = Arc::new(BackupNode::new(event_manager, metrics_registry));
+
+        let backup_node_cancel_token = cancel_token.child_token();
+        let backup_node_handle = tokio::spawn(async move {
+            let cancel_token = backup_node_cancel_token.clone();
+
+            // Actually run the backup node!
+            let result = backup_node.run(backup_node_cancel_token).await;
+
+            if exit_notifier.send(()).is_err() && !cancel_token.is_cancelled() {
+                tracing::warn!(
+                    "unable to notify that the backup node has exited, \
+                        but shutdown is not in progress?"
+                )
+            }
+            if let Err(ref error) = result {
+                tracing::error!(?error, "backup node exited with an error");
+            }
+
+            result
+        });
+
+        Ok(Self {
+            runtime,
+            backup_node_handle,
+        })
+    }
+
+    /// Waits for the backup node to shutdown.
+    pub fn join(&mut self) -> Result<(), anyhow::Error> {
+        self.runtime.block_on(&mut self.backup_node_handle)?
+    }
+}
+
+mod defaults {
+    use std::net::{Ipv4Addr, SocketAddr};
+
+    /// Default backup node metrics port.
+    pub const METRICS_PORT: u16 = 10184;
+
+    /// Returns the default metrics address.
+    pub fn metrics_address() -> SocketAddr {
+        (Ipv4Addr::LOCALHOST, METRICS_PORT).into()
+    }
+
+    /// Returns true iff the value is the default and we don't run in test mode.
+    pub fn is_default<T: PartialEq + Default>(t: &T) -> bool {
+        // The `cfg!(test)` check is there to allow serializing the full configuration, specifically
+        // to generate the example configuration files.
+        !cfg!(test) && t == &T::default()
+    }
+}

--- a/crates/walrus-service/src/common.rs
+++ b/crates/walrus-service/src/common.rs
@@ -5,7 +5,8 @@
 
 pub(crate) mod active_committees;
 pub(crate) mod api;
-pub mod blocklist;
+pub(crate) mod blocklist;
+pub mod config;
 pub(crate) mod telemetry;
 pub mod utils;
 

--- a/crates/walrus-service/src/common/config.rs
+++ b/crates/walrus-service/src/common/config.rs
@@ -1,0 +1,146 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Common configuration module.
+
+use std::{path::PathBuf, time::Duration};
+
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DurationMilliSeconds};
+use sui_sdk::wallet_context::WalletContext;
+use walrus_sui::client::{
+    contract_config::ContractConfig,
+    SuiClientError,
+    SuiContractClient,
+    SuiReadClient,
+};
+use walrus_utils::backoff::ExponentialBackoffConfig;
+
+use crate::common::utils::{self, LoadConfig};
+
+/// Sui-specific configuration for Walrus
+#[serde_with::serde_as]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct SuiConfig {
+    /// HTTP URL of the Sui full-node RPC endpoint (including scheme). This is used in the event
+    /// processor and some other read operations; for all write operations, the RPC URL from the
+    /// wallet is used.
+    pub rpc: String,
+    /// Configuration of the contract packages and shared objects.
+    #[serde(flatten)]
+    pub contract_config: ContractConfig,
+    /// Interval with which events are polled, in milliseconds.
+    #[serde_as(as = "DurationMilliSeconds")]
+    #[serde(
+        rename = "event_polling_interval_millis",
+        default = "defaults::polling_interval"
+    )]
+    pub event_polling_interval: Duration,
+    /// Location of the wallet config.
+    #[serde(deserialize_with = "utils::resolve_home_dir")]
+    pub wallet_config: PathBuf,
+    /// The configuration for the backoff strategy used for retries.
+    #[serde(default, skip_serializing_if = "defaults::is_default")]
+    pub backoff_config: ExponentialBackoffConfig,
+    /// Gas budget for transactions.
+    #[serde(default = "defaults::gas_budget")]
+    pub gas_budget: u64,
+}
+
+impl SuiConfig {
+    /// Creates a new [`SuiReadClient`] based on the configuration.
+    pub async fn new_read_client(&self) -> Result<SuiReadClient, SuiClientError> {
+        SuiReadClient::new_for_rpc(
+            &self.rpc,
+            &self.contract_config,
+            self.backoff_config.clone(),
+        )
+        .await
+    }
+
+    /// Creates a [`SuiContractClient`] based on the configuration.
+    pub async fn new_contract_client(&self) -> Result<SuiContractClient, SuiClientError> {
+        SuiContractClient::new(
+            WalletContext::new(&self.wallet_config, None, None)?,
+            &self.contract_config,
+            self.backoff_config.clone(),
+            self.gas_budget,
+        )
+        .await
+    }
+}
+
+impl LoadConfig for SuiConfig {}
+
+impl From<&SuiConfig> for SuiReaderConfig {
+    fn from(config: &SuiConfig) -> Self {
+        Self {
+            rpc: config.rpc.clone(),
+            contract_config: config.contract_config.clone(),
+            event_polling_interval: config.event_polling_interval,
+            backoff_config: config.backoff_config.clone(),
+        }
+    }
+}
+
+/// Backup-specific configuration for Sui.
+#[serde_with::serde_as]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct SuiReaderConfig {
+    /// HTTP URL of the Sui full-node RPC endpoint (including scheme). This is used in the event
+    /// processor and some other read operations; for all write operations, the RPC URL from the
+    /// wallet is used.
+    pub rpc: String,
+    /// Configuration of the contract packages and shared objects.
+    #[serde(flatten)]
+    pub contract_config: ContractConfig,
+    /// Interval with which events are polled, in milliseconds.
+    #[serde_as(as = "DurationMilliSeconds")]
+    #[serde(
+        rename = "event_polling_interval_millis",
+        default = "defaults::polling_interval"
+    )]
+    pub event_polling_interval: Duration,
+    /// The configuration for the backoff strategy used for retries.
+    #[serde(default, skip_serializing_if = "defaults::is_default")]
+    pub backoff_config: ExponentialBackoffConfig,
+}
+
+impl SuiReaderConfig {
+    /// Creates a new [`SuiReadClient`] based on the configuration.
+    pub async fn new_read_client(&self) -> Result<SuiReadClient, SuiClientError> {
+        SuiReadClient::new_for_rpc(
+            &self.rpc,
+            &self.contract_config,
+            self.backoff_config.clone(),
+        )
+        .await
+    }
+}
+
+impl LoadConfig for SuiReaderConfig {}
+
+/// Shared configuration defaults.
+pub mod defaults {
+    use super::*;
+
+    /// Default polling interval in milliseconds.
+    pub const POLLING_INTERVAL_MS: u64 = 400;
+
+    /// Returns the default polling interval.
+    pub fn polling_interval() -> Duration {
+        Duration::from_millis(POLLING_INTERVAL_MS)
+    }
+
+    /// Returns true iff the value is the default and we don't run in test mode.
+    pub fn is_default<T: PartialEq + Default>(t: &T) -> bool {
+        // The `cfg!(test)` check is there to allow serializing the full configuration, specifically
+        // to generate the example configuration files.
+        !cfg!(test) && t == &T::default()
+    }
+
+    /// Returns the default gas budget.
+    pub fn gas_budget() -> u64 {
+        500_000_000
+    }
+}

--- a/crates/walrus-service/src/common/event_blob_downloader.rs
+++ b/crates/walrus-service/src/common/event_blob_downloader.rs
@@ -15,12 +15,14 @@ use crate::{
 };
 
 /// Responsible for downloading and managing event blobs
+#[derive(Debug)]
 pub struct EventBlobDownloader {
     walrus_client: WalrusClient<SuiReadClient>,
     sui_read_client: SuiReadClient,
 }
 
 impl EventBlobDownloader {
+    /// Creates a new instance of the event blob downloader.
     pub fn new(walrus_client: WalrusClient<SuiReadClient>, sui_read_client: SuiReadClient) -> Self {
         Self {
             walrus_client,

--- a/crates/walrus-service/src/lib.rs
+++ b/crates/walrus-service/src/lib.rs
@@ -12,8 +12,11 @@ pub mod node;
 #[cfg(feature = "deploy")]
 pub mod testbed;
 
+#[cfg(feature = "backup")]
+pub mod backup;
+
 #[cfg(any(feature = "client", feature = "node"))]
-pub(crate) mod common;
+pub mod common;
 #[cfg(any(feature = "client", feature = "node"))]
 pub use common::utils;
 

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -20,25 +20,27 @@ use serde_with::{
     ser::SerializeAsWrap,
     serde_as,
     DeserializeAs,
-    DurationMilliSeconds,
     DurationSeconds,
     SerializeAs,
 };
-use sui_sdk::wallet_context::WalletContext;
 use sui_types::base_types::SuiAddress;
 use walrus_core::{
     keys::{KeyPairParseError, NetworkKeyPair, ProtocolKeyPair, SupportedKeyPair, TaggedKeyPair},
     messages::ProofOfPossession,
 };
-use walrus_sui::{
-    client::{contract_config::ContractConfig, SuiClientError, SuiContractClient, SuiReadClient},
-    types::{move_structs::VotingParams, NetworkAddress, NodeMetadata, NodeRegistrationParams},
+use walrus_sui::types::{
+    move_structs::VotingParams,
+    NetworkAddress,
+    NodeMetadata,
+    NodeRegistrationParams,
 };
-use walrus_utils::backoff::ExponentialBackoffConfig;
 
 use super::storage::DatabaseConfig;
 use crate::{
-    common::utils::{self, LoadConfig},
+    common::{
+        config::SuiConfig,
+        utils::{self, LoadConfig},
+    },
     node::events::EventProcessorConfig,
 };
 
@@ -392,60 +394,6 @@ impl Default for ShardSyncConfig {
     }
 }
 
-/// Sui-specific configuration for Walrus
-#[serde_with::serde_as]
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
-pub struct SuiConfig {
-    /// HTTP URL of the Sui full-node RPC endpoint (including scheme). This is used in the event
-    /// processor and some other read operations; for all write operations, the RPC URL from the
-    /// wallet is used.
-    pub rpc: String,
-    /// Configuration of the contract packages and shared objects.
-    #[serde(flatten)]
-    pub contract_config: ContractConfig,
-    /// Interval with which events are polled, in milliseconds.
-    #[serde_as(as = "DurationMilliSeconds")]
-    #[serde(
-        rename = "event_polling_interval_millis",
-        default = "defaults::polling_interval"
-    )]
-    pub event_polling_interval: Duration,
-    /// Location of the wallet config.
-    #[serde(deserialize_with = "utils::resolve_home_dir")]
-    pub wallet_config: PathBuf,
-    /// The configuration for the backoff strategy used for retries.
-    #[serde(default, skip_serializing_if = "defaults::is_default")]
-    pub backoff_config: ExponentialBackoffConfig,
-    /// Gas budget for transactions.
-    #[serde(default = "defaults::gas_budget")]
-    pub gas_budget: u64,
-}
-
-impl SuiConfig {
-    /// Creates a new [`SuiReadClient`] based on the configuration.
-    pub async fn new_read_client(&self) -> Result<SuiReadClient, SuiClientError> {
-        SuiReadClient::new_for_rpc(
-            &self.rpc,
-            &self.contract_config,
-            self.backoff_config.clone(),
-        )
-        .await
-    }
-
-    /// Creates a [`SuiContractClient`] based on the configuration.
-    pub async fn new_contract_client(&self) -> Result<SuiContractClient, SuiClientError> {
-        SuiContractClient::new(
-            WalletContext::new(&self.wallet_config, None, None)?,
-            &self.contract_config,
-            self.backoff_config.clone(),
-            self.gas_budget,
-        )
-        .await
-    }
-}
-
-impl LoadConfig for SuiConfig {}
-
 /// Default values for the storage-node configuration.
 pub mod defaults {
     use std::net::Ipv4Addr;
@@ -453,13 +401,12 @@ pub mod defaults {
     use walrus_sui::utils::SuiNetwork;
 
     use super::*;
+    pub use crate::common::config::defaults::{gas_budget, is_default, polling_interval};
 
     /// Default metrics port.
     pub const METRICS_PORT: u16 = 9184;
     /// Default REST API port.
     pub const REST_API_PORT: u16 = 9185;
-    /// Default polling interval in milliseconds.
-    pub const POLLING_INTERVAL_MS: u64 = 400;
     /// Default number of seconds to wait for graceful shutdown.
     pub const REST_GRACEFUL_SHUTDOWN_PERIOD_SECS: u64 = 60;
 
@@ -483,16 +430,6 @@ pub mod defaults {
         (Ipv4Addr::UNSPECIFIED, REST_API_PORT).into()
     }
 
-    /// Returns the default polling interval.
-    pub fn polling_interval() -> Duration {
-        Duration::from_millis(POLLING_INTERVAL_MS)
-    }
-
-    /// Returns the default gas budget.
-    pub fn gas_budget() -> u64 {
-        500_000_000
-    }
-
     /// Returns the default network ([`SuiNetwork::Devnet`])
     pub fn network() -> SuiNetwork {
         SuiNetwork::Devnet
@@ -510,13 +447,6 @@ pub mod defaults {
     /// The default vote for the write price.
     pub fn write_price() -> u64 {
         2000
-    }
-
-    /// Returns true iff the value is the default and we don't run in test mode.
-    pub fn is_default<T: PartialEq + Default>(t: &T) -> bool {
-        // The `cfg!(test)` check is there to allow serializing the full configuration, specifically
-        // to generate the example configuration files.
-        !cfg!(test) && t == &T::default()
     }
 
     /// Returns true iff the value is `None` and we don't run in test mode.
@@ -672,6 +602,7 @@ mod tests {
     use sui_types::base_types::ObjectID;
     use tempfile::NamedTempFile;
     use walrus_core::test_utils;
+    use walrus_sui::client::contract_config::ContractConfig;
     use walrus_test_utils::Result as TestResult;
 
     use super::*;

--- a/crates/walrus-service/src/node/contract_service.rs
+++ b/crates/walrus-service/src/node/contract_service.rs
@@ -26,7 +26,8 @@ use walrus_sui::{
 };
 use walrus_utils::backoff::{self, ExponentialBackoff};
 
-use super::{committee::CommitteeService, config::SuiConfig};
+use super::committee::CommitteeService;
+use crate::common::config::SuiConfig;
 
 const MIN_BACKOFF: Duration = Duration::from_secs(1);
 const MAX_BACKOFF: Duration = Duration::from_secs(3600);

--- a/crates/walrus-service/src/node/events/event_blob_writer.rs
+++ b/crates/walrus-service/src/node/events/event_blob_writer.rs
@@ -349,6 +349,7 @@ impl EventBlobWriterFactory {
 }
 
 /// EventBlobWriter manages the creation, storage, and certification of event blobs.
+/// ```
 ///                   +-------------------+
 ///                   |  EventBlobWriter  |
 ///                   +-------------------+
@@ -366,6 +367,7 @@ impl EventBlobWriterFactory {
 ///                                                           +-----------+
 ///
 /// Flow: Current -> Pending -> Attested -> Certified
+/// ```
 ///
 /// Blob Lifecycle:
 ///

--- a/crates/walrus-service/src/node/system_events.rs
+++ b/crates/walrus-service/src/node/system_events.rs
@@ -15,16 +15,19 @@ use tokio_stream::{wrappers::IntervalStream, Stream};
 use tracing::Level;
 use walrus_sui::client::{ReadClient, SuiReadClient};
 
-use super::{config::SuiConfig, metrics, StorageNodeInner, STATUS_PENDING, STATUS_PERSISTED};
-use crate::node::{
-    events::{
-        event_processor::EventProcessor,
-        CheckpointEventPosition,
-        EventStreamCursor,
-        InitState,
-        PositionedStreamEvent,
+use super::{metrics, StorageNodeInner, STATUS_PENDING, STATUS_PERSISTED};
+use crate::{
+    common::config::SuiConfig,
+    node::{
+        events::{
+            event_processor::EventProcessor,
+            CheckpointEventPosition,
+            EventStreamCursor,
+            InitState,
+            PositionedStreamEvent,
+        },
+        storage::EventProgress,
     },
-    storage::EventProgress,
 };
 
 /// The capacity of the event channel.

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -66,7 +66,7 @@ use walrus_test_utils::WithTempDir;
 use walrus_utils::backoff::ExponentialBackoffConfig;
 
 #[cfg(msim)]
-use crate::node::config::SuiConfig;
+use crate::common::config::SuiConfig;
 use crate::{
     common::active_committees::ActiveCommittees,
     node::{

--- a/crates/walrus-service/src/testbed.rs
+++ b/crates/walrus-service/src/testbed.rs
@@ -45,11 +45,10 @@ use walrus_utils::backoff::ExponentialBackoffConfig;
 
 use crate::{
     client::{self, ClientCommunicationConfig},
-    common::utils::LoadConfig,
+    common::{config::SuiConfig, utils::LoadConfig},
     node::config::{
         defaults::{self, REST_API_PORT},
         StorageNodeConfig,
-        SuiConfig,
     },
 };
 

--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -50,6 +50,7 @@ NOTE_ORDER = [
     "Aggregator",
     "Publisher",
     "CLI",
+    "Backup node",
 ]
 
 class Note(NamedTuple):


### PR DESCRIPTION
## Description

Create most of the boilerplate for running a backup node.

## Test plan

Minimal testing at this point.

---

## Release notes

- [x] Backup node: an entrypoint called walrus-backup will now be included in the build process. It has minimal (tailing Walrus-related Sui events) functionality at this point.
