### PR TITLE
fix(client): correct cost computation in store dry-run

### DIFF
--- a/crates/walrus-service/src/client/cli/cli_output.rs
+++ b/crates/walrus-service/src/client/cli/cli_output.rs
@@ -181,11 +181,13 @@ impl CliOutput for DryRunOutput {
     fn print_cli_output(&self) {
         println!(
             "{} Store dry-run succeeded.\n\
+                Path: {}\n\
                 Blob ID: {}\n\
                 Unencoded size: {}\n\
                 Encoded size (including replicated metadata): {}\n\
-                Cost (excluding gas): {}\n",
+                Cost to store as new blob (excluding gas): {}\n",
             success(),
+            self.path.display(),
             self.blob_id,
             HumanReadableBytes(self.unencoded_size),
             HumanReadableBytes(self.encoded_size),

--- a/crates/walrus-service/src/client/responses.rs
+++ b/crates/walrus-service/src/client/responses.rs
@@ -205,6 +205,8 @@ impl From<BlobIdDecimal> for BlobIdConversionOutput {
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct DryRunOutput {
+    /// The file path to the blob.
+    pub path: PathBuf,
     /// The blob ID.
     #[serde_as(as = "DisplayFromStr")]
     pub blob_id: BlobId,


### PR DESCRIPTION
## Description

We forgot to adjust the cost computation for the store dry-run when adding the write fee. This uses the same (correct) cost computation as for the actual store.

Includes some refactoring and adds the file path to the dry-run output.

## Test plan

Manually running `walrus store --dry-run` and comparing the output to `walrus store`.

---

## Release notes

- [x] CLI: Fixes the cost computation for the `store --dry-run` command.
