### PR TITLE
chore: reduce checkpoint-download workers in local testbed

### DIFF
--- a/scripts/local-testbed.sh
+++ b/scripts/local-testbed.sh
@@ -119,6 +119,9 @@ if ! $existing; then
     # Generate configs
     echo Generating configuration...
     ./target/release/walrus-deploy generate-dry-run-configs --working-dir $working_dir
+
+    echo "event_processor_config:\n  adaptive_downloader_config:\n    max_workers: 2\n    initial_workers: 2" | \
+      tee -a $working_dir/dryrun-node-*[0-9].yaml >/dev/null
 fi
 
 i=0


### PR DESCRIPTION
## Description

Because we run multiple nodes at the same IP address, they get rate limited pretty quickly by the full node if they download checkpoints at maximum speed.

This limits the number of checkpoint-download workers for the nodes in the local testbed.

## Test plan

Ran the local testbed.
