### PR TITLE
feat: retry the exact same Sui transaction when encounter retryable error (such as 429, or 502)

### DIFF
--- a/crates/walrus-service/src/node/blob_sync.rs
+++ b/crates/walrus-service/src/node/blob_sync.rs
@@ -583,7 +583,7 @@ impl BlobSynchronizer {
             .get_invalid_blob_certificate(self.blob_id, inconsistency_proof)
             .await;
         self.contract_service()
-            .invalidate_blob_id(&invalid_blob_certificate)
+            .invalidate_blob_id(Arc::new(invalid_blob_certificate))
             .await
     }
 }

--- a/crates/walrus-service/src/node/events/event_blob_writer.rs
+++ b/crates/walrus-service/src/node/events/event_blob_writer.rs
@@ -730,25 +730,16 @@ impl EventBlobWriter {
         checkpoint_sequence_number: CheckpointSequenceNumber,
     ) -> Result<()> {
         tracing::debug!("attesting event blob in epoch: {}", self.current_epoch);
-        match self
-            .node
+        self.node
             .contract_service
             .certify_event_blob(
                 metadata.try_into()?,
                 checkpoint_sequence_number,
                 self.current_epoch,
             )
-            .await
-        {
-            Ok(_) => {
-                tracing::info!("attested event blob with id: {:?}", metadata.blob_id());
-                Ok(())
-            }
-            Err(e) => {
-                tracing::info!("failed to attest event blob: {:?}", e);
-                Ok(())
-            }
-        }
+            .await;
+        tracing::info!("attested event blob with id: {:?}", metadata.blob_id());
+        Ok(())
     }
 
     /// Attests the next pending blob.

--- a/crates/walrus-service/src/node/storage/shard.rs
+++ b/crates/walrus-service/src/node/storage/shard.rs
@@ -1068,7 +1068,7 @@ impl ShardStorage {
                     .get_invalid_blob_certificate(blob_id, &inconsistency_proof)
                     .await;
                 node.contract_service
-                    .invalidate_blob_id(&invalid_blob_certificate)
+                    .invalidate_blob_id(Arc::new(invalid_blob_certificate))
                     .await
             }
         }

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -17,7 +17,6 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use anyhow::Error;
 use async_trait::async_trait;
 use chrono::Utc;
 use futures::{stream::FuturesUnordered, StreamExt};
@@ -1225,7 +1224,7 @@ pub struct StubContractService {
 
 #[async_trait]
 impl SystemContractService for StubContractService {
-    async fn invalidate_blob_id(&self, _certificate: &InvalidBlobCertificate) {}
+    async fn invalidate_blob_id(&self, _certificate: Arc<InvalidBlobCertificate>) {}
 
     async fn epoch_sync_done(&self, _epoch: Epoch) {}
 
@@ -1254,8 +1253,7 @@ impl SystemContractService for StubContractService {
         _blob_metadata: BlobObjectMetadata,
         _ending_checkpoint_seq_num: u64,
         _epoch: u32,
-    ) -> Result<(), Error> {
-        anyhow::bail!("stub service cannot certify event blob")
+    ) {
     }
 
     async fn refresh_contract_package(&self) -> Result<(), anyhow::Error> {
@@ -1820,7 +1818,7 @@ where
         self.as_ref().inner.end_voting().await
     }
 
-    async fn invalidate_blob_id(&self, certificate: &InvalidBlobCertificate) {
+    async fn invalidate_blob_id(&self, certificate: Arc<InvalidBlobCertificate>) {
         self.as_ref().inner.invalidate_blob_id(certificate).await
     }
 
@@ -1849,7 +1847,7 @@ where
         blob_metadata: BlobObjectMetadata,
         ending_checkpoint_seq_num: u64,
         epoch: u32,
-    ) -> Result<(), Error> {
+    ) {
         self.as_ref()
             .inner
             .certify_event_blob(blob_metadata, ending_checkpoint_seq_num, epoch)

--- a/crates/walrus-sui/src/client/transaction_builder.rs
+++ b/crates/walrus-sui/src/client/transaction_builder.rs
@@ -7,6 +7,7 @@ use std::{
     collections::{BTreeSet, HashSet},
     fmt::Debug,
     str::FromStr,
+    sync::Arc,
 };
 
 use fastcrypto::traits::ToFromBytes;
@@ -325,7 +326,7 @@ impl WalrusPtbBuilder {
     /// Adds a call to `certify_event_blob` to the `pt_builder`.
     pub async fn certify_event_blob(
         &mut self,
-        blob_metadata: BlobObjectMetadata,
+        blob_metadata: &BlobObjectMetadata,
         storage_node_cap: ArgumentOrOwnedObject,
         ending_checkpoint_seq_num: u64,
         epoch: u32,
@@ -546,7 +547,7 @@ impl WalrusPtbBuilder {
     /// Adds a call to `invalidate_blob_id` to the PTB.
     pub async fn invalidate_blob_id(
         &mut self,
-        certificate: &InvalidBlobCertificate,
+        certificate: Arc<InvalidBlobCertificate>,
     ) -> SuiClientResult<()> {
         let signers = self.signers_to_bitmap(&certificate.signers).await?;
 

--- a/crates/walrus-sui/tests/test_walrus_sui.rs
+++ b/crates/walrus-sui/tests/test_walrus_sui.rs
@@ -24,6 +24,7 @@ use walrus_sui::{
         CoinType,
         PostStoreAction,
         ReadClient,
+        RetriableOperation,
         SuiClientError,
         SuiContractClient,
     },
@@ -287,7 +288,10 @@ async fn test_invalidate_blob() -> anyhow::Result<()> {
 
     walrus_client
         .as_ref()
-        .invalidate_blob_id(&certificate)
+        .execute_retriable_contract_operation(
+            RetriableOperation::InvalidateBlobId(Arc::new(certificate)),
+            None,
+        )
         .await?;
 
     // Make sure that we got the expected event


### PR DESCRIPTION
## Description

When a contract is experiencing retryable error, it's unclear whether this transaction has locked object on chain or not. To reduce the chance of equivocation and locked object, we should retry the exact same transaction instead of building a new one.

The main motivation is that we have seen the `epoch_sync_done` transaction equivocated several times, which blocks the epoch change progress. Although this is less of a concern on mainnet since the epoch on mainnet is much longer than sui epoch, and locked objects can be unlocked, we still don't want `epoch_sync_done` transaction to take a day to commit.

This PR only targets at transactions that perform retry currently.

Close WAL-494

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
