### PR TITLE
fix: Fix blob path during blob based catchup

### DIFF
--- a/crates/walrus-service/src/common/event_blob_downloader.rs
+++ b/crates/walrus-service/src/common/event_blob_downloader.rs
@@ -71,7 +71,7 @@ impl EventBlobDownloader {
 
             let blob_path = path.join(prev_event_blob.to_string());
             let blob = if blob_path.exists() {
-                std::fs::read(path)?
+                std::fs::read(blob_path.as_path())?
             } else {
                 let result = self
                     .walrus_client


### PR DESCRIPTION
## Description

This only gets triggered when the process is restarted during catchup process which is not very common occuring. And hence didn;t get caught yet.

## Test plan

Running locally using the command in https://github.com/MystenLabs/walrus/pull/1409 works after killing and restarting the catchup process several times.
