### PR TITLE
fix: [jh/host and name defaults for labels]

### DIFF
--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -236,7 +236,8 @@ impl MetricsPushConfig {
     pub fn set_name(&mut self, name: &str) {
         self.labels
             .get_or_insert_with(HashMap::new)
-            .insert("name".into(), name.into());
+            .entry("name".into())
+            .or_insert_with(|| name.into());
 
         // also set the host label and try to get the hostname to do it.  if we cannot
         // use name as a fallback.
@@ -249,7 +250,8 @@ impl MetricsPushConfig {
     fn set_host(&mut self, host: String) {
         self.labels
             .get_or_insert_with(HashMap::new)
-            .insert("host".into(), host);
+            .entry("host".into())
+            .or_insert_with(|| host);
     }
 }
 


### PR DESCRIPTION
## Description
a compromise between what @mlegner asked for and what @pei-mysten asked for.

If a user does nothing except add a name config item (not related to metrics) and then enable metric push, this will set the labels:
```
name=<set name from config>
host=<hostname or defaults to name>
```
If they provide either name or host in the label subconfig of the metrics push, those values will persist.  I can imagine some edge cases where they will want to modify their underlying hostname to avoid leaking data or use a vanity name.

## Test Plan
local

## Description

Describe the changes or additions included in this PR.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
