### PR TITLE
ci: more robust simtest setup

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -140,7 +140,6 @@ jobs:
     needs: diff
     if: ${{ needs.diff.outputs.isRelevantForRustTests == 'true' }}
     runs-on: ubuntu-ghcloud
-    continue-on-error: true
     env:
       MSIM_TEST_NUM: 5
       RUST_LOG: error
@@ -152,6 +151,20 @@ jobs:
       - run: ./scripts/simtest/install.sh
       - name: Run tests
         run: cargo simtest simtest --profile simtest
+
+  simtests-build:
+    name: Build all simtests
+    needs: diff
+    if: ${{ needs.diff.outputs.isRelevantForRustTests == 'true' }}
+    runs-on: ubuntu-ghcloud
+    steps:
+      - uses: taiki-e/install-action@v2.47.2
+        with:
+          tool: cargo-nextest
+      - uses: actions/checkout@v4
+      - run: ./scripts/simtest/install.sh
+      - name: Build simtests
+        run: cargo simtest build
 
   test-move:
     name: Test Move code
@@ -239,7 +252,7 @@ jobs:
       - lint
       - build
       - test
-      - simtests
+      - simtests-build
       - test-move
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description

- Add a `simtests-build` job to the CI workflow for PRs that build the simtests. This job *must succeed* before the PR can be merged.
- The existing `simtests` job in the workflow is kept, but does not block PRs from being merged.

This strikes a balance of making simtest failures visible but to allow ignoring them to merge PRs.

Related to WAL-315.

## Test plan

See the workflow run for this PR: https://github.com/MystenLabs/walrus/actions/runs/12784338630

The simtests job fails, which causes the whole workflow to fail. However, this PR is still mergeable.
