### PR TITLE
fix(client): response serialization inconsistency

### DIFF
--- a/crates/walrus-service/src/client/responses.rs
+++ b/crates/walrus-service/src/client/responses.rs
@@ -73,6 +73,7 @@ impl Display for EventOrObjectId {
 
 /// Blob store result with its file path.
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct BlobStoreResultWithPath {
     /// The result of the store operation.
     pub blob_store_result: BlobStoreResult,


### PR DESCRIPTION
## Description

We were missing a serde annotation on a struct that caused it to be serialized inconsistently.

## Test plan

Run the client manually.

---

## Release notes

- [x] CLI: Fix serialization of JSON output for the `walrus store` command.
