### PR TITLE
chore: reduce log level in get_proof and verify_proof

### DIFF
--- a/crates/walrus-core/src/merkle.rs
+++ b/crates/walrus-core/src/merkle.rs
@@ -65,7 +65,7 @@ impl AsRef<[u8]> for Node {
 /// The operations required to authenticate a Merkle proof.
 pub trait MerkleAuth: Clone + alloc::fmt::Debug {
     /// Verifies the proof given a Merkle root and the leaf data.
-    #[tracing::instrument(skip(leaf))]
+    #[tracing::instrument(level = Level::DEBUG, skip(leaf))]
     fn verify_proof(&self, root: &Node, leaf: &[u8], leaf_index: usize) -> bool {
         self.compute_root(leaf, leaf_index).as_ref() == Some(root)
     }
@@ -236,7 +236,7 @@ where
 
     /// Get the [`MerkleProof`] for the leaf at `leaf_index` consisting
     /// of all sibling hashes on the path from the leaf to the root.
-    #[tracing::instrument(level = Level::WARN, fields(n_leaves = self.n_leaves))]
+    #[tracing::instrument(level = Level::DEBUG, fields(n_leaves = self.n_leaves))]
     pub fn get_proof(&self, leaf_index: usize) -> Result<MerkleProof<T>, LeafIndexOutOfBounds> {
         tracing::trace!("computing Merkle proof");
         if leaf_index >= self.n_leaves {


### PR DESCRIPTION
## Description

During the slow blob sync investigation, we see that `get_proof` and `verify_proof` consume a lot of CPU (the highlighted pink box).

<img width="1535" alt="Screenshot 2025-01-13 at 11 54 47 PM" src="https://github.com/user-attachments/assets/cd8235db-a658-4bac-bbb2-b50485e1fd02" />

And majority of the CPU time is creating tracing spans:

<img width="1691" alt="Screenshot 2025-01-13 at 11 55 55 PM" src="https://github.com/user-attachments/assets/1c9e58dc-08da-438b-bf00-2698b1bd5e48" />

It seems to show that creating span is way more expensive than the function logic itself... So reduce the span level to save some CPUs.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
