### PR TITLE
test: use commit sha as test seed in simtest in CI

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -142,6 +142,8 @@ jobs:
     runs-on: ubuntu-ghcloud
     env:
       MSIM_TEST_NUM: 5
+      # Use first u16 of the commit sha as test seed.
+      MSIM_TEST_SEED: ${{ fromJson(toJson(github.sha | slice(0, 4))) }}
       RUST_LOG: error
     steps:
       - uses: taiki-e/install-action@v2.47.2


### PR DESCRIPTION
## Description

Have a way for folk to re-run simtest in CI without need to change the code.

With this PR, this can be achieved by doing

`git commit --amend` and generate a new commit sha.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
