### PR TITLE
chore: update testnet-contracts

### DIFF
--- a/testnet-contracts/wal/Move.lock
+++ b/testnet-contracts/wal/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "DE8F504E870C20B240C78405DEA586FFD27C37F950BB57458D05C799E2A51DCC"
+manifest_digest = "B34B8CCE2F6AA4DAC35056EBAC5177C323AB50BC941CB065497D8D89BEF07030"
 deps_digest = "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -10,17 +10,25 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.39.1", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.40.1", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.39.1", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.40.1", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
 ]
 
 [move.toolchain-version]
-compiler-version = "1.39.1"
+compiler-version = "1.40.1"
 edition = "2024.beta"
 flavor = "sui"
+
+[env]
+
+[env.testnet]
+chain-id = "4c78adac"
+original-published-id = "0x8190b041122eb492bf63cb464476bd68c6b7e570a4079645a8b28732b6197a82"
+latest-published-id = "0x8190b041122eb492bf63cb464476bd68c6b7e570a4079645a8b28732b6197a82"
+published-version = "1"

--- a/testnet-contracts/wal/Move.toml
+++ b/testnet-contracts/wal/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.39.1" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.40.1" }
 
 # For remote import, use the `{ git = "...", subdir = "...", rev = "..." }`.
 # Revision can be a branch, a tag, and a commit hash.

--- a/testnet-contracts/wal_exchange/Move.lock
+++ b/testnet-contracts/wal_exchange/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "3BAF3CC1E79B1E2F5B8706DAF65680CEA8B45F3BB171D882C1E5FB41E631844F"
+manifest_digest = "E8A73998BB19856A920661D91415EDBA6E46F6D387EFD3B0BF7496F722024AC8"
 deps_digest = "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -11,11 +11,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.39.1", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.40.1", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.39.1", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.40.1", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -30,6 +30,14 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.39.1"
+compiler-version = "1.40.1"
 edition = "2024.beta"
 flavor = "sui"
+
+[env]
+
+[env.testnet]
+chain-id = "4c78adac"
+original-published-id = "0x17365683421a6242d21cc795298cfd61de541618a8dc9d03a12642571808821b"
+latest-published-id = "0x17365683421a6242d21cc795298cfd61de541618a8dc9d03a12642571808821b"
+published-version = "1"

--- a/testnet-contracts/wal_exchange/Move.toml
+++ b/testnet-contracts/wal_exchange/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.39.1" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.40.1" }
 WAL = { local = "../wal" }
 
 # For remote import, use the `{ git = "...", subdir = "...", rev = "..." }`.

--- a/testnet-contracts/walrus/Move.lock
+++ b/testnet-contracts/walrus/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "FFDD90EFFBEDFEFED1EB8D03C41D05DA522DDD4B1C91184389143693F9B686D2"
+manifest_digest = "E3BCC1B897451B84D6AB8385FF4C28A91F77D84D53313BC0CD9D0EB82A75BB10"
 deps_digest = "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -12,11 +12,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.39.1", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.40.1", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.39.1", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.40.1", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -40,7 +40,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.39.1"
+compiler-version = "1.40.1"
 edition = "2024.beta"
 flavor = "sui"
 
@@ -48,6 +48,6 @@ flavor = "sui"
 
 [env.testnet]
 chain-id = "4c78adac"
-original-published-id = "0x9f992cc2430a1f442ca7a5ca7638169f5d5c00e0ebc3977a65e9ac6e497fe5ef"
-latest-published-id = "0x3d35ad1028562025f6f24336f0298d3775ba896bbbb63be7ad5b9fee8255dd89"
-published-version = "3"
+original-published-id = "0x795ddbc26b8cfff2551f45e198b87fc19473f2df50f995376b924ac80e56f88b"
+latest-published-id = "0x795ddbc26b8cfff2551f45e198b87fc19473f2df50f995376b924ac80e56f88b"
+published-version = "1"

--- a/testnet-contracts/walrus/Move.toml
+++ b/testnet-contracts/walrus/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.39.1" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.40.1" }
 WAL = { local = "../wal" }
 # TODO: Remove this after we publish contracts separately (#909).
 WAL_exchange = { local = "../wal_exchange" }

--- a/testnet-contracts/walrus/docs/msg_formats.txt
+++ b/testnet-contracts/walrus/docs/msg_formats.txt
@@ -29,7 +29,9 @@ Intent types (add here):
 
 const PROOF_OF_POSSESSION_MSG_TYPE: u8 = 0;
 const BLOB_CERT_MSG_TYPE: u8 = 1;
-const INVALID_BLOB_ID_MSG_TYPE : u8 = 2;
+const INVALID_BLOB_ID_MSG_TYPE: u8 = 2;
+const DENY_LIST_UPDATE_MSG_TYPE: u8 = 3;
+const DENY_LIST_BLOB_DELETED_MSG_TYPE: u8 = 4;
 
 PROOF_OF_POSSESSION message
 -----------------
@@ -37,16 +39,39 @@ PROOF_OF_POSSESSION message
 The body contains the sui address followed by the bls public key (encoded as 48 byte fixed
 size array) of the signer.
 
-
 BLOB_CERT message
 -----------------
 
-The body is the blob_id : u256 (32 bytes) of a blob. The storage node certified that all
-shards that were assigned to it for the message epoch have been received, checked and
-persisted to store.
+The body is the blob_id : u256 (32 bytes) of a blob followed by the bcs encoding of the blob
+persistence type defined below, i.e. 1 byte that is 0 for permanent blobs and 1 for deletable
+blobs, followed by the object id of the deletable blob if it is a deletable blob.
+
+```
+enum BlobPersistenceType {
+    Permanent,
+    Deletable { object_id: [u8; 32] },
+}
+```
+
+The storage node certified that all shards that were assigned to it for the message epoch have
+been received, checked and persisted to store.
 
 INVALID_BLOB_ID
 ---------------
 
 The body is the blob_id : u256 (32 bytes) of a blob. The storage node certified that
 it has verified an inconsistency proof and the blob id is invalid.
+
+DENY_LIST_UPDATE_MSG_TYPE
+---------------
+
+The body is the node_id : address (32 bytes) of the storage node,
+deny_list_sequence_number : u64 (8 bytes) sequence number, deny_list_size : u64 (8 bytes)
+the size of the deny list of the node, deny_list_root : u256 (32 bytes) the root hash of
+the deny list.
+
+DENY_LIST_BLOB_DELETED_MSG_TYPE
+---------------
+
+The body is the blob_id : u256 (32 bytes) of a blob. f+1 nodes have added the blob id to
+their deny lists, and the blob should be deleted.

--- a/testnet-contracts/walrus/sources/init.move
+++ b/testnet-contracts/walrus/sources/init.move
@@ -3,8 +3,14 @@
 
 module walrus::init;
 
-use sui::clock::Clock;
-use walrus::{staking, system};
+use std::type_name;
+use sui::{clock::Clock, package::UpgradeCap};
+use walrus::{events, staking::{Self, Staking}, system::{Self, System}, upgrade};
+
+// Error codes
+// Error types in `walrus-sui/types/move_errors.rs` are auto-generated from the Move error codes.
+const EInvalidMigration: u64 = 0;
+const EInvalidUpgradeCap: u64 = 1;
 
 /// Must only be created by `init`.
 public struct InitCap has key, store {
@@ -24,17 +30,44 @@ fun init(ctx: &mut TxContext) {
 /// This can only be called once, after which the `InitCap` is destroyed.
 /// TODO: decide what to add as system parameters instead of constants.
 public fun initialize_walrus(
-    cap: InitCap,
+    init_cap: InitCap,
+    upgrade_cap: UpgradeCap,
     epoch_zero_duration: u64,
     epoch_duration: u64,
     n_shards: u16,
     max_epochs_ahead: u32,
     clock: &Clock,
     ctx: &mut TxContext,
-) {
-    system::create_empty(max_epochs_ahead, ctx);
-    staking::create(epoch_zero_duration, epoch_duration, n_shards, clock, ctx);
-    cap.destroy();
+): upgrade::EmergencyUpgradeCap {
+    let package_id = upgrade_cap.package();
+    assert!(
+        type_name::get<InitCap>().get_address() == package_id.to_address().to_ascii_string(),
+        EInvalidUpgradeCap,
+    );
+    system::create_empty(max_epochs_ahead, package_id, ctx);
+    staking::create(epoch_zero_duration, epoch_duration, n_shards, package_id, clock, ctx);
+    let emergency_upgrade_cap = upgrade::new(upgrade_cap, ctx);
+    init_cap.destroy();
+    emergency_upgrade_cap
+}
+
+/// Migrate the staking and system objects to the new package id.
+///
+/// This must be called in the new package after an upgrade is committed
+/// to emit an event that informs all storage nodes and prevent previous package
+/// versions from being used.
+public fun migrate(staking: &mut Staking, system: &mut System) {
+    staking.migrate();
+    system.migrate();
+    // Check that the package id and version are the same.
+    assert!(staking.package_id() == system.package_id(), EInvalidMigration);
+    assert!(staking.version() == system.version(), EInvalidMigration);
+    // Emit an event to inform storage nodes of the upgrade.
+    events::emit_contract_upgraded(
+        staking.epoch(),
+        staking.package_id(),
+        staking.version(),
+    );
 }
 
 fun destroy(cap: InitCap) {
@@ -47,4 +80,27 @@ fun destroy(cap: InitCap) {
 #[test_only]
 public fun init_for_testing(ctx: &mut TxContext) {
     init(ctx);
+}
+
+#[test_only]
+/// Does the same as `initialize_walrus` but does not check the package id of the upgrade cap.
+///
+/// This is needed for testing, since the package ID of all types will be zero, which cannot be used
+/// as the package ID for an upgrade cap.
+public fun initialize_for_testing(
+    init_cap: InitCap,
+    upgrade_cap: UpgradeCap,
+    epoch_zero_duration: u64,
+    epoch_duration: u64,
+    n_shards: u16,
+    max_epochs_ahead: u32,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): upgrade::EmergencyUpgradeCap {
+    let package_id = upgrade_cap.package();
+    system::create_empty(max_epochs_ahead, package_id, ctx);
+    staking::create(epoch_zero_duration, epoch_duration, n_shards, package_id, clock, ctx);
+    let emergency_upgrade_cap = upgrade::new(upgrade_cap, ctx);
+    init_cap.destroy();
+    emergency_upgrade_cap
 }

--- a/testnet-contracts/walrus/sources/staking.move
+++ b/testnet-contracts/walrus/sources/staking.move
@@ -6,14 +6,21 @@
 module walrus::staking;
 
 use std::string::String;
-use sui::{clock::Clock, coin::Coin, dynamic_object_field as df};
+use sui::{clock::Clock, coin::Coin, dynamic_field as df};
 use wal::wal::WAL;
 use walrus::{
+    auth::{Self, Authenticated, Authorized},
+    committee::Committee,
+    node_metadata::NodeMetadata,
     staked_wal::StakedWal,
     staking_inner::{Self, StakingInnerV1},
     storage_node::{Self, StorageNodeCap},
     system::System
 };
+
+// Error codes
+// Error types in `walrus-sui/types/move_errors.rs` are auto-generated from the Move error codes.
+const EInvalidMigration: u64 = 0;
 
 /// Flag to indicate the version of the Walrus system.
 const VERSION: u64 = 0;
@@ -22,20 +29,26 @@ const VERSION: u64 = 0;
 public struct Staking has key {
     id: UID,
     version: u64,
+    package_id: ID,
+    new_package_id: Option<ID>,
 }
 
 /// Creates and shares a new staking object.
 /// Must only be called by the initialization function.
-///
-/// TODO: consider removing `epoch_duration` parameter when the testing is over.
 public(package) fun create(
     epoch_zero_duration: u64,
     epoch_duration: u64,
     n_shards: u16,
+    package_id: ID,
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
-    let mut staking = Staking { id: object::new(ctx), version: VERSION };
+    let mut staking = Staking {
+        id: object::new(ctx),
+        version: VERSION,
+        package_id,
+        new_package_id: option::none(),
+    };
     df::add(
         &mut staking.id,
         VERSION,
@@ -58,55 +71,110 @@ public fun register_candidate(
     // node info
     name: String,
     network_address: String,
+    metadata: NodeMetadata,
     public_key: vector<u8>,
     network_public_key: vector<u8>,
     proof_of_possession: vector<u8>,
     // voting parameters
-    commission_rate: u64,
+    commission_rate: u16,
     storage_price: u64,
     write_price: u64,
     node_capacity: u64,
     ctx: &mut TxContext,
 ): StorageNodeCap {
     // use the Pool Object ID as the identifier of the storage node
-    let node_id = staking
-        .inner_mut()
-        .create_pool(
-            name,
-            network_address,
-            public_key,
-            network_public_key,
-            proof_of_possession,
-            commission_rate,
-            storage_price,
-            write_price,
-            node_capacity,
-            ctx,
-        );
+    let staking_mut = staking.inner_mut();
+    let node_id = staking_mut.create_pool(
+        name,
+        network_address,
+        metadata,
+        public_key,
+        network_public_key,
+        proof_of_possession,
+        commission_rate,
+        storage_price,
+        write_price,
+        node_capacity,
+        ctx,
+    );
 
-    storage_node::new_cap(node_id, ctx)
+    // Switch the commission receiver from the sender (default) to the cap.
+    let cap = storage_node::new_cap(node_id, ctx);
+    let receiver = auth::authorized_object(object::id(&cap));
+    staking_mut.set_commission_receiver(node_id, auth::authenticate_sender(ctx), receiver);
+    cap
 }
 
+#[allow(unused_function)]
 /// Blocks staking for the nodes staking pool
 /// Marks node as "withdrawing",
 /// - excludes it from the next committee selection
 /// - still has to remain active while it is part of the committee and until all shards have
 ///     been transferred to its successor
 /// - The staking pool is deleted once the last funds have been withdrawn from it by its stakers
-public fun withdraw_node(staking: &mut Staking, cap: &mut StorageNodeCap) {
+fun withdraw_node(staking: &mut Staking, cap: &mut StorageNodeCap) {
     staking.inner_mut().set_withdrawing(cap.node_id());
     staking.inner_mut().withdraw_node(cap);
 }
 
+// === Commission ===
+
 /// Sets next_commission in the staking pool, which will then take effect as commission rate
 /// one epoch after setting the value (to allow stakers to react to setting this).
-public fun set_next_commission(staking: &mut Staking, cap: &StorageNodeCap, commission_rate: u64) {
+public fun set_next_commission(staking: &mut Staking, cap: &StorageNodeCap, commission_rate: u16) {
     staking.inner_mut().set_next_commission(cap, commission_rate);
 }
 
-/// Returns the accumulated commission for the storage node.
-public fun collect_commission(staking: &mut Staking, cap: &StorageNodeCap): Coin<WAL> {
-    staking.inner_mut().collect_commission(cap)
+/// Collects the commission for the node. Transaction sender must be the
+/// `CommissionReceiver` for the `StakingPool`.
+public fun collect_commission(
+    staking: &mut Staking,
+    node_id: ID,
+    auth: Authenticated,
+    ctx: &mut TxContext,
+): Coin<WAL> {
+    staking.inner_mut().collect_commission(node_id, auth).into_coin(ctx)
+}
+
+/// Sets the commission receiver for the node.
+public fun set_commission_receiver(
+    staking: &mut Staking,
+    node_id: ID,
+    auth: Authenticated,
+    receiver: Authorized,
+) {
+    staking.inner_mut().set_commission_receiver(node_id, auth, receiver);
+}
+
+// === Governance ===
+
+/// Sets the governance authorized object for the pool.
+public fun set_governance_authorized(
+    staking: &mut Staking,
+    node_id: ID,
+    auth: Authenticated,
+    authorized: Authorized,
+) {
+    staking.inner_mut().set_governance_authorized(node_id, auth, authorized);
+}
+
+/// Checks if the governance authorized object matches the authenticated object.
+public(package) fun check_governance_authorization(
+    staking: &Staking,
+    node_id: ID,
+    auth: Authenticated,
+): bool {
+    staking.inner().check_governance_authorization(node_id, auth)
+}
+
+/// Returns the current node weight for the given node id.
+public(package) fun get_current_node_weight(staking: &Staking, node_id: ID): u16 {
+    staking.inner().get_current_node_weight(node_id)
+}
+
+/// Computes the committee for the next epoch.
+public fun compute_next_committee(staking: &Staking): Committee {
+    staking.inner().compute_next_committee()
 }
 
 // === Voting ===
@@ -126,7 +194,12 @@ public fun set_node_capacity_vote(self: &mut Staking, cap: &StorageNodeCap, node
     self.inner_mut().set_node_capacity_vote(cap, node_capacity);
 }
 
-// === Update Node Parameters ===
+// === Get/ Update Node Parameters ===
+
+/// Get `NodeMetadata` for the given node.
+public fun node_metadata(self: &Staking, node_id: ID): NodeMetadata {
+    self.inner().node_metadata(node_id)
+}
 
 /// Sets the public key of a node to be used starting from the next epoch for which the node is
 /// selected.
@@ -157,6 +230,11 @@ public fun set_network_public_key(
     network_public_key: vector<u8>,
 ) {
     self.inner_mut().set_network_public_key(cap, network_public_key);
+}
+
+/// Sets the metadata of a storage node.
+public fun set_node_metadata(self: &mut Staking, cap: &StorageNodeCap, metadata: NodeMetadata) {
+    self.inner_mut().set_node_metadata(cap, metadata);
 }
 
 // === Epoch Change ===
@@ -238,6 +316,66 @@ public fun withdraw_stake(
     staking.inner_mut().withdraw_stake(staked_wal, ctx)
 }
 
+// === Accessors ===
+
+public(package) fun package_id(staking: &Staking): ID {
+    staking.package_id
+}
+
+public(package) fun version(staking: &Staking): u64 {
+    staking.version
+}
+
+/// Returns the current epoch of the staking object.
+public fun epoch(staking: &Staking): u32 {
+    staking.inner().epoch()
+}
+
+/// Checks if the weight reaches a quorum.
+public(package) fun is_quorum(staking: &Staking, weight: u16): bool {
+    staking.inner().is_quorum(weight)
+}
+
+// === Utility functions ===
+
+/// Calculate the rewards for an amount with value `staked_principal`, staked in the pool with
+/// the given `node_id` between `activation_epoch` and `withdraw_epoch`.
+///
+/// This function can be used with `dev_inspect` to calculate the expected rewards for a `StakedWal`
+/// object or, more generally, the returns provided by a given node over a given period.
+public fun calculate_rewards(
+    staking: &Staking,
+    node_id: ID,
+    staked_principal: u64,
+    activation_epoch: u32,
+    withdraw_epoch: u32,
+): u64 {
+    staking.inner().calculate_rewards(node_id, staked_principal, activation_epoch, withdraw_epoch)
+}
+
+// === Upgrade ===
+
+public(package) fun set_new_package_id(staking: &mut Staking, new_package_id: ID) {
+    staking.new_package_id = option::some(new_package_id);
+}
+
+/// Migrate the staking object to the new package id.
+///
+/// This function sets the new package id and version and can be modified in future versions
+/// to migrate changes in the `staking_inner` object if needed.
+public(package) fun migrate(staking: &mut Staking) {
+    assert!(staking.version < VERSION, EInvalidMigration);
+
+    // Move the old system state inner to the new version.
+    let staking_inner: StakingInnerV1 = df::remove(&mut staking.id, staking.version);
+    df::add(&mut staking.id, VERSION, staking_inner);
+    staking.version = VERSION;
+
+    // Set the new package id.
+    assert!(staking.new_package_id.is_some(), EInvalidMigration);
+    staking.package_id = staking.new_package_id.extract();
+}
+
 // === Internals ===
 
 /// Get a mutable reference to `StakingInner` from the `Staking`.
@@ -265,7 +403,12 @@ public(package) fun inner_for_testing(staking: &Staking): &StakingInnerV1 {
 #[test_only]
 public(package) fun new_for_testing(ctx: &mut TxContext): Staking {
     let clock = clock::create_for_testing(ctx);
-    let mut staking = Staking { id: object::new(ctx), version: VERSION };
+    let mut staking = Staking {
+        id: object::new(ctx),
+        version: VERSION,
+        package_id: new_id(ctx),
+        new_package_id: option::none(),
+    };
     df::add(&mut staking.id, VERSION, staking_inner::new(0, 10, 1000, &clock, ctx));
     clock.destroy_for_testing();
     staking
@@ -279,4 +422,9 @@ public(package) fun is_epoch_sync_done(self: &Staking): bool {
 #[test_only]
 fun new_id(ctx: &mut TxContext): ID {
     ctx.fresh_object_address().to_id()
+}
+
+#[test_only]
+public(package) fun new_package_id(staking: &Staking): Option<ID> {
+    staking.new_package_id
 }

--- a/testnet-contracts/walrus/sources/staking/active_set.move
+++ b/testnet-contracts/walrus/sources/staking/active_set.move
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// Contains an active set of storage nodes. The active set is a smart collection
-/// that only stores up to a 1000 nodes. The nodes are sorted by the amount of
-/// staked WAL. Additionally, the active set tracks the total amount of staked
+/// that only stores up to a 1000 nodes. The active set tracks the total amount of staked
 /// WAL to make the calculation of the rewards and voting power distribution easier.
 ///
 /// TODOs:
@@ -12,16 +11,18 @@
 ///   shards and total_staked (#715)
 module walrus::active_set;
 
-/// Active set cannot have maximum size of 0.
+// Error codes
+// Error types in `walrus-sui/types/move_errors.rs` are auto-generated from the Move error codes.
 const EZeroMaxSize: u64 = 0;
+const EDuplicateInsertion: u64 = 1;
 
-public struct ActiveSetEntry has store, copy, drop {
+public struct ActiveSetEntry has copy, drop, store {
     node_id: ID,
     staked_amount: u64,
 }
 
 /// The active set of storage nodes, a smart collection that only stores up
-/// to a 1000 nodes. The nodes are sorted by the amount of staked WAL.
+/// to a 1000 nodes.
 /// Additionally, the active set tracks the total amount of staked WAL to make
 /// the calculation of the rewards and voting power distribution easier.
 ///
@@ -29,7 +30,7 @@ public struct ActiveSetEntry has store, copy, drop {
 /// size and K is the number of nodes that are in the process of being added to
 /// the active set. This will allow us to handle removals from the active set
 /// without refetching the nodes from the storage.
-public struct ActiveSet has store, copy, drop {
+public struct ActiveSet has copy, drop, store {
     /// The maximum number of storage nodes in the active set.
     /// Potentially remove this field.
     max_size: u16,
@@ -72,7 +73,7 @@ public(package) fun update(set: &mut ActiveSet, node_id: ID, staked_amount: u64)
         return false
     };
     index.do!(|idx| {
-        set.total_stake = set.total_stake - set.nodes[idx].staked_amount + staked_amount;
+        set.total_stake = set.total_stake + staked_amount - set.nodes[idx].staked_amount;
         set.nodes[idx].staked_amount = staked_amount;
     });
     true
@@ -84,7 +85,7 @@ public(package) fun update(set: &mut ActiveSet, node_id: ID, staked_amount: u64)
 /// staked WAL is removed to make space for the new node.
 /// Returns true if the node was inserted, false otherwise.
 public(package) fun insert(set: &mut ActiveSet, node_id: ID, staked_amount: u64): bool {
-    assert!(set.nodes.find_index!(|entry| entry.node_id == node_id ).is_none());
+    assert!(set.nodes.find_index!(|entry| entry.node_id == node_id).is_none(), EDuplicateInsertion);
 
     // Check if the staked amount is enough to be included in the active set.
     if (staked_amount < set.threshold_stake) return false;
@@ -92,27 +93,28 @@ public(package) fun insert(set: &mut ActiveSet, node_id: ID, staked_amount: u64)
     // If the nodes are less than the max size, insert the node.
     if (set.nodes.length() as u16 < set.max_size) {
         set.total_stake = set.total_stake + staked_amount;
-        set.nodes.push_back(ActiveSetEntry {node_id, staked_amount});
+        set.nodes.push_back(ActiveSetEntry { node_id, staked_amount });
+        return true
+    };
+
+    // Find the node with the smallest amount of stake and less than the new node.
+    let mut min_stake = staked_amount;
+    let mut min_idx = option::none();
+    set.nodes.length().do!(|i| {
+        if (set.nodes[i].staked_amount < min_stake) {
+            min_idx = option::some(i);
+            min_stake = set.nodes[i].staked_amount;
+        }
+    });
+
+    // If there is such a node, replace it in the list.
+    if (min_idx.is_some()) {
+        let min_idx = min_idx.extract();
+        set.total_stake = set.total_stake - min_stake + staked_amount;
+        *&mut set.nodes[min_idx] = ActiveSetEntry { node_id, staked_amount };
         true
     } else {
-        // Find the node with the smallest amount of stake and less than the new node.
-        let mut min_stake = staked_amount;
-        let mut min_idx = option::none();
-        set.nodes.length().do!(|i| {
-            if (set.nodes[i].staked_amount < min_stake) {
-                min_idx = option::some(i);
-                min_stake = set.nodes[i].staked_amount;
-            }
-        });
-        // If there is such a node, replace it in the list.
-        if (min_idx.is_some()) {
-            let min_idx = min_idx.extract();
-            set.total_stake = set.total_stake - min_stake + staked_amount;
-            *&mut set.nodes[min_idx] = ActiveSetEntry { node_id, staked_amount };
-            true
-        } else {
-            false
-        }
+        false
     }
 }
 
@@ -175,8 +177,11 @@ public(package) fun cur_min_stake(set: &ActiveSet): u64 {
 
 #[test_only]
 public fun stake_for_node(set: &ActiveSet, node_id: ID): u64 {
-    set.nodes.find_index!(|entry| entry.node_id == node_id)
-        .map!(|index| set.nodes[index].staked_amount ).destroy_with_default(0)
+    set
+        .nodes
+        .find_index!(|entry| entry.node_id == node_id)
+        .map!(|index| set.nodes[index].staked_amount)
+        .destroy_or!(0)
 }
 
 // === Test ===
@@ -184,18 +189,18 @@ public fun stake_for_node(set: &ActiveSet, node_id: ID): u64 {
 #[test]
 fun test_evict_correct_node_simple() {
     let mut set = new(5, 0);
-    set.insert_or_update(object::id_from_address(@1), 10);
-    set.insert_or_update(object::id_from_address(@2), 9);
-    set.insert_or_update(object::id_from_address(@3), 8);
-    set.insert_or_update(object::id_from_address(@4), 7);
-    set.insert_or_update(object::id_from_address(@5), 6);
+    set.insert_or_update(object::id_from_address(@0x1), 10);
+    set.insert_or_update(object::id_from_address(@0x2), 9);
+    set.insert_or_update(object::id_from_address(@0x3), 8);
+    set.insert_or_update(object::id_from_address(@0x4), 7);
+    set.insert_or_update(object::id_from_address(@0x5), 6);
 
     let mut total_stake = 10 + 9 + 8 + 7 + 6;
 
     assert!(set.total_stake == total_stake);
 
     // insert another node which should eject node 5
-    set.insert_or_update(object::id_from_address(@6), 11);
+    set.insert_or_update(object::id_from_address(@0x6), 11);
 
     // check if total stake was updated correctly
     total_stake = total_stake - 6 + 11;
@@ -204,25 +209,25 @@ fun test_evict_correct_node_simple() {
     let active_ids = set.active_ids();
 
     // node 5 should not be part of the set
-    assert!(!active_ids.contains(&object::id_from_address(@5)));
+    assert!(!active_ids.contains(&object::id_from_address(@0x5)));
 
     // all other nodes should be
-    assert!(active_ids.contains(&object::id_from_address(@1)));
-    assert!(active_ids.contains(&object::id_from_address(@2)));
-    assert!(active_ids.contains(&object::id_from_address(@3)));
-    assert!(active_ids.contains(&object::id_from_address(@4)));
-    assert!(active_ids.contains(&object::id_from_address(@6)));
+    assert!(active_ids.contains(&object::id_from_address(@0x1)));
+    assert!(active_ids.contains(&object::id_from_address(@0x2)));
+    assert!(active_ids.contains(&object::id_from_address(@0x3)));
+    assert!(active_ids.contains(&object::id_from_address(@0x4)));
+    assert!(active_ids.contains(&object::id_from_address(@0x6)));
 }
 
 #[test]
 fun test_evict_correct_node_with_updates() {
     let nodes = vector[
-        object::id_from_address(@1),
-        object::id_from_address(@2),
-        object::id_from_address(@3),
-        object::id_from_address(@4),
-        object::id_from_address(@5),
-        object::id_from_address(@6),
+        object::id_from_address(@0x1),
+        object::id_from_address(@0x2),
+        object::id_from_address(@0x3),
+        object::id_from_address(@0x4),
+        object::id_from_address(@0x5),
+        object::id_from_address(@0x6),
     ];
 
     let mut set = new(5, 0);

--- a/testnet-contracts/walrus/sources/staking/apportionment_queue.move
+++ b/testnet-contracts/walrus/sources/staking/apportionment_queue.move
@@ -1,0 +1,162 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// A custom priority queue implementation for use in the apportionment algorithm.
+/// This implementation uses a quotient-based priority with a tie-breaker to break ties when
+/// priorities are equal.
+module walrus::apportionment_queue;
+
+use std::uq64_64::UQ64_64;
+
+/// Error code for popping from an empty heap.
+const EPopFromEmptyHeap: u64 = 0;
+
+/// Struct representing a priority queue.
+public struct ApportionmentQueue<T> has drop {
+    /// The `entries` vector contains a max heap, where the children of the node at index `i` are at
+    /// indices `2 * i + 1` and `2 * i + 2`.
+    /// INV: The parent node's priority is always higher or equal to its child nodes' priorities.
+    entries: vector<Entry<T>>,
+}
+
+public struct Entry<T> has drop {
+    priority: UQ64_64, // higher value means higher priority and will be popped first
+    tie_breaker: u64, // used to break ties when priorities are equal
+    value: T,
+}
+
+/// Create a new priority queue.
+public fun new<T>(): ApportionmentQueue<T> {
+    ApportionmentQueue { entries: vector[] }
+}
+
+/// Pop the entry with the highest priority value.
+public fun pop_max<T>(pq: &mut ApportionmentQueue<T>): (UQ64_64, u64, T) {
+    let len = pq.entries.length();
+    assert!(len > 0, EPopFromEmptyHeap);
+    // Swap the max element with the last element in the entries and remove the max element.
+    let Entry { priority, tie_breaker, value } = pq.entries.swap_remove(0);
+    // Restore the max heap condition at the root node.
+    bubble_down(&mut pq.entries);
+    (priority, tie_breaker, value)
+}
+
+/// Insert a new entry into the queue.
+public fun insert<T>(
+    pq: &mut ApportionmentQueue<T>,
+    priority: UQ64_64,
+    tie_breaker: u64,
+    value: T,
+) {
+    pq.entries.push_back(Entry { priority, tie_breaker, value });
+    bubble_up(&mut pq.entries);
+}
+
+/// Restore the max heap condition at the root node after popping the max element.
+fun bubble_down<T>(elements: &mut vector<Entry<T>>) {
+    let len = elements.length();
+    let mut i = 0;
+    while (i < len) {
+        let left = i * 2 + 1;
+        let right = left + 1;
+        let mut max = i;
+        // Find the node with the highest priority betweenthe node and its children.
+        if (left < len && elements[left].higher_priority_than(&elements[max])) {
+            max = left;
+        };
+        if (right < len && elements[right].higher_priority_than(&elements[max])) {
+            max = right;
+        };
+        // If the current node has the highest priority, we're done.
+        if (max == i) {
+            break
+        };
+        // Swap the current node with the node with the highest priority one.
+        elements.swap(max, i);
+        i = max;
+    }
+}
+
+/// Restore the max heap condition after inserting a new element at the end of the entries.
+fun bubble_up<T>(elements: &mut vector<Entry<T>>) {
+    let len = elements.length();
+    let mut i = len - 1;
+    while (i > 0) {
+        let parent = (i - 1) / 2;
+        if (elements[i].higher_priority_than(&elements[parent])) {
+            elements.swap(i, parent);
+        } else {
+            break
+        };
+        i = parent;
+    }
+}
+
+fun higher_priority_than<T>(entry1: &Entry<T>, entry2: &Entry<T>): bool {
+    (entry1.priority.gt(entry2.priority)) ||
+        (entry1.priority == entry2.priority && entry1.tie_breaker > entry2.tie_breaker)
+}
+
+#[test_only]
+use std::uq64_64;
+
+#[test_only]
+public fun new_filled<T>(
+    mut priorities: vector<UQ64_64>,
+    mut tie_breakers: vector<u64>,
+    mut values: vector<T>,
+): ApportionmentQueue<T> {
+    let len = priorities.length();
+    assert!(tie_breakers.length() == len, 0);
+    assert!(values.length() == len, 0);
+    priorities.reverse();
+    tie_breakers.reverse();
+    values.reverse();
+    let mut queue = new();
+    let mut i = 0;
+    while (i < len) {
+        let priority = priorities.pop_back();
+        let tie_breaker = tie_breakers.pop_back();
+        let value = values.pop_back();
+        queue.insert(priority, tie_breaker, value);
+        i = i + 1;
+    };
+    values.destroy_empty();
+    queue
+}
+
+#[test]
+fun test_pq() {
+    let priorities = vector[3, 1, 4, 2, 5, 2].map!(|val| uq64_64::from_raw(val));
+    let tie_breakers = vector[1, 2, 3, 4, 5, 6];
+    let values = vector[10, 20, 30, 40, 50, 60];
+    let mut h = new_filled(priorities, tie_breakers, values);
+    h.check_pop_max(5, 50);
+    h.check_pop_max(4, 30);
+    h.check_pop_max(3, 10);
+    h.insert(uq64_64::from_raw(7), 7, 70);
+    h.check_pop_max(7, 70);
+    h.check_pop_max(2, 60);
+    h.insert(uq64_64::from_raw(0), 8, 80);
+    h.check_pop_max(2, 40);
+    h.check_pop_max(1, 20);
+    h.check_pop_max(0, 80);
+
+    let priorities = vector[5, 3, 1, 2, 4].map!(|val| uq64_64::from_raw(val));
+    let tie_breakers = vector[10, 20, 30, 40, 50];
+    let values = vector[10, 20, 30, 40, 50];
+    let mut h = new_filled(priorities, tie_breakers, values);
+    h.check_pop_max(5, 10);
+    h.check_pop_max(4, 50);
+    h.check_pop_max(3, 20);
+    h.check_pop_max(2, 40);
+    h.check_pop_max(1, 30);
+}
+
+#[test_only]
+fun check_pop_max(h: &mut ApportionmentQueue<u64>, expected_priority: u128, expected_value: u64) {
+    let expected_priority = uq64_64::from_raw(expected_priority);
+    let (priority, _tie_breaker, value) = h.pop_max();
+    assert!(priority == expected_priority);
+    assert!(value == expected_value);
+}

--- a/testnet-contracts/walrus/sources/staking/auth.move
+++ b/testnet-contracts/walrus/sources/staking/auth.move
@@ -1,0 +1,57 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module walrus::auth;
+
+/// Authentication for either a sender or an object.
+/// Unlike the `Authorized` type, it cannot be stored and must be used or ignored in the same
+/// transaction.
+public enum Authenticated has drop {
+    Sender(address),
+    Object(ID),
+}
+
+/// Defines the ways to authorize an action. It can be either an address - checked
+/// with `ctx.sender()`, - or an object - checked with `object::id(..)`.
+public enum Authorized has copy, drop, store {
+    Address(address),
+    ObjectID(ID),
+}
+
+/// Authenticates the sender as the authorizer.
+public fun authenticate_sender(ctx: &TxContext): Authenticated {
+    Authenticated::Sender(ctx.sender())
+}
+
+/// Authenticates an object as the authorizer.
+public fun authenticate_with_object<T: key>(obj: &T): Authenticated {
+    Authenticated::Object(object::id(obj))
+}
+
+/// Returns the `Authorized` as an address.
+public fun authorized_address(addr: address): Authorized {
+    Authorized::Address(addr)
+}
+
+/// Returns the `Authorized` as an address.
+public fun authorized_object(id: ID): Authorized {
+    Authorized::ObjectID(id)
+}
+
+/// Checks if the authentication matches the authorization.
+public(package) fun matches(authenticated: &Authenticated, authorized: &Authorized): bool {
+    match (authenticated) {
+        Authenticated::Sender(sender) => {
+            match (authorized) {
+                Authorized::Address(addr) => sender == addr,
+                _ => false,
+            }
+        },
+        Authenticated::Object(id) => {
+            match (authorized) {
+                Authorized::ObjectID(obj_id) => id == obj_id,
+                _ => false,
+            }
+        },
+    }
+}

--- a/testnet-contracts/walrus/sources/staking/committee.move
+++ b/testnet-contracts/walrus/sources/staking/committee.move
@@ -7,20 +7,37 @@
 module walrus::committee;
 
 use sui::vec_map::{Self, VecMap};
+use walrus::sort;
+
+// Error codes
+// Error types in `walrus-sui/types/move_errors.rs` are auto-generated from the Move error codes.
+const EInvalidShardAssignment: u64 = 0;
 
 /// Represents the current committee in the system. Each node in the committee
 /// has assigned shard IDs.
-public struct Committee(VecMap<ID, vector<u16>>) has store, copy, drop;
+///
+/// The `VecMap` inside the `Committee` is guaranteed to be sorted by the node ID.
+public struct Committee(VecMap<ID, vector<u16>>) has copy, drop, store;
 
 /// Creates an empty committee. Only relevant for epoch 0, when no nodes are
 /// assigned any shards.
 public(package) fun empty(): Committee { Committee(vec_map::empty()) }
 
+/// Check if the given `ID` is in the `Committee`.
+public(package) fun contains(cmt: &Committee, node_id: &ID): bool {
+    cmt.0.contains(node_id)
+}
+
 /// Initializes the committee with the given `assigned_number` of shards per
 /// node. Shards are assigned sequentially to each node.
+///
+/// Assumptions:
+/// - The values of assigned_number are <= 1000 (i.e., the limit of a vector)
 public(package) fun initialize(assigned_number: VecMap<ID, u16>): Committee {
     let mut shard_idx: u16 = 0;
-    let (keys, values) = assigned_number.into_keys_values();
+    let sorted_assignments = sort::sort_vec_map_by_node_id!(assigned_number);
+    let (keys, values) = sorted_assignments.into_keys_values();
+
     let cmt = vec_map::from_keys_values(
         keys,
         values.map!(|v| vector::tabulate!(v as u64, |_| {
@@ -36,16 +53,23 @@ public(package) fun initialize(assigned_number: VecMap<ID, u16>): Committee {
 /// Transitions the current committee to the new committee with the given shard
 /// assignments. The function tries to minimize the number of changes by keeping
 /// as many shards in place as possible.
-///
-/// This assumes that the number of shards in the new committee is equal to the
-/// number of shards in the current committee. Check for this is not performed.
 public(package) fun transition(cmt: &Committee, mut new_assignments: VecMap<ID, u16>): Committee {
+    // Store the total number of shards in the new committee, before
+    // new_assignments is modified.
+    let mut new_num_of_shards = 0;
+    new_assignments.size().do!(|idx| {
+        let (_, shards) = new_assignments.get_entry_by_idx(idx);
+        new_num_of_shards = new_num_of_shards + *shards;
+    });
+
     let mut new_cmt = vec_map::empty();
     let mut to_move = vector[];
     let size = cmt.0.size();
 
+    let mut current_num_of_shards = 0;
     size.do!(|idx| {
         let (node_id, prev_shards) = cmt.0.get_entry_by_idx(idx);
+        current_num_of_shards = current_num_of_shards + prev_shards.length();
         let node_id = *node_id;
         let assigned_len = new_assignments.get_idx_opt(&node_id).map!(|idx| {
             let (_, value) = new_assignments.remove_entry_by_idx(idx);
@@ -77,22 +101,15 @@ public(package) fun transition(cmt: &Committee, mut new_assignments: VecMap<ID, 
             new_cmt.insert(node_id, node_shards);
         };
 
-        // if the node is in the new committee, and we already freed enough
-        // shards from other nodes, perform the reassignment. Alternatively,
-        // mark the node as needing more shards, so when we free up enough
-        // shards, we can assign them to this node
+        // Mark the node as needing more shards.
         if (curr_len < assigned_len) {
-            let diff = assigned_len - curr_len;
-            if (to_move.length() >= diff) {
-                let mut node_shards = *prev_shards;
-                diff.do!(|_| node_shards.push_back(to_move.pop_back()));
-                new_cmt.insert(node_id, node_shards);
-            } else {
-                // insert it back, we didn't have enough shards to assign
-                new_assignments.insert(node_id, assigned_len as u16);
-            };
+            new_assignments.insert(node_id, assigned_len as u16);
         };
     });
+
+    // Check that the number of shards in the new committee is equal to
+    // the number of shards in the current committee.
+    assert!((new_num_of_shards as u64) == current_num_of_shards, EInvalidShardAssignment);
 
     // Now the `new_assignments` only contains nodes for which we didn't have
     // enough shards to assign, and the nodes that were not part of the old
@@ -110,7 +127,7 @@ public(package) fun transition(cmt: &Committee, mut new_assignments: VecMap<ID, 
         new_cmt.insert(key, current_shards);
     });
 
-    Committee(new_cmt)
+    Committee(sort::sort_vec_map_by_node_id!(new_cmt))
 }
 
 #[syntax(index)]
@@ -132,4 +149,62 @@ public(package) fun inner(cmt: &Committee): &VecMap<ID, vector<u16>> {
 /// Copy the inner representation of the committee.
 public(package) fun to_inner(cmt: &Committee): VecMap<ID, vector<u16>> {
     cmt.0
+}
+
+/// Finds the difference between two committees, returns the difference in two
+/// sets of nodes, one set for nodes that are in the first committee but not in
+/// the second, and the other set is vice versa.
+///
+/// Committee is always sorted by the node ID, so the diff algorithm is simple.
+public(package) fun diff(cmt_1: &Committee, cmt_2: &Committee): (vector<ID>, vector<ID>) {
+    let mut i = 0;
+    let mut j = 0;
+    let mut diff_1 = vector[];
+    let mut diff_2 = vector[];
+    let lhs_size = cmt_1.size();
+    let rhs_size = cmt_2.size();
+
+    while (i < lhs_size && j < rhs_size) {
+        let (lhs, _) = cmt_1.0.get_entry_by_idx(i);
+        let (rhs, _) = cmt_2.0.get_entry_by_idx(j);
+
+        if (lhs == rhs) {
+            i = i + 1;
+            j = j + 1;
+            continue
+        };
+
+        // in LHS, but not in RHS
+        if (lhs.to_address().to_u256() < rhs.to_address().to_u256()) {
+            i = i + 1;
+            diff_1.push_back(*lhs);
+            continue
+        };
+
+        // in RHS, but not in LHS
+        diff_2.push_back(*rhs);
+        j = j + 1;
+    };
+
+    // fill in the rest, if any, for the LHS
+    while (i < lhs_size) {
+        let (lhs, _) = cmt_1.0.get_entry_by_idx(i);
+        diff_1.push_back(*lhs);
+        i = i + 1;
+    };
+
+    // fill in the rest, if any, for the RHS
+    while (j < rhs_size) {
+        let (rhs, _) = cmt_2.0.get_entry_by_idx(j);
+        diff_2.push_back(*rhs);
+        j = j + 1;
+    };
+
+    (diff_1, diff_2)
+}
+
+#[test_only]
+/// Check if the committee is sorted by the node ID.
+public(package) fun is_sorted(cmt: &Committee): bool {
+    sort::is_vec_map_sorted_by_node_id!(&cmt.0)
 }

--- a/testnet-contracts/walrus/sources/staking/exchange_rate.move
+++ b/testnet-contracts/walrus/sources/staking/exchange_rate.move
@@ -5,52 +5,64 @@
 /// It stores a fixed point exchange rate between the Wal token and pool token.
 module walrus::pool_exchange_rate;
 
+// Error codes
+// Error types in `walrus-sui/types/move_errors.rs` are auto-generated from the Move error codes.
+const EInvalidRate: u64 = 0;
+
 /// Represents the exchange rate for the staking pool.
-public struct PoolExchangeRate has store, copy, drop {
-    /// Amount of staked WAL tokens this epoch.
-    wal_amount: u128,
-    /// Amount of total tokens in the pool this epoch.
-    pool_token_amount: u128,
+public enum PoolExchangeRate has copy, drop, store {
+    Flat, // one to one exchange rate
+    Variable {
+        /// Amount of staked WAL tokens + rewards.
+        wal_amount: u128,
+        /// Amount of total shares in the pool (<= wal_amount, as long as slashing is not
+        /// implemented).
+        share_amount: u128,
+    },
 }
 
 /// Create an empty exchange rate.
-public(package) fun empty(): PoolExchangeRate {
-    PoolExchangeRate {
-        wal_amount: 0,
-        pool_token_amount: 0,
-    }
+public(package) fun flat(): PoolExchangeRate {
+    PoolExchangeRate::Flat
 }
 
 /// Create a new exchange rate with the given amounts.
-public(package) fun new(wal_amount: u64, pool_token_amount: u64): PoolExchangeRate {
-    PoolExchangeRate {
-        wal_amount: (wal_amount as u128),
-        pool_token_amount: (pool_token_amount as u128),
+public(package) fun new(wal_amount: u64, share_amount: u64): PoolExchangeRate {
+    // pool_token_amount <= wal_amount as long as slashing is not implemented.
+    assert!(share_amount <= wal_amount, EInvalidRate);
+    match (wal_amount) {
+        0 => PoolExchangeRate::Flat,
+        _ => {
+            PoolExchangeRate::Variable {
+                wal_amount: (wal_amount as u128),
+                share_amount: (share_amount as u128),
+            }
+        },
     }
 }
 
-public(package) fun get_wal_amount(exchange_rate: &PoolExchangeRate, token_amount: u64): u64 {
-    // When either amount is 0, that means we have no stakes with this pool.
-    // The other amount might be non-zero when there's dust left in the pool.
-    if (exchange_rate.wal_amount == 0 || exchange_rate.pool_token_amount == 0) {
-        return token_amount
-    };
-
-    let token_amount = (token_amount as u128);
-    let res = token_amount * exchange_rate.wal_amount / exchange_rate.pool_token_amount;
-
-    res as u64
+/// Assumptions:
+/// - amount is at most the amount of pool tokens in the pool
+public(package) fun convert_to_wal_amount(exchange_rate: &PoolExchangeRate, amount: u64): u64 {
+    match (exchange_rate) {
+        PoolExchangeRate::Flat => amount,
+        PoolExchangeRate::Variable { wal_amount, share_amount } => {
+            let amount = (amount as u128);
+            let res = (amount * *wal_amount) / *share_amount;
+            res as u64
+        },
+    }
 }
 
-public(package) fun get_token_amount(exchange_rate: &PoolExchangeRate, wal_amount: u64): u64 {
-    // When either amount is 0, that means we have no stakes with this pool.
-    // The other amount might be non-zero when there's dust left in the pool.
-    if (exchange_rate.wal_amount == 0 || exchange_rate.pool_token_amount == 0) {
-        return wal_amount
-    };
-
-    let wal_amount = (wal_amount as u128);
-    let res = wal_amount * exchange_rate.pool_token_amount / exchange_rate.wal_amount;
-
-    res as u64
+/// Assumptions:
+/// - amount is at most the amount of WAL in the pool
+public(package) fun convert_to_share_amount(exchange_rate: &PoolExchangeRate, amount: u64): u64 {
+    match (exchange_rate) {
+        PoolExchangeRate::Flat => amount,
+        PoolExchangeRate::Variable { wal_amount, share_amount } => {
+            let amount = (amount as u128);
+            let res = (amount * *share_amount) / *wal_amount;
+            res as u64
+        },
+    }
 }

--- a/testnet-contracts/walrus/sources/staking/node_metadata.move
+++ b/testnet-contracts/walrus/sources/staking/node_metadata.move
@@ -1,0 +1,96 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Metadata that describes a Storage Node. Attached to the `StakingPool`
+module walrus::node_metadata;
+
+use std::string::String;
+use sui::vec_map::{Self, VecMap};
+
+/// Standard metadata for a Validator. Created during the node registration.
+public struct NodeMetadata has copy, drop, store {
+    image_url: String,
+    project_url: String,
+    description: String,
+    extra_fields: VecMap<String, String>,
+}
+
+/// Create a new `NodeMetadata` instance
+public fun new(image_url: String, project_url: String, description: String): NodeMetadata {
+    NodeMetadata {
+        image_url,
+        project_url,
+        description,
+        extra_fields: vec_map::empty(),
+    }
+}
+
+/// Set the image URL of the Validator.
+public fun set_image_url(metadata: &mut NodeMetadata, image_url: String) {
+    metadata.image_url = image_url;
+}
+
+/// Set the project URL of the Validator.
+public fun set_project_url(metadata: &mut NodeMetadata, project_url: String) {
+    metadata.project_url = project_url;
+}
+
+/// Set the description of the Validator.
+public fun set_description(metadata: &mut NodeMetadata, description: String) {
+    metadata.description = description;
+}
+
+/// Set an extra field of the Validator.
+public fun set_extra_fields(metadata: &mut NodeMetadata, extra_fields: VecMap<String, String>) {
+    metadata.extra_fields = extra_fields;
+}
+
+// === Accessors ===
+
+/// Returns the image URL of the Validator.
+public fun image_url(metadata: &NodeMetadata): String { metadata.image_url }
+
+/// Returns the project URL of the Validator.
+public fun project_url(metadata: &NodeMetadata): String { metadata.project_url }
+
+/// Returns the description of the Validator.
+public fun description(metadata: &NodeMetadata): String { metadata.description }
+
+/// Returns the extra fields of the Validator.
+public fun extra_fields(metadata: &NodeMetadata): &VecMap<String, String> {
+    &metadata.extra_fields
+}
+
+/// Create a default empty `NodeMetadata` instance.
+public(package) fun default(): NodeMetadata {
+    NodeMetadata {
+        image_url: b"".to_string(),
+        project_url: b"".to_string(),
+        description: b"".to_string(),
+        extra_fields: vec_map::empty(),
+    }
+}
+
+#[test]
+fun test_validator_metadata() {
+    use std::unit_test::assert_eq;
+
+    let mut metadata = new(
+        b"image_url".to_string(),
+        b"project_url".to_string(),
+        b"description".to_string(),
+    );
+
+    assert_eq!(metadata.image_url(), b"image_url".to_string());
+    assert_eq!(metadata.project_url(), b"project_url".to_string());
+    assert_eq!(metadata.description(), b"description".to_string());
+    assert!(metadata.extra_fields().is_empty());
+
+    metadata.set_image_url(b"new_image_url".to_string());
+    metadata.set_project_url(b"new_project_url".to_string());
+    metadata.set_description(b"new_description".to_string());
+
+    assert_eq!(metadata.image_url(), b"new_image_url".to_string());
+    assert_eq!(metadata.project_url(), b"new_project_url".to_string());
+    assert_eq!(metadata.description(), b"new_description".to_string());
+}

--- a/testnet-contracts/walrus/sources/staking/staked_wal.move
+++ b/testnet-contracts/walrus/sources/staking/staked_wal.move
@@ -11,34 +11,31 @@ module walrus::staked_wal;
 
 use sui::balance::Balance;
 use wal::wal::WAL;
+use walrus::walrus_context::WalrusContext;
 
-// Keep errors in `walrus-sui/types/move_errors.rs` up to date with changes here.
+// Error codes
+// Error types in `walrus-sui/types/move_errors.rs` are auto-generated from the Move error codes.
 const ENotWithdrawing: u64 = 0;
 const EMetadataMismatch: u64 = 1;
 const EInvalidAmount: u64 = 2;
 const ENonZeroPrincipal: u64 = 3;
-// TODO: possibly enable this behavior in the future
-const ECantJoinWithdrawing: u64 = 4;
-// TODO: possibly enable this behavior in the future
-const ECantSplitWithdrawing: u64 = 5;
+/// Trying to mark stake as withdrawing when it is already marked as withdrawing.
+const EAlreadyWithdrawing: u64 = 6;
 
 /// The state of the staked WAL. It can be either `Staked` or `Withdrawing`.
 /// The `Withdrawing` state contains the epoch when the staked WAL can be
-///
-public enum StakedWalState has store, copy, drop {
+/// withdrawn.
+public enum StakedWalState has copy, drop, store {
     // Default state of the staked WAL - it is staked in the staking pool.
     Staked,
     // The staked WAL is in the process of withdrawing. The value inside the
     // variant is the epoch when the staked WAL can be withdrawn.
-    Withdrawing { withdraw_epoch: u32, pool_token_amount: u64 },
+    Withdrawing { withdraw_epoch: u32 },
 }
 
 /// Represents a staked WAL, does not store the `Balance` inside, but uses
 /// `u64` to represent the staked amount. Behaves similarly to `Balance` and
 /// `Coin` providing methods to `split` and `join`.
-///
-/// TODO: consider adding a `version` field to the struct to allow public API
-///       upgrades in the future.
 public struct StakedWal has key, store {
     id: UID,
     /// Whether the staked WAL is active or withdrawing.
@@ -75,12 +72,31 @@ public(package) fun into_balance(sw: StakedWal): Balance<WAL> {
 }
 
 /// Sets the staked WAL state to `Withdrawing`
-public(package) fun set_withdrawing(
-    sw: &mut StakedWal,
-    withdraw_epoch: u32,
-    pool_token_amount: u64,
-) {
-    sw.state = StakedWalState::Withdrawing { withdraw_epoch, pool_token_amount };
+public(package) fun set_withdrawing(sw: &mut StakedWal, withdraw_epoch: u32) {
+    assert!(sw.is_staked(), EAlreadyWithdrawing);
+    sw.state = StakedWalState::Withdrawing { withdraw_epoch };
+}
+
+/// Checks if the staked WAL can be withdrawn directly.
+///
+/// The staked WAL can be withdrawn early if:
+/// - activation epoch is current epoch + 2
+/// - activation epoch is current epoch + 1 and !node_in_next_committee
+///   (or committee not selected yet)
+public(package) fun can_withdraw_early(
+    sw: &StakedWal,
+    node_in_next_committee: bool,
+    wctx: &WalrusContext,
+): bool {
+    if (sw.is_withdrawing()) {
+        return false
+    };
+
+    let activation_epoch = sw.activation_epoch;
+    let current_epoch = wctx.epoch();
+
+    activation_epoch == current_epoch + 2 ||
+    (sw.activation_epoch == current_epoch + 1 && !node_in_next_committee)
 }
 
 // === Accessors ===
@@ -115,35 +131,36 @@ public fun withdraw_epoch(sw: &StakedWal): u32 {
     }
 }
 
-/// Return the `withdraw_amount` of the staked WAL if it is in the `Withdrawing`.
-/// Aborts otherwise.
-public fun pool_token_amount(sw: &StakedWal): u64 {
-    match (sw.state) {
-        StakedWalState::Withdrawing { pool_token_amount, .. } => pool_token_amount,
-        _ => abort ENotWithdrawing,
-    }
-}
-
 // === Public APIs ===
-
-// TODO: do we want to version them? And should we take precaution measures such
-//      as adding a `ctx` parameter for future extensions? What about versioning
-//      the staked WAL itself by adding a `version` field into the struct?
 
 /// Joins the staked WAL with another staked WAL, adding the `principal` of the
 /// `other` staked WAL to the current staked WAL.
 ///
 /// Aborts if the `node_id` or `activation_epoch` of the staked WALs do not match.
 public fun join(sw: &mut StakedWal, other: StakedWal) {
-    let StakedWal { id, state, node_id, activation_epoch, principal } = other;
-    assert!(sw.state == state, EMetadataMismatch);
-    assert!(sw.node_id == node_id, EMetadataMismatch);
-    assert!(!sw.is_withdrawing(), ECantJoinWithdrawing);
-    assert!(sw.activation_epoch == activation_epoch, EMetadataMismatch);
+    assert!(sw.node_id == other.node_id, EMetadataMismatch);
 
-    id.delete();
+    // Simple scenario - staked wal is in `Staked` state. We guarantee that the
+    // metadata is identical: same activation epoch and both are in the same state.
+    if (sw.is_staked()) {
+        assert!(other.is_staked(), EMetadataMismatch);
+        assert!(sw.activation_epoch == other.activation_epoch, EMetadataMismatch);
 
+        let StakedWal { id, principal, .. } = other;
+        sw.principal.join(principal);
+        id.delete();
+        return
+    };
+
+    // Withdrawing scenario - we no longer check that the activation epoch is
+    // the same, as the staked WAL is in the process of withdrawing. Instead,
+    // we make sure that the withdraw epoch is the same.
+    assert!(sw.is_withdrawing() && other.is_withdrawing(), EMetadataMismatch);
+    assert!(sw.withdraw_epoch() == other.withdraw_epoch(), EMetadataMismatch);
+
+    let StakedWal { id, principal, .. } = other;
     sw.principal.join(principal);
+    id.delete();
 }
 
 /// Splits the staked WAL into two parts, one with the `amount` and the other
@@ -151,9 +168,10 @@ public fun join(sw: &mut StakedWal, other: StakedWal) {
 /// same for both the staked WALs.
 ///
 /// Aborts if the `amount` is greater than the `principal` of the staked WAL.
+/// Aborts if the `amount` is zero.
 public fun split(sw: &mut StakedWal, amount: u64, ctx: &mut TxContext): StakedWal {
-    assert!(sw.principal.value() >= amount, EInvalidAmount);
-    assert!(!sw.is_withdrawing(), ECantSplitWithdrawing);
+    assert!(sw.principal.value() > amount, EInvalidAmount);
+    assert!(amount > 0, EInvalidAmount);
 
     StakedWal {
         id: object::new(ctx),

--- a/testnet-contracts/walrus/sources/staking/staking_inner.move
+++ b/testnet-contracts/walrus/sources/staking/staking_inner.move
@@ -1,34 +1,29 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// TODO:
-// 1. registering the node
-// 2. adding staked wal to the pool
-// 3. selecting the committee
-// 4. withdrawing staked wal from the pool
-//
-// NOTES:
-// - advance_epoch - initiates the epoch change
-// - initiate epoch change - bumped in `advance_epoch`
-// - get "epoch_sync_done" event
 module walrus::staking_inner;
 
 use std::string::String;
 use sui::{
     balance::{Self, Balance},
+    bls12381::UncompressedG1,
     clock::Clock,
     coin::Coin,
+    group_ops::Element,
     object_table::{Self, ObjectTable},
     priority_queue::{Self, PriorityQueue},
-    vec_map
+    vec_map::{Self, VecMap}
 };
 use wal::wal::WAL;
 use walrus::{
     active_set::{Self, ActiveSet},
+    auth::{Authenticated, Authorized},
     bls_aggregate::{Self, BlsCommittee},
     committee::{Self, Committee},
     epoch_parameters::{Self, EpochParams},
     events,
+    extended_field::{Self, ExtendedField},
+    node_metadata::NodeMetadata,
     staked_wal::StakedWal,
     staking_pool::{Self, StakingPool},
     storage_node::StorageNodeCap,
@@ -42,13 +37,22 @@ const MIN_STAKE: u64 = 0;
 /// TODO: Remove once solutions are in place to prevent hitting move execution limits (#935).
 const TEMP_ACTIVE_SET_SIZE_LIMIT: u16 = 100;
 
+/// The number of nodes from which a flat shards limit is applied.
+const MIN_NODES_FOR_SHARDS_LIMIT: u8 = 20;
+
+/// The maximum number of shards per node as a denominator of the total number of shards.
+/// When the number of nodes is smaller than MIN_NODES_FOR_SHARDS_LIMIT, the shards limit
+/// is multiplied by MIN_NODES_FOR_SHARDS_LIMIT / number of nodes.
+const SHARDS_LIMIT_DENOMINATOR: u8 = 10; // 10%
+
 // The delta between the epoch change finishing and selecting the next epoch parameters in ms.
 // Currently half of an epoch.
 // TODO: currently replaced by the epoch duration / 2. Consider making this a separate system
 // parameter.
 // const PARAM_SELECTION_DELTA: u64 = 7 * 24 * 60 * 60 * 1000 / 2;
 
-// Keep errors in `walrus-sui/types/move_errors.rs` up to date with changes here.
+// Error codes
+// Error types in `walrus-sui/types/move_errors.rs` are auto-generated from the Move error codes.
 const EWrongEpochState: u64 = 0;
 const EInvalidSyncEpoch: u64 = 1;
 const EDuplicateSyncDone: u64 = 2;
@@ -56,12 +60,13 @@ const ENoStake: u64 = 3;
 const ENotInCommittee: u64 = 4;
 const ECommitteeSelected: u64 = 5;
 const ENextCommitteeIsEmpty: u64 = 6;
-
+const EInvalidNodeWeight: u64 = 7;
+const EPoolNotFound: u64 = 8;
 // TODO: remove this once the module is implemented.
 const ENotImplemented: u64 = 264;
 
 /// The epoch state.
-public enum EpochState has store, copy, drop {
+public enum EpochState has copy, drop, store {
     // Epoch change is currently in progress. Contains the weight of the nodes that
     // have already attested that they finished the sync.
     EpochChangeSync(u16),
@@ -73,9 +78,7 @@ public enum EpochState has store, copy, drop {
 }
 
 /// The inner object for the staking part of the system.
-public struct StakingInnerV1 has store, key {
-    /// The object ID
-    id: UID,
+public struct StakingInnerV1 has store {
     /// The number of shards in the system.
     n_shards: u16,
     /// The duration of an epoch in ms. Does not affect the first (zero) epoch.
@@ -92,9 +95,8 @@ public struct StakingInnerV1 has store, key {
     /// The current epoch of the Walrus system. The epochs are not the same as
     /// the Sui epochs, not to be mistaken with `ctx.epoch()`.
     epoch: u32,
-    /// Stores the active set of storage nodes. Provides automatic sorting and
-    /// tracks the total amount of staked WAL.
-    active_set: ActiveSet,
+    /// Stores the active set of storage nodes. Tracks the total amount of staked WAL.
+    active_set: ExtendedField<ActiveSet>,
     /// The next committee in the system.
     next_committee: Option<Committee>,
     /// The current committee in the system.
@@ -105,8 +107,10 @@ public struct StakingInnerV1 has store, key {
     next_epoch_params: Option<EpochParams>,
     /// The state of the current epoch.
     epoch_state: EpochState,
-    /// Rewards left over from the previous epoch that couldn't be distributed due to rounding.
-    leftover_rewards: Balance<WAL>,
+    /// The public keys for the next epoch. The keys are stored in a sorted `VecMap`, and mirror
+    /// the order of the nodes in the `next_committee`. The value is set in the `select_committee`
+    /// function and consumed in the `next_bls_committee` function.
+    next_epoch_public_keys: ExtendedField<VecMap<ID, Element<UncompressedG1>>>,
 }
 
 /// Creates a new `StakingInnerV1` object with default values.
@@ -118,19 +122,21 @@ public(package) fun new(
     ctx: &mut TxContext,
 ): StakingInnerV1 {
     StakingInnerV1 {
-        id: object::new(ctx),
         n_shards,
         epoch_duration,
         first_epoch_start: epoch_zero_duration + clock.timestamp_ms(),
         pools: object_table::new(ctx),
         epoch: 0,
-        active_set: active_set::new(TEMP_ACTIVE_SET_SIZE_LIMIT, MIN_STAKE),
+        active_set: extended_field::new(
+            active_set::new(TEMP_ACTIVE_SET_SIZE_LIMIT, MIN_STAKE),
+            ctx,
+        ),
         next_committee: option::none(),
         committee: committee::empty(),
         previous_committee: committee::empty(),
         next_epoch_params: option::none(),
         epoch_state: EpochState::EpochChangeDone(clock.timestamp_ms()),
-        leftover_rewards: balance::zero(),
+        next_epoch_public_keys: extended_field::new(vec_map::empty(), ctx),
     }
 }
 
@@ -141,10 +147,11 @@ public(package) fun create_pool(
     self: &mut StakingInnerV1,
     name: String,
     network_address: String,
+    metadata: NodeMetadata,
     public_key: vector<u8>,
     network_public_key: vector<u8>,
     proof_of_possession: vector<u8>,
-    commission_rate: u64,
+    commission_rate: u16,
     storage_price: u64,
     write_price: u64,
     node_capacity: u64,
@@ -153,6 +160,7 @@ public(package) fun create_pool(
     let pool = staking_pool::new(
         name,
         network_address,
+        metadata,
         public_key,
         network_public_key,
         proof_of_possession,
@@ -176,8 +184,23 @@ public(package) fun withdraw_node(self: &mut StakingInnerV1, cap: &mut StorageNo
     self.pools[cap.node_id()].set_withdrawing(wctx);
 }
 
-public(package) fun collect_commission(_: &mut StakingInnerV1, _: &StorageNodeCap): Coin<WAL> {
-    abort ENotImplemented
+/// Sets the commission receiver for the pool.
+public(package) fun set_commission_receiver(
+    self: &mut StakingInnerV1,
+    node_id: ID,
+    auth: Authenticated,
+    receiver: Authorized,
+) {
+    self.pools[node_id].set_commission_receiver(auth, receiver)
+}
+
+/// Collect commission for the pool using the `StorageNodeCap`.
+public(package) fun collect_commission(
+    self: &mut StakingInnerV1,
+    node_id: ID,
+    auth: Authenticated,
+): Balance<WAL> {
+    self.pools[node_id].collect_commission(auth)
 }
 
 public(package) fun voting_end(self: &mut StakingInnerV1, clock: &Clock) {
@@ -213,8 +236,9 @@ public(package) fun voting_end(self: &mut StakingInnerV1, clock: &Clock) {
 public(package) fun calculate_votes(self: &StakingInnerV1): EpochParams {
     assert!(self.next_committee.is_some(), ENextCommitteeIsEmpty);
 
-    let size = self.next_committee.borrow().size();
-    let inner = self.next_committee.borrow().inner();
+    let committee = self.next_committee.borrow();
+    let size = committee.size();
+    let inner = committee.inner();
     let mut write_prices = priority_queue::new(vector[]);
     let mut storage_prices = priority_queue::new(vector[]);
     let mut capacity_votes = priority_queue::new(vector[]);
@@ -226,7 +250,7 @@ public(package) fun calculate_votes(self: &StakingInnerV1): EpochParams {
         write_prices.insert(pool.write_price(), weight);
         storage_prices.insert(pool.storage_price(), weight);
         // The vote for capacity is determined by the node capacity and number of assigned shards.
-        let capacity_vote = pool.node_capacity() / weight * (self.n_shards as u64);
+        let capacity_vote = (pool.node_capacity() * (self.n_shards as u64)) / weight;
         capacity_votes.insert(capacity_vote, weight);
     });
 
@@ -261,15 +285,46 @@ fun take_threshold_value(vote_queue: &mut PriorityQueue<u64>, threshold_weight: 
     }
 }
 
+// === Governance ===
+
+/// Sets the governance authorized object for the pool.
+public(package) fun set_governance_authorized(
+    self: &mut StakingInnerV1,
+    node_id: ID,
+    auth: Authenticated,
+    authorized: Authorized,
+) {
+    self.pools[node_id].set_governance_authorized(auth, authorized)
+}
+
+/// Checks if the governance authorized object matches the authenticated object.
+public(package) fun check_governance_authorization(
+    self: &StakingInnerV1,
+    node_id: ID,
+    auth: Authenticated,
+): bool {
+    auth.matches(self.pools[node_id].governance_authorized())
+}
+
+/// Returns the current node weight for the given node id.
+public(package) fun get_current_node_weight(self: &StakingInnerV1, node_id: ID): u16 {
+    // Check if the node is in the committee.
+    assert!(self.committee.inner().contains(&node_id), ENotInCommittee);
+    let weight = self.committee.shards(&node_id).length();
+    assert!(weight <= std::u16::max_value!() as u64, EInvalidNodeWeight);
+    weight as u16
+}
+
 // === Voting ===
 
 /// Sets the next commission rate for the pool.
 public(package) fun set_next_commission(
     self: &mut StakingInnerV1,
     cap: &StorageNodeCap,
-    commission_rate: u64,
+    commission_rate: u16,
 ) {
-    self.pools[cap.node_id()].set_next_commission(commission_rate);
+    let wctx = &self.new_walrus_context();
+    self.pools[cap.node_id()].set_next_commission(commission_rate, wctx);
 }
 
 /// Sets the storage price vote for the pool.
@@ -337,6 +392,15 @@ public(package) fun set_network_public_key(
     self.pools[cap.node_id()].set_network_public_key(network_public_key);
 }
 
+/// Sets the metadata of a storage node.
+public(package) fun set_node_metadata(
+    self: &mut StakingInnerV1,
+    cap: &StorageNodeCap,
+    metadata: NodeMetadata,
+) {
+    self.pools[cap.node_id()].set_node_metadata(metadata);
+}
+
 // === Staking ===
 
 /// Blocks staking for the pool, marks it as "withdrawing".
@@ -372,7 +436,7 @@ public(package) fun stake_with_pool(
         EpochState::NextParamsSelected(_) => pool.wal_balance_at_epoch(wctx.epoch() + 2),
         _ => pool.wal_balance_at_epoch(wctx.epoch() + 1),
     };
-    self.active_set.insert_or_update(node_id, balance);
+    self.active_set.borrow_mut().insert_or_update(node_id, balance);
     staked_wal
 }
 
@@ -385,7 +449,15 @@ public(package) fun request_withdraw_stake(
     _ctx: &mut TxContext,
 ) {
     let wctx = &self.new_walrus_context();
-    self.pools[staked_wal.node_id()].request_withdraw_stake(staked_wal, wctx);
+    let node_id = staked_wal.node_id();
+    self
+        .pools[node_id]
+        .request_withdraw_stake(
+            staked_wal,
+            self.committee.contains(&node_id),
+            self.next_committee.is_some_and!(|cmt| cmt.contains(&node_id)),
+            wctx,
+        );
 }
 
 /// Perform the withdrawal of the staked WAL, returning the amount to the caller.
@@ -397,39 +469,55 @@ public(package) fun withdraw_stake(
     ctx: &mut TxContext,
 ): Coin<WAL> {
     let wctx = &self.new_walrus_context();
-    self.pools[staked_wal.node_id()].withdraw_stake(staked_wal, wctx).into_coin(ctx)
+    let node_id = staked_wal.node_id();
+    self
+        .pools[node_id]
+        .withdraw_stake(
+            staked_wal,
+            self.committee.contains(&node_id),
+            self.next_committee.is_some_and!(|cmt| cmt.contains(&node_id)),
+            wctx,
+        )
+        .into_coin(ctx)
 }
 
 // === System ===
 
-/// Selects the committee for the next epoch.
-///
-/// TODO: current solution is temporary, we need to have a proper algorithm for shard assignment.
-public(package) fun select_committee(self: &mut StakingInnerV1) {
-    assert!(self.next_committee.is_none(), ECommitteeSelected);
-
+/// Computes the committee for the next epoch.
+public(package) fun compute_next_committee(self: &StakingInnerV1): Committee {
     let (active_ids, shards) = self.apportionment();
     let distribution = vec_map::from_keys_values(active_ids, shards);
 
-    // if we're dealing with the first epoch, we need to assign the shards to the
-    // nodes in a sequential manner. Assuming there's at least 1 node in the set.
-    let committee = if (self.committee.size() == 0) committee::initialize(distribution)
-    else self.committee.transition(distribution);
+    // if we are dealing with the first epoch, we need to assign the shards to the
+    // nodes in a sequential manner. Assuming there is at least 1 node in the set.
+    if (self.committee.size() == 0) committee::initialize(distribution)
+    else self.committee.transition(distribution)
+}
 
+/// Selects the committee for the next epoch.
+public(package) fun select_committee(self: &mut StakingInnerV1) {
+    assert!(self.next_committee.is_none(), ECommitteeSelected);
+
+    let committee = self.compute_next_committee();
+
+    // inherently sorted by node ID
+    let public_keys = vec_map::from_keys_values(
+        committee.inner().keys(),
+        committee.inner().keys().map!(|id| *self.pools[id].node_info().next_epoch_public_key()),
+    );
+
+    self.next_epoch_public_keys.swap(public_keys);
     self.next_committee = option::some(committee);
 }
 
 fun apportionment(self: &StakingInnerV1): (vector<ID>, vector<u16>) {
-    let (active_ids, stake) = self.active_set.active_ids_and_stake();
+    let (active_ids, stake) = self.active_set.borrow().active_ids_and_stake();
     let n_nodes = stake.length();
     // TODO better ranking (#943)
     let priorities = vector::tabulate!(n_nodes, |i| n_nodes - i);
     let shards = dhondt(priorities, self.n_shards, stake);
     (active_ids, shards)
 }
-
-// TODO remove this when we have a higher resolution fixed point number (#835)
-const DHONDT_TOTAL_STAKE_MAX: u64 = 0xFFFF_FFFF;
 
 // Implementation of the D'Hondt method (aka Jefferson method) for apportionment.
 fun dhondt(
@@ -439,20 +527,17 @@ fun dhondt(
     n_shards: u16,
     stake: vector<u64>,
 ): vector<u16> {
-    use std::uq32_32;
+    use std::uq64_64;
+    use walrus::apportionment_queue;
 
     let total_stake = stake.fold!(0, |acc, x| acc + x);
-
-    // TODO remove this when we have a higher resolution fixed point number (#835)
-    let scaling = DHONDT_TOTAL_STAKE_MAX
-        .max(total_stake)
-        .divide_and_round_up(DHONDT_TOTAL_STAKE_MAX);
-    let total_stake = total_stake / scaling;
-    let stake = stake.map!(|s| s / scaling);
 
     let n_nodes = stake.length();
     let n_shards = n_shards as u64;
     assert!(total_stake > 0, ENoStake);
+
+    // Limit the number of shards per node if there are enough nodes.
+    let max_shards = max_shards_per_node(n_nodes, n_shards);
 
     // Initial assignment following Hagenbach-Bischoff.
     // This assigns an initial number of shards to each node, s.t. this does not exceed the final
@@ -461,60 +546,50 @@ fun dhondt(
     // is the amount of stake that guarantees receiving a shard with the d'Hondt method. By
     // dividing the stake per node by this distribution number and rounding down (integer
     // division), we therefore get a lower bound for the number of shards assigned to the node.
-    let mut shards = stake.map_ref!(|s| *s / (total_stake/(n_shards + 1) + 1));
+    let mut shards = stake.map_ref!(|s| (*s / (total_stake / (n_shards + 1) + 1)).min(max_shards));
     // Set up quotients priority queue.
-    let mut quotients = priority_queue::new(vector[]);
+    let mut quotients = apportionment_queue::new();
     n_nodes.do!(|index| {
-        let quotient = uq32_32::from_quotient(stake[index], shards[index] + 1);
-        quotients.insert(quotient.to_raw(), index);
+        if (shards[index] != max_shards) {
+            let quotient = uq64_64::from_quotient(stake[index] as u128, shards[index] as u128 + 1);
+            quotients.insert(quotient, node_priorities[index], index);
+        };
     });
-
-    // Set up a priority queue for the ranking of nodes with equal quotient.
-    let mut equal_quotient_ranking = priority_queue::new(vector[]);
-    // Priority_queue currently doesn't allow peeking at the head or checking the length.
-    // TODO: improve priority queue and change this afterwards.
-    let mut equal_quotient_ranking_len = 0;
 
     if (n_nodes == 0) return vector[];
     let mut n_shards_distributed = shards.fold!(0, |acc, x| acc + x);
-    // loop until all shards are distributed
+    // Loop until all shards are distributed.
     while (n_shards_distributed != n_shards) {
-        let index = if (equal_quotient_ranking_len > 0) {
-            let (_priority, index) = equal_quotient_ranking.pop_max();
-            equal_quotient_ranking_len = equal_quotient_ranking_len - 1;
-            index
-        } else {
-            let (quotient, index) = quotients.pop_max();
-            equal_quotient_ranking.insert(node_priorities[index], index);
-            equal_quotient_ranking_len = equal_quotient_ranking_len + 1;
-            // Condition ensures that `quotients` is not empty.
-            while (n_nodes > equal_quotient_ranking_len) {
-                let (next_quotient, next_index) = quotients.pop_max();
-                if (next_quotient == quotient) {
-                    equal_quotient_ranking.insert(node_priorities[next_index], next_index);
-                    equal_quotient_ranking_len = equal_quotient_ranking_len + 1;
-                } else {
-                    quotients.insert(next_quotient, next_index);
-                    break
-                }
-            };
-            let (_priority, index) = equal_quotient_ranking.pop_max();
-            equal_quotient_ranking_len = equal_quotient_ranking_len - 1;
-            index
-        };
+        // Get the node with the highest quotient, assign an additional shard and adjust the
+        // quotient.
+        // quotients is non-empty since SHARDS_LIMIT_DENOMINATOR <= MIN_NODES_FOR_SHARDS_LIMIT.
+        let (_quotient, tie_breaker, index) = quotients.pop_max();
         *&mut shards[index] = shards[index] + 1;
-        let quotient = uq32_32::from_quotient(stake[index], shards[index] + 1);
-        quotients.insert(quotient.to_raw(), index);
+        if (shards[index] != max_shards) {
+            let quotient = uq64_64::from_quotient(stake[index] as u128, shards[index] as u128 + 1);
+            quotients.insert(quotient, tie_breaker, index);
+        };
         n_shards_distributed = n_shards_distributed + 1;
     };
     shards.map!(|s| s as u16)
+}
+
+/// Returns the maximum number of shards per node.
+fun max_shards_per_node(n_nodes: u64, n_shards: u64): u64 {
+    if (n_nodes >= (MIN_NODES_FOR_SHARDS_LIMIT as u64)) {
+        n_shards / (SHARDS_LIMIT_DENOMINATOR as u64)
+    } else {
+        (n_shards * (MIN_NODES_FOR_SHARDS_LIMIT as u64)).divide_and_round_up(
+            n_nodes * (SHARDS_LIMIT_DENOMINATOR as u64),
+        )
+    }
 }
 
 /// Initiates the epoch change if the current time allows.
 public(package) fun initiate_epoch_change(
     self: &mut StakingInnerV1,
     clock: &Clock,
-    rewards: Balance<WAL>,
+    rewards: VecMap<ID, Balance<WAL>>,
 ) {
     let last_epoch_change = match (self.epoch_state) {
         EpochState::NextParamsSelected(last_epoch_change) => last_epoch_change,
@@ -530,9 +605,7 @@ public(package) fun initiate_epoch_change(
 }
 
 /// Sets the next epoch of the system and emits the epoch change start event.
-///
-/// TODO: `advance_epoch` needs to be either pre or post handled by each staking pool as well.
-public(package) fun advance_epoch(self: &mut StakingInnerV1, mut rewards: Balance<WAL>) {
+public(package) fun advance_epoch(self: &mut StakingInnerV1, rewards: VecMap<ID, Balance<WAL>>) {
     assert!(self.next_committee.is_some(), EWrongEpochState);
 
     self.epoch = self.epoch + 1;
@@ -540,32 +613,28 @@ public(package) fun advance_epoch(self: &mut StakingInnerV1, mut rewards: Balanc
     self.committee = self.next_committee.extract(); // overwrites the current committee
     self.epoch_state = EpochState::EpochChangeSync(0);
 
+    // Wctx is already for the new epoch.
     let wctx = &self.new_walrus_context();
 
-    // Distribute the rewards.
+    // Take the `ActiveSet` into the function scope just once.
+    let active_set = self.active_set.borrow_mut();
 
-    // Add any leftover rewards to the rewards to distribute.
-    let leftover_value = self.leftover_rewards.value();
-    rewards.join(self.leftover_rewards.split(leftover_value));
-    let rewards_per_shard = rewards.value() / (self.n_shards as u64);
+    // Find nodes that just joined, and advance their epoch.
+    let (_, new_ids) = committee::diff(&self.previous_committee, &self.committee);
 
-    // Add any nodes that are new in the committee to the previous shard assignments
-    // without any shards, s.t. we call advance_epoch on them and update the active set.
-    let mut prev_shard_assignments = *self.previous_committee.inner();
-    self.committee.inner().keys().do!(|node_id| if (!prev_shard_assignments.contains(&node_id)) {
-        prev_shard_assignments.insert(node_id, vector[]);
-    });
-    let (node_ids, shard_assignments) = prev_shard_assignments.into_keys_values();
-
-    node_ids.zip_do!(shard_assignments, |node_id, shards| {
-        self.pools[node_id].advance_epoch(rewards.split(rewards_per_shard * shards.length()), wctx);
-        self
-            .active_set
-            .update(node_id, self.pools[node_id].wal_balance_at_epoch(wctx.epoch() + 1));
+    let (node_ids, rewards) = rewards.into_keys_values();
+    rewards.zip_do!(node_ids, |node_reward, node_id| {
+        let pool = &mut self.pools[node_id];
+        pool.advance_epoch(node_reward, wctx);
+        active_set.update(node_id, pool.wal_balance_at_epoch(wctx.epoch() + 1));
     });
 
-    // Save any leftover rewards due to rounding.
-    self.leftover_rewards.join(rewards);
+    // fill-in the nodes that just joined and don't have rewards yet
+    new_ids.do!(|node_id| {
+        let pool = &mut self.pools[node_id];
+        pool.advance_epoch(balance::zero(), wctx);
+        active_set.update(node_id, pool.wal_balance_at_epoch(wctx.epoch() + 1));
+    });
 
     // Emit epoch change start event.
     events::emit_epoch_change_start(self.epoch);
@@ -588,7 +657,7 @@ public(package) fun epoch_sync_done(
     match (self.epoch_state) {
         EpochState::EpochChangeSync(weight) => {
             let weight = weight + (node_shards.length() as u16);
-            if (is_quorum(weight, self.n_shards)) {
+            if (self.is_quorum(weight)) {
                 self.epoch_state = EpochState::EpochChangeDone(clock.timestamp_ms());
                 events::emit_epoch_change_done(self.epoch);
             } else {
@@ -607,7 +676,7 @@ public(package) fun epoch_sync_done(
 /// - also checks that for the provided shards, this function has not been called before
 /// - if so, slashes both nodes and emits an event that allows the receiving node to start
 ///     shard recovery
-public fun shard_transfer_failed(
+public(package) fun shard_transfer_failed(
     _staking: &mut StakingInnerV1,
     _cap: &StorageNodeCap,
     _other_node_id: ID,
@@ -618,14 +687,19 @@ public fun shard_transfer_failed(
 
 // === Accessors ===
 
+/// Returns the metadata of the node with the given `ID`.
+public(package) fun node_metadata(self: &StakingInnerV1, node_id: ID): NodeMetadata {
+    self.pools[node_id].node_info().metadata()
+}
+
 /// Returns the Option with next committee.
 public(package) fun next_committee(self: &StakingInnerV1): &Option<Committee> {
     &self.next_committee
 }
 
 /// Returns the next epoch parameters if set, otherwise aborts with an error.
-public(package) fun next_epoch_params(self: &StakingInnerV1): EpochParams {
-    *self.next_epoch_params.borrow()
+public(package) fun next_epoch_params(self: &StakingInnerV1): &EpochParams {
+    self.next_epoch_params.borrow()
 }
 
 /// Get the current epoch.
@@ -644,18 +718,52 @@ public(package) fun previous_committee(self: &StakingInnerV1): &Committee {
 }
 
 /// Construct the BLS committee for the next epoch.
-public(package) fun next_bls_committee(self: &StakingInnerV1): BlsCommittee {
+public(package) fun next_bls_committee(self: &mut StakingInnerV1): BlsCommittee {
+    assert!(self.next_committee.is_some(), ENextCommitteeIsEmpty);
+
+    let public_keys = self.next_epoch_public_keys.swap(vec_map::empty());
+    let (pk_ids, public_keys) = public_keys.into_keys_values();
     let (ids, shard_assignments) = (*self.next_committee.borrow().inner()).into_keys_values();
-    let members = ids.zip_map!(shard_assignments, |id, shards| {
-        let pk = self.pools.borrow(id).node_info().next_epoch_public_key();
-        bls_aggregate::new_bls_committee_member(*pk, shards.length() as u16, id)
+
+    // All of the sets are guaranteed to be sorted and of the same length.
+    // Therefore, we can safely iterate over them in parallel.
+    let members = vector::tabulate!(ids.length(), |i| {
+        let node_id = &ids[i];
+        let shards = shard_assignments[i].length() as u16;
+        let pk_node_id = &pk_ids[i];
+        let pk = public_keys[i];
+
+        // sanity check that the keys are in the same order
+        assert!(node_id == pk_node_id);
+        bls_aggregate::new_bls_committee_member(pk, shards, *node_id)
     });
+
     bls_aggregate::new_bls_committee(self.epoch + 1, members)
 }
 
 /// Check if a node with the given `ID` exists in the staking pools.
 public(package) fun has_pool(self: &StakingInnerV1, node_id: ID): bool {
     self.pools.contains(node_id)
+}
+
+/// Returns the total number of shards.
+public(package) fun n_shards(self: &StakingInnerV1): u16 {
+    self.n_shards
+}
+
+// === Utility functions ===
+
+/// Calculate the rewards for an amount with value `staked_principal`, staked in the pool with
+/// the given `node_id` between `activation_epoch` and `withdraw_epoch`.
+public(package) fun calculate_rewards(
+    self: &StakingInnerV1,
+    node_id: ID,
+    staked_principal: u64,
+    activation_epoch: u32,
+    withdraw_epoch: u32,
+): u64 {
+    assert!(self.pools.contains(node_id), EPoolNotFound);
+    self.pools[node_id].calculate_rewards(staked_principal, activation_epoch, withdraw_epoch)
 }
 
 // === Internal ===
@@ -668,8 +776,8 @@ fun new_walrus_context(self: &StakingInnerV1): WalrusContext {
     )
 }
 
-fun is_quorum(weight: u16, n_shards: u16): bool {
-    3 * (weight as u64) >= 2 * (n_shards as u64) + 1
+public(package) fun is_quorum(self: &StakingInnerV1, weight: u16): bool {
+    3 * (weight as u64) >= 2 * (self.n_shards as u64) + 1
 }
 
 // ==== Tests ===
@@ -686,7 +794,7 @@ public(package) fun is_epoch_sync_done(self: &StakingInnerV1): bool {
 
 #[test_only]
 public(package) fun active_set(self: &mut StakingInnerV1): &mut ActiveSet {
-    &mut self.active_set
+    self.active_set.borrow_mut()
 }
 
 #[test_only]

--- a/testnet-contracts/walrus/sources/staking/staking_pool.move
+++ b/testnet-contracts/walrus/sources/staking/staking_pool.move
@@ -5,10 +5,12 @@
 module walrus::staking_pool;
 
 use std::string::String;
-use sui::{balance::{Self, Balance}, table::{Self, Table}};
+use sui::{bag::{Self, Bag}, balance::{Self, Balance}, table::{Self, Table}};
 use wal::wal::WAL;
 use walrus::{
+    auth::{Self, Authenticated, Authorized},
     messages,
+    node_metadata::NodeMetadata,
     pending_values::{Self, PendingValues},
     pool_exchange_rate::{Self, PoolExchangeRate},
     staked_wal::{Self, StakedWal},
@@ -16,7 +18,8 @@ use walrus::{
     walrus_context::WalrusContext
 };
 
-// Keep errors in `walrus-sui/types/move_errors.rs` up to date with changes here.
+// Error codes
+// Error types in `walrus-sui/types/move_errors.rs` are auto-generated from the Move error codes.
 const EPoolAlreadyUpdated: u64 = 0;
 const ECalculationError: u64 = 1;
 const EIncorrectEpochAdvance: u64 = 2;
@@ -30,9 +33,7 @@ const EPoolAlreadyWithdrawing: u64 = 5;
 const EPoolIsNotActive: u64 = 6;
 /// Trying to stake zero amount.
 const EZeroStake: u64 = 7;
-/// Pool is not in `New` state.
-#[allow(unused)]
-const EPoolIsNotNew: u64 = 8;
+// code 8 is available
 /// Trying to withdraw stake from the incorrect pool.
 const EIncorrectPoolId: u64 = 9;
 /// Trying to withdraw active stake.
@@ -41,13 +42,15 @@ const ENotWithdrawing: u64 = 10;
 const EWithdrawEpochNotReached: u64 = 11;
 /// Attempt to withdraw before `activation_epoch`.
 const EActivationEpochNotReached: u64 = 12;
+/// Requesting withdrawal for the stake that can be withdrawn directly.
+const EWithdrawDirectly: u64 = 13;
+/// Incorrect commission rate.
+const EIncorrectCommissionRate: u64 = 14;
+/// Trying to collect commission or change receiver without authorization.
+const EAuthorizationFailure: u64 = 15;
 
 /// Represents the state of the staking pool.
-///
-/// TODO: revisit the state machine.
-public enum PoolState has store, copy, drop {
-    // The pool is new and awaits the stake to be added.
-    New,
+public enum PoolState has copy, drop, store {
     // The pool is active and can accept stakes.
     Active,
     // The pool awaits the stake to be withdrawn. The value inside the
@@ -58,7 +61,7 @@ public enum PoolState has store, copy, drop {
 }
 
 /// The parameters for the staking pool. Stored for the next epoch.
-public struct VotingParams has store, copy, drop {
+public struct VotingParams has copy, drop, store {
     /// Voting: storage price for the next epoch.
     storage_price: u64,
     /// Voting: write price for the next epoch.
@@ -70,6 +73,27 @@ public struct VotingParams has store, copy, drop {
 /// Represents a single staking pool for a token. Even though it is never
 /// transferred or shared, the `key` ability is added for discoverability
 /// in the `ObjectTable`.
+///
+/// High level overview of the staking pool:
+/// The pool maintains a balance of WAL 'wal_balance' that is increased
+/// when stakes/rewards are added to the pool, and is decreased when
+/// stakes are withdrawn.
+/// To track the users' portion of the pool, we associate shares to the
+/// staked WAL. Initially, the share price is 1 WAL per share.
+/// When a new stake is added to the pool, the total number of shares
+/// increases by an amount that corresponds to the share price at that
+/// time. E.g., if the share price is 2 WAL per share, and 10 WAL are
+/// added to the pool, the total number of shares is increased by 5
+/// shares. The total number of shares is stored in 'num_shares'.
+///
+/// As stakes are added/withdrawn only in the granularity of epochs, we
+/// maintain a share price per epoch in 'exchange_rates'.
+/// StakedWal objects only need to store the epoch when they are created,
+/// and the amount of WAL they locked. Whenever a settlement is performed
+/// for a StakedWal, we calculate the number of shares that correspond to
+/// the amount of WAL that was locked using the exchange rate at the time
+/// of the lock, and then convert it to the amount of WAL that corresponds
+/// to the current share price.
 public struct StakingPool has key, store {
     id: UID,
     /// The current state of the pool.
@@ -86,15 +110,22 @@ public struct StakingPool has key, store {
     latest_epoch: u32,
     /// Currently staked WAL in the pool + rewards pool.
     wal_balance: u64,
-    /// Balance of the pool token in the pool in the current epoch.
-    pool_token_balance: u64,
-    /// The amount of the pool token that will be withdrawn in E+1 or E+2.
+    /// The total number of shares in the current epoch.
+    num_shares: u64,
+    /// The amount of the shares that will be withdrawn in E+1 or E+2.
     /// We use this amount to calculate the WAL withdrawal in the
     /// `process_pending_stake`.
-    pending_pool_token_withdraw: PendingValues,
-    /// The commission rate for the pool.
-    /// TODO: allow changing the commission rate in E+2.
-    commission_rate: u64,
+    pending_shares_withdraw: PendingValues,
+    /// The amount of the stake requested for withdrawal for a node that may
+    /// part of the next committee. Stores principals of not yet active stakes.
+    /// In practice, those tokens are staked for exactly one epoch.
+    pre_active_withdrawals: PendingValues,
+    /// The pending commission rate for the pool. Commission rate is applied in
+    /// E+2, so we store the value for the matching epoch and apply it in the
+    /// `advance_epoch` function.
+    pending_commission_rate: PendingValues,
+    /// The commission rate for the pool, in basis points.
+    commission_rate: u16,
     /// Historical exchange rates for the pool. The key is the epoch when the
     /// exchange rate was set, and the value is the exchange rate (the ratio of
     /// the amount of WAL tokens for the pool token).
@@ -113,6 +144,14 @@ public struct StakingPool has key, store {
     pending_stake: PendingValues,
     /// The rewards that the pool has received from being in the committee.
     rewards_pool: Balance<WAL>,
+    /// The commission that the pool has received from the rewards.
+    commission: Balance<WAL>,
+    /// An Object or an address which can claim the commission.
+    commission_receiver: Authorized,
+    /// An Object or address that can authorize governance actions, such as upgrades.
+    governance_authorized: Authorized,
+    /// Reserved for future use and migrations.
+    extra_fields: Bag,
 }
 
 /// Create a new `StakingPool` object.
@@ -121,10 +160,11 @@ public struct StakingPool has key, store {
 public(package) fun new(
     name: String,
     network_address: String,
+    metadata: NodeMetadata,
     public_key: vector<u8>,
     network_public_key: vector<u8>,
     proof_of_possession: vector<u8>,
-    commission_rate: u64,
+    commission_rate: u16,
     storage_price: u64,
     write_price: u64,
     node_capacity: u64,
@@ -152,7 +192,7 @@ public(package) fun new(
     };
 
     let mut exchange_rates = table::new(ctx);
-    exchange_rates.add(activation_epoch, pool_exchange_rate::empty());
+    exchange_rates.add(activation_epoch, pool_exchange_rate::flat());
 
     StakingPool {
         id,
@@ -169,15 +209,23 @@ public(package) fun new(
             network_address,
             public_key,
             network_public_key,
+            metadata,
+            ctx,
         ),
         commission_rate,
         activation_epoch,
         latest_epoch: wctx.epoch(),
         pending_stake: pending_values::empty(),
-        pending_pool_token_withdraw: pending_values::empty(),
+        pending_shares_withdraw: pending_values::empty(),
+        pre_active_withdrawals: pending_values::empty(),
+        pending_commission_rate: pending_values::empty(),
         wal_balance: 0,
-        pool_token_balance: 0,
+        num_shares: 0,
         rewards_pool: balance::zero(),
+        commission: balance::zero(),
+        commission_receiver: auth::authorized_address(ctx.sender()),
+        governance_authorized: auth::authorized_address(ctx.sender()),
+        extra_fields: bag::new(ctx),
     }
 }
 
@@ -195,7 +243,7 @@ public(package) fun stake(
     wctx: &WalrusContext,
     ctx: &mut TxContext,
 ): StakedWal {
-    assert!(pool.is_active() || pool.is_new(), EPoolIsNotActive);
+    assert!(pool.is_active(), EPoolIsNotActive);
     assert!(to_stake.value() > 0, EZeroStake);
 
     let current_epoch = wctx.epoch();
@@ -223,42 +271,58 @@ public(package) fun stake(
 ///
 /// TODO: if pool is out and is withdrawing, we can perform the withdrawal
 /// immediately
-/// TODO: consider the case of early withdrawal if stake hasn't been activated
-/// and committee not selected.
-///
-/// TODO: remove the return value (currently returns total amount expected)
 public(package) fun request_withdraw_stake(
     pool: &mut StakingPool,
     staked_wal: &mut StakedWal,
+    in_current_committee: bool,
+    in_next_committee: bool,
     wctx: &WalrusContext,
 ) {
     assert!(staked_wal.value() > 0);
     assert!(staked_wal.node_id() == pool.id.to_inner());
-    assert!(staked_wal.activation_epoch() <= wctx.epoch());
+    assert!(staked_wal.is_staked());
+
+    // only allow requesting if the stake cannot be withdrawn directly
+    assert!(!staked_wal.can_withdraw_early(in_next_committee, wctx), EWithdrawDirectly);
+
+    // early withdrawal request: only possible if activation epoch has not been
+    // reached, and the stake is already counted for the next committee selection
+    if (staked_wal.activation_epoch() == wctx.epoch() + 1) {
+        let withdraw_epoch = staked_wal.activation_epoch() + 1;
+        // register principal in the early withdrawals, the value will get converted to
+        // the token amount in the `process_pending_stake` function
+        pool.pre_active_withdrawals.insert_or_add(withdraw_epoch, staked_wal.value());
+        staked_wal.set_withdrawing(withdraw_epoch);
+        return
+    };
+
+    assert!(staked_wal.activation_epoch() <= wctx.epoch(), EActivationEpochNotReached);
 
     // If the node is in the committee, the stake will be withdrawn in E+2,
     // otherwise in E+1.
-    // TODO: add a check that the node is in the committee: `node_in_committee &&`
-    // let node_in_committee = wctx.committee().contains(pool.id.as_inner());
-    let withdraw_epoch = if (wctx.committee_selected()) {
+    let withdraw_epoch = if (in_next_committee) {
         wctx.epoch() + 2
-    } else {
+    } else if (in_current_committee) {
         wctx.epoch() + 1
+    } else {
+        abort EWithdrawDirectly
     };
 
     let principal_amount = staked_wal.value();
-    let token_amount = pool
+    let share_amount = pool
         .exchange_rate_at_epoch(staked_wal.activation_epoch())
-        .get_token_amount(principal_amount);
+        .convert_to_share_amount(principal_amount);
 
-    pool.pending_pool_token_withdraw.insert_or_add(withdraw_epoch, token_amount);
-    staked_wal.set_withdrawing(withdraw_epoch, token_amount);
+    pool.pending_shares_withdraw.insert_or_add(withdraw_epoch, share_amount);
+    staked_wal.set_withdrawing(withdraw_epoch);
 }
 
 /// Perform the withdrawal of the staked WAL, returning the amount to the caller.
 public(package) fun withdraw_stake(
     pool: &mut StakingPool,
     staked_wal: StakedWal,
+    in_current_committee: bool,
+    in_next_committee: bool,
     wctx: &WalrusContext,
 ): Balance<WAL> {
     assert!(staked_wal.value() > 0, EZeroStake);
@@ -266,30 +330,43 @@ public(package) fun withdraw_stake(
 
     let activation_epoch = staked_wal.activation_epoch();
 
-    // early withdrawal in the case when committee before activation epoch hasn't
-    // been selected. covers both E+1 and E+2 cases.
-    if (
-        activation_epoch > wctx.epoch() &&
-        (wctx.epoch().diff(activation_epoch) == 2 || !wctx.committee_selected())
-    ) {
+    // one step, early withdrawal in the case when committee before
+    // activation epoch hasn't been selected. covers both E+1 and E+2 cases.
+    if (staked_wal.can_withdraw_early(in_next_committee, wctx)) {
         pool.pending_stake.reduce(activation_epoch, staked_wal.value());
         return staked_wal.into_balance()
     };
 
-    assert!(staked_wal.is_withdrawing(), ENotWithdrawing);
-    assert!(staked_wal.withdraw_epoch() <= wctx.epoch(), EWithdrawEpochNotReached);
-    assert!(staked_wal.activation_epoch() <= wctx.epoch(), EActivationEpochNotReached);
+    let rewards_amount = if (
+        !in_current_committee && !in_next_committee && staked_wal.is_staked()
+    ) {
+        // one step withdrawal for an inactive node
+        if (activation_epoch > wctx.epoch()) {
+            // not even active stake yet, remove from pending stake
+            pool.pending_stake.reduce(activation_epoch, staked_wal.value());
+            0
+        } else {
+            // active stake, remove it with the current epoch as the withdraw epoch
+            let share_amount = pool
+                .exchange_rate_at_epoch(activation_epoch)
+                .convert_to_share_amount(staked_wal.value());
+            pool.pending_shares_withdraw.insert_or_add(wctx.epoch(), share_amount);
+            pool.calculate_rewards(staked_wal.value(), activation_epoch, wctx.epoch())
+        }
+        // note that if the stake is in state Withdrawing, it can either be
+        // from a pre-active withdrawal, but then
+        // (in_current_committee || in_next_committee) is true since it was
+        // an early withdrawal, or from a standard two step withdrawal,
+        // which is handled below.
+    } else {
+        // normal two-step withdrawals
+        assert!(staked_wal.is_withdrawing(), ENotWithdrawing);
+        assert!(staked_wal.withdraw_epoch() <= wctx.epoch(), EWithdrawEpochNotReached);
+        assert!(activation_epoch <= wctx.epoch(), EActivationEpochNotReached);
+        pool.calculate_rewards(staked_wal.value(), activation_epoch, staked_wal.withdraw_epoch())
+    };
 
-    // withdraw epoch and pool token amount are stored in the `StakedWal`
-    let token_amount = staked_wal.pool_token_amount();
-    let withdraw_epoch = staked_wal.withdraw_epoch();
-
-    // calculate the total amount to withdraw by converting token amount via the exchange rate
-    let total_amount = pool.exchange_rate_at_epoch(withdraw_epoch).get_wal_amount(token_amount);
     let principal = staked_wal.into_balance();
-    let rewards_amount = if (total_amount >= principal.value()) {
-        total_amount - principal.value()
-    } else 0;
 
     // withdraw rewards. due to rounding errors, there's a chance that the
     // rewards amount is higher than the rewards pool, in this case, we
@@ -303,7 +380,7 @@ public(package) fun withdraw_stake(
 /// Advance epoch for the `StakingPool`.
 public(package) fun advance_epoch(
     pool: &mut StakingPool,
-    rewards: Balance<WAL>,
+    mut rewards: Balance<WAL>,
     wctx: &WalrusContext,
 ) {
     // process the pending and withdrawal amounts
@@ -312,16 +389,28 @@ public(package) fun advance_epoch(
     assert!(current_epoch > pool.latest_epoch, EPoolAlreadyUpdated);
     assert!(rewards.value() == 0 || pool.wal_balance > 0, EIncorrectEpochAdvance);
 
-    // if rewards are calculated only for full epochs, rewards addition should
-    // happen prior to pool token calculation. Otherwise we can add then to the
-    // final rate instead of the
+    // update the commission_rate if there's a pending value for the current epoch.
+    // note that pending commission rates are set 2 epochs ahead, so users are
+    // aware of the rate change in advance.
+    pool.pending_commission_rate.inner().try_get(&current_epoch).do!(|commission_rate| {
+        pool.commission_rate = commission_rate as u16;
+        pool.pending_commission_rate.flush(current_epoch);
+    });
+
+    // split the commission from the rewards
+    let total_rewards = rewards.value();
+    let commission = rewards.split(total_rewards * (pool.commission_rate as u64) / 100_00);
+    pool.commission.join(commission);
+
+    // add rewards to the pool and update the `wal_balance`
     let rewards_amount = rewards.value();
     pool.rewards_pool.join(rewards);
     pool.wal_balance = pool.wal_balance + rewards_amount;
     pool.latest_epoch = current_epoch;
     pool.node_info.rotate_public_key();
 
-    process_pending_stake(pool, wctx)
+    // perform stake deduction / addition for the current epoch - wctx.epoch()
+    pool.process_pending_stake(wctx);
 }
 
 /// Process the pending stake and withdrawal requests for the pool. Called in the
@@ -331,10 +420,10 @@ public(package) fun advance_epoch(
 public(package) fun process_pending_stake(pool: &mut StakingPool, wctx: &WalrusContext) {
     let current_epoch = wctx.epoch();
 
-    // Get the exchange rate to use for all conversions and store it for future use.
+    // Set the exchange rate for the current epoch.
     let exchange_rate = pool_exchange_rate::new(
         pool.wal_balance,
-        pool.pool_token_balance,
+        pool.num_shares,
     );
     pool.exchange_rates.add(current_epoch, exchange_rate);
 
@@ -342,24 +431,50 @@ public(package) fun process_pending_stake(pool: &mut StakingPool, wctx: &WalrusC
     pool.wal_balance = pool.wal_balance + pool.pending_stake.flush(current_epoch);
 
     // Process withdrawals.
-    let token_withdraw = pool.pending_pool_token_withdraw.flush(wctx.epoch());
-    let pending_withdrawal = exchange_rate.get_wal_amount(token_withdraw);
+
+    // each value in pending withdrawals contains the principal which became
+    // active in the previous epoch. so unlike other pending values, we need to
+    // flush it one by one, recalculating the exchange rate and pool token amount
+    // for each early withdrawal epoch.
+    let mut pre_active_shares_withdraw = 0;
+    let mut pre_active_withdrawals = pool.pre_active_withdrawals.unwrap();
+    pre_active_withdrawals.keys().do!(|epoch| if (epoch <= current_epoch) {
+        let (_, epoch_value) = pre_active_withdrawals.remove(&epoch);
+        // recall that pre_active_withdrawals contains stakes that were
+        // active for exactly 1 epoch.
+        let activation_epoch = epoch - 1;
+        let shares_for_epoch = pool
+            .exchange_rate_at_epoch(activation_epoch)
+            .convert_to_share_amount(epoch_value);
+
+        pre_active_shares_withdraw = pre_active_shares_withdraw + shares_for_epoch;
+    });
+    // don't forget to flush the early withdrawals since we worked on a copy
+    let _ = pool.pre_active_withdrawals.flush(current_epoch);
+
+    let shares_withdraw = pool.pending_shares_withdraw.flush(wctx.epoch());
+    let pending_withdrawal = exchange_rate.convert_to_wal_amount(
+        shares_withdraw + pre_active_shares_withdraw,
+    );
 
     // Check that the amount is not higher than the pool balance
     assert!(pool.wal_balance >= pending_withdrawal, ECalculationError);
     pool.wal_balance = pool.wal_balance - pending_withdrawal;
 
-    // Recalculate the pool token balance.
-    pool.pool_token_balance = exchange_rate.get_token_amount(pool.wal_balance);
+    // Recalculate the total number of shares according to the exchange rate.
+    pool.num_shares = exchange_rate.convert_to_share_amount(pool.wal_balance);
 }
 
 // === Pool parameters ===
 
 /// Sets the next commission rate for the pool.
-/// TODO: implement changing commission rate in E+2, the change should not be
-/// immediate.
-public(package) fun set_next_commission(pool: &mut StakingPool, commission_rate: u64) {
-    pool.commission_rate = commission_rate;
+public(package) fun set_next_commission(
+    pool: &mut StakingPool,
+    commission_rate: u16,
+    wctx: &WalrusContext,
+) {
+    assert!(commission_rate <= 100_00, EIncorrectCommissionRate);
+    pool.pending_commission_rate.insert_or_replace(wctx.epoch() + 2, commission_rate as u64);
 }
 
 /// Sets the next storage price for the pool.
@@ -412,6 +527,11 @@ public(package) fun set_network_public_key(self: &mut StakingPool, network_publi
     self.node_info.set_network_public_key(network_public_key);
 }
 
+/// Sets the node metadata.
+public(package) fun set_node_metadata(self: &mut StakingPool, metadata: NodeMetadata) {
+    self.node_info.set_node_metadata(metadata);
+}
+
 /// Destroy the pool if it is empty.
 public(package) fun destroy_empty(pool: StakingPool) {
     assert!(pool.is_empty(), EPoolNotEmpty);
@@ -421,12 +541,18 @@ public(package) fun destroy_empty(pool: StakingPool) {
         pending_stake,
         exchange_rates,
         rewards_pool,
+        commission,
+        extra_fields,
+        node_info,
         ..,
     } = pool;
 
     id.delete();
     exchange_rates.drop();
+    node_info.destroy();
+    commission.destroy_zero();
     rewards_pool.destroy_zero();
+    extra_fields.destroy_empty();
 
     let (_epochs, pending_stakes) = pending_stake.unwrap().into_keys_values();
     pending_stakes.do!(|stake| assert!(stake == 0));
@@ -435,6 +561,8 @@ public(package) fun destroy_empty(pool: StakingPool) {
 /// Returns the exchange rate for the given current or future epoch. If there
 /// isn't a value for the specified epoch, it will look for the most recent
 /// value down to the pool activation epoch.
+/// Note that exchange rates are only set for epochs in which the node is in
+/// the committee, and otherwise the rate remains static.
 public(package) fun exchange_rate_at_epoch(pool: &StakingPool, mut epoch: u32): PoolExchangeRate {
     let activation_epoch = pool.activation_epoch;
     while (epoch >= activation_epoch) {
@@ -444,7 +572,7 @@ public(package) fun exchange_rate_at_epoch(pool: &StakingPool, mut epoch: u32): 
         epoch = epoch - 1;
     };
 
-    pool_exchange_rate::empty()
+    pool_exchange_rate::flat()
 }
 
 /// Returns the expected active stake for current or future epoch `E` for the pool.
@@ -455,20 +583,75 @@ public(package) fun exchange_rate_at_epoch(pool: &StakingPool, mut epoch: u32): 
 /// the given epoch, due to the complexity of the pending stake and withdrawal
 /// requests, and lack of immediate updates.
 public(package) fun wal_balance_at_epoch(pool: &StakingPool, epoch: u32): u64 {
-    let mut expected = pool.wal_balance;
-    let exchange_rate = pool_exchange_rate::new(pool.wal_balance, pool.pool_token_balance);
-    let token_withdraw = pool.pending_pool_token_withdraw.value_at(epoch);
-    let pending_withdrawal = exchange_rate.get_wal_amount(token_withdraw);
+    let exchange_rate = pool_exchange_rate::new(pool.wal_balance, pool.num_shares);
 
-    expected = expected + pool.pending_stake.value_at(epoch);
-    expected = expected - pending_withdrawal;
-    expected
+    let mut pre_active_shares_withdraw = 0;
+    let pre_active_withdrawals = pool.pre_active_withdrawals.unwrap();
+    pre_active_withdrawals.keys().do_ref!(|old_epoch| if (*old_epoch <= epoch) {
+        let wal_value = pre_active_withdrawals.get(old_epoch);
+        // recall that pre_active_withdrawals contains stakes that were
+        // active for exactly 1 epoch. since the node might have been
+        // inactive, this list may contain more than one value
+        // (although exchange_rate_at_epoch will return the same value).
+        let activation_epoch = *old_epoch - 1;
+        let shares_for_epoch = pool
+            .exchange_rate_at_epoch(activation_epoch)
+            .convert_to_share_amount(*wal_value);
+
+        pre_active_shares_withdraw = pre_active_shares_withdraw + shares_for_epoch;
+    });
+    let shares_withdraw = pool.pending_shares_withdraw.value_at(epoch);
+    let pending_withdrawal = exchange_rate.convert_to_wal_amount(
+        shares_withdraw + pre_active_shares_withdraw,
+    );
+
+    pool.wal_balance + pool.pending_stake.value_at(epoch) - pending_withdrawal
 }
 
 // === Accessors ===
 
+/// Returns the governance authorized object for the pool.
+public(package) fun governance_authorized(pool: &StakingPool): &Authorized {
+    &pool.governance_authorized
+}
+
+/// Sets the governance authorized object for the pool.
+public(package) fun set_governance_authorized(
+    pool: &mut StakingPool,
+    authenticated: Authenticated,
+    authorized: Authorized,
+) {
+    assert!(authenticated.matches(&pool.governance_authorized), EAuthorizationFailure);
+    pool.governance_authorized = authorized
+}
+
+/// Returns the commission receiver for the pool.
+public(package) fun commission_receiver(pool: &StakingPool): &Authorized {
+    &pool.commission_receiver
+}
+
+/// Sets the commission receiver for the pool.
+public(package) fun set_commission_receiver(
+    pool: &mut StakingPool,
+    auth: Authenticated,
+    receiver: Authorized,
+) {
+    assert!(auth.matches(&pool.commission_receiver), EAuthorizationFailure);
+    pool.commission_receiver = receiver
+}
+
 /// Returns the commission rate for the pool.
-public(package) fun commission_rate(pool: &StakingPool): u64 { pool.commission_rate }
+public(package) fun commission_rate(pool: &StakingPool): u16 { pool.commission_rate }
+
+/// Returns the commission amount for the pool.
+public(package) fun commission_amount(pool: &StakingPool): u64 { pool.commission.value() }
+
+/// Withdraws the commission from the pool. Amount is optional, if not provided,
+/// the full commission is withdrawn.
+public(package) fun collect_commission(pool: &mut StakingPool, auth: Authenticated): Balance<WAL> {
+    assert!(auth.matches(&pool.commission_receiver), EAuthorizationFailure);
+    pool.commission.withdraw_all()
+}
 
 /// Returns the rewards amount for the pool.
 public(package) fun rewards_amount(pool: &StakingPool): u64 { pool.rewards_pool.value() }
@@ -491,9 +674,6 @@ public(package) fun activation_epoch(pool: &StakingPool): u32 { pool.activation_
 /// Returns the node info for the pool.
 public(package) fun node_info(pool: &StakingPool): &StorageNodeInfo { &pool.node_info }
 
-/// Returns `true` if the pool is empty.
-public(package) fun is_new(pool: &StakingPool): bool { pool.state == PoolState::New }
-
 /// Returns `true` if the pool is active.
 public(package) fun is_active(pool: &StakingPool): bool { pool.state == PoolState::Active }
 
@@ -505,10 +685,37 @@ public(package) fun is_withdrawing(pool: &StakingPool): bool {
     }
 }
 
-///  Returns `true` if the pool is empty.
+/// Returns `true` if the pool is empty.
 public(package) fun is_empty(pool: &StakingPool): bool {
     let pending_stake = pool.pending_stake.unwrap();
     let non_empty = pending_stake.keys().count!(|epoch| pending_stake[epoch] != 0);
 
-    pool.wal_balance == 0 && non_empty == 0 && pool.pool_token_balance == 0
+    pool.rewards_pool.value() == 0 &&
+    pool.num_shares == 0 &&
+    pool.commission.value() == 0 &&
+    pool.wal_balance == 0 &&
+    non_empty == 0
 }
+
+/// Calculate the rewards for an amount with value `staked_principal`, staked in the pool between
+/// `activation_epoch` and `withdraw_epoch`.
+public(package) fun calculate_rewards(
+    pool: &StakingPool,
+    staked_principal: u64,
+    activation_epoch: u32,
+    withdraw_epoch: u32,
+): u64 {
+    let shares = pool
+        .exchange_rate_at_epoch(activation_epoch)
+        .convert_to_share_amount(staked_principal);
+    let wal_amount = pool.exchange_rate_at_epoch(withdraw_epoch).convert_to_wal_amount(shares);
+    if (wal_amount >= staked_principal) {
+        wal_amount - staked_principal
+    } else 0
+}
+
+#[test_only]
+public(package) fun num_shares(pool: &StakingPool): u64 { pool.num_shares }
+
+#[test_only]
+public(package) fun latest_epoch(pool: &StakingPool): u32 { pool.latest_epoch }

--- a/testnet-contracts/walrus/sources/staking/storage_node.move
+++ b/testnet-contracts/walrus/sources/staking/storage_node.move
@@ -5,21 +5,26 @@
 module walrus::storage_node;
 
 use std::string::String;
-use sui::{bls12381::{G1, g1_from_bytes}, group_ops::Element};
-use walrus::event_blob::EventBlobAttestation;
+use sui::{bls12381::{UncompressedG1, g1_from_bytes, g1_to_uncompressed_g1}, group_ops::Element};
+use walrus::{
+    event_blob::EventBlobAttestation,
+    extended_field::{Self, ExtendedField},
+    node_metadata::NodeMetadata
+};
 
 // Error codes
-// Keep errors in `walrus-sui/types/move_errors.rs` up to date with changes here.
+// Error types in `walrus-sui/types/move_errors.rs` are auto-generated from the Move error codes.
 const EInvalidNetworkPublicKey: u64 = 0;
 
 /// Represents a storage node in the system.
-public struct StorageNodeInfo has store, copy, drop {
+public struct StorageNodeInfo has store {
     name: String,
     node_id: ID,
     network_address: String,
-    public_key: Element<G1>,
-    next_epoch_public_key: Option<Element<G1>>,
+    public_key: Element<UncompressedG1>,
+    next_epoch_public_key: Option<Element<UncompressedG1>>,
     network_public_key: vector<u8>,
+    metadata: ExtendedField<NodeMetadata>,
 }
 
 /// A Capability which represents a storage node and authorizes the holder to
@@ -29,6 +34,12 @@ public struct StorageNodeCap has key, store {
     node_id: ID,
     last_epoch_sync_done: u32,
     last_event_blob_attestation: Option<EventBlobAttestation>,
+    /// Stores the Merkle root of the deny list for the storage node.
+    deny_list_root: u256,
+    /// Stores the sequence number of the deny list for the storage node.
+    deny_list_sequence: u64,
+    /// Stores the size of the deny list for the storage node.
+    deny_list_size: u64,
 }
 
 /// A public constructor for the StorageNodeInfo.
@@ -38,15 +49,18 @@ public(package) fun new(
     network_address: String,
     public_key: vector<u8>,
     network_public_key: vector<u8>,
+    metadata: NodeMetadata,
+    ctx: &mut TxContext,
 ): StorageNodeInfo {
     assert!(network_public_key.length() == 33, EInvalidNetworkPublicKey);
     StorageNodeInfo {
         node_id,
         name,
         network_address,
-        public_key: g1_from_bytes(&public_key),
+        public_key: g1_to_uncompressed_g1(&g1_from_bytes(&public_key)),
         next_epoch_public_key: option::none(),
         network_public_key,
+        metadata: extended_field::new(metadata, ctx),
     }
 }
 
@@ -57,18 +71,26 @@ public(package) fun new_cap(node_id: ID, ctx: &mut TxContext): StorageNodeCap {
         node_id,
         last_epoch_sync_done: 0,
         last_event_blob_attestation: option::none(),
+        deny_list_root: 0,
+        deny_list_sequence: 0,
+        deny_list_size: 0,
     }
 }
 
 // === Accessors ===
 
 /// Return the public key of the storage node.
-public(package) fun public_key(self: &StorageNodeInfo): &Element<G1> {
+public(package) fun public_key(self: &StorageNodeInfo): &Element<UncompressedG1> {
     &self.public_key
 }
 
+/// Return the name of the storage node.
+public(package) fun metadata(self: &StorageNodeInfo): NodeMetadata {
+    *self.metadata.borrow()
+}
+
 /// Return the public key of the storage node for the next epoch.
-public(package) fun next_epoch_public_key(self: &StorageNodeInfo): &Element<G1> {
+public(package) fun next_epoch_public_key(self: &StorageNodeInfo): &Element<UncompressedG1> {
     self.next_epoch_public_key.borrow_with_default(&self.public_key)
 }
 
@@ -89,6 +111,12 @@ public fun last_event_blob_attestation(cap: &mut StorageNodeCap): Option<EventBl
     cap.last_event_blob_attestation
 }
 
+/// Return the deny list root of the storage node.
+public fun deny_list_root(cap: &StorageNodeCap): u256 { cap.deny_list_root }
+
+/// Return the deny list sequence number of the storage node.
+public fun deny_list_sequence(cap: &StorageNodeCap): u64 { cap.deny_list_sequence }
+
 // === Modifiers ===
 
 /// Set the last epoch in which the storage node attested that it has finished syncing.
@@ -106,7 +134,8 @@ public(package) fun set_last_event_blob_attestation(
 
 /// Sets the public key to be used starting from the next epoch for which the node is selected.
 public(package) fun set_next_public_key(self: &mut StorageNodeInfo, public_key: vector<u8>) {
-    self.next_epoch_public_key.swap_or_fill(g1_from_bytes(&public_key));
+    let public_key = g1_from_bytes(&public_key);
+    self.next_epoch_public_key.swap_or_fill(g1_to_uncompressed_g1(&public_key));
 }
 
 /// Sets the name of the storage node.
@@ -124,7 +153,13 @@ public(package) fun set_network_public_key(
     self: &mut StorageNodeInfo,
     network_public_key: vector<u8>,
 ) {
+    assert!(network_public_key.length() == 33, EInvalidNetworkPublicKey);
     self.network_public_key = network_public_key;
+}
+
+/// Sets the metadata of the storage node.
+public(package) fun set_node_metadata(self: &mut StorageNodeInfo, metadata: NodeMetadata) {
+    self.metadata.swap(metadata);
 }
 
 /// Set the public key to the next epochs public key.
@@ -132,6 +167,24 @@ public(package) fun rotate_public_key(self: &mut StorageNodeInfo) {
     if (self.next_epoch_public_key.is_some()) {
         self.public_key = self.next_epoch_public_key.extract()
     }
+}
+
+/// Destroy the storage node.
+public(package) fun destroy(self: StorageNodeInfo) {
+    let StorageNodeInfo { metadata, .. } = self;
+    metadata.destroy();
+}
+
+/// Set the deny list root of the storage node.
+public(package) fun set_deny_list_properties(
+    self: &mut StorageNodeCap,
+    root: u256,
+    sequence: u64,
+    size: u64,
+) {
+    self.deny_list_root = root;
+    self.deny_list_sequence = sequence;
+    self.deny_list_size = size;
 }
 
 // === Testing ===
@@ -145,9 +198,10 @@ public fun new_for_testing(public_key: vector<u8>): StorageNodeInfo {
         node_id,
         name: b"node".to_string(),
         network_address: b"127.0.0.1".to_string(),
-        public_key: g1_from_bytes(&public_key),
+        public_key: g1_to_uncompressed_g1(&g1_from_bytes(&public_key)),
         next_epoch_public_key: option::none(),
         network_public_key: x"820e2b273530a00de66c9727c40f48be985da684286983f398ef7695b8a44677ab",
+        metadata: extended_field::new(walrus::node_metadata::default(), ctx),
     }
 }
 

--- a/testnet-contracts/walrus/sources/system/blob.move
+++ b/testnet-contracts/walrus/sources/system/blob.move
@@ -3,25 +3,29 @@
 
 module walrus::blob;
 
-use sui::{bcs, dynamic_field, hash};
 use std::string::String;
+use sui::{bcs, dynamic_field, hash};
 use walrus::{
     encoding,
     events::{emit_blob_registered, emit_blob_certified, emit_blob_deleted},
     messages::CertifiedBlobMessage,
     metadata::Metadata,
-    storage_resource::Storage,
+    storage_resource::Storage
 };
 
 // Error codes
-// Keep errors in `walrus-sui/types/move_errors.rs` up to date with changes here.
+// Error types in `walrus-sui/types/move_errors.rs` are auto-generated from the Move error codes.
 const ENotCertified: u64 = 0;
 const EBlobNotDeletable: u64 = 1;
 const EResourceBounds: u64 = 2;
 const EResourceSize: u64 = 3;
-const EWrongEpoch: u64 = 4;
+// const EWrongEpoch: u64 = 4;
 const EAlreadyCertified: u64 = 5;
 const EInvalidBlobId: u64 = 6;
+const EDuplicateMetadata: u64 = 7;
+const EMissingMetadata: u64 = 8;
+const EInvalidBlobPersistenceType: u64 = 9;
+const EInvalidBlobObject: u64 = 10;
 
 // The fixed dynamic filed name for metadata
 const METADATA_DF: vector<u8> = b"metadata";
@@ -44,6 +48,10 @@ public struct Blob has key, store {
 }
 
 // === Accessors ===
+
+public fun object_id(self: &Blob): ID {
+    object::id(self)
+}
 
 public fun registered_epoch(self: &Blob): u32 {
     self.registered_epoch
@@ -101,7 +109,7 @@ public struct BlobIdDerivation has drop {
 }
 
 /// Derives the blob_id for a blob given the root_hash, encoding_type and size.
-public(package) fun derive_blob_id(root_hash: u256, encoding_type: u8, size: u64): u256 {
+public fun derive_blob_id(root_hash: u256, encoding_type: u8, size: u64): u256 {
     let blob_id_struct = BlobIdDerivation {
         encoding_type,
         size,
@@ -145,7 +153,7 @@ public(package) fun new(
     assert!(encoded_size <= storage.storage_size(), EResourceSize);
 
     // Cryptographically verify that the Blob ID authenticates
-    // both the size and fe_type.
+    // both the size and encoding_type (sanity check).
     assert!(derive_blob_id(root_hash, encoding_type, size) == blob_id, EInvalidBlobId);
 
     // Emit register event
@@ -179,19 +187,30 @@ public(package) fun certify_with_certified_msg(
     message: CertifiedBlobMessage,
 ) {
     // Check that the blob is registered in the system
-    assert!(blob_id(blob) == message.certified_blob_id(), EInvalidBlobId);
+    assert!(blob.blob_id() == message.certified_blob_id(), EInvalidBlobId);
 
     // Check that the blob is not already certified
     assert!(!blob.certified_epoch.is_some(), EAlreadyCertified);
 
-    // Check that the message is from the current epoch
-    assert!(message.certified_epoch() == current_epoch, EWrongEpoch);
-
     // Check that the storage in the blob is still valid
-    assert!(message.certified_epoch() < blob.storage.end_epoch(), EResourceBounds);
+    assert!(current_epoch < blob.storage.end_epoch(), EResourceBounds);
+
+    // Check the blob persistence type
+    assert!(
+        blob.deletable == message.blob_persistence_type().is_deletable(),
+        EInvalidBlobPersistenceType,
+    );
+
+    // Check that the object id matches the message
+    if (blob.deletable) {
+        assert!(
+            message.blob_persistence_type().object_id() == object::id(blob),
+            EInvalidBlobObject,
+        );
+    };
 
     // Mark the blob as certified
-    blob.certified_epoch.fill(message.certified_epoch());
+    blob.certified_epoch.fill(current_epoch);
 
     blob.emit_certified(false);
 }
@@ -200,7 +219,9 @@ public(package) fun certify_with_certified_msg(
 ///
 /// Emits a `BlobDeleted` event for the given epoch.
 /// Aborts if the Blob is not deletable or already expired.
-public(package) fun delete(self: Blob, epoch: u32): Storage {
+/// Also removes any metadata associated with the blob.
+public(package) fun delete(mut self: Blob, epoch: u32): Storage {
+    dynamic_field::remove_if_exists<_, Metadata>(&mut self.id, METADATA_DF);
     let Blob {
         id,
         storage,
@@ -222,12 +243,11 @@ public(package) fun delete(self: Blob, epoch: u32): Storage {
 public use fun walrus::shared_blob::new as Blob.share;
 
 /// Allow the owner of a blob object to destroy it.
-public fun burn(blob: Blob) {
-    let Blob {
-        id,
-        storage,
-        ..,
-    } = blob;
+///
+/// This function also burns any [`Metadata`] associated with the blob, if present.
+public fun burn(mut self: Blob) {
+    dynamic_field::remove_if_exists<_, Metadata>(&mut self.id, METADATA_DF);
+    let Blob { id, storage, .. } = self;
 
     id.delete();
     storage.destroy();
@@ -276,6 +296,7 @@ public(package) fun emit_certified(self: &Blob, is_extension: bool) {
 ///
 /// Aborts if the metadata is already present.
 public fun add_metadata(self: &mut Blob, metadata: Metadata) {
+    assert!(!dynamic_field::exists_(&self.id, METADATA_DF), EDuplicateMetadata);
     dynamic_field::add(&mut self.id, METADATA_DF, metadata)
 }
 
@@ -283,6 +304,7 @@ public fun add_metadata(self: &mut Blob, metadata: Metadata) {
 ///
 /// Aborts if the metadata does not exist.
 public fun take_metadata(self: &mut Blob): Metadata {
+    assert!(dynamic_field::exists_(&self.id, METADATA_DF), EMissingMetadata);
     dynamic_field::remove(&mut self.id, METADATA_DF)
 }
 
@@ -290,6 +312,7 @@ public fun take_metadata(self: &mut Blob): Metadata {
 ///
 /// Aborts if the metadata does not exist.
 fun metadata(self: &mut Blob): &mut Metadata {
+    assert!(dynamic_field::exists_(&self.id, METADATA_DF), EMissingMetadata);
     dynamic_field::borrow_mut(&mut self.id, METADATA_DF)
 }
 
@@ -305,4 +328,13 @@ public fun insert_or_update_metadata_pair(self: &mut Blob, key: String, value: S
 /// Aborts if the metadata does not exist.
 public fun remove_metadata_pair(self: &mut Blob, key: &String): (String, String) {
     self.metadata().remove(key)
+}
+
+#[test_only]
+public fun certify_with_certified_msg_for_testing(
+    blob: &mut Blob,
+    current_epoch: u32,
+    message: CertifiedBlobMessage,
+) {
+    certify_with_certified_msg(blob, current_epoch, message)
 }

--- a/testnet-contracts/walrus/sources/system/bls_aggregate.move
+++ b/testnet-contracts/walrus/sources/system/bls_aggregate.move
@@ -3,31 +3,44 @@
 
 module walrus::bls_aggregate;
 
-use sui::bls12381::{Self, bls12381_min_pk_verify, G1};
-use sui::group_ops::{Self, Element};
-use sui::vec_map::{Self, VecMap};
+use sui::{
+    bls12381::{Self, bls12381_min_pk_verify, G1, UncompressedG1},
+    group_ops::{Self, Element},
+    vec_map::{Self, VecMap}
+};
 use walrus::messages::{Self, CertifiedMessage};
 
 // Error codes
-const ETotalMemberOrder: u64 = 0;
+// Error types in `walrus-sui/types/move_errors.rs` are auto-generated from the Move error codes.
+const EInvalidBitmap: u64 = 0;
 const ESigVerification: u64 = 1;
 const ENotEnoughStake: u64 = 2;
 const EIncorrectCommittee: u64 = 3;
 
-public struct BlsCommitteeMember has store, copy, drop {
-    public_key: Element<G1>,
+public struct BlsCommitteeMember has copy, drop, store {
+    public_key: Element<UncompressedG1>,
     weight: u16,
     node_id: ID,
 }
 
 /// This represents a BLS signing committee for a given epoch.
-public struct BlsCommittee has store, copy, drop {
+public struct BlsCommittee has copy, drop, store {
     /// A vector of committee members
     members: vector<BlsCommitteeMember>,
     /// The total number of shards held by the committee
     n_shards: u16,
     /// The epoch in which the committee is active.
     epoch: u32,
+    /// The aggregation of public keys for all members of the committee
+    total_aggregated_key: Element<G1>,
+}
+
+/// The type of weight verification to perform.
+public enum RequiredWeight {
+    /// Verify that the signers form a quorum.
+    Quorum,
+    /// Verify that the signers include at least one correct node.
+    OneCorrectNode,
 }
 
 /// Constructor for committee.
@@ -48,12 +61,19 @@ public(package) fun new_bls_committee(
     //       the staking, and don't require Option<BlsCommittee> there.
     // assert!(n_shards != 0, EIncorrectCommittee);
 
-    BlsCommittee { members, n_shards, epoch }
+    // Compute the total aggregated key, e.g. the sum of all public keys in the committee.
+    let total_aggregated_key = bls12381::uncompressed_g1_to_g1(
+        &bls12381::uncompressed_g1_sum(
+            &members.map!(|member| member.public_key),
+        ),
+    );
+
+    BlsCommittee { members, n_shards, epoch, total_aggregated_key }
 }
 
 /// Constructor for committee member.
 public(package) fun new_bls_committee_member(
-    public_key: Element<G1>,
+    public_key: Element<UncompressedG1>,
     weight: u16,
     node_id: ID,
 ): BlsCommitteeMember {
@@ -67,7 +87,7 @@ public(package) fun new_bls_committee_member(
 // === Accessors for BlsCommitteeMember ===
 
 /// Get the node id of the committee member.
-public(package) fun node_id(self: &BlsCommitteeMember): sui::object::ID {
+public(package) fun node_id(self: &BlsCommitteeMember): ID {
     self.node_id
 }
 
@@ -83,9 +103,14 @@ public(package) fun n_shards(self: &BlsCommittee): u16 {
     self.n_shards
 }
 
+/// Returns the number of members in the committee.
+public(package) fun n_members(self: &BlsCommittee): u64 {
+    self.members.length()
+}
+
 /// Returns the member at given index
 public(package) fun get_idx(self: &BlsCommittee, idx: u64): &BlsCommitteeMember {
-    self.members.borrow(idx)
+    &self.members[idx]
 }
 
 /// Checks if the committee contains a given node.
@@ -95,14 +120,11 @@ public(package) fun contains(self: &BlsCommittee, node_id: &ID): bool {
 
 /// Returns the member weight if it is part of the committee or 0 otherwise
 public(package) fun get_member_weight(self: &BlsCommittee, node_id: &ID): u16 {
-    self.find_index(node_id).and!(|idx| {
-        let member = &self.members[idx];
-        option::some(member.weight)
-    }).get_with_default(0)
+    self.find_index(node_id).map!(|idx| self.members[idx].weight).destroy_or!(0)
 }
 
 /// Finds the index of the member by node_id
-public(package) fun find_index(self: &BlsCommittee, node_id: &ID): std::option::Option<u64> {
+public(package) fun find_index(self: &BlsCommittee, node_id: &ID): Option<u64> {
     self.members.find_index!(|member| &member.node_id == node_id)
 }
 
@@ -117,71 +139,138 @@ public(package) fun to_vec_map(self: &BlsCommittee): VecMap<ID, u16> {
 
 /// Verifies that a message is signed by a quorum of the members of a committee.
 ///
-/// The signers are listed as indices into the `members` vector of the committee
-/// in increasing
-/// order and with no repetitions. The total weight of the signers (i.e. total
-/// number of shards)
-/// is returned, but if a quorum is not reached the function aborts with an
-/// error.
+/// The signers are given as a bitmap for the indices into the `members` vector of
+/// the committee.
+///
+/// If the signers form a quorum and the signature is valid, the function returns
+/// a new `CertifiedMessage` with the message, the epoch, and the total stake of
+/// the signers. Otherwise, it aborts with an error.
 public(package) fun verify_quorum_in_epoch(
     self: &BlsCommittee,
     signature: vector<u8>,
-    signers: vector<u16>,
+    signers_bitmap: vector<u8>,
     message: vector<u8>,
 ): CertifiedMessage {
-    let stake_support = self.verify_certificate(
+    let stake_support = self.verify_certificate_and_weight(
         &signature,
-        &signers,
+        &signers_bitmap,
         &message,
+        RequiredWeight::Quorum,
     );
 
     messages::new_certified_message(message, self.epoch, stake_support)
 }
 
 /// Returns true if the weight is more than the aggregate weight of quorum members of a committee.
-public(package) fun verify_quorum(self: &BlsCommittee, weight: u16): bool {
+public(package) fun is_quorum(self: &BlsCommittee, weight: u16): bool {
     3 * (weight as u64) >= 2 * (self.n_shards as u64) + 1
 }
 
+/// Verifies that a message is signed by at least one correct node of a committee.
+///
+/// The signers are given as a bitmap for the indices into the `members` vector of
+/// the committee.
+/// If the signers include at least one correct node and the signature is valid,
+/// the function returns a new `CertifiedMessage` with the message, the epoch,
+/// and the total stake of the signers. Otherwise, it aborts with an error.
+public(package) fun verify_one_correct_node_in_epoch(
+    self: &BlsCommittee,
+    signature: vector<u8>,
+    signers_bitmap: vector<u8>,
+    message: vector<u8>,
+): CertifiedMessage {
+    let stake_support = self.verify_certificate_and_weight(
+        &signature,
+        &signers_bitmap,
+        &message,
+        RequiredWeight::OneCorrectNode,
+    );
+
+    messages::new_certified_message(message, self.epoch, stake_support)
+}
+
+/// Returns true if the weight is enough to ensure that at least one honest node contributed.
+public(package) fun includes_one_correct_node(self: &BlsCommittee, weight: u16): bool {
+    3 * (weight as u64) >= self.n_shards as u64 + 1
+}
+
 /// Verify an aggregate BLS signature is a certificate in the epoch, and return
-/// the type of
-/// certificate and the bytes certified. The `signers` vector is an increasing
-/// list of indexes
-/// into the `members` vector of the committee. If there is a certificate, the
-/// function
-/// returns the total stake. Otherwise, it aborts.
-public(package) fun verify_certificate(
+/// the total stake of the signers.
+/// The `signers_bitmap` is a bitmap of the indices of the signers in the committee.
+/// The `weight_verification_type` is the type of weight verification to perform,
+/// either check that the signers forms a quorum or includes at least one correct node.
+/// If there is a certificate, the function returns the total stake. Otherwise, it aborts.
+fun verify_certificate_and_weight(
     self: &BlsCommittee,
     signature: &vector<u8>,
-    signers: &vector<u16>,
+    signers_bitmap: &vector<u8>,
     message: &vector<u8>,
+    required_weight: RequiredWeight,
 ): u16 {
-    // Use the signers flags to construct the key and the weights.
+    // Use the signers_bitmap to construct the key and the weights.
 
-    // Lower bound for the next `member_index` to ensure they are monotonically
-    // increasing
-    let mut min_next_member_index = 0;
-    let mut aggregate_key = bls12381::g1_identity();
-    let mut aggregate_weight = 0;
+    let mut non_signer_aggregate_weight = 0;
+    let mut non_signer_public_keys: vector<Element<UncompressedG1>> = vector::empty();
+    let mut offset: u64 = 0;
+    let n_members = self.n_members();
+    let max_bitmap_len_bytes = n_members.divide_and_round_up(8);
 
-    signers.do_ref!(|member_index| {
-        let member_index = *member_index as u64;
-        assert!(member_index >= min_next_member_index, ETotalMemberOrder);
-        min_next_member_index = member_index + 1;
+    // The signers bitmap must not be longer than necessary to hold all members.
+    // It may be shorter, in which case the excluded members are treated as non-signers.
+    assert!(signers_bitmap.length() <= max_bitmap_len_bytes, EInvalidBitmap);
 
-        // Bounds check happens here
-        let member = &self.members[member_index];
-        let key = &member.public_key;
-        let weight = member.weight;
+    // Iterate over the signers bitmap and check if each member is a signer.
+    max_bitmap_len_bytes.do!(|i| {
+        // Get the current byte or 0 if we've reached the end of the bitmap.
+        let byte = if (i < signers_bitmap.length()) {
+            signers_bitmap[i]
+        } else {
+            0
+        };
 
-        aggregate_key = bls12381::g1_add(&aggregate_key, key);
-        aggregate_weight = aggregate_weight + weight;
+        (8u8).do!(|i| {
+            let index = offset + (i as u64);
+            let is_signer = (byte >> i) & 1 == 1;
+
+            // If the index is out of bounds, the bit must be 0 to ensure
+            // uniqueness of the signers_bitmap.
+            if (index >= n_members) {
+                assert!(!is_signer, EInvalidBitmap);
+                return
+            };
+
+            // There will be fewer non-signers than signers, so we handle
+            // non-signers here.
+            if (!is_signer) {
+                let member = self.members[index];
+                non_signer_aggregate_weight = non_signer_aggregate_weight + member.weight;
+                non_signer_public_keys.push_back(member.public_key);
+            };
+        });
+        offset = offset + 8;
     });
 
-    // The expression below is the solution to the inequality:
-    // n_shards = 3 f + 1
-    // stake >= 2f + 1
-    assert!(verify_quorum(self, aggregate_weight), ENotEnoughStake);
+    // Compute the aggregate weight as the difference between the total number of shards
+    // and the total weight of the non-signers.
+    let aggregate_weight = self.n_shards - non_signer_aggregate_weight;
+
+    // Check if the aggregate weight is enough to satisfy the required weight.
+    match (required_weight) {
+        RequiredWeight::Quorum => assert!(self.is_quorum(aggregate_weight), ENotEnoughStake),
+        RequiredWeight::OneCorrectNode => assert!(
+            self.includes_one_correct_node(aggregate_weight),
+            ENotEnoughStake,
+        ),
+    };
+
+    // Compute the aggregate public key as the difference between the total
+    // aggregated key and the sum of the non-signer public keys.
+    let aggregate_key = bls12381::g1_sub(
+        &self.total_aggregated_key,
+        &bls12381::uncompressed_g1_to_g1(
+            &bls12381::uncompressed_g1_sum(&non_signer_public_keys),
+        ),
+    );
 
     // Verify the signature
     let pub_key_bytes = group_ops::bytes(&aggregate_key);
@@ -201,4 +290,14 @@ public(package) fun verify_certificate(
 /// Increments the committee epoch by one.
 public fun increment_epoch_for_testing(self: &mut BlsCommittee) {
     self.epoch = self.epoch + 1;
+}
+
+#[test_only]
+public fun verify_certificate(
+    self: &BlsCommittee,
+    signature: &vector<u8>,
+    signers_bitmap: &vector<u8>,
+    message: &vector<u8>,
+): u16 {
+    self.verify_certificate_and_weight(signature, signers_bitmap, message, RequiredWeight::Quorum)
 }

--- a/testnet-contracts/walrus/sources/system/encoding.move
+++ b/testnet-contracts/walrus/sources/system/encoding.move
@@ -8,7 +8,8 @@ use walrus::redstuff;
 // Supported Encoding Types
 const RED_STUFF_ENCODING: u8 = 0;
 
-// Errors
+// Error codes
+// Error types in `walrus-sui/types/move_errors.rs` are auto-generated from the Move error codes.
 const EInvalidEncoding: u64 = 0;
 
 /// Computes the encoded length of a blob given its unencoded length, encoding type

--- a/testnet-contracts/walrus/sources/system/epoch_parameters.move
+++ b/testnet-contracts/walrus/sources/system/epoch_parameters.move
@@ -4,7 +4,7 @@
 module walrus::epoch_parameters;
 
 /// The epoch parameters for the system.
-public struct EpochParams has store, copy, drop {
+public struct EpochParams has copy, drop, store {
     /// The storage capacity of the system.
     total_capacity_size: u64,
     /// The price per unit size of storage.
@@ -46,6 +46,7 @@ public(package) fun write_price(self: &EpochParams): u64 {
 
 // === Test only ===
 
+#[test_only]
 public fun epoch_params_for_testing(): EpochParams {
     EpochParams {
         total_capacity_size: 1_000_000_000,

--- a/testnet-contracts/walrus/sources/system/events.move
+++ b/testnet-contracts/walrus/sources/system/events.move
@@ -18,6 +18,7 @@ public struct BlobRegistered has copy, drop {
     end_epoch: u32,
     deletable: bool,
     // The object id of the related `Blob` object
+    // Used for keeping track of deletable blobs on the storage nodes.
     object_id: ID,
 }
 
@@ -78,6 +79,47 @@ public struct ShardRecoveryStart has copy, drop {
     shards: vector<u16>,
 }
 
+/// Signals that the contract has been upgraded and migrated.
+public struct ContractUpgraded has copy, drop {
+    epoch: u32,
+    package_id: ID,
+    version: u64,
+}
+
+/// Signals that a Denylist update has started.
+public struct RegisterDenyListUpdate has copy, drop {
+    epoch: u32,
+    root: u256,
+    sequence_number: u64,
+    node_id: ID,
+}
+
+/// Signals that a Denylist update has been certified.
+public struct DenyListUpdate has copy, drop {
+    epoch: u32,
+    root: u256,
+    sequence_number: u64,
+    node_id: ID,
+}
+
+/// Signals that a blob was denylisted by f+1 nodes.
+public struct DenyListBlobDeleted has copy, drop {
+    epoch: u32,
+    blob_id: u256,
+}
+
+/// Signals that a new contract upgrade has been proposed.
+public struct ContractUpgradeProposed has copy, drop {
+    epoch: u32,
+    package_digest: vector<u8>,
+}
+
+/// Signals that a contract upgrade proposal has received a quorum of votes.
+public struct ContractUpgradeQuorumReached has copy, drop {
+    epoch: u32,
+    package_digest: vector<u8>,
+}
+
 // === Functions to emit the events from other modules ===
 
 public(package) fun emit_blob_registered(
@@ -120,7 +162,7 @@ public(package) fun emit_blob_deleted(
     blob_id: u256,
     end_epoch: u32,
     object_id: ID,
-    was_certified: bool
+    was_certified: bool,
 ) {
     event::emit(BlobDeleted { epoch, blob_id, end_epoch, object_id, was_certified });
 }
@@ -143,4 +185,38 @@ public(package) fun emit_epoch_parameters_selected(next_epoch: u32) {
 
 public(package) fun emit_shard_recovery_start(epoch: u32, shards: vector<u16>) {
     event::emit(ShardRecoveryStart { epoch, shards })
+}
+
+public(package) fun emit_contract_upgraded(epoch: u32, package_id: ID, version: u64) {
+    event::emit(ContractUpgraded { epoch, package_id, version })
+}
+
+public(package) fun emit_register_deny_list_update(
+    epoch: u32,
+    root: u256,
+    sequence_number: u64,
+    node_id: ID,
+) {
+    event::emit(RegisterDenyListUpdate { epoch, root, sequence_number, node_id })
+}
+
+public(package) fun emit_deny_list_update(
+    epoch: u32,
+    root: u256,
+    sequence_number: u64,
+    node_id: ID,
+) {
+    event::emit(DenyListUpdate { epoch, root, sequence_number, node_id })
+}
+
+public(package) fun emit_deny_listed_blob_deleted(epoch: u32, blob_id: u256) {
+    event::emit(DenyListBlobDeleted { epoch, blob_id })
+}
+
+public(package) fun emit_contract_upgrade_proposed(epoch: u32, package_digest: vector<u8>) {
+    event::emit(ContractUpgradeProposed { epoch, package_digest })
+}
+
+public(package) fun emit_contract_upgrade_quorum_reached(epoch: u32, package_digest: vector<u8>) {
+    event::emit(ContractUpgradeQuorumReached { epoch, package_digest })
 }

--- a/testnet-contracts/walrus/sources/system/messages.move
+++ b/testnet-contracts/walrus/sources/system/messages.move
@@ -3,7 +3,7 @@
 
 module walrus::messages;
 
-use sui::{bcs, bls12381::bls12381_min_pk_verify};
+use sui::{bcs::{Self, BCS}, bls12381::bls12381_min_pk_verify};
 
 const APP_ID: u8 = 3;
 const INTENT_VERSION: u8 = 0;
@@ -14,12 +14,17 @@ const BLS_KEY_LEN: u64 = 48;
 const PROOF_OF_POSSESSION_MSG_TYPE: u8 = 0;
 const BLOB_CERT_MSG_TYPE: u8 = 1;
 const INVALID_BLOB_ID_MSG_TYPE: u8 = 2;
+const DENY_LIST_UPDATE_MSG_TYPE: u8 = 3;
+const DENY_LIST_BLOB_DELETED_MSG_TYPE: u8 = 4;
 
-// Errors
+// Error codes
+// Error types in `walrus-sui/types/move_errors.rs` are auto-generated from the Move error codes.
 const EIncorrectAppId: u64 = 0;
 const EIncorrectEpoch: u64 = 1;
 const EInvalidMsgType: u64 = 2;
 const EIncorrectIntentVersion: u64 = 3;
+const EInvalidBlobPersistenceType: u64 = 4;
+const ENotDeletable: u64 = 5;
 
 #[error]
 const EInvalidKeyLength: vector<u8> = b"The length of the provided bls key is incorrect.";
@@ -83,8 +88,14 @@ public struct CertifiedMessage has drop {
     intent_type: u8,
     intent_version: u8,
     cert_epoch: u32,
-    stake_support: u16,
     message: vector<u8>,
+    stake_support: u16, // Metadata, not part of the actual certified message.
+}
+
+/// The persistence type of a blob. Used for storage confirmation.
+public enum BlobPersistenceType has copy, drop {
+    Permanent,
+    Deletable { object_id: ID },
 }
 
 /// Message type for certifying a blob.
@@ -92,8 +103,8 @@ public struct CertifiedMessage has drop {
 /// Constructed from a `CertifiedMessage`, states that `blob_id` has been certified in `epoch`
 /// by a quorum.
 public struct CertifiedBlobMessage has drop {
-    epoch: u32,
     blob_id: u256,
+    blob_persistence_type: BlobPersistenceType,
 }
 
 /// Message type for Invalid Blob Certificates.
@@ -101,7 +112,25 @@ public struct CertifiedBlobMessage has drop {
 /// Constructed from a `CertifiedMessage`, states that `blob_id` has been marked as invalid
 /// in `epoch` by a quorum.
 public struct CertifiedInvalidBlobId has drop {
-    epoch: u32,
+    blob_id: u256,
+}
+
+/// Message type for DenyList updates.
+///
+/// Constructed from a `CertifiedMessage`, states that the deny list has been updated in `epoch` for
+/// a given node.
+public struct DenyListUpdateMessage has drop {
+    storage_node_id: ID,
+    deny_list_sequence_number: u64,
+    deny_list_size: u64,
+    deny_list_root: u256,
+}
+
+/// Message type for deleting a blob that has been denylisted.
+///
+/// Constructed from a `CertifiedMessage`, states that `blob_id` has been deleted in `epoch` by an
+/// f+1 quorum.
+public struct DenyListBlobDeleted has drop {
     blob_id: u256,
 }
 
@@ -127,43 +156,41 @@ public(package) fun new_certified_message(
 
     let message = bcs_message.into_remainder_bytes();
 
-    CertifiedMessage { intent_type, intent_version, cert_epoch, stake_support, message }
+    CertifiedMessage { intent_type, intent_version, cert_epoch, message, stake_support }
 }
 
 /// Constructs the certified blob message, note that constructing
 /// implies a certified message, that is already checked.
 public(package) fun certify_blob_message(message: CertifiedMessage): CertifiedBlobMessage {
-    // Assert type is correct
     assert!(message.intent_type() == BLOB_CERT_MSG_TYPE, EInvalidMsgType);
 
     // The certified blob message contain a blob_id : u256
-    let epoch = message.cert_epoch();
     let message_body = message.into_message();
 
     let mut bcs_body = bcs::new(message_body);
     let blob_id = bcs_body.peel_u256();
 
+    let blob_persistence_type = peel_blob_persistence_type(&mut bcs_body);
+
     // On purpose we do not check that nothing is left in the message
     // to allow in the future for extensibility.
 
-    CertifiedBlobMessage { epoch, blob_id }
+    CertifiedBlobMessage { blob_id, blob_persistence_type }
 }
 
 /// Constructs the certified blob message, note this is only
 /// used for event blobs
-public(package) fun certified_event_blob_message(epoch: u32, blob_id: u256): CertifiedBlobMessage {
-    CertifiedBlobMessage { epoch, blob_id }
+public(package) fun certified_event_blob_message(blob_id: u256): CertifiedBlobMessage {
+    CertifiedBlobMessage { blob_id, blob_persistence_type: BlobPersistenceType::Permanent }
 }
 
 /// Construct the certified invalid Blob ID message, note that constructing
 /// implies a certified message, that is already checked.
 public(package) fun invalid_blob_id_message(message: CertifiedMessage): CertifiedInvalidBlobId {
-    // Assert type is correct
     assert!(message.intent_type() == INVALID_BLOB_ID_MSG_TYPE, EInvalidMsgType);
 
     // The InvalidBlobID message has no payload besides the blob_id.
     // The certified blob message contain a blob_id : u256
-    let epoch = message.cert_epoch();
     let message_body = message.into_message();
 
     let mut bcs_body = bcs::new(message_body);
@@ -172,7 +199,44 @@ public(package) fun invalid_blob_id_message(message: CertifiedMessage): Certifie
     // This output is provided as a service in case anything else needs to rely on
     // certified invalid blob ID information in the future. But out base design only
     // uses the event emitted here.
-    CertifiedInvalidBlobId { epoch, blob_id }
+    CertifiedInvalidBlobId { blob_id }
+}
+
+/// Construct the certified deny list update message, note that constructing
+/// implies a certified message, that is already checked.
+public(package) fun deny_list_update_message(message: CertifiedMessage): DenyListUpdateMessage {
+    assert!(message.intent_type() == DENY_LIST_UPDATE_MSG_TYPE, EInvalidMsgType);
+
+    // The DenyListUpdateMessage contains the storage_node_id, deny_list_sequence_number,
+    // deny_list_size, and deny_list_root.
+    let message_body = message.into_message();
+
+    let mut bcs_body = bcs::new(message_body);
+    let storage_node_id = bcs_body.peel_address().to_id();
+    let deny_list_sequence_number = bcs_body.peel_u64();
+    let deny_list_size = bcs_body.peel_u64();
+    let deny_list_root = bcs_body.peel_u256();
+
+    DenyListUpdateMessage {
+        storage_node_id,
+        deny_list_sequence_number,
+        deny_list_size,
+        deny_list_root,
+    }
+}
+
+/// Construct the deny list blob deleted message, note that constructing
+/// implies a certified message, that is already checked.
+public(package) fun deny_list_blob_deleted_message(message: CertifiedMessage): DenyListBlobDeleted {
+    assert!(message.intent_type() == DENY_LIST_BLOB_DELETED_MSG_TYPE, EInvalidMsgType);
+
+    // The DenyListBlobDeleted message contains the blob_id.
+    let message_body = message.into_message();
+
+    let mut bcs_body = bcs::new(message_body);
+    let blob_id = bcs_body.peel_u256();
+
+    DenyListBlobDeleted { blob_id }
 }
 
 // === Accessors for CertifiedMessage ===
@@ -204,22 +268,72 @@ public(package) fun into_message(self: CertifiedMessage): vector<u8> {
 
 // === Accessors for CertifiedBlobMessage ===
 
-public(package) fun certified_epoch(self: &CertifiedBlobMessage): u32 {
-    self.epoch
-}
-
 public(package) fun certified_blob_id(self: &CertifiedBlobMessage): u256 {
     self.blob_id
 }
 
-// === Accessors for CertifiedInvalidBlobId ===
-
-public(package) fun certified_invalid_epoch(self: &CertifiedInvalidBlobId): u32 {
-    self.epoch
+public(package) fun blob_persistence_type(self: &CertifiedBlobMessage): BlobPersistenceType {
+    self.blob_persistence_type
 }
+
+// === Accessors for CertifiedInvalidBlobId ===
 
 public(package) fun invalid_blob_id(self: &CertifiedInvalidBlobId): u256 {
     self.blob_id
+}
+
+// === Accessors for DenyListUpdateMessage ===
+
+public(package) fun storage_node_id(self: &DenyListUpdateMessage): ID {
+    self.storage_node_id
+}
+
+public(package) fun sequence_number(self: &DenyListUpdateMessage): u64 {
+    self.deny_list_sequence_number
+}
+
+public(package) fun size(self: &DenyListUpdateMessage): u64 {
+    self.deny_list_size
+}
+
+public(package) fun root(self: &DenyListUpdateMessage): u256 {
+    self.deny_list_root
+}
+
+// === Accessors for DenyListBlobDeleted ===
+
+public(package) fun blob_id(self: &DenyListBlobDeleted): u256 {
+    self.blob_id
+}
+
+// === Accessors for BlobPersistenceType ===
+
+public(package) fun is_deletable(self: &BlobPersistenceType): bool {
+    match (self) {
+        BlobPersistenceType::Deletable { .. } => true,
+        BlobPersistenceType::Permanent => false,
+    }
+}
+
+public(package) fun object_id(self: &BlobPersistenceType): ID {
+    match (self) {
+        BlobPersistenceType::Deletable { object_id } => *object_id,
+        BlobPersistenceType::Permanent => abort ENotDeletable,
+    }
+}
+
+// === BCS deserialization ===
+
+public(package) fun peel_blob_persistence_type(bcs: &mut BCS): BlobPersistenceType {
+    let type_id = bcs.peel_u8();
+    if (type_id == 0) {
+        return BlobPersistenceType::Permanent
+    };
+    if (type_id == 1) {
+        let object_id = bcs.peel_address().to_id();
+        return BlobPersistenceType::Deletable { object_id }
+    };
+    abort EInvalidBlobPersistenceType
 }
 
 // === Test only functions ===
@@ -232,23 +346,49 @@ public fun certified_message_for_testing(
     stake_support: u16,
     message: vector<u8>,
 ): CertifiedMessage {
-    CertifiedMessage { intent_type, intent_version, cert_epoch, stake_support, message }
+    CertifiedMessage { intent_type, intent_version, cert_epoch, message, stake_support }
 }
 
 #[test_only]
-public fun certified_blob_message_for_testing(epoch: u32, blob_id: u256): CertifiedBlobMessage {
-    CertifiedBlobMessage { epoch, blob_id }
+public fun certified_permanent_blob_message_for_testing(blob_id: u256): CertifiedBlobMessage {
+    CertifiedBlobMessage { blob_id, blob_persistence_type: BlobPersistenceType::Permanent }
 }
 
 #[test_only]
-public fun certified_message_bytes(epoch: u32, blob_id: u256): vector<u8> {
+public fun certified_deletable_blob_message_for_testing(
+    blob_id: u256,
+    object_id: ID,
+): CertifiedBlobMessage {
+    CertifiedBlobMessage {
+        blob_id,
+        blob_persistence_type: BlobPersistenceType::Deletable { object_id },
+    }
+}
+
+#[test_only]
+fun certified_message_bytes(
+    epoch: u32,
+    blob_id: u256,
+    blob_persistence_type: BlobPersistenceType,
+): vector<u8> {
     let mut message = vector<u8>[];
     message.push_back(BLOB_CERT_MSG_TYPE);
     message.push_back(INTENT_VERSION);
     message.push_back(APP_ID);
     message.append(bcs::to_bytes(&epoch));
     message.append(bcs::to_bytes(&blob_id));
+    message.append(bcs::to_bytes(&blob_persistence_type));
     message
+}
+
+#[test_only]
+public fun certified_permanent_message_bytes(epoch: u32, blob_id: u256): vector<u8> {
+    certified_message_bytes(epoch, blob_id, BlobPersistenceType::Permanent)
+}
+
+#[test_only]
+public fun certified_deletable_message_bytes(epoch: u32, blob_id: u256, object_id: ID): vector<u8> {
+    certified_message_bytes(epoch, blob_id, BlobPersistenceType::Deletable { object_id })
 }
 
 #[test_only]
@@ -266,8 +406,19 @@ public fun invalid_message_bytes(epoch: u32, blob_id: u256): vector<u8> {
 fun test_message_creation() {
     let epoch = 42;
     let blob_id = 0xdeadbeefdeadbeefdeadbeefdeadbeef;
-    let msg = certified_message_bytes(epoch, blob_id);
+    let msg = certified_permanent_message_bytes(epoch, blob_id);
     let cert_msg = new_certified_message(msg, epoch, 1).certify_blob_message();
     assert!(cert_msg.blob_id == blob_id);
-    assert!(cert_msg.epoch == epoch);
+}
+
+#[test]
+fun test_certified_deletable_blob_message() {
+    let epoch = 42;
+    let blob_id = 0xdeadbeefdeadbeefdeadbeefdeadbeef;
+    let object_id = object::id_from_address(@42);
+    let msg = certified_deletable_message_bytes(epoch, blob_id, object_id);
+    let cert_msg = new_certified_message(msg, epoch, 1).certify_blob_message();
+    assert!(cert_msg.blob_id == blob_id);
+    assert!(cert_msg.blob_persistence_type().is_deletable());
+    assert!(cert_msg.blob_persistence_type().object_id() == object_id);
 }

--- a/testnet-contracts/walrus/sources/system/metadata.move
+++ b/testnet-contracts/walrus/sources/system/metadata.move
@@ -4,19 +4,18 @@
 /// Contains the metadata for Blobs on Walrus.
 module walrus::metadata;
 
-use sui::vec_map::{Self, VecMap};
 use std::string::String;
-
+use sui::vec_map::{Self, VecMap};
 
 /// The metadata struct for Blob objects.
-public struct Metadata has store, drop {
-    metadata: VecMap<String, String>
+public struct Metadata has drop, store {
+    metadata: VecMap<String, String>,
 }
 
 /// Creates a new instance of Metadata.
 public fun new(): Metadata {
     Metadata {
-        metadata: vec_map::empty()
+        metadata: vec_map::empty(),
     }
 }
 
@@ -29,7 +28,6 @@ public fun insert_or_update(self: &mut Metadata, key: String, value: String) {
     };
     self.metadata.insert(key, value);
 }
-
 
 /// Removes the metadata associated with the given key.
 public fun remove(self: &mut Metadata, key: &String): (String, String) {

--- a/testnet-contracts/walrus/sources/system/redstuff.move
+++ b/testnet-contracts/walrus/sources/system/redstuff.move
@@ -25,12 +25,12 @@ public(package) fun encoded_blob_length(unencoded_length: u64, n_shards: u16): u
 
 /// The number of primary source symbols per sliver given `n_shards`.
 fun source_symbols_primary(n_shards: u16): u16 {
-    n_shards - max_byzantine(n_shards) - decoding_safety_limit(n_shards)
+    n_shards - 2 * max_byzantine(n_shards) - decoding_safety_limit(n_shards)
 }
 
 /// The number of secondary source symbols per sliver given `n_shards`.
 fun source_symbols_secondary(n_shards: u16): u16 {
-    n_shards - 2 * max_byzantine(n_shards) - decoding_safety_limit(n_shards)
+    n_shards - max_byzantine(n_shards) - decoding_safety_limit(n_shards)
 }
 
 /// The total number of source symbols given `n_shards`.
@@ -101,4 +101,21 @@ fun test_symbol_too_large() {
     let unencoded_length = (0xffff + 1) * n_source_symbols(n_shards);
     // Test should fail here
     let _ = symbol_size(unencoded_length, n_shards);
+}
+
+#[test_only]
+fun assert_primary_secondary_source_symbols(n_shards: u16, primary: u16, secondary: u16) {
+    assert!(source_symbols_primary(n_shards) == primary, 0);
+    assert!(source_symbols_secondary(n_shards) == secondary, 0);
+}
+
+#[test]
+fun test_source_symbols_number() {
+    // These values are taken from the RedStuff docs.
+    assert_primary_secondary_source_symbols(7, 3, 5);
+    assert_primary_secondary_source_symbols(10, 4, 7);
+    assert_primary_secondary_source_symbols(31, 9, 19);
+    assert_primary_secondary_source_symbols(100, 29, 62);
+    assert_primary_secondary_source_symbols(300, 97, 196);
+    assert_primary_secondary_source_symbols(1000, 329, 662);
 }

--- a/testnet-contracts/walrus/sources/system/shared_blob.move
+++ b/testnet-contracts/walrus/sources/system/shared_blob.move
@@ -24,6 +24,15 @@ public fun new(blob: Blob, ctx: &mut TxContext) {
     })
 }
 
+/// Shares the provided `blob` as a `SharedBlob` with funds.
+public fun new_funded(blob: Blob, funds: Coin<WAL>, ctx: &mut TxContext) {
+    transfer::share_object(SharedBlob {
+        id: object::new(ctx),
+        blob,
+        funds: funds.into_balance(),
+    })
+}
+
 /// Adds the provided `Coin` to the stored funds.
 public fun fund(self: &mut SharedBlob, added_funds: Coin<WAL>) {
     self.funds.join(added_funds.into_balance());

--- a/testnet-contracts/walrus/sources/system/storage_accounting.move
+++ b/testnet-contracts/walrus/sources/system/storage_accounting.move
@@ -6,8 +6,8 @@ module walrus::storage_accounting;
 use sui::balance::{Self, Balance};
 use wal::wal::WAL;
 
-// Errors
-// Keep errors in `walrus-sui/types/move_errors.rs` up to date with changes here.
+// Error codes
+// Error types in `walrus-sui/types/move_errors.rs` are auto-generated from the Move error codes.
 const ETooFarInFuture: u64 = 0;
 
 /// Holds information about a future epoch, namely how much
@@ -58,21 +58,13 @@ public(package) fun delete_empty_future_accounting(self: FutureAccounting) {
 }
 
 public(package) fun unwrap_balance(self: FutureAccounting): Balance<WAL> {
-    let FutureAccounting {
-        rewards_to_distribute,
-        ..,
-    } = self;
+    let FutureAccounting { rewards_to_distribute, .. } = self;
     rewards_to_distribute
 }
 
 #[test_only]
 public(package) fun burn_for_testing(self: FutureAccounting) {
-    let FutureAccounting {
-        rewards_to_distribute,
-        ..,
-    } = self;
-
-    rewards_to_distribute.destroy_for_testing();
+    self.unwrap_balance().destroy_for_testing();
 }
 
 /// A ring buffer holding future accounts for a continuous range of epochs.
@@ -93,7 +85,7 @@ public(package) fun ring_new(length: u32): FutureAccountingRingBuffer {
         },
     );
 
-    FutureAccountingRingBuffer { current_index: 0, length: length, ring_buffer: ring_buffer }
+    FutureAccountingRingBuffer { current_index: 0, length, ring_buffer }
 }
 
 /// Lookup an entry a number of epochs in the future.

--- a/testnet-contracts/walrus/sources/system/system_state_inner.move
+++ b/testnet-contracts/walrus/sources/system/system_state_inner.move
@@ -4,7 +4,7 @@
 #[allow(unused_variable, unused_mut_parameter, unused_field)]
 module walrus::system_state_inner;
 
-use sui::{balance::Balance, coin::Coin};
+use sui::{balance::Balance, coin::Coin, vec_map::{Self, VecMap}};
 use wal::wal::WAL;
 use walrus::{
     blob::{Self, Blob},
@@ -12,7 +12,8 @@ use walrus::{
     encoding::encoded_blob_length,
     epoch_parameters::EpochParams,
     event_blob::{Self, EventBlobCertificationState, new_attestation},
-    events::emit_invalid_blob_id,
+    events,
+    extended_field::{Self, ExtendedField},
     messages,
     storage_accounting::{Self, FutureAccountingRingBuffer},
     storage_node::StorageNodeCap,
@@ -26,8 +27,8 @@ const MAX_MAX_EPOCHS_AHEAD: u32 = 1000;
 // Keep in sync with the same constant in `crates/walrus-sui/utils.rs`.
 const BYTES_PER_UNIT_SIZE: u64 = 1_024 * 1_024; // 1 MiB
 
-// Errors
-// Keep errors in `walrus-sui/types/move_errors.rs` up to date with changes here.
+// Error codes
+// Error types in `walrus-sui/types/move_errors.rs` are auto-generated from the Move error codes.
 const EInvalidMaxEpochsAhead: u64 = 0;
 const EStorageExceeded: u64 = 1;
 const EInvalidEpochsAhead: u64 = 2;
@@ -37,11 +38,12 @@ const EInvalidAccountingEpoch: u64 = 5;
 const EIncorrectAttestation: u64 = 6;
 const ERepeatedAttestation: u64 = 7;
 const ENotCommitteeMember: u64 = 8;
+const EIncorrectDenyListSequence: u64 = 9;
+const EIncorrectDenyListNode: u64 = 10;
 
 /// The inner object that is not present in signatures and can be versioned.
 #[allow(unused_field)]
-public struct SystemStateInnerV1 has key, store {
-    id: UID,
+public struct SystemStateInnerV1 has store {
     /// The current committee, with the current epoch.
     committee: BlsCommittee,
     // Some accounting
@@ -55,6 +57,13 @@ public struct SystemStateInnerV1 has key, store {
     future_accounting: FutureAccountingRingBuffer,
     /// Event blob certification state
     event_blob_certification_state: EventBlobCertificationState,
+    /// Sizes of deny lists for storage nodes. Only current committee members
+    /// can register their updates in this map. Hence, we don't expect it to bloat.
+    ///
+    /// Max number of stored entries is ~6500. If there's any concern about the
+    /// performance of the map, it can be cleaned up as a side effect of the
+    /// updates / registrations.
+    deny_list_sizes: ExtendedField<VecMap<ID, u64>>,
 }
 
 /// Creates an empty system state with a capacity of zero and an empty
@@ -63,12 +72,8 @@ public(package) fun create_empty(max_epochs_ahead: u32, ctx: &mut TxContext): Sy
     let committee = bls_aggregate::new_bls_committee(0, vector[]);
     assert!(max_epochs_ahead <= MAX_MAX_EPOCHS_AHEAD, EInvalidMaxEpochsAhead);
     let future_accounting = storage_accounting::ring_new(max_epochs_ahead);
-    let event_blob_certification_state = event_blob::create_with_empty_state(
-        ctx,
-    );
-    let id = object::new(ctx);
+    let event_blob_certification_state = event_blob::create_with_empty_state();
     SystemStateInnerV1 {
-        id,
         committee,
         total_capacity_size: 0,
         used_capacity_size: 0,
@@ -76,24 +81,28 @@ public(package) fun create_empty(max_epochs_ahead: u32, ctx: &mut TxContext): Sy
         write_price_per_unit_size: 0,
         future_accounting,
         event_blob_certification_state,
+        deny_list_sizes: extended_field::new(vec_map::empty(), ctx),
     }
 }
 
 /// Update epoch to next epoch, and update the committee, price and capacity.
 ///
 /// Called by the epoch change function that connects `Staking` and `System`.
-/// Returns
-/// the balance of the rewards from the previous epoch.
+/// Returns the mapping of node IDs from the old committee to the rewards they
+/// received in the epoch.
+///
+/// Note: VecMap must contain values only for the nodes from the previous
+/// committee, the `staking` part of the system relies on this assumption.
 public(package) fun advance_epoch(
     self: &mut SystemStateInnerV1,
     new_committee: BlsCommittee,
-    new_epoch_params: EpochParams,
-): Balance<WAL> {
+    new_epoch_params: &EpochParams,
+): VecMap<ID, Balance<WAL>> {
     // Check new committee is valid, the existence of a committee for the next
-    // epoch
-    // is proof that the time has come to move epochs.
+    // epoch is proof that the time has come to move epochs.
     let old_epoch = self.epoch();
     let new_epoch = old_epoch + 1;
+    let old_committee = self.committee;
 
     assert!(new_committee.epoch() == new_epoch, EIncorrectCommittee);
     self.committee = new_committee;
@@ -113,7 +122,43 @@ public(package) fun advance_epoch(
 
     // Update storage based on the accounts data.
     self.used_capacity_size = self.used_capacity_size - accounts_old_epoch.storage_to_reclaim();
-    accounts_old_epoch.unwrap_balance()
+
+    // === Rewards distribution ===
+
+    let mut total_rewards = accounts_old_epoch.unwrap_balance();
+
+    // to perform the calculation of rewards, we account for the deny list sizes
+    // in comparison to the used capacity size, and the weights of the nodes in
+    // the committee.
+    //
+    // specific reward for a node is calculated as:
+    // reward = (weight * (used_capacity_size - deny_list_size)) / total_stored * total_rewards
+    // where `total_stored` is the sum of all nodes' values.
+    //
+    // leftover rewards are added to the next epoch's accounting to avoid rounding errors.
+
+    let deny_list_sizes = self.deny_list_sizes.borrow();
+    let (node_ids, weights) = old_committee.to_vec_map().into_keys_values();
+    let mut stored_vec = vector[];
+    let mut total_stored = 0;
+
+    node_ids.zip_do!(weights, |node_id, weight| {
+        let deny_list_size = deny_list_sizes.try_get(&node_id).destroy_or!(0);
+        let stored = (weight as u128) * ((self.used_capacity_size - deny_list_size) as u128);
+
+        total_stored = total_stored + stored;
+        stored_vec.push_back(stored);
+    });
+
+    let total_stored = total_stored.max(1); // avoid division by zero
+    let total_rewards_value = total_rewards.value() as u128;
+    let reward_values = stored_vec.map!(|stored| {
+        total_rewards.split((stored * total_rewards_value / total_stored) as u64)
+    });
+
+    // add the leftover rewards to the next epoch
+    self.future_accounting.ring_lookup_mut(0).rewards_balance().join(total_rewards);
+    vec_map::from_keys_values(node_ids, reward_values)
 }
 
 /// Allow buying a storage reservation for a given period of epochs.
@@ -154,10 +199,12 @@ fun reserve_space_without_payment(
     self.used_capacity_size = self.used_capacity_size + storage_amount;
 
     // Account the space to reclaim in the future.
-    let final_account = self.future_accounting.ring_lookup_mut(epochs_ahead - 1);
-    final_account.increase_storage_to_reclaim(storage_amount);
+    self
+        .future_accounting
+        .ring_lookup_mut(epochs_ahead - 1)
+        .increase_storage_to_reclaim(storage_amount);
 
-    let self_epoch = epoch(self);
+    let self_epoch = self.epoch();
 
     storage_resource::create_storage(
         self_epoch,
@@ -173,28 +220,25 @@ fun reserve_space_without_payment(
 public(package) fun invalidate_blob_id(
     self: &SystemStateInnerV1,
     signature: vector<u8>,
-    members: vector<u16>,
+    members_bitmap: vector<u8>,
     message: vector<u8>,
 ): u256 {
     let certified_message = self
         .committee
-        .verify_quorum_in_epoch(
+        .verify_one_correct_node_in_epoch(
             signature,
-            members,
+            members_bitmap,
             message,
         );
 
+    let epoch = certified_message.cert_epoch();
     let invalid_blob_message = certified_message.invalid_blob_id_message();
     let blob_id = invalid_blob_message.invalid_blob_id();
     // Assert the epoch is correct.
-    let epoch = invalid_blob_message.certified_invalid_epoch();
     assert!(epoch == self.epoch(), EInvalidIdEpoch);
 
     // Emit the event about a blob id being invalid here.
-    emit_invalid_blob_id(
-        epoch,
-        blob_id,
-    );
+    events::emit_invalid_blob_id(epoch, blob_id);
     blob_id
 }
 
@@ -225,7 +269,7 @@ public(package) fun register_blob(
         ctx,
     );
     let write_price = self.write_price(blob.encoded_size(self.n_shards()));
-    let payment = write_payment_coin.split(write_price, ctx).into_balance();
+    let payment = write_payment_coin.balance_mut().split(write_price);
     let accounts = self.future_accounting.ring_lookup_mut(0).rewards_balance().join(payment);
     blob
 }
@@ -237,16 +281,18 @@ public(package) fun certify_blob(
     self: &SystemStateInnerV1,
     blob: &mut Blob,
     signature: vector<u8>,
-    signers: vector<u16>,
+    signers_bitmap: vector<u8>,
     message: vector<u8>,
 ) {
     let certified_msg = self
         .committee()
         .verify_quorum_in_epoch(
             signature,
-            signers,
+            signers_bitmap,
             message,
         );
+    assert!(certified_msg.cert_epoch() == self.epoch(), EInvalidIdEpoch);
+
     let certified_blob_msg = certified_msg.certify_blob_message();
     blob.certify_with_certified_msg(self.epoch(), certified_blob_msg);
 }
@@ -320,18 +366,15 @@ fun process_storage_payments(
     end_offset: u32,
     payment: &mut Coin<WAL>,
 ) {
-    let storage_units = storage_units_from_size(storage_size);
+    let storage_units = storage_units_from_size!(storage_size);
     let period_payment_due = self.storage_price_per_unit_size * storage_units;
     let coin_balance = payment.balance_mut();
 
     start_offset.range_do!(end_offset, |i| {
-        let accounts = self.future_accounting.ring_lookup_mut(i);
-
         // Distribute rewards
-        let rewards_balance = accounts.rewards_balance();
         // Note this will abort if the balance is not enough.
         let epoch_payment = coin_balance.split(period_payment_due);
-        rewards_balance.join(epoch_payment);
+        self.future_accounting.ring_lookup_mut(i).rewards_balance().join(epoch_payment);
     });
 }
 
@@ -349,9 +392,7 @@ public(package) fun certify_event_blob(
     assert!(self.committee().contains(&cap.node_id()), ENotCommitteeMember);
     assert!(epoch == self.epoch(), EInvalidIdEpoch);
 
-    let cap_attestion = cap.last_event_blob_attestation();
-    if (cap_attestion.is_some()) {
-        let attestation = cap_attestion.destroy_some();
+    cap.last_event_blob_attestation().do!(|attestation| {
         assert!(
             attestation.last_attested_event_blob_epoch() < self.epoch() ||
                 ending_checkpoint_sequence_num >
@@ -361,12 +402,13 @@ public(package) fun certify_event_blob(
         let latest_certified_checkpoint_seq_num = self
             .event_blob_certification_state
             .get_latest_certified_checkpoint_sequence_number();
+
         if (latest_certified_checkpoint_seq_num.is_some()) {
-            let certified_checkpoint_seq_num = latest_certified_checkpoint_seq_num.destroy_some();
+            let latest_certified_cp_seq_num = latest_certified_checkpoint_seq_num.destroy_some();
             assert!(
                 attestation.last_attested_event_blob_epoch() < self.epoch() ||
                     attestation.last_attested_event_blob_checkpoint_seq_num()
-                        <= certified_checkpoint_seq_num,
+                        <= latest_certified_cp_seq_num,
                 EIncorrectAttestation,
             );
         } else {
@@ -375,16 +417,15 @@ public(package) fun certify_event_blob(
                 EIncorrectAttestation,
             );
         }
-    };
+    });
 
     let attestation = new_attestation(ending_checkpoint_sequence_num, epoch);
     cap.set_last_event_blob_attestation(attestation);
 
     let blob_certified = self
         .event_blob_certification_state
-        .is_blob_already_certified(
-            ending_checkpoint_sequence_num,
-        );
+        .is_blob_already_certified(ending_checkpoint_sequence_num);
+
     if (blob_certified) {
         return
     };
@@ -392,7 +433,7 @@ public(package) fun certify_event_blob(
     self.event_blob_certification_state.start_tracking_blob(blob_id);
     let weight = self.committee().get_member_weight(&cap.node_id());
     let agg_weight = self.event_blob_certification_state.update_aggregate_weight(blob_id, weight);
-    let certified = self.committee().verify_quorum(agg_weight);
+    let certified = self.committee().is_quorum(agg_weight);
     if (!certified) {
         return
     };
@@ -400,11 +441,7 @@ public(package) fun certify_event_blob(
     let num_shards = self.n_shards();
     let epochs_ahead = self.future_accounting.max_epochs_ahead();
     let storage = self.reserve_space_without_payment(
-        encoded_blob_length(
-            size,
-            encoding_type,
-            num_shards,
-        ),
+        encoded_blob_length(size, encoding_type, num_shards),
         epochs_ahead,
         ctx,
     );
@@ -419,10 +456,7 @@ public(package) fun certify_event_blob(
         self.n_shards(),
         ctx,
     );
-    let certified_blob_msg = messages::certified_event_blob_message(
-        self.epoch(),
-        blob_id,
-    );
+    let certified_blob_msg = messages::certified_event_blob_message(blob_id);
     blob.certify_with_certified_msg(self.epoch(), certified_blob_msg);
     self
         .event_blob_certification_state
@@ -430,8 +464,49 @@ public(package) fun certify_event_blob(
             ending_checkpoint_sequence_num,
             blob_id,
         );
-    self.event_blob_certification_state.stop_tracking_blob(blob_id);
+    // Stop tracking all event blobs
+    // It is safe to reset the event blob certification state here for several reasons:
+    // This reset happens after a blob has been certified, so all previous attestations
+    // are no longer relevant because:
+    //  a. Each node is allowed one outstanding attestation
+    //  b. Majority of the nodes attested to the same blob ID at checkpoint X (which got certified)
+    //  c. For previous certified blob (before checkpoint X) at checkpoint X' where X' < X:
+    //     - Any attestations to blobs at checkpoint Y where X' < Y < X are invalid and can be
+    //       ignored
+    //  d. For next certified blob (after checkpoint X) at checkpoint X'':
+    //     - Attestations at checkpoint Z (Z > X) where Z == X'' are impossible because every event
+    //       blob requires a pointer to previous certified blob, and we just certified blob at
+    //       checkpoint X
+    self.event_blob_certification_state.reset();
     blob.burn();
+}
+
+/// Adds rewards to the system for the specified number of epochs ahead.
+/// The rewards are split equally across the future accounting ring buffer up to the
+/// specified epoch.
+public(package) fun add_subsidy(
+    self: &mut SystemStateInnerV1,
+    subsidy: Coin<WAL>,
+    epochs_ahead: u32,
+) {
+    // Check the period is within the allowed range.
+    assert!(epochs_ahead > 0, EInvalidEpochsAhead);
+    assert!(epochs_ahead <= self.future_accounting.max_epochs_ahead(), EInvalidEpochsAhead);
+
+    let mut subsidy_balance = subsidy.into_balance();
+    let reward_per_epoch = subsidy_balance.value() / (epochs_ahead as u64);
+    let leftover_rewards = subsidy_balance.value() % (epochs_ahead as u64);
+
+    epochs_ahead.do!(|i| {
+        self
+            .future_accounting
+            .ring_lookup_mut(i)
+            .rewards_balance()
+            .join(subsidy_balance.split(reward_per_epoch));
+    });
+
+    // Add leftover rewards to the first epoch's accounting.
+    self.future_accounting.ring_lookup_mut(0).rewards_balance().join(subsidy_balance);
 }
 
 // === Accessors ===
@@ -466,63 +541,157 @@ public(package) fun n_shards(self: &SystemStateInnerV1): u16 {
 }
 
 public(package) fun write_price(self: &SystemStateInnerV1, write_size: u64): u64 {
-    let storage_units = storage_units_from_size(write_size);
+    let storage_units = storage_units_from_size!(write_size);
     self.write_price_per_unit_size * storage_units
 }
 
-fun storage_units_from_size(size: u64): u64 {
-    (size + BYTES_PER_UNIT_SIZE - 1) / BYTES_PER_UNIT_SIZE
+#[test_only]
+public(package) fun deny_list_sizes(self: &SystemStateInnerV1): &VecMap<ID, u64> {
+    self.deny_list_sizes.borrow()
+}
+
+#[test_only]
+public(package) fun deny_list_sizes_mut(self: &mut SystemStateInnerV1): &mut VecMap<ID, u64> {
+    self.deny_list_sizes.borrow_mut()
+}
+
+macro fun storage_units_from_size($size: u64): u64 {
+    let size = $size;
+    size.divide_and_round_up(BYTES_PER_UNIT_SIZE)
+}
+
+// === DenyList ===
+
+/// Announce a deny list update for a storage node.
+public(package) fun register_deny_list_update(
+    self: &SystemStateInnerV1,
+    cap: &StorageNodeCap,
+    deny_list_root: u256,
+    deny_list_sequence: u64,
+) {
+    assert!(self.committee().contains(&cap.node_id()), ENotCommitteeMember);
+    assert!(deny_list_sequence > cap.deny_list_sequence(), EIncorrectDenyListSequence);
+
+    events::emit_register_deny_list_update(
+        self.epoch(),
+        deny_list_root,
+        deny_list_sequence,
+        cap.node_id(),
+    );
+}
+
+/// Perform the update of the deny list; register updated root and sequence in
+/// the `StorageNodeCap`.
+public(package) fun update_deny_list(
+    self: &mut SystemStateInnerV1,
+    cap: &mut StorageNodeCap,
+    signature: vector<u8>,
+    members_bitmap: vector<u8>,
+    message: vector<u8>,
+) {
+    assert!(self.committee().contains(&cap.node_id()), ENotCommitteeMember);
+
+    let certified_message = self
+        .committee
+        .verify_quorum_in_epoch(signature, members_bitmap, message);
+
+    let epoch = certified_message.cert_epoch();
+    let message = certified_message.deny_list_update_message();
+    let node_id = message.storage_node_id();
+    let size = message.size();
+
+    assert!(epoch == self.epoch(), EInvalidIdEpoch);
+    assert!(node_id == cap.node_id(), EIncorrectDenyListNode);
+    assert!(cap.deny_list_sequence() < message.sequence_number(), EIncorrectDenyListSequence);
+
+    let deny_list_root = message.root();
+    let sequence_number = message.sequence_number();
+
+    // update deny_list properties in the cap
+    cap.set_deny_list_properties(deny_list_root, sequence_number, size);
+
+    // then register the update in the system storage
+    let sizes = self.deny_list_sizes.borrow_mut();
+    if (sizes.contains(&node_id)) {
+        *&mut sizes[&node_id] = message.size();
+    } else {
+        sizes.insert(node_id, message.size());
+    };
+
+    events::emit_deny_list_update(
+        self.epoch(),
+        deny_list_root,
+        sequence_number,
+        cap.node_id(),
+    );
+}
+
+/// Certify that a blob is on the deny list for at least one honest node. Emit
+/// an event to mark it for deletion.
+public(package) fun delete_deny_listed_blob(
+    self: &SystemStateInnerV1,
+    signature: vector<u8>,
+    members_bitmap: vector<u8>,
+    message: vector<u8>,
+) {
+    let certified_message = self
+        .committee
+        .verify_one_correct_node_in_epoch(signature, members_bitmap, message);
+
+    let epoch = certified_message.cert_epoch();
+    let message = certified_message.deny_list_blob_deleted_message();
+
+    assert!(epoch == self.epoch(), EInvalidIdEpoch);
+
+    events::emit_deny_listed_blob_deleted(epoch, message.blob_id());
 }
 
 // === Testing ===
 
 #[test_only]
-use walrus::{test_utils};
+use walrus::test_utils;
 
 #[test_only]
 public(package) fun new_for_testing(): SystemStateInnerV1 {
     let committee = test_utils::new_bls_committee_for_testing(0);
     let ctx = &mut tx_context::dummy();
-    let id = object::new(ctx);
     SystemStateInnerV1 {
-        id,
         committee,
         total_capacity_size: 1_000_000_000,
         used_capacity_size: 0,
         storage_price_per_unit_size: 5,
         write_price_per_unit_size: 1,
         future_accounting: storage_accounting::ring_new(104),
-        event_blob_certification_state: event_blob::create_with_empty_state(
-            ctx,
-        ),
+        event_blob_certification_state: event_blob::create_with_empty_state(),
+        deny_list_sizes: extended_field::new(vec_map::empty(), ctx),
     }
 }
 
 #[test_only]
 public(package) fun new_for_testing_with_multiple_members(ctx: &mut TxContext): SystemStateInnerV1 {
-    let committee = test_utils::new_bls_committee_with_multiple_members_for_testing(
-        0,
-        ctx,
-    );
-
-    let id = object::new(ctx);
+    let committee = test_utils::new_bls_committee_with_multiple_members_for_testing(0, ctx);
     SystemStateInnerV1 {
-        id,
         committee,
         total_capacity_size: 1_000_000_000,
         used_capacity_size: 0,
         storage_price_per_unit_size: 5,
         write_price_per_unit_size: 1,
         future_accounting: storage_accounting::ring_new(104),
-        event_blob_certification_state: event_blob::create_with_empty_state(
-            ctx,
-        ),
+        event_blob_certification_state: event_blob::create_with_empty_state(),
+        deny_list_sizes: extended_field::new(vec_map::empty(), ctx),
     }
 }
 
 #[test_only]
-public(package) fun get_event_blob_certification_state(
+public(package) fun event_blob_certification_state(
     system: &SystemStateInnerV1,
 ): &EventBlobCertificationState {
     &system.event_blob_certification_state
+}
+
+#[test_only]
+public(package) fun future_accounting_mut(
+    self: &mut SystemStateInnerV1,
+): &mut FutureAccountingRingBuffer {
+    &mut self.future_accounting
 }

--- a/testnet-contracts/walrus/sources/upgrade.move
+++ b/testnet-contracts/walrus/sources/upgrade.move
@@ -1,0 +1,243 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Module to manage Walrus contract upgrades.
+///
+/// This allows upgrading the contract with a quorum of storage nodes or using an emergency upgrade
+/// capability.
+///
+/// Requiring a quorum instead of a simple majority guarantees that (i) a majority of honest nodes
+/// (by weight) have voted for the upgrade, and (ii) that an upgrade cannot be blocked solely by
+/// byzantine nodes.
+module walrus::upgrade;
+
+use sui::{
+    package::{UpgradeCap, UpgradeTicket, UpgradeReceipt},
+    table::{Self, Table},
+    vec_set::{Self, VecSet}
+};
+use walrus::{auth::Authenticated, events, staking::Staking, system::System};
+
+const EInvalidUpgradeManager: u64 = 0;
+const ENotAuthorized: u64 = 1;
+const EDuplicateVote: u64 = 2;
+const EInvalidPackageDigest: u64 = 3;
+const ENoProposalForDigest: u64 = 4;
+const EWrongEpoch: u64 = 5;
+const ENotEnoughVotes: u64 = 6;
+const EWrongVersion: u64 = 7;
+
+/// Newtype for package digests, ensures that the digest is always 32 bytes long.
+public struct PackageDigest(vector<u8>) has copy, drop, store;
+
+/// An upgrade proposal containing the digest of the package to upgrade to and the votes on the
+/// proposal.
+public struct UpgradeProposal has drop, store {
+    /// The epoch in which the proposal was created.
+    /// The upgrade must be performed in the same epoch.
+    epoch: u32,
+    /// The digest of the package to upgrade to.
+    digest: PackageDigest,
+    /// The version of the package to upgrade to.
+    /// This allows to easily clean up old proposals.
+    version: u64,
+    /// The voting weight of the proposal.
+    voting_weight: u16,
+    /// The node IDs that have voted for this proposal.
+    /// Note: the number of nodes in the committee is capped, so we can use a VecSet.
+    voters: VecSet<ID>,
+}
+
+/// The upgrade manager object.
+///
+/// This object contains the upgrade cap for the package and is used to authorize upgrades.
+public struct UpgradeManager has key {
+    id: UID,
+    cap: UpgradeCap,
+    upgrade_proposals: Table<PackageDigest, UpgradeProposal>,
+}
+
+/// A capability that allows upgrades to be performed without quorum.
+///
+/// This is intended for emergency use and should be burned once the community has matured.
+public struct EmergencyUpgradeCap has key, store {
+    id: UID,
+    upgrade_manager_id: ID,
+}
+
+/// Create a new upgrade manager.
+///
+/// This is called from the `init::initialize_walrus` function and will
+/// create a unique `UpgradeManager` and `EmergencyUpgradeCap` object.
+public(package) fun new(cap: UpgradeCap, ctx: &mut TxContext): EmergencyUpgradeCap {
+    let upgrade_manager = UpgradeManager {
+        id: object::new(ctx),
+        cap,
+        upgrade_proposals: table::new(ctx),
+    };
+    let emergency_upgrade_cap = EmergencyUpgradeCap {
+        id: object::new(ctx),
+        upgrade_manager_id: object::id(&upgrade_manager),
+    };
+    transfer::share_object(upgrade_manager);
+    emergency_upgrade_cap
+}
+
+// === Upgrade Manager Public API ===
+
+/// Vote for an upgrade given the digest of the package to upgrade to.
+///
+/// This will create a new upgrade proposal if none exists for the given digest.
+public fun vote_for_upgrade(
+    self: &mut UpgradeManager,
+    staking: &Staking,
+    auth: Authenticated,
+    node_id: ID,
+    digest: vector<u8>,
+) {
+    assert!(staking.check_governance_authorization(node_id, auth), ENotAuthorized);
+    let weight = staking.get_current_node_weight(node_id);
+    let epoch = staking.epoch();
+    let digest = package_digest!(digest);
+    // Check if a proposal already exists for the given digest.
+
+    let proposal = if (self.upgrade_proposals.contains(digest)) {
+        // Check if the proposal is for the current epoch.
+        let proposal = self.upgrade_proposals.borrow_mut(digest);
+        // check epoch and version and reset if they don't match
+        if (proposal.epoch != epoch || proposal.version != self.cap.version() + 1) {
+            *proposal = fresh_proposal(epoch, digest, self.cap.version() + 1);
+        };
+        proposal
+    } else {
+        let proposal = fresh_proposal(epoch, digest, self.cap.version() + 1);
+        self.upgrade_proposals.add(digest, proposal);
+        self.upgrade_proposals.borrow_mut(digest)
+    };
+    proposal.add_vote(node_id, weight);
+    // Check if the proposal has reached quorum and emit an event if it has.
+    if (staking.is_quorum(proposal.voting_weight)) {
+        events::emit_contract_upgrade_quorum_reached(epoch, digest.0);
+    }
+}
+
+/// Authorizes an upgrade that has reached quorum.
+public fun authorize_upgrade(
+    self: &mut UpgradeManager,
+    staking: &Staking,
+    digest: vector<u8>,
+): UpgradeTicket {
+    let digest = package_digest!(digest);
+
+    assert!(self.upgrade_proposals.contains(digest), ENoProposalForDigest);
+    let proposal = self.upgrade_proposals.remove(digest);
+
+    // Check that the proposal is for the current epoch and that the quorum is reached.
+    assert!(proposal.epoch == staking.epoch(), EWrongEpoch);
+    assert!(staking.is_quorum(proposal.voting_weight), ENotEnoughVotes);
+
+    // Check that the version is correct.
+    assert!(self.cap.version() + 1 == proposal.version, EWrongVersion);
+
+    let policy = self.cap.policy();
+    self.cap.authorize(policy, digest.0)
+}
+
+/// Authorizes an upgrade using the emergency upgrade cap.
+///
+/// This should be used sparingly and once walrus has a healthy community and governance,
+/// the EmergencyUpgradeCap should be burned.
+public fun authorize_emergency_upgrade(
+    upgrade_manager: &mut UpgradeManager,
+    emergency_upgrade_cap: &EmergencyUpgradeCap,
+    digest: vector<u8>,
+): UpgradeTicket {
+    assert!(
+        emergency_upgrade_cap.upgrade_manager_id == object::id(upgrade_manager),
+        EInvalidUpgradeManager,
+    );
+    let policy = upgrade_manager.cap.policy();
+    upgrade_manager.cap.authorize(policy, digest)
+}
+
+/// Commits an upgrade and sets the new package id in the staking and system objects.
+///
+/// After committing an upgrade, the staking and system objects should be migrated
+/// using the [`package::migrate`] function to emit an event that informs all storage nodes
+/// and prevent previous package versions from being used.
+public fun commit_upgrade(
+    upgrade_manager: &mut UpgradeManager,
+    staking: &mut Staking,
+    system: &mut System,
+    receipt: UpgradeReceipt,
+) {
+    let new_package_id = receipt.package();
+    staking.set_new_package_id(new_package_id);
+    system.set_new_package_id(new_package_id);
+    upgrade_manager.cap.commit(receipt)
+}
+
+/// Cleans up the upgrade proposals table.
+///
+/// Deletes all proposals from past epochs and versions that are lower than the current version.
+public fun cleanup_upgrade_proposals(
+    self: &mut UpgradeManager,
+    staking: &Staking,
+    proposals: vector<vector<u8>>,
+) {
+    proposals.do!(|digest| {
+        let digest = package_digest!(digest);
+        if (self.upgrade_proposals.contains(digest)) {
+            let proposal = self.upgrade_proposals.borrow(digest);
+            if (proposal.version <= self.cap.version() || proposal.epoch < staking.epoch()) {
+                self.upgrade_proposals.remove(digest);
+            }
+        }
+    });
+}
+
+// === Emergency Upgrade Cap Public API ===
+
+/// Burns the emergency upgrade cap.
+///
+/// This will prevent any further upgrades using the `EmergencyUpgradeCap` and will
+/// make upgrades fully reliant on quorum-based governance.
+public fun burn_emergency_upgrade_cap(emergency_upgrade_cap: EmergencyUpgradeCap) {
+    let EmergencyUpgradeCap { id, .. } = emergency_upgrade_cap;
+    id.delete();
+}
+
+// === Upgrade Manager internal functions ===
+
+/// Creates a new upgrade proposal.
+///
+/// This will emit an event that signals that a new upgrade proposal has been created.
+fun fresh_proposal(epoch: u32, digest: PackageDigest, version: u64): UpgradeProposal {
+    events::emit_contract_upgrade_proposed(epoch, digest.0);
+    UpgradeProposal { epoch, digest, version, voting_weight: 0, voters: vec_set::empty() }
+}
+
+/// Adds a vote to an upgrade proposal.
+fun add_vote(proposal: &mut UpgradeProposal, node_id: ID, weight: u16) {
+    assert!(!proposal.voters.contains(&node_id), EDuplicateVote);
+    proposal.voters.insert(node_id);
+    proposal.voting_weight = proposal.voting_weight + weight;
+}
+
+// === Package Digest ===
+
+/// Creates a new package digest given a byte vector.
+///
+/// Aborts if the digest is not 32 bytes long.
+macro fun package_digest($digest: vector<u8>): PackageDigest {
+    let digest = $digest;
+    assert!(digest.length() == 32, EInvalidPackageDigest);
+    PackageDigest(digest)
+}
+
+// === Test only ===
+
+#[test_only]
+public fun digest_for_testing(ctx: &mut TxContext): vector<u8> {
+    ctx.fresh_object_address().to_bytes()
+}

--- a/testnet-contracts/walrus/sources/utils/extended_field.move
+++ b/testnet-contracts/walrus/sources/utils/extended_field.move
@@ -1,0 +1,47 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Module: extended_field
+module walrus::extended_field;
+
+use sui::dynamic_field as df;
+
+/// Extended field acts as a field, but stored in a dynamic field, hence, it does
+/// not bloat the original object's storage, storing only `UID` of the extended
+/// field.
+public struct ExtendedField<phantom T: store> has key, store { id: UID }
+
+/// Key to store the value in the extended field. Never changes.
+public struct Key() has copy, drop, store;
+
+/// Creates a new extended field with the given value.
+public fun new<T: store>(value: T, ctx: &mut TxContext): ExtendedField<T> {
+    let mut id = object::new(ctx);
+    df::add(&mut id, Key(), value);
+    ExtendedField { id }
+}
+
+/// Borrows the value stored in the extended field.
+public fun borrow<T: store>(field: &ExtendedField<T>): &T {
+    df::borrow(&field.id, Key())
+}
+
+/// Borrows the value stored in the extended field mutably.
+public fun borrow_mut<T: store>(field: &mut ExtendedField<T>): &mut T {
+    df::borrow_mut(&mut field.id, Key())
+}
+
+/// Swaps the value stored in the extended field with the given value.
+public fun swap<T: store>(field: &mut ExtendedField<T>, value: T): T {
+    let old = df::remove(&mut field.id, Key());
+    df::add(&mut field.id, Key(), value);
+    old
+}
+
+/// Destroys the extended field and returns the value stored in it.
+public fun destroy<T: store>(field: ExtendedField<T>): T {
+    let ExtendedField { mut id } = field;
+    let value = df::remove(&mut id, Key());
+    id.delete();
+    value
+}

--- a/testnet-contracts/walrus/sources/utils/sort.move
+++ b/testnet-contracts/walrus/sources/utils/sort.move
@@ -1,0 +1,50 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Implements sorting macros for commonly used data structures.
+module walrus::sort;
+
+use sui::vec_map::{Self, VecMap};
+
+/// Sort the given `VecMap` by the node ID transformed into `u256`.
+///
+/// Uses the insertion sort algorithm, given that the `VecMap` is already mostly sorted.
+public macro fun sort_vec_map_by_node_id<$V>($self: VecMap<ID, $V>): VecMap<ID, $V> {
+    let self = $self;
+
+    if (self.size() <= 1) return self;
+    let (mut keys, mut values) = self.into_keys_values();
+    let len = keys.length();
+    let mut i = 1;
+
+    while (i < len) {
+        let mut j = i;
+        while (j > 0 && keys[j - 1].to_address().to_u256() > keys[j].to_address().to_u256()) {
+            keys.swap(j - 1, j);
+            values.swap(j - 1, j);
+            j = j - 1;
+        };
+        i = i + 1;
+    };
+
+    vec_map::from_keys_values(keys, values)
+}
+
+/// Check if the given `VecMap` is sorted by the node ID transformed into `u256`.
+public macro fun is_vec_map_sorted_by_node_id<$V>($self: &VecMap<ID, $V>): bool {
+    let self = $self;
+
+    let len = self.size();
+    if (len <= 1) return true;
+    let mut i = 1;
+    while (i < len) {
+        let (lhs, _) = self.get_entry_by_idx(i - 1);
+        let (rhs, _) = self.get_entry_by_idx(i);
+        if (lhs.to_address().to_u256() > rhs.to_address().to_u256()) {
+            return false
+        };
+        i = i + 1;
+    };
+
+    true
+}

--- a/testnet-contracts/walrus/tests/e2e_runner.move
+++ b/testnet-contracts/walrus/tests/e2e_runner.move
@@ -4,9 +4,20 @@
 module walrus::e2e_runner;
 
 use sui::{clock::{Self, Clock}, test_scenario::{Self, Scenario}, test_utils};
-use walrus::{init, staking::Staking, system::System};
+use walrus::{
+    init,
+    node_metadata,
+    staking::Staking,
+    system::System,
+    test_node::{Self, TestStorageNode},
+    test_utils as walrus_test_utils,
+    upgrade::UpgradeManager
+};
 
 const MAX_EPOCHS_AHEAD: u32 = 104;
+const DEFAULT_EPOCH_ZERO_DURATION: u64 = 100000000;
+const DEFAULT_EPOCH_DURATION: u64 = 7 * 24 * 60 * 60 * 1000 / 2;
+const DEFAULT_N_SHARDS: u16 = 100;
 
 // === Tests Runner ===
 
@@ -69,9 +80,9 @@ public fun n_shards(mut self: InitBuilder, n: u16): InitBuilder {
 /// Build the test runner with the given parameters.
 public fun build(self: InitBuilder): TestRunner {
     let InitBuilder { admin, epoch_duration, epoch_zero_duration, n_shards } = self;
-    let epoch_zero_duration = epoch_zero_duration.destroy_or!(100000000);
-    let epoch_duration = epoch_duration.destroy_or!(7 * 24 * 60 * 60 * 1000 / 2);
-    let n_shards = n_shards.destroy_or!(100);
+    let epoch_zero_duration = epoch_zero_duration.destroy_or!(DEFAULT_EPOCH_ZERO_DURATION);
+    let epoch_duration = epoch_duration.destroy_or!(DEFAULT_EPOCH_DURATION);
+    let n_shards = n_shards.destroy_or!(DEFAULT_N_SHARDS);
 
     let mut scenario = test_scenario::begin(admin);
     let clock = clock::create_for_testing(scenario.ctx());
@@ -79,11 +90,15 @@ public fun build(self: InitBuilder): TestRunner {
 
     init::init_for_testing(ctx);
 
+    // We need an upgrade cap for package with address 0x0
+    let upgrade_cap = sui::package::test_publish(ctx.fresh_object_address().to_id(), ctx);
+
     scenario.next_tx(admin);
     let cap = scenario.take_from_sender<init::InitCap>();
     let ctx = scenario.ctx();
-    init::initialize_walrus(
+    let emergency_upgrade_cap = init::initialize_for_testing(
         cap,
+        upgrade_cap,
         epoch_zero_duration,
         epoch_duration,
         n_shards,
@@ -91,6 +106,9 @@ public fun build(self: InitBuilder): TestRunner {
         &clock,
         ctx,
     );
+
+    transfer::public_transfer(emergency_upgrade_cap, admin);
+    scenario.next_tx(admin);
 
     TestRunner { scenario, clock, admin }
 }
@@ -113,8 +131,11 @@ public fun epoch(self: &mut TestRunner): u32 {
     epoch
 }
 
+/// Returns the default epoch duration.
+public fun default_epoch_duration(): u64 { DEFAULT_EPOCH_DURATION }
+
 /// Run a transaction as a `sender`, and call the function `f` with the `Staking`,
-/// `System` and `TxContext` as arguments.
+/// `System`, and `TxContext` as arguments.
 public macro fun tx(
     $runner: &mut TestRunner,
     $sender: address,
@@ -133,7 +154,96 @@ public macro fun tx(
     test_scenario::return_shared(system);
 }
 
+/// Returns TransactionEffects of the last transaction.
+public fun last_tx_effects(runner: &mut TestRunner): test_scenario::TransactionEffects {
+    runner.scenario().next_tx(@1)
+}
+
+/// Run a transaction as a `sender`, and call the function `f` with the `Staking`,
+/// `System`, `UpgradeManager`, and `TxContext` as arguments.
+public macro fun tx_with_upgrade_manager(
+    $runner: &mut TestRunner,
+    $sender: address,
+    $f: |&mut Staking, &mut System, &mut UpgradeManager, &mut TxContext|,
+) {
+    let runner = $runner;
+    let scenario = runner.scenario();
+    scenario.next_tx($sender);
+    let mut staking = scenario.take_shared<Staking>();
+    let mut system = scenario.take_shared<System>();
+    let mut upgrade_manager = scenario.take_shared<UpgradeManager>();
+    let ctx = scenario.ctx();
+
+    $f(&mut staking, &mut system, &mut upgrade_manager, ctx);
+
+    test_scenario::return_shared(upgrade_manager);
+    test_scenario::return_shared(staking);
+    test_scenario::return_shared(system);
+}
+
 /// Destroy the test runner and all resources.
 public fun destroy(self: TestRunner) {
     test_utils::destroy(self)
+}
+
+#[allow(lint(self_transfer), unused_mut_ref)]
+public fun setup_committee_for_epoch_one(): (TestRunner, vector<TestStorageNode>) {
+    let admin = @0xA11CE;
+    let mut nodes = test_node::test_nodes();
+    let mut runner = prepare(admin).build();
+    let commission_rate: u16 = 0;
+    let storage_price: u64 = 5;
+    let write_price: u64 = 1;
+    let node_capacity: u64 = 1_000_000_000;
+
+    // === register candidates ===
+    let epoch = runner.epoch();
+    nodes.do_mut!(|node| {
+        runner.tx!(node.sui_address(), |staking, _, ctx| {
+            let cap = staking.register_candidate(
+                node.name(),
+                node.network_address(),
+                node_metadata::default(),
+                node.bls_pk(),
+                node.network_key(),
+                node.create_proof_of_possession(epoch),
+                commission_rate,
+                storage_price,
+                write_price,
+                node_capacity,
+                ctx,
+            );
+            node.set_storage_node_cap(cap);
+        });
+    });
+
+    // === stake with each node ===
+
+    nodes.do_ref!(|node| {
+        runner.tx!(node.sui_address(), |staking, _, ctx| {
+            let coin = walrus_test_utils::mint(1000, ctx);
+            let staked_wal = staking.stake_with_pool(coin, node.node_id(), ctx);
+            transfer::public_transfer(staked_wal, ctx.sender());
+        });
+    });
+
+    // === advance clock and end voting ===
+    // === check if epoch state is changed correctly ==
+
+    runner.clock().increment_for_testing(DEFAULT_EPOCH_ZERO_DURATION);
+    runner.tx!(admin, |staking, system, _| {
+        staking.voting_end(runner.clock());
+        staking.initiate_epoch_change(system, runner.clock());
+        nodes.do_ref!(|node| assert!(system.committee().contains(&node.node_id())));
+    });
+
+    // === send epoch sync done messages from all nodes ===
+    let epoch = runner.epoch();
+    nodes.do_mut!(|node| {
+        runner.tx!(node.sui_address(), |staking, _, _| {
+            staking.epoch_sync_done(node.cap_mut(), epoch, runner.clock());
+        });
+    });
+
+    (runner, nodes)
 }

--- a/testnet-contracts/walrus/tests/e2e_tests.move
+++ b/testnet-contracts/walrus/tests/e2e_tests.move
@@ -5,10 +5,9 @@
 module walrus::e2e_tests;
 
 use std::unit_test::assert_eq;
-use walrus::{e2e_runner, staking_pool, test_node, test_utils};
-use sui::test_scenario;
+use walrus::{auth, e2e_runner, staking_pool, test_node::{Self, TestStorageNode}, test_utils};
 
-const COMMISSION: u64 = 1;
+const COMMISSION_RATE: u16 = 0;
 const STORAGE_PRICE: u64 = 5;
 const WRITE_PRICE: u64 = 1;
 const NODE_CAPACITY: u64 = 1_000_000_000;
@@ -36,10 +35,11 @@ fun test_init_and_first_epoch_change() {
             let cap = staking.register_candidate(
                 node.name(),
                 node.network_address(),
+                node.metadata(),
                 node.bls_pk(),
                 node.network_key(),
                 node.create_proof_of_possession(epoch),
-                COMMISSION,
+                COMMISSION_RATE,
                 STORAGE_PRICE,
                 WRITE_PRICE,
                 NODE_CAPACITY,
@@ -138,10 +138,11 @@ fun test_stake_after_committee_selection() {
             let cap = staking.register_candidate(
                 node.name(),
                 node.network_address(),
+                node.metadata(),
                 node.bls_pk(),
                 node.network_key(),
                 node.create_proof_of_possession(epoch),
-                COMMISSION,
+                COMMISSION_RATE,
                 STORAGE_PRICE,
                 WRITE_PRICE,
                 NODE_CAPACITY,
@@ -244,10 +245,11 @@ fun node_voting_parameters() {
             let cap = staking.register_candidate(
                 node.name(),
                 node.network_address(),
+                node.metadata(),
                 node.bls_pk(),
                 node.network_key(),
                 node.create_proof_of_possession(epoch),
-                COMMISSION,
+                COMMISSION_RATE,
                 i * 1000,
                 i * 1000,
                 i * 1000,
@@ -313,10 +315,11 @@ fun test_first_epoch_too_soon_fail() {
             let cap = staking.register_candidate(
                 node.name(),
                 node.network_address(),
+                node.metadata(),
                 node.bls_pk(),
                 node.network_key(),
                 node.create_proof_of_possession(epoch),
-                COMMISSION,
+                COMMISSION_RATE,
                 STORAGE_PRICE,
                 WRITE_PRICE,
                 NODE_CAPACITY,
@@ -341,7 +344,7 @@ fun test_first_epoch_too_soon_fail() {
 }
 
 #[test]
-fun test_epoch_change_with_rewards() {
+fun test_epoch_change_with_rewards_and_commission() {
     let admin = @0xA11CE;
     let mut nodes = test_node::test_nodes();
     let mut runner = e2e_runner::prepare(admin)
@@ -357,10 +360,11 @@ fun test_epoch_change_with_rewards() {
             let cap = staking.register_candidate(
                 node.name(),
                 node.network_address(),
+                node.metadata(),
                 node.bls_pk(),
                 node.network_key(),
                 node.create_proof_of_possession(epoch),
-                COMMISSION,
+                100_00, // 100.00% commission
                 STORAGE_PRICE,
                 WRITE_PRICE,
                 NODE_CAPACITY,
@@ -374,7 +378,7 @@ fun test_epoch_change_with_rewards() {
 
     nodes.do_ref!(|node| {
         runner.tx!(node.sui_address(), |staking, _, ctx| {
-            let coin = test_utils::mint(1000, ctx);
+            let coin = test_utils::mint(1_000_000_000, ctx);
             let staked_wal = staking.stake_with_pool(coin, node.node_id(), ctx);
             transfer::public_transfer(staked_wal, ctx.sender());
         });
@@ -411,6 +415,52 @@ fun test_epoch_change_with_rewards() {
         transfer::public_transfer(coin, ctx.sender());
     });
 
+    // === register deny list update with each node (for tests) ===
+
+    nodes.do_mut!(|node| {
+        runner.tx!(node.sui_address(), |_, system, _| {
+            system.register_deny_list_update(node.cap_mut(), @1.to_u256(), 1);
+        });
+
+        // make sure that the event was emitted
+        assert_eq!(runner.last_tx_effects().num_user_events(), 1);
+    });
+
+    // === register once more, now with incremented sequence number ===
+
+    nodes.do_mut!(|node| {
+        runner.tx!(node.sui_address(), |_, system, _| {
+            system.register_deny_list_update(node.cap_mut(), @2.to_u256(), 2);
+        });
+
+        // make sure that the event was emitted
+        assert_eq!(runner.last_tx_effects().num_user_events(), 1);
+    });
+
+    // === sign a message for the first node to update deny list size ===
+
+    let node = &nodes[0];
+    let deny_list_node = nodes[0].node_id();
+    let certified_message = node.update_deny_list_message(runner.epoch(), 2u256, 10_000_000, 1);
+    let (signature, members_bitmap) = nodes.sign(certified_message);
+
+    // === send the message from the first node
+    let node = &mut nodes[0];
+    runner.tx!(node.sui_address(), |_, system, _| {
+        system.update_deny_list(node.cap_mut(), signature, members_bitmap, certified_message);
+
+        // check the VecMap with sizes
+        let deny_list_sizes = system.inner().deny_list_sizes();
+
+        assert_eq!(deny_list_sizes.size(), 1);
+        assert!(deny_list_sizes.contains(&node.node_id()));
+        assert_eq!(*deny_list_sizes.get(&node.node_id()), 10_000_000);
+    });
+
+    assert_eq!(runner.last_tx_effects().num_user_events(), 1); // update deny list event emitted
+    assert_eq!(node.cap().deny_list_root(), 2u256); // deny list root updated
+    assert_eq!(node.cap().deny_list_sequence(), 1); // sequence number incremented
+
     // === perform another epoch change ===
     // === check if epoch state is changed correctly ==
 
@@ -427,8 +477,8 @@ fun test_epoch_change_with_rewards() {
     runner.tx!(admin, |staking, system, _| {
         staking.initiate_epoch_change(system, runner.clock());
 
-        assert!(system.epoch() == 2);
-        assert!(system.committee().n_shards() == N_SHARDS);
+        assert_eq!(system.epoch(), 2);
+        assert_eq!(system.committee().n_shards(), N_SHARDS);
 
         nodes.do_ref!(|node| assert!(system.committee().contains(&node.node_id())));
     });
@@ -445,7 +495,72 @@ fun test_epoch_change_with_rewards() {
 
     runner.tx!(admin, |staking, _, _| assert!(staking.is_epoch_sync_done()));
 
+    // === check rewards for each node ===
+
+    // each node is getting 470 in rewards, 10% of that is - 47 - commission
+    nodes.do_mut!(|node| {
+        runner.tx!(node.sui_address(), |staking, _, ctx| {
+            let auth = auth::authenticate_with_object(node.cap());
+            let commission = staking.collect_commission(node.node_id(), auth, ctx);
+
+            // deny_list_node has 10% less rewards
+            // all nodes claim 100% of their rewards
+            if (node.node_id() == deny_list_node) {
+                assert_eq!(commission.burn_for_testing(), 472);
+            } else {
+                assert_eq!(commission.burn_for_testing(), 477);
+            };
+        });
+    });
+
     // === cleanup ===
+
+    nodes.destroy!(|node| node.destroy());
+    runner.destroy();
+}
+
+#[test]
+fun node_update_metadata() {
+    let admin = @0xA11CE;
+    let mut nodes = test_node::test_nodes();
+    let mut runner = e2e_runner::prepare(admin)
+        .epoch_zero_duration(EPOCH_ZERO_DURATION)
+        .epoch_duration(EPOCH_DURATION)
+        .n_shards(N_SHARDS)
+        .build();
+
+    let epoch = runner.epoch();
+    let node = &mut nodes[0];
+
+    runner.tx!(node.sui_address(), |staking, _, ctx| {
+        let cap = staking.register_candidate(
+            node.name(),
+            node.network_address(),
+            node.metadata(),
+            node.bls_pk(),
+            node.network_key(),
+            node.create_proof_of_possession(epoch),
+            COMMISSION_RATE,
+            STORAGE_PRICE,
+            WRITE_PRICE,
+            NODE_CAPACITY,
+            ctx,
+        );
+        node.set_storage_node_cap(cap);
+    });
+
+    runner.tx!(node.sui_address(), |staking, _, _| {
+        let mut metadata = staking.node_metadata(node.node_id());
+        metadata.set_description(b"Tusk Crew".to_string());
+        metadata.set_project_url(b"https://crew.walrus.site/".to_string());
+        staking.set_node_metadata(node.cap(), metadata);
+    });
+
+    runner.tx!(node.sui_address(), |staking, _, _| {
+        let metadata = staking.node_metadata(node.node_id());
+        assert_eq!(metadata.description(), b"Tusk Crew".to_string());
+        assert_eq!(metadata.project_url(), b"https://crew.walrus.site/".to_string());
+    });
 
     nodes.destroy!(|node| node.destroy());
     runner.destroy();
@@ -469,10 +584,11 @@ fun test_register_invalid_pop_epoch() {
         let cap = staking.register_candidate(
             node.name(),
             node.network_address(),
+            node.metadata(),
             node.bls_pk(),
             node.network_key(),
             node.create_proof_of_possession(epoch),
-            COMMISSION,
+            COMMISSION_RATE,
             STORAGE_PRICE,
             WRITE_PRICE,
             NODE_CAPACITY,
@@ -504,10 +620,11 @@ fun test_register_invalid_pop_signer() {
         let cap = staking.register_candidate(
             node.name(),
             node.network_address(),
+            node.metadata(),
             node.bls_pk(),
             node.network_key(),
             pop,
-            COMMISSION,
+            COMMISSION_RATE,
             STORAGE_PRICE,
             WRITE_PRICE,
             NODE_CAPACITY,
@@ -518,8 +635,6 @@ fun test_register_invalid_pop_signer() {
 
     abort 0
 }
-
-
 
 #[test]
 fun withdraw_rewards_before_joining_committee() {
@@ -538,10 +653,11 @@ fun withdraw_rewards_before_joining_committee() {
             let cap = staking.register_candidate(
                 node.name(),
                 node.network_address(),
+                node.metadata(),
                 node.bls_pk(),
                 node.network_key(),
                 node.create_proof_of_possession(epoch),
-                COMMISSION,
+                COMMISSION_RATE,
                 STORAGE_PRICE,
                 WRITE_PRICE,
                 NODE_CAPACITY,
@@ -603,14 +719,13 @@ fun withdraw_rewards_before_joining_committee() {
         });
     });
 
-
     // === withdraw stake from excluded node ===
 
-    let mut staked_wal = runner.scenario().take_from_address(excluded_node.sui_address());
+    let staked_wal = runner.scenario().take_from_address(excluded_node.sui_address());
     runner.tx!(excluded_node.sui_address(), |staking, _, ctx| {
-        staking.request_withdraw_stake(&mut staked_wal, ctx);
+        let coin = staking.withdraw_stake(staked_wal, ctx);
+        coin.burn_for_testing();
     });
-    test_scenario::return_to_address(excluded_node.sui_address(), staked_wal);
 
     // === add stake to excluded node again ===
 
@@ -637,5 +752,17 @@ fun withdraw_rewards_before_joining_committee() {
     nodes.destroy!(|node| node.destroy());
     excluded_node.destroy();
     runner.destroy();
+}
 
+// local alias for simplicity
+use fun sign as vector.sign;
+
+fun sign(nodes: &vector<TestStorageNode>, message: vector<u8>): (vector<u8>, vector<u8>) {
+    let signatures = nodes.map_ref!(|node| node.sign_message(message));
+    let members_bitmap = test_utils::signers_to_bitmap(
+        &vector::tabulate!(nodes.length(), |i| i as u16),
+    );
+    let signature = test_utils::bls_aggregate_sigs(&signatures);
+
+    (signature, members_bitmap)
 }

--- a/testnet-contracts/walrus/tests/staking/active_set_tests.move
+++ b/testnet-contracts/walrus/tests/staking/active_set_tests.move
@@ -18,61 +18,61 @@ use walrus::active_set;
 #[test]
 fun test_insert() {
     let mut set = active_set::new(3, 100);
-    set.insert(@0x1.to_id(), 200);
-    set.insert(@0x2.to_id(), 300);
-    set.insert(@0x3.to_id(), 400);
+    set.insert(@1.to_id(), 200);
+    set.insert(@2.to_id(), 300);
+    set.insert(@3.to_id(), 400);
 
     assert_eq!(set.size(), 3);
     assert_eq!(set.max_size(), 3);
 
     let active_ids = set.active_ids();
-    assert!(active_ids.contains(&@0x1.to_id()));
-    assert!(active_ids.contains(&@0x2.to_id()));
-    assert!(active_ids.contains(&@0x3.to_id()));
+    assert!(active_ids.contains(&@1.to_id()));
+    assert!(active_ids.contains(&@2.to_id()));
+    assert!(active_ids.contains(&@3.to_id()));
     assert_eq!(set.cur_min_stake(), 200);
 
     // now insert a node with even more staked WAL
-    set.insert(@0x4.to_id(), 500);
+    set.insert(@4.to_id(), 500);
 
     assert_eq!(set.size(), 3);
     assert_eq!(set.cur_min_stake(), 300);
 
     let active_ids = set.active_ids();
-    assert!(active_ids.contains(&@0x2.to_id()));
-    assert!(active_ids.contains(&@0x3.to_id()));
-    assert!(active_ids.contains(&@0x4.to_id()));
+    assert!(active_ids.contains(&@2.to_id()));
+    assert!(active_ids.contains(&@3.to_id()));
+    assert!(active_ids.contains(&@4.to_id()));
 
     // and now insert a node with less staked WAL
-    set.insert(@0x5.to_id(), 250);
+    set.insert(@5.to_id(), 250);
 
     assert_eq!(set.size(), 3);
     assert_eq!(set.cur_min_stake(), 300);
 
     let active_ids = set.active_ids();
-    assert!(active_ids.contains(&@0x2.to_id()));
-    assert!(active_ids.contains(&@0x3.to_id()));
-    assert!(active_ids.contains(&@0x4.to_id()));
+    assert!(active_ids.contains(&@2.to_id()));
+    assert!(active_ids.contains(&@3.to_id()));
+    assert!(active_ids.contains(&@4.to_id()));
 
     // and now insert 3 more nodes with super high staked WAL
-    set.insert(@0x6.to_id(), 1000);
-    set.insert(@0x7.to_id(), 1000);
-    set.insert(@0x8.to_id(), 1000);
+    set.insert(@6.to_id(), 1000);
+    set.insert(@7.to_id(), 1000);
+    set.insert(@8.to_id(), 1000);
 
     assert_eq!(set.size(), 3);
     assert_eq!(set.cur_min_stake(), 1000);
 
     let active_ids = set.active_ids();
-    assert!(active_ids.contains(&@0x6.to_id()));
-    assert!(active_ids.contains(&@0x7.to_id()));
-    assert!(active_ids.contains(&@0x8.to_id()));
+    assert!(active_ids.contains(&@6.to_id()));
+    assert!(active_ids.contains(&@7.to_id()));
+    assert!(active_ids.contains(&@8.to_id()));
 }
 
 #[test]
 fun test_size_1() {
     let mut set = active_set::new(1, 100);
     assert_eq!(set.cur_min_stake(), 100);
-    set.insert(@0x1.to_id(), 1000);
+    set.insert(@1.to_id(), 1000);
     assert_eq!(set.cur_min_stake(), 1000);
-    set.insert(@0x2.to_id(), 1001);
+    set.insert(@2.to_id(), 1001);
     assert_eq!(set.cur_min_stake(), 1001);
 }

--- a/testnet-contracts/walrus/tests/staking/committee_tests.move
+++ b/testnet-contracts/walrus/tests/staking/committee_tests.move
@@ -3,22 +3,23 @@
 
 module walrus::committee_tests;
 
+use std::unit_test::{assert_eq, assert_ref_eq};
 use sui::{address, vec_map};
-use walrus::committee;
+use walrus::committee::{Self, Committee};
 
 #[test]
 fun empty_committee() {
     let cmt = committee::empty();
-    assert!(cmt.size() == 0);
+    assert_eq!(cmt.size(), 0);
 }
 
 #[test]
 fun default_scenario() {
-    let n1 = @0x1.to_id();
-    let n2 = @0x2.to_id();
-    let n3 = @0x3.to_id();
-    let n4 = @0x4.to_id();
-    let n5 = @0x5.to_id();
+    let n1 = @1.to_id();
+    let n2 = @2.to_id();
+    let n3 = @3.to_id();
+    let n4 = @4.to_id();
+    let n5 = @5.to_id();
 
     // Initialize the committee with 2 shards per node, 5 nodes, 10 shards in total
     let cmt = committee::initialize(
@@ -28,13 +29,13 @@ fun default_scenario() {
         ),
     );
 
-    assert!(cmt.size() == 5);
+    assert_eq!(cmt.size(), 5);
 
-    assert!(cmt[&n1] == &vector[0, 1]);
-    assert!(cmt[&n2] == &vector[2, 3]);
-    assert!(cmt[&n3] == &vector[4, 5]);
-    assert!(cmt[&n4] == &vector[6, 7]);
-    assert!(cmt[&n5] == &vector[8, 9]);
+    assert_eq!(cmt[&n1], vector[0, 1]);
+    assert_eq!(cmt[&n2], vector[2, 3]);
+    assert_eq!(cmt[&n3], vector[4, 5]);
+    assert_eq!(cmt[&n4], vector[6, 7]);
+    assert_eq!(cmt[&n5], vector[8, 9]);
 
     // Transition the committee to 4/3 shards per node, 3 nodes, same number of shards
     let cmt2 = cmt.transition(
@@ -44,19 +45,19 @@ fun default_scenario() {
         ),
     );
 
-    assert!(cmt2.size() == 3);
+    assert_eq!(cmt2.size(), 3);
 
     // we make sure that the shards this node had are still in place
     // repeat the checks for all nodes 1-3
-    assert!(cmt2[&n1].length() == 4);
+    assert_eq!(cmt2[&n1].length(), 4);
     assert!(cmt2[&n1].contains(&0));
     assert!(cmt2[&n1].contains(&1));
 
-    assert!(cmt2[&n2].length() == 3);
+    assert_eq!(cmt2[&n2].length(), 3);
     assert!(cmt2[&n2].contains(&2));
     assert!(cmt2[&n2].contains(&3));
 
-    assert!(cmt2[&n3].length() == 3);
+    assert_eq!(cmt2[&n3].length(), 3);
     assert!(cmt2[&n3].contains(&4));
     assert!(cmt2[&n3].contains(&5));
 
@@ -72,15 +73,15 @@ fun default_scenario() {
         ),
     );
 
-    assert!(cmt3.size() == 4);
+    assert_eq!(cmt3.size(), 4);
 
     // Make sure that n2 and n3 have the same shards as before
-    assert!(cmt3[&n2] == n2_shards);
-    assert!(cmt3[&n3] == n3_shards);
+    assert_eq!(cmt3[&n2], n2_shards);
+    assert_eq!(cmt3[&n3], n3_shards);
 
     // Make sure that n4 and n5 have correct number of shards
-    assert!(cmt3[&n4].length() == 2);
-    assert!(cmt3[&n5].length() == 2);
+    assert_eq!(cmt3[&n4].length(), 2);
+    assert_eq!(cmt3[&n5].length(), 2);
 
     // Transition the committee to just N1 owning all the shards
     let cmt4 = cmt3.transition(
@@ -106,33 +107,30 @@ fun default_scenario() {
 
 #[test]
 fun ignore_empty_assignments() {
-    let (n1, n2, n3, n4, n5) = (
-        @0x1.to_id(),
-        @0x2.to_id(),
-        @0x3.to_id(),
-        @0x4.to_id(),
-        @0x5.to_id(),
-    );
+    let (n1, n2, n3, n4, n5) = (@1, @2, @3, @4, @5);
 
     // expect n4 and n5 to be ignored
     let cmt = committee::initialize(
         vec_map::from_keys_values(
-            vector[n1, n2, n3, n4, n5],
+            vector[n1, n2, n3, n4, n5].map!(|addr| addr.to_id()),
             vector[2, 2, 2, 0, 0],
         ),
     );
 
+    assert!(cmt.is_sorted());
+
     // expect n1 and n5 to be ignored
     let cmt2 = cmt.transition(
         vec_map::from_keys_values(
-            vector[n1, n2, n3, n4, n5],
+            vector[n1, n2, n3, n4, n5].map!(|addr| addr.to_id()),
             vector[0, 2, 2, 2, 0],
         ),
     );
 
-    assert!(cmt2.size() == 3);
-    assert!(cmt.shards(&n2) == cmt2.shards(&n2));
-    assert!(cmt.shards(&n3) == cmt2.shards(&n3));
+    assert!(cmt2.is_sorted());
+    assert_eq!(cmt2.size(), 3);
+    assert_ref_eq!(cmt.shards(&n2.to_id()), cmt2.shards(&n2.to_id()));
+    assert_ref_eq!(cmt.shards(&n3.to_id()), cmt2.shards(&n3.to_id()));
 }
 
 // #[test] // requires manual --gas-limit set, ignored for convenience
@@ -156,4 +154,54 @@ fun large_set_assignments_2() {
             vector::tabulate!(1000, |i| (i % 3) as u16),
         ),
     );
+}
+
+#[test, expected_failure(abort_code = committee::EInvalidShardAssignment)]
+fun reject_invalid_shard_assignment() {
+    let (n1, n2, n3) = (@1.to_id(), @2.to_id(), @3.to_id());
+
+    let cmt = committee::initialize(
+        vec_map::from_keys_values(
+            vector[n1, n2, n3],
+            vector[2, 2, 2],
+        ),
+    );
+
+    // expect transaction to succeed (same number of shards)
+    let cmt2 = cmt.transition(
+        vec_map::from_keys_values(
+            vector[n1, n2, n3],
+            vector[1, 3, 2],
+        ),
+    );
+
+    assert!(cmt2.is_sorted());
+
+    // expect transaction to fail (different number of shards)
+    let _ = cmt2.transition(
+        vec_map::from_keys_values(
+            vector[n1, n2, n3],
+            vector[3, 3, 2],
+        ),
+    );
+}
+
+#[test]
+fun diff_at_different_sizes() {
+    let cmt_1 = cmt(vector[@1, @2, @3]);
+    let cmt_2 = cmt(vector[@2, @3, @4]);
+    let (left, right) = committee::diff(&cmt_1, &cmt_2);
+
+    assert_eq!(left, vector[@1.to_id()]);
+    assert_eq!(right, vector[@4.to_id()]);
+}
+
+fun cmt(ids: vector<address>): Committee {
+    let size = ids.length();
+    committee::initialize(
+        vec_map::from_keys_values(
+            ids.map!(|addr| addr.to_id()),
+            vector::tabulate!(size, |i| i as u16),
+        ),
+    )
 }

--- a/testnet-contracts/walrus/tests/staking/staked_wal_tests.move
+++ b/testnet-contracts/walrus/tests/staking/staked_wal_tests.move
@@ -3,90 +3,116 @@
 
 module walrus::staked_wal_tests;
 
-use sui::test_utils::destroy;
+use std::unit_test::assert_eq;
 use walrus::{staked_wal, test_utils::mint_balance};
 
 #[test]
 // Scenario: Test the staked WAL flow
-fun test_staked_wal_flow() {
+fun staked_wal_lifecycle() {
     let ctx = &mut tx_context::dummy();
     let node_id = ctx.fresh_object_address().to_id();
     let mut staked_wal = staked_wal::mint(node_id, mint_balance(100), 1, ctx);
 
     // assert that the staked WAL is created correctly
-    assert!(staked_wal.value() == 100);
-    assert!(staked_wal.node_id() == node_id);
-    assert!(staked_wal.activation_epoch() == 1);
+    assert_eq!(staked_wal.value(), 100);
+    assert_eq!(staked_wal.node_id(), node_id);
+    assert_eq!(staked_wal.activation_epoch(), 1);
 
     // test that splitting works correctly and copies the parameters
     let other = staked_wal.split(50, ctx);
-    assert!(other.value() == 50);
-    assert!(other.node_id() == node_id);
-    assert!(other.activation_epoch() == 1);
-    assert!(staked_wal.value() == 50);
+    assert_eq!(other.value(), 50);
+    assert_eq!(other.node_id(), node_id);
+    assert_eq!(other.activation_epoch(), 1);
+    assert_eq!(staked_wal.value(), 50);
 
     // test that joining works correctly
     staked_wal.join(other);
-    assert!(staked_wal.value() == 100);
-    assert!(staked_wal.node_id() == node_id);
-    assert!(staked_wal.activation_epoch() == 1);
-
-    // test that zero can be destroyed
-    let zero = staked_wal.split(0, ctx);
-    zero.destroy_zero();
+    assert_eq!(staked_wal.value(), 100);
+    assert_eq!(staked_wal.node_id(), node_id);
+    assert_eq!(staked_wal.activation_epoch(), 1);
 
     // test that the staked WAL can be burned
     let principal = staked_wal.into_balance();
-    assert!(principal.value() == 100);
-
-    destroy(principal);
+    assert_eq!(principal.destroy_for_testing(), 100);
 }
 
-#[test, expected_failure(abort_code = staked_wal::ECantSplitWithdrawing)]
-// Scenario: Try splitting a staked WAL in the withdrawing state
-// TODO: consider enabling this behavior in the future
-fun test_unable_to_split_withdrawing() {
+#[test]
+// Scenario: Test the staked WAL flow
+fun withdrawing_wal_lifecycle() {
     let ctx = &mut tx_context::dummy();
     let node_id = ctx.fresh_object_address().to_id();
     let mut staked_wal = staked_wal::mint(node_id, mint_balance(100), 1, ctx);
+    staked_wal.set_withdrawing(2);
 
-    staked_wal.set_withdrawing(2, 100);
-    let _other = staked_wal.split(50, ctx);
+    // assert that the staked WAL is created correctly
+    assert_eq!(staked_wal.value(), 100);
+    assert_eq!(staked_wal.node_id(), node_id);
+    assert_eq!(staked_wal.activation_epoch(), 1);
+    assert_eq!(staked_wal.withdraw_epoch(), 2);
 
-    abort 1337
+    // test that splitting works correctly and copies the parameters
+    let other = staked_wal.split(50, ctx);
+    assert_eq!(other.value(), 50);
+    assert_eq!(other.node_id(), node_id);
+    assert_eq!(other.activation_epoch(), 1);
+    assert_eq!(other.withdraw_epoch(), 2);
+    assert_eq!(staked_wal.value(), 50);
+
+    // test that joining works correctly
+    staked_wal.join(other);
+    assert_eq!(staked_wal.value(), 100);
+    assert_eq!(staked_wal.node_id(), node_id);
+    assert_eq!(staked_wal.activation_epoch(), 1);
+    assert_eq!(staked_wal.withdraw_epoch(), 2);
+
+    // test that the staked WAL can be burned
+    let principal = staked_wal.into_balance();
+    assert_eq!(principal.destroy_for_testing(), 100);
 }
 
-#[test, expected_failure(abort_code = staked_wal::ECantJoinWithdrawing)]
-// Scenario: Try splitting a staked WAL in the withdrawing state
-// TODO: consider enabling this behavior in the future
-fun test_unable_to_join_withdrawing() {
+#[test]
+fun destroy_zero() {
     let ctx = &mut tx_context::dummy();
     let node_id = ctx.fresh_object_address().to_id();
-    let mut staked_wal_a = staked_wal::mint(node_id, mint_balance(100), 1, ctx);
-    let mut staked_wal_b = staked_wal::mint(node_id, mint_balance(100), 1, ctx);
+    let zero = staked_wal::mint(node_id, mint_balance(0), 1, ctx);
+    zero.destroy_zero();
+}
 
-    staked_wal_a.set_withdrawing(2, 100);
-    staked_wal_b.set_withdrawing(2, 100);
-    staked_wal_a.join(staked_wal_b);
+#[test, expected_failure(abort_code = staked_wal::EInvalidAmount)]
+fun try_splitting_full_amount() {
+    let ctx = &mut tx_context::dummy();
+    let node_id = ctx.fresh_object_address().to_id();
+    let mut sw = staked_wal::mint(node_id, mint_balance(1000), 1, ctx);
+    let _v = sw.split(1000, ctx);
 
-    abort 1337
+    abort
+}
+
+#[test, expected_failure(abort_code = staked_wal::EInvalidAmount)]
+fun try_split_zero() {
+    let ctx = &mut tx_context::dummy();
+    let node_id = ctx.fresh_object_address().to_id();
+    let mut sw = staked_wal::mint(node_id, mint_balance(1000), 1, ctx);
+    sw.split(0, ctx).destroy_zero();
+
+    abort
 }
 
 #[test, expected_failure(abort_code = staked_wal::EInvalidAmount)]
 // Scenario: Split a staked WAL with a larger amount
-fun test_unable_to_split_larger_amount() {
+fun unable_to_split_larger_amount() {
     let ctx = &mut tx_context::dummy();
     let node_id = ctx.fresh_object_address().to_id();
     let mut staked_wal = staked_wal::mint(node_id, mint_balance(100), 1, ctx);
 
     let _other = staked_wal.split(101, ctx);
 
-    abort 1337
+    abort
 }
 
 #[test, expected_failure(abort_code = staked_wal::EMetadataMismatch)]
 // Scenario: Join a staked WAL with a different activation epoch
-fun test_unable_to_join_activation_epoch() {
+fun unable_to_join_activation_epoch() {
     let ctx = &mut tx_context::dummy();
     let node_id = ctx.fresh_object_address().to_id();
     let mut sw1 = staked_wal::mint(node_id, mint_balance(100), 1, ctx);
@@ -94,12 +120,12 @@ fun test_unable_to_join_activation_epoch() {
 
     sw1.join(sw2);
 
-    abort 1337
+    abort
 }
 
 #[test, expected_failure(abort_code = staked_wal::EMetadataMismatch)]
 // Scenario: Join a staked WAL with a different pool ID
-fun test_unable_to_join_different_pool() {
+fun unable_to_join_different_pool() {
     let ctx = &mut tx_context::dummy();
     let node_id1 = ctx.fresh_object_address().to_id();
     let node_id2 = ctx.fresh_object_address().to_id();
@@ -108,17 +134,17 @@ fun test_unable_to_join_different_pool() {
 
     sw1.join(sw2);
 
-    abort 1337
+    abort
 }
 
 #[test, expected_failure(abort_code = staked_wal::ENonZeroPrincipal)]
 // Scenario: Destroy a staked WAL with non-zero principal
-fun test_unable_to_destroy_non_zero() {
+fun unable_to_destroy_non_zero() {
     let ctx = &mut tx_context::dummy();
     let node_id = ctx.fresh_object_address().to_id();
     let sw = staked_wal::mint(node_id, mint_balance(100), 1, ctx);
 
     sw.destroy_zero();
 
-    abort 1337
+    abort
 }

--- a/testnet-contracts/walrus/tests/staking/staking_inner_compute_tests.move
+++ b/testnet-contracts/walrus/tests/staking/staking_inner_compute_tests.move
@@ -1,0 +1,138 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module walrus::staking_inner_compute_tests;
+
+use sui::{clock, test_utils::destroy};
+use walrus::{staking_inner, test_utils as test};
+
+const EPOCH_DURATION: u64 = 7 * 24 * 60 * 60 * 1000;
+
+#[test]
+fun test_compute_single_node() {
+    let ctx = &mut tx_context::dummy();
+    let clock = clock::create_for_testing(ctx);
+    let mut staking = staking_inner::new(0, EPOCH_DURATION, 10, &clock, ctx);
+    let pool_one = test::pool().register(&mut staking, ctx);
+    let wal_alice = staking.stake_with_pool(test::mint(1_000_000, ctx), pool_one, ctx);
+
+    let committee = staking.compute_next_committee();
+
+    assert!(committee.size() == 1);
+    assert!(committee[&pool_one].length() == 10);
+
+    destroy(wal_alice);
+    destroy(staking);
+    clock.destroy_for_testing();
+}
+
+#[test]
+fun test_compute_even_distribution() {
+    let ctx = &mut tx_context::dummy();
+    let clock = clock::create_for_testing(ctx);
+    let mut staking = staking_inner::new(0, EPOCH_DURATION, 6, &clock, ctx);
+
+    let pool_one = test::pool().register(&mut staking, ctx);
+    let pool_two = test::pool().register(&mut staking, ctx);
+    let pool_three = test::pool().register(&mut staking, ctx);
+
+    let wal_alice = staking.stake_with_pool(test::mint(1_000, ctx), pool_one, ctx);
+    let wal_bob = staking.stake_with_pool(test::mint(1_000, ctx), pool_two, ctx);
+    let wal_karl = staking.stake_with_pool(test::mint(1_000, ctx), pool_three, ctx);
+
+    let committee = staking.compute_next_committee();
+
+    assert!(committee.size() == 3);
+    assert!(committee[&pool_one].length() == 2);
+    assert!(committee[&pool_two].length() == 2);
+    assert!(committee[&pool_three].length() == 2);
+
+    destroy(wal_alice);
+    destroy(wal_bob);
+    destroy(wal_karl);
+    destroy(staking);
+    clock.destroy_for_testing();
+}
+
+#[test]
+fun test_compute_uneven_distribution() {
+    let ctx = &mut tx_context::dummy();
+    let clock = clock::create_for_testing(ctx);
+    let mut staking = staking_inner::new(0, EPOCH_DURATION, 10, &clock, ctx);
+
+    let pool_one = test::pool().register(&mut staking, ctx);
+    let pool_two = test::pool().register(&mut staking, ctx);
+    let pool_three = test::pool().register(&mut staking, ctx);
+
+    let wal_alice = staking.stake_with_pool(test::mint(4_000, ctx), pool_one, ctx);
+    let wal_bob = staking.stake_with_pool(test::mint(2_000, ctx), pool_two, ctx);
+    let wal_karl = staking.stake_with_pool(test::mint(1_000, ctx), pool_three, ctx);
+
+    let committee = staking.compute_next_committee();
+
+    assert!(committee.size() == 3);
+    assert!(committee[&pool_one].length() == 6);
+    assert!(committee[&pool_two].length() == 3);
+    assert!(committee[&pool_three].length() == 1);
+
+    destroy(wal_alice);
+    destroy(wal_bob);
+    destroy(wal_karl);
+    destroy(staking);
+    clock.destroy_for_testing();
+}
+
+#[test]
+fun test_compute_equal_stake_nodes() {
+    let ctx = &mut tx_context::dummy();
+    let clock = clock::create_for_testing(ctx);
+    let mut staking = staking_inner::new(0, EPOCH_DURATION, 10, &clock, ctx);
+
+    let pool_one = test::pool().register(&mut staking, ctx);
+    let pool_two = test::pool().register(&mut staking, ctx);
+    let pool_three = test::pool().register(&mut staking, ctx);
+
+    let wal_alice = staking.stake_with_pool(test::mint(1_000, ctx), pool_one, ctx);
+    let wal_bob = staking.stake_with_pool(test::mint(1_000, ctx), pool_two, ctx);
+    let wal_karl = staking.stake_with_pool(test::mint(1_000, ctx), pool_three, ctx);
+
+    let committee = staking.compute_next_committee();
+
+    assert!(committee.size() == 3);
+    assert!(committee[&pool_one].length() == 4);
+    assert!(committee[&pool_two].length() == 3);
+    assert!(committee[&pool_three].length() == 3);
+
+    destroy(wal_alice);
+    destroy(wal_bob);
+    destroy(wal_karl);
+    destroy(staking);
+    clock.destroy_for_testing();
+}
+
+#[test]
+fun test_compute_large_committee() {
+    let ctx = &mut tx_context::dummy();
+    let clock = clock::create_for_testing(ctx);
+    let mut staking = staking_inner::new(0, EPOCH_DURATION, 100, &clock, ctx);
+
+    let n_nodes: u16 = 20;
+    let mut staked_wals = vector::empty();
+
+    n_nodes.do!(|i| {
+        let pool = test::pool().register(&mut staking, ctx);
+        let stake = 1_000 + i;
+        staked_wals.push_back(staking.stake_with_pool(
+            test::mint(stake as u64, ctx),
+            pool,
+            ctx,
+        ));
+    });
+
+    let committee = staking.compute_next_committee();
+    assert!(committee.size() == 20);
+
+    destroy(staking);
+    destroy(staked_wals);
+    clock.destroy_for_testing();
+}

--- a/testnet-contracts/walrus/tests/staking/staking_pool/pool_commission_tests.move
+++ b/testnet-contracts/walrus/tests/staking/staking_pool/pool_commission_tests.move
@@ -1,0 +1,160 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module walrus::pool_commission_tests;
+
+use walrus::{auth, test_utils::{mint_balance, pool, context_runner, assert_eq}};
+
+#[test]
+// Scenario:
+// 0. Pool has initial commission rate of 10%
+// 1. E0: Alice stakes
+// 2. E1: Alice requests withdrawal
+// 2. E2: Pool receives 10_000 rewards, Alice withdraws her stake
+fun collect_commission_with_rewards() {
+    let mut test = context_runner();
+    let (wctx, ctx) = test.current();
+    let mut pool = pool().commission_rate(10_00).build(&wctx, ctx);
+
+    // Alice stakes before committee selection, stake applied E+1
+    // And she performs the withdrawal right away
+    let mut sw1 = pool.stake(mint_balance(1000), &wctx, ctx);
+
+    let (wctx, _) = test.next_epoch();
+    pool.advance_epoch(mint_balance(0), &wctx);
+    pool.request_withdraw_stake(&mut sw1, true, false, &wctx);
+
+    let (wctx, ctx) = test.next_epoch();
+    pool.advance_epoch(mint_balance(10_000), &wctx);
+
+    // Alice's stake: 1000 + 9000 (90%) rewards
+    assert_eq!(pool.withdraw_stake(sw1, true, false, &wctx).destroy_for_testing(), 10_000);
+    assert_eq!(pool.commission_amount(), 1000);
+
+    // Commission is 10% -> 1000
+    let auth = auth::authenticate_sender(ctx);
+    let commission = pool.collect_commission(auth);
+    assert_eq!(commission.destroy_for_testing(), 1000);
+
+    pool.destroy_empty();
+}
+
+public struct TestObject has key { id: UID }
+
+#[test]
+fun change_commission_receiver() {
+    let mut test = context_runner();
+    let (wctx, ctx) = test.current();
+    let mut pool = pool().commission_rate(10_00).build(&wctx, ctx);
+
+    // by default sender is the receiver
+    let auth = auth::authenticate_sender(ctx);
+    let cap = TestObject { id: object::new(ctx) };
+    let new_receiver = auth::authorized_object(object::id(&cap));
+
+    // make sure the initial setting is correct
+    assert!(pool.commission_receiver() == &auth::authorized_address(ctx.sender()));
+
+    // update the receiver
+    pool.set_commission_receiver(auth, new_receiver);
+
+    // check the new receiver
+    assert!(pool.commission_receiver() == &new_receiver);
+
+    // try claiming the commission with the new receiver
+    let auth = auth::authenticate_with_object(&cap);
+    pool.collect_commission(auth).destroy_zero();
+
+    // change it back
+    let auth = auth::authenticate_with_object(&cap);
+    let new_receiver = auth::authorized_address(ctx.sender());
+    pool.set_commission_receiver(auth, new_receiver);
+
+    // check the new receiver
+    assert!(pool.commission_receiver() == &new_receiver);
+
+    // try claiming the commission with the new receiver
+    let auth = auth::authenticate_sender(ctx);
+    pool.collect_commission(auth).destroy_zero();
+
+    let TestObject { id } = cap;
+    id.delete();
+    pool.destroy_empty();
+}
+
+#[test, expected_failure(abort_code = ::walrus::staking_pool::EAuthorizationFailure)]
+fun change_commission_receiver_fail_incorrect_auth() {
+    let mut test = context_runner();
+    let (wctx, ctx) = test.current();
+    let mut pool = pool().commission_rate(10_00).build(&wctx, ctx);
+
+    // by default sender is the receiver
+    let cap = TestObject { id: object::new(ctx) };
+    let auth = auth::authenticate_with_object(&cap);
+    let new_receiver = auth::authorized_object(object::id(&cap));
+
+    // failure!
+    pool.set_commission_receiver(auth, new_receiver);
+
+    abort
+}
+
+#[test, expected_failure(abort_code = ::walrus::staking_pool::EAuthorizationFailure)]
+fun collect_commission_receiver_fail_incorrect_auth() {
+    let mut test = context_runner();
+    let (wctx, ctx) = test.current();
+    let mut pool = pool().commission_rate(10_00).build(&wctx, ctx);
+
+    // by default sender is the receiver
+    let cap = TestObject { id: object::new(ctx) };
+    let auth = auth::authenticate_with_object(&cap);
+
+    // failure!
+    pool.collect_commission(auth).destroy_zero();
+
+    abort
+}
+
+#[test]
+fun commission_setting_at_different_epochs() {
+    let mut test = context_runner();
+    let (wctx, ctx) = test.current();
+    let mut pool = pool().commission_rate(0).build(&wctx, ctx);
+
+    assert_eq!(pool.commission_rate(), 0);
+    pool.set_next_commission(10_00, &wctx); // applied E+2
+    assert_eq!(pool.commission_rate(), 0);
+
+    let (wctx, _) = test.next_epoch(); // E+1
+    pool.advance_epoch(mint_balance(0), &wctx);
+
+    assert_eq!(pool.commission_rate(), 0);
+    pool.set_next_commission(20_00, &wctx); // set E+3
+    pool.set_next_commission(30_00, &wctx); // override E+3
+
+    let (wctx, _) = test.next_epoch(); // E+2
+    pool.advance_epoch(mint_balance(0), &wctx);
+    assert_eq!(pool.commission_rate(), 10_00);
+    pool.set_next_commission(40_00, &wctx); // set E+4
+
+    let (wctx, _) = test.next_epoch(); // E+3
+    pool.advance_epoch(mint_balance(0), &wctx);
+    assert_eq!(pool.commission_rate(), 30_00);
+
+    let (wctx, _) = test.next_epoch(); // E+4
+    pool.advance_epoch(mint_balance(0), &wctx);
+    assert_eq!(pool.commission_rate(), 40_00);
+
+    pool.destroy_empty();
+}
+
+#[test, expected_failure(abort_code = ::walrus::staking_pool::EIncorrectCommissionRate)]
+fun set_incorrect_commission_rate_fail() {
+    let mut test = context_runner();
+    let (wctx, ctx) = test.current();
+    let mut pool = pool().commission_rate(0).build(&wctx, ctx);
+
+    pool.set_next_commission(100_01, &wctx);
+
+    abort
+}

--- a/testnet-contracts/walrus/tests/staking/staking_pool/pool_direct_withdraw_tests.move
+++ b/testnet-contracts/walrus/tests/staking/staking_pool/pool_direct_withdraw_tests.move
@@ -1,0 +1,206 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[allow(unused_use, unused_const)]
+module walrus::pool_direct_withdraw_tests;
+
+use sui::test_utils::destroy;
+use walrus::test_utils::{mint_balance, pool, context_runner, assert_eq, dbg};
+
+const E0: u32 = 0;
+const E1: u32 = 1;
+const E2: u32 = 2;
+const E3: u32 = 3;
+
+#[test]
+fun withdraw_same_epoch() {
+    let mut test = context_runner();
+    let (wctx, ctx) = test.current();
+    let mut pool = pool().build(&wctx, ctx);
+
+    // Alice stakes before committee selection, stake applied E+1
+    // And she performs the withdrawal right away
+    let sw1 = pool.stake(mint_balance(1000), &wctx, ctx);
+    assert_eq!(sw1.activation_epoch(), E1);
+    assert_eq!(pool.wal_balance_at_epoch(E1), 1000);
+
+    let balance = pool.withdraw_stake(sw1, true, false, &wctx);
+    assert_eq!(balance.destroy_for_testing(), 1000);
+    assert_eq!(pool.wal_balance_at_epoch(E1), 0);
+
+    destroy(pool);
+}
+
+#[test]
+// Scenario:
+// 1. Alice stakes before committee selection, committee selected, node is not
+//    in the committee (epoch not advanced)
+// 2. Alice performs immediate withdrawal from inactive pool.
+fun withdraw_after_committee_selection() {
+    let mut test = context_runner();
+    let (wctx, ctx) = test.current();
+    let mut pool = pool().build(&wctx, ctx);
+
+    // Alice stakes after committee selection, stake applied E+1
+    // And she performs the withdrawal right away
+    let sw1 = pool.stake(mint_balance(1000), &wctx, ctx);
+    assert_eq!(sw1.activation_epoch(), E1);
+    assert_eq!(pool.wal_balance_at_epoch(E1), 1000);
+
+    let (_, _) = test.next_epoch(); // E1
+    let (wctx, _) = test.next_epoch(); // E2
+
+    let balance = pool.withdraw_stake(sw1, false, false, &wctx);
+    assert_eq!(balance.destroy_for_testing(), 1000);
+    assert_eq!(pool.wal_balance_at_epoch(E3), 0); // ERROR: balance not zero
+
+    destroy(pool);
+}
+
+#[test]
+// Scenario:
+// 1. Alice stakes before committee selection, so does Bob.
+// 2. Pool is in the committee and selects rewards, then Bob requests withdrawal.
+// 3. Pool is not in the committee, Bob withdraws his stake in a regular way.
+// 4. Alice performs immediate withdrawal from inactive pool.
+fun withdraw_after_the_pool_became_inactive() {
+    let mut test = context_runner();
+    let (wctx, ctx) = test.current();
+    let mut pool = pool().build(&wctx, ctx);
+
+    // Alice stakes before committee selection, stake applied E+1
+    let sw1 = pool.stake(mint_balance(1000), &wctx, ctx);
+    assert_eq!(sw1.activation_epoch(), E1);
+    assert_eq!(pool.wal_balance_at_epoch(E1), 1000);
+
+    // Bob stakes before committee selection, stake applied E+1
+    let mut sw2 = pool.stake(mint_balance(1000), &wctx, ctx);
+    assert_eq!(sw2.activation_epoch(), E1);
+    assert_eq!(pool.wal_balance_at_epoch(E1), 2000);
+
+    let (wctx, _) = test.next_epoch(); // E1
+    pool.advance_epoch(mint_balance(0), &wctx);
+
+    let (wctx, _) = test.next_epoch(); // E2
+    pool.advance_epoch(mint_balance(2000), &wctx);
+
+    // Bob requests withdrawal (E2)
+    pool.request_withdraw_stake(&mut sw2, true, false, &wctx);
+    assert_eq!(pool.wal_balance_at_epoch(E2), 4000); // same epoch
+    assert_eq!(pool.wal_balance_at_epoch(E3), 2000); // next, after request
+
+    let (wctx, _) = test.next_epoch(); // E3 (Bob's withdrawal)
+    pool.advance_epoch(mint_balance(2000), &wctx);
+
+    // Bob withdraws his stake (E3)
+    let balance = pool.withdraw_stake(sw2, false, false, &wctx);
+    assert_eq!(balance.destroy_for_testing(), 3000);
+
+    // Pool is inactive, Alice performs immediate withdrawal
+    // Alice performs immediate withdrawal
+    let balance = pool.withdraw_stake(sw1, false, false, &wctx);
+    assert_eq!(balance.destroy_for_testing(), 3000);
+    assert_eq!(pool.wal_balance_at_epoch(E3), 0);
+
+    destroy(pool);
+}
+
+#[test]
+// Scenario:
+// - same as above, but Bob directly withdraws once the pool is inactive;
+fun withdraw_after_the_pool_became_inactive_alternative() {
+    let mut test = context_runner();
+    let (wctx, ctx) = test.current();
+    let mut pool = pool().build(&wctx, ctx);
+
+    // Alice stakes before committee selection, stake applied E+1
+    // Bob stakes before committee selection, stake applied E+1
+    let sw1 = pool.stake(mint_balance(1000), &wctx, ctx);
+    let mut sw2 = pool.stake(mint_balance(1000), &wctx, ctx);
+
+    let (wctx, _) = test.next_epoch(); // E1
+    pool.advance_epoch(mint_balance(0), &wctx);
+
+    let (wctx, _) = test.next_epoch(); // E2
+    pool.advance_epoch(mint_balance(2000), &wctx);
+
+    // Bob requests withdrawal (E2)
+    pool.request_withdraw_stake(&mut sw2, true, false, &wctx);
+
+    let (wctx, _) = test.next_epoch(); // E3 (Bob's withdrawal)
+    pool.advance_epoch(mint_balance(2000), &wctx);
+
+    // Bob directly withdraws his stake (E3)
+    let balance = pool.withdraw_stake(sw2, false, false, &wctx);
+    assert_eq!(balance.destroy_for_testing(), 3000);
+
+    // Alice directly withdraws her stake (E3)
+    let balance = pool.withdraw_stake(sw1, false, false, &wctx);
+    assert_eq!(balance.destroy_for_testing(), 3000);
+    assert_eq!(pool.wal_balance_at_epoch(E3), 0);
+
+    destroy(pool);
+}
+
+#[test, expected_failure(abort_code = walrus::staking_pool::EWithdrawDirectly)]
+// Scenario:
+// - try to request withdrawal for an inactive pool
+fun try_to_request_withdrawal_for_inactive_pool() {
+    let mut test = context_runner();
+    let (wctx, ctx) = test.current();
+    let mut pool = pool().build(&wctx, ctx);
+
+    // Alice stakes after committee selection, stake applied E+1
+    // And she performs the withdrawal right away
+    let mut sw1 = pool.stake(mint_balance(1000), &wctx, ctx);
+    assert_eq!(sw1.activation_epoch(), E1);
+    assert_eq!(pool.wal_balance_at_epoch(E1), 1000);
+
+    let (_, _) = test.next_epoch(); // E1
+    let (wctx, _) = test.next_epoch(); // E2
+
+    pool.request_withdraw_stake(&mut sw1, false, false, &wctx);
+
+    abort
+}
+
+#[test]
+// Scenario:
+// - withdraw pre-active stake from inactive pool
+fun direct_withdraw_for_inactive_pool_pre_active_stake() {
+    let mut test = context_runner();
+    let (wctx, ctx) = test.current();
+    let mut pool = pool().build(&wctx, ctx);
+
+    let sw1 = pool.stake(mint_balance(1000), &wctx, ctx);
+    assert_eq!(sw1.activation_epoch(), E1);
+    assert_eq!(pool.wal_balance_at_epoch(E1), 1000);
+    let balance = pool.withdraw_stake(sw1, false, false, &wctx);
+    assert_eq!(balance.destroy_for_testing(), 1000);
+
+    let (_, _) = test.next_epoch(); // E1
+    assert_eq!(pool.wal_balance_at_epoch(E1), 0);
+
+    destroy(pool);
+}
+
+#[test]
+// Scenario:
+// - withdraw active stake from inactive pool
+fun direct_withdraw_for_inactive_pool_active_stake() {
+    let mut test = context_runner();
+    let (wctx, ctx) = test.current();
+    let mut pool = pool().build(&wctx, ctx);
+
+    let sw1 = pool.stake(mint_balance(1000), &wctx, ctx);
+    assert_eq!(sw1.activation_epoch(), E1);
+    assert_eq!(pool.wal_balance_at_epoch(E1), 1000);
+
+    let (_, _) = test.next_epoch(); // E1
+    assert_eq!(pool.wal_balance_at_epoch(E1), 1000);
+
+    let balance = pool.withdraw_stake(sw1, false, false, &wctx);
+    assert_eq!(balance.destroy_for_testing(), 1000);
+
+    destroy(pool);
+}

--- a/testnet-contracts/walrus/tests/staking/staking_pool/pool_early_withdraw_tests.move
+++ b/testnet-contracts/walrus/tests/staking/staking_pool/pool_early_withdraw_tests.move
@@ -1,6 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+// Early withdrawal mechanics (for E0, E0', E1, E1', E2, E2'):
+// ```
+// - stake(E0,  AE=E1) -> immediate withdrawal(E0)              // no rewards
+// - stake(E0,  AE=E1) -> request_withdraw(E0') -> withdraw(E2) // rewards for E1
+// - stake(E0', AE=E2) -> immediate withdrawal(E0', E1)         // no rewards
+// - stake(E0', AE=E2) -> request_withdraw(E1') -> withdraw(E3) // rewards for E2
+
 #[allow(unused_use, unused_const)]
 module walrus::pool_early_withdraw_tests;
 
@@ -27,55 +34,144 @@ fun withdraw_before_activation_before_committee_selection() {
     assert_eq!(sw1.activation_epoch(), E1);
     assert_eq!(pool.wal_balance_at_epoch(E1), 1000);
 
-    let balance = pool.withdraw_stake(sw1, &wctx);
+    let balance = pool.withdraw_stake(sw1, true, false, &wctx);
     assert_eq!(balance.destroy_for_testing(), 1000);
     assert_eq!(pool.wal_balance_at_epoch(E1), 0);
 
     destroy(pool);
 }
 
-#[test, expected_failure]
+#[test]
+// Scenario:
+// 1. Alice stakes in E0 and immediately withdraws in E0
+// 2. Bob stakes in E0 (and then requests after committee selection)
+// 3. Charlie stakes in E0' (after committee selection) and withdraws in E1
+// 4. Dave stakes in E0' (after committee selection) and requests in E1' and withdraws in E2
+fun withdraw_processing_at_different_epochs() {
+    let mut test = context_runner();
+    let (wctx, ctx) = test.current();
+    let mut pool = pool().build(&wctx, ctx);
+
+    // Alice stakes before committee selection, stake applied E+1
+    // And she performs the withdrawal right away
+    let alice = pool.stake(mint_balance(1000), &wctx, ctx);
+    assert_eq!(alice.activation_epoch(), E1);
+    assert_eq!(pool.wal_balance_at_epoch(E1), 1000);
+    let balance = pool.withdraw_stake(alice, true, false, &wctx);
+    assert_eq!(balance.destroy_for_testing(), 1000);
+    assert_eq!(pool.wal_balance_at_epoch(E1), 0);
+
+    // Bob stakes before committee selection, stake applied E+1
+    let mut bob = pool.stake(mint_balance(1000), &wctx, ctx);
+    assert_eq!(bob.activation_epoch(), E1);
+    assert_eq!(pool.wal_balance_at_epoch(E1), 1000);
+
+    let (wctx, ctx) = test.select_committee();
+
+    // Bob requests withdrawal after committee selection
+    pool.request_withdraw_stake(&mut bob, true, true, &wctx);
+    assert!(bob.activation_epoch() > wctx.epoch());
+    assert_eq!(pool.wal_balance_at_epoch(E1), 1000);
+    assert_eq!(bob.withdraw_epoch(), E2);
+
+    // Charlie stakes after committee selection, stake applied E+2
+    let charlie = pool.stake(mint_balance(1000), &wctx, ctx);
+    assert_eq!(charlie.activation_epoch(), E2);
+
+    // Dave stakes after committee selection, stake applied E+2
+    let mut dave = pool.stake(mint_balance(1000), &wctx, ctx);
+    assert_eq!(dave.activation_epoch(), E2);
+
+    // E1: Charlie withdraws his stake directly, without requesting
+    let (wctx, _ctx) = test.next_epoch();
+    pool.advance_epoch(mint_balance(0), &wctx);
+    let balance = pool.withdraw_stake(charlie, true, false, &wctx);
+    assert_eq!(balance.destroy_for_testing(), 1000);
+
+    // E1': Dave requests withdrawal
+    let (wctx, _ctx) = test.select_committee();
+    pool.request_withdraw_stake(&mut dave, true, true, &wctx);
+    assert_eq!(dave.activation_epoch(), E2);
+    assert_eq!(dave.withdraw_epoch(), E3);
+
+    // E2: Bob withdraws his stake
+    let (wctx, _ctx) = test.next_epoch();
+    pool.advance_epoch(mint_balance(1000), &wctx);
+
+    let balance = pool.withdraw_stake(bob, true, false, &wctx);
+    assert_eq!(balance.destroy_for_testing(), 2000); // 1000 + rewards
+
+    // E3: Dave withdraws his stake
+    let (wctx, _ctx) = test.next_epoch();
+    pool.advance_epoch(mint_balance(1000), &wctx);
+
+    let balance = pool.withdraw_stake(dave, true, false, &wctx);
+    assert_eq!(balance.destroy_for_testing(), 2000); // 1000 + rewards
+
+    // empty wal balance but not empty pool tokens
+    // because we haven't registered the pool token withdrawal
+    assert_eq!(pool.wal_balance(), 0);
+
+    pool.destroy_empty();
+}
+
+#[test, expected_failure(abort_code = walrus::staking_pool::ENotWithdrawing)]
 // Scenario:
 // 1. Alice stakes in E0,
 // 2. Committee selected
-// 3. Alice tries to withdraw and fails
+// 3. Alice tries to withdraw and fails - need to request withdrawal first
 fun request_withdraw_after_committee_selection() {
     let mut test = context_runner();
     let (wctx, ctx) = test.current();
     let mut pool = pool().build(&wctx, ctx);
 
     // Alice stakes in E0, tries to withdraw after committee selection
-    let mut sw1 = pool.stake(mint_balance(1000), &wctx, ctx);
-    assert_eq!(sw1.activation_epoch(), E1);
+    let sw1 = pool.stake(mint_balance(1000), &wctx, ctx);
     assert_eq!(pool.wal_balance_at_epoch(E1), 1000);
+    assert_eq!(sw1.activation_epoch(), E1);
 
     let (wctx, _ctx) = test.select_committee();
+    let _ = pool.withdraw_stake(sw1, true, true, &wctx).destroy_for_testing();
 
-    pool.request_withdraw_stake(&mut sw1, &wctx);
-
-    destroy(sw1);
-    destroy(pool);
+    abort
 }
 
-#[test]
-// Scenario:
-// 1. Alice stakes in E0 after committee selection
-// 2. Alice withdraws in the next epoch before committee selection
-// 3. Success
-fun request_withdraw_after_committee_selection_next_epoch() {
+#[test, expected_failure(abort_code = walrus::staking_pool::EWithdrawDirectly)]
+// Scenario (see `request_withdraw_can_withdraw_directly` for symmetrical successful case)
+// 1. Alice stakes in E0 before committee selection
+// 2. Alice requests withdrawal (even though it's not needed)
+// 3. Failure
+fun request_withdraw_when_can_withdraw_directly() {
     let mut test = context_runner();
     let (wctx, ctx) = test.current();
     let mut pool = pool().build(&wctx, ctx);
 
-    // Alice stakes in E0 after committee selection, withdraws in the next epoch
-    let (wctx, ctx) = test.select_committee();
+    // Alice stakes in E0 before committee selection
+    let mut sw1 = pool.stake(mint_balance(1000), &wctx, ctx);
+    assert_eq!(pool.wal_balance_at_epoch(E1), 1000);
+    assert_eq!(sw1.activation_epoch(), E1);
+
+    pool.request_withdraw_stake(&mut sw1, true, false, &wctx);
+
+    abort
+}
+
+#[test]
+// Scenario (see `request_withdraw_when_can_withdraw_directly` for symmetrical failure case)
+// 1. Alice stakes in E0 before committee selection
+// 2. Alice withdraws directly
+fun request_withdraw_can_withdraw_directly() {
+    let mut test = context_runner();
+    let (wctx, ctx) = test.current();
+    let mut pool = pool().build(&wctx, ctx);
+
+    // Alice stakes in E0 before committee selection
     let sw1 = pool.stake(mint_balance(1000), &wctx, ctx);
-    assert_eq!(sw1.activation_epoch(), E2);
-    assert_eq!(pool.wal_balance_at_epoch(E2), 1000);
+    assert_eq!(pool.wal_balance_at_epoch(E1), 1000);
+    assert_eq!(sw1.activation_epoch(), E1);
 
-    let (wctx, _ctx) = test.next_epoch();
-    let amount = pool.withdraw_stake(sw1, &wctx).destroy_for_testing();
+    let balance = pool.withdraw_stake(sw1, true, false, &wctx);
+    assert_eq!(balance.destroy_for_testing(), 1000);
 
-    assert_eq!(amount, 1000);
     destroy(pool);
 }

--- a/testnet-contracts/walrus/tests/staking/staking_pool/pool_rounding_tests.move
+++ b/testnet-contracts/walrus/tests/staking/staking_pool/pool_rounding_tests.move
@@ -1,0 +1,91 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module walrus::pool_rounding_tests;
+
+use walrus::{auth, test_utils::{mint_balance, pool, context_runner, assert_eq}};
+
+#[test, expected_failure(abort_code = ::walrus::staking_pool::EPoolNotEmpty)]
+// Failure reason: rewards left in the pool after all stakes are withdrawn
+fun split_odd_number_of_rewards_pool_leftovers_failure() {
+    let mut test = context_runner();
+
+    // E0: Alice stakes 199 WAL; Bob stakes 100 WAL
+    let (wctx, ctx) = test.current();
+    let mut pool = pool().build(&wctx, ctx);
+    let mut staked_a = pool.stake(mint_balance(100), &wctx, ctx);
+    let mut staked_b = pool.stake(mint_balance(100), &wctx, ctx);
+    assert_eq!(pool.wal_balance(), 0);
+
+    // E1: No rewards received yet, pool is expected to join the committee
+    let (wctx, _) = test.next_epoch();
+    pool.advance_epoch(mint_balance(0), &wctx);
+    assert_eq!(pool.wal_balance(), 200);
+
+    // E2: Rewards received, Alice withdraws everything, Bob too
+    // 200 WAL rewards:
+    // Alice gets 201 / 2 = 100
+    // Bob   gets 201 / 2 = 100
+    let (wctx, _) = test.next_epoch();
+    pool.advance_epoch(mint_balance(201), &wctx);
+    assert_eq!(pool.wal_balance(), 401);
+
+    pool.request_withdraw_stake(&mut staked_a, true, false, &wctx);
+    pool.request_withdraw_stake(&mut staked_b, true, false, &wctx);
+
+    let (wctx, _) = test.next_epoch();
+
+    let balance_a = pool.withdraw_stake(staked_a, true, false, &wctx);
+    let balance_b = pool.withdraw_stake(staked_b, true, false, &wctx);
+
+    assert_eq!(balance_a.destroy_for_testing(), 200);
+    assert_eq!(balance_b.destroy_for_testing(), 200);
+    assert_eq!(pool.num_shares(), 200); // epoch change hasn't happened yet
+
+    let (wctx, _) = test.next_epoch();
+    pool.advance_epoch(mint_balance(0), &wctx);
+    assert_eq!(pool.num_shares(), 0); // 0 pool tokens left
+
+    pool.destroy_empty(); // fails because there's dust in the `staked_wal`
+
+    abort
+}
+
+#[test]
+// Not failing when mixed with commission.
+// Commission seems to not affect rewards calculation in terms for rounding.
+fun commission_rounding_success() {
+    let mut test = context_runner();
+
+    // E0: Alice stakes 100 WAL
+    let (wctx, ctx) = test.current();
+    let mut pool = pool().commission_rate(10_00).build(&wctx, ctx);
+    let mut staked_a = pool.stake(mint_balance(100), &wctx, ctx);
+    assert_eq!(pool.wal_balance(), 0);
+
+    // E1: No rewards received yet, pool is expected to join the committee
+    let (wctx, _) = test.next_epoch();
+    pool.advance_epoch(mint_balance(0), &wctx);
+
+    // E2: Rewards received, Alice withdraws everything
+    // 202 WAL rewards: Alice gets 100% of the rewards post 10% commission (20)
+    let (wctx, _) = test.next_epoch();
+    pool.advance_epoch(mint_balance(202), &wctx);
+
+    assert_eq!(pool.commission_amount(), 20); // 9%
+    assert_eq!(pool.wal_balance(), 282);
+
+    pool.request_withdraw_stake(&mut staked_a, true, false, &wctx);
+
+    let (wctx, ctx) = test.next_epoch();
+    let balance_a = pool.withdraw_stake(staked_a, true, false, &wctx);
+    assert_eq!(balance_a.destroy_for_testing(), 282); // 100 + 183 rewards?
+
+    let auth = auth::authenticate_sender(ctx);
+    let commission = pool.collect_commission(auth);
+    assert_eq!(commission.destroy_for_testing(), 20);
+
+    let (wctx, _) = test.next_epoch();
+    pool.advance_epoch(mint_balance(0), &wctx);
+    pool.destroy_empty();
+}

--- a/testnet-contracts/walrus/tests/staking/staking_pool/staking_pool_tests.move
+++ b/testnet-contracts/walrus/tests/staking/staking_pool/staking_pool_tests.move
@@ -1,14 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// TODO: better comments above test cases
-// TODO: more tests? come up with new scenarios
-
-#[allow(unused_use)]
 module walrus::staking_pool_tests;
 
 use sui::test_utils::destroy;
-use walrus::test_utils::{mint_balance, pool, context_runner, assert_eq, dbg};
+use walrus::test_utils::{mint_balance, pool, context_runner, assert_eq};
 
 #[test]
 // Scenario: Alice stakes, pool receives rewards, Alice withdraws everything
@@ -32,15 +28,15 @@ fun stake_and_receive_rewards() {
     // E2: Rewards received, Alice withdraws everything
     let (wctx, _) = test.next_epoch();
     pool.advance_epoch(mint_balance(1000), &wctx);
-    pool.request_withdraw_stake(&mut staked_a, &wctx);
+    pool.request_withdraw_stake(&mut staked_a, true, false, &wctx);
 
     assert_eq!(pool.wal_balance(), 2000);
-    assert_eq!(staked_a.pool_token_amount(), 1000);
+    assert!(staked_a.is_withdrawing());
 
     // E3: Alice withdraws everything
     let (wctx, _) = test.next_epoch();
     pool.advance_epoch(mint_balance(0), &wctx);
-    let balance_a = pool.withdraw_stake(staked_a, &wctx);
+    let balance_a = pool.withdraw_stake(staked_a, true, false, &wctx);
 
     assert_eq!(balance_a.destroy_for_testing(), 2000);
     assert_eq!(pool.wal_balance(), 0);
@@ -75,25 +71,25 @@ fun stake_no_rewards_different_epochs() {
     // E2: Alice requests withdrawal, expecting to withdraw 1000 WAL + 100 rewards.
     let (wctx, _) = test.next_epoch();
     pool.advance_epoch(mint_balance(0), &wctx);
-    pool.request_withdraw_stake(&mut staked_a, &wctx);
+    pool.request_withdraw_stake(&mut staked_a, true, false, &wctx);
 
     assert_eq!(pool.wal_balance(), 2000);
-    assert_eq!(staked_a.pool_token_amount(), 1000);
+    assert!(staked_a.is_withdrawing());
 
     // E3: Bob requests withdrawal
     let (wctx, _) = test.next_epoch();
     pool.advance_epoch(mint_balance(0), &wctx);
-    pool.request_withdraw_stake(&mut staked_b, &wctx);
-    let balance_a = pool.withdraw_stake(staked_a, &wctx);
+    pool.request_withdraw_stake(&mut staked_b, true, false, &wctx);
+    let balance_a = pool.withdraw_stake(staked_a, true, false, &wctx);
 
     assert_eq!(pool.wal_balance(), 1000);
     assert_eq!(balance_a.destroy_for_testing(), 1000);
-    assert_eq!(staked_b.pool_token_amount(), 1000);
+    assert!(staked_b.is_withdrawing());
 
     // E5: Bob withdraws
     let (wctx, _) = test.next_epoch();
     pool.advance_epoch(mint_balance(0), &wctx);
-    let balance_b = pool.withdraw_stake(staked_b, &wctx);
+    let balance_b = pool.withdraw_stake(staked_b, true, false, &wctx);
     assert_eq!(balance_b.destroy_for_testing(), 1000);
 
     pool.destroy_empty()
@@ -117,13 +113,13 @@ fun stake_and_receive_partial_rewards() {
     // E1: Rewards received, Alice requests withdrawal of 1000 WAL + rewards
     let (wctx, _) = test.next_epoch();
     pool.advance_epoch(mint_balance(1000), &wctx);
-    pool.request_withdraw_stake(&mut staked_a, &wctx);
-    pool.request_withdraw_stake(&mut staked_b, &wctx);
+    pool.request_withdraw_stake(&mut staked_a, true, false, &wctx);
+    pool.request_withdraw_stake(&mut staked_b, true, false, &wctx);
 
     // E2: Alice withdraws 500 WAL + rewards
     let (wctx, _) = test.next_epoch();
     pool.advance_epoch(mint_balance(0), &wctx);
-    let balance_a = pool.withdraw_stake(staked_a, &wctx);
+    let balance_a = pool.withdraw_stake(staked_a, true, false, &wctx);
     assert!(balance_a.destroy_for_testing().diff(1500) < 10);
 
     let (wctx, _) = test.next_epoch();
@@ -132,7 +128,7 @@ fun stake_and_receive_partial_rewards() {
     // E3: Bob a little late to withdraw
     let (wctx, _) = test.next_epoch();
     pool.advance_epoch(mint_balance(0), &wctx);
-    let balance_b = pool.withdraw_stake(staked_b, &wctx);
+    let balance_b = pool.withdraw_stake(staked_b, true, false, &wctx);
     assert!(balance_b.destroy_for_testing().diff(1500) < 10);
 
     pool.destroy_empty()
@@ -161,20 +157,20 @@ fun stake_split_stake() {
     // E2
     let (wctx, _) = test.next_epoch();
     pool.advance_epoch(mint_balance(1000), &wctx);
-    pool.request_withdraw_stake(&mut staked_a, &wctx);
+    pool.request_withdraw_stake(&mut staked_a, true, false, &wctx);
 
     // E3
     let (wctx, _) = test.next_epoch();
     pool.advance_epoch(mint_balance(1000), &wctx);
-    pool.request_withdraw_stake(&mut staked_b, &wctx);
-    let balance_a = pool.withdraw_stake(staked_a, &wctx);
+    pool.request_withdraw_stake(&mut staked_b, true, false, &wctx);
+    let balance_a = pool.withdraw_stake(staked_a, true, false, &wctx);
 
     assert_eq!(balance_a.destroy_for_testing(), 1500);
 
     // E4
     let (wctx, _) = test.next_epoch();
     pool.advance_epoch(mint_balance(0), &wctx);
-    let balance_b = pool.withdraw_stake(staked_b, &wctx);
+    let balance_b = pool.withdraw_stake(staked_b, true, false, &wctx);
 
     assert_eq!(balance_b.destroy_for_testing(), 1500);
 
@@ -204,23 +200,23 @@ fun stake_maintain_ratio() {
     // E2: +1000 Rewards; Alice requests withdrawal
     let (wctx, _) = test.next_epoch();
     pool.advance_epoch(mint_balance(1000), &wctx);
-    pool.request_withdraw_stake(&mut staked_a, &wctx);
-    assert_eq!(staked_a.pool_token_amount(), 1000);
+    pool.request_withdraw_stake(&mut staked_a, true, false, &wctx);
+    assert!(staked_a.is_withdrawing());
 
     // E3: +1000 Rewards; Alice withdraws (1000 + 1000); Bob requests withdrawal
     let (wctx, _) = test.next_epoch();
     pool.advance_epoch(mint_balance(1000), &wctx);
-    pool.request_withdraw_stake(&mut staked_b, &wctx);
-    assert_eq!(staked_b.pool_token_amount(), 1000);
+    pool.request_withdraw_stake(&mut staked_b, true, false, &wctx);
+    assert!(staked_b.is_withdrawing());
 
-    let balance_a = pool.withdraw_stake(staked_a, &wctx);
+    let balance_a = pool.withdraw_stake(staked_a, true, false, &wctx);
     assert_eq!(balance_a.destroy_for_testing(), 2500);
 
     // E4: Bob withdraws (1000 + 1000); pool is empty
     let (wctx, _) = test.next_epoch();
     pool.advance_epoch(mint_balance(0), &wctx);
 
-    let balance_b = pool.withdraw_stake(staked_b, &wctx);
+    let balance_b = pool.withdraw_stake(staked_b, true, false, &wctx);
     assert_eq!(balance_b.destroy_for_testing(), 2500);
 
     pool.destroy_empty()
@@ -320,7 +316,7 @@ fun wal_balance_at_epoch() {
         assert_eq!(pool.wal_balance_at_epoch(E4), 7000); // D stake applied
     };
 
-    pool.request_withdraw_stake(&mut staked_wal_a, &wctx); // -2000 E+1
+    pool.request_withdraw_stake(&mut staked_wal_a, true, false, &wctx); // -2000 E+1
 
     {
         assert_eq!(pool.wal_balance_at_epoch(E2), 5000);
@@ -330,7 +326,7 @@ fun wal_balance_at_epoch() {
 
     // E2+: committee selected, another stake applied in E+2
     let (wctx, _) = test.select_committee();
-    pool.request_withdraw_stake(&mut staked_wal_b, &wctx); // -1000 E+2
+    pool.request_withdraw_stake(&mut staked_wal_b, true, true, &wctx); // -1000 E+2
 
     {
         assert_eq!(pool.wal_balance_at_epoch(E2), 5000);
@@ -359,7 +355,7 @@ fun wal_balance_at_epoch() {
         assert_eq!(pool.wal_balance_at_epoch(E5), 6000);
     };
 
-    pool.request_withdraw_stake(&mut staked_wal_c, &wctx); // C (-4000)
+    pool.request_withdraw_stake(&mut staked_wal_c, true, false, &wctx); // C (-4000)
 
     {
         assert_eq!(pool.wal_balance_at_epoch(E3), 8000);
@@ -369,7 +365,7 @@ fun wal_balance_at_epoch() {
 
     // E3+: committee selected, D requests withdrawal
     let (wctx, _) = test.select_committee();
-    pool.request_withdraw_stake(&mut staked_wal_d, &wctx); // D (-2000)
+    pool.request_withdraw_stake(&mut staked_wal_d, true, true, &wctx); // D (-2000)
 
     {
         assert_eq!(pool.wal_balance_at_epoch(E3), 8000);
@@ -405,16 +401,141 @@ fun wal_balance_at_epoch() {
 
     assert_eq!(pool.wal_balance_at_epoch(E5), 0);
 
-    let balance_a = pool.withdraw_stake(staked_wal_a, &wctx);
-    let balance_b = pool.withdraw_stake(staked_wal_b, &wctx);
-    let balance_c = pool.withdraw_stake(staked_wal_c, &wctx);
-    let balance_d = pool.withdraw_stake(staked_wal_d, &wctx);
+    let balance_a = pool.withdraw_stake(staked_wal_a, true, false, &wctx);
+    let balance_b = pool.withdraw_stake(staked_wal_b, true, false, &wctx);
+    let balance_c = pool.withdraw_stake(staked_wal_c, true, false, &wctx);
+    let balance_d = pool.withdraw_stake(staked_wal_d, true, false, &wctx);
 
     assert_eq!(balance_a.destroy_for_testing(), 4000);
     assert_eq!(balance_b.destroy_for_testing(), 3000);
     assert_eq!(balance_c.destroy_for_testing(), 6000);
     assert_eq!(balance_d.destroy_for_testing(), 3000);
 
+    pool.destroy_empty()
+}
+
+#[test]
+// Check that wal_balance_at_epoch correctly updates after a pre-active stake
+// withdrawal.
+fun wal_balance_after_pre_active_withdrawal() {
+    let mut test = context_runner();
+
+    // E0:
+    // A stakes 1000 (E1)
+    // B stakes 500 (E1)
+    let (wctx, ctx) = test.current();
+    let mut pool = pool().build(&wctx, ctx);
+
+    assert_eq!(pool.wal_balance(), 0);
+
+    let mut staked_wal_a = pool.stake(mint_balance(1000), &wctx, ctx);
+    let mut staked_wal_b = pool.stake(mint_balance(500), &wctx, ctx);
+
+    {
+        assert_eq!(pool.wal_balance(), 0);
+        assert_eq!(pool.wal_balance_at_epoch(E1), 1500);
+        assert_eq!(pool.wal_balance_at_epoch(E2), 1500);
+    };
+
+    // E0+: committee has been selected, B unstakes pre-active stake, C stakes 1000 (E2)
+    let (wctx, ctx) = test.select_committee();
+    pool.request_withdraw_stake(&mut staked_wal_b, true, true, &wctx); // -1000 E+1
+    let staked_wal_c = pool.stake(mint_balance(1000), &wctx, ctx);
+    {
+        assert_eq!(pool.wal_balance_at_epoch(E0), 0);
+        assert_eq!(pool.wal_balance_at_epoch(E1), 1500);
+        assert_eq!(pool.wal_balance_at_epoch(E2), 2000);
+    };
+
+    // Since we are still in E0, the stake is not active yet
+    // and can be withdrawn immediately.
+    let balance_c = pool.withdraw_stake(staked_wal_c, true, false, &wctx);
+
+    {
+        assert_eq!(pool.wal_balance_at_epoch(E0), 0);
+        assert_eq!(pool.wal_balance_at_epoch(E1), 1500);
+        assert_eq!(pool.wal_balance_at_epoch(E2), 1000);
+    };
+
+    // Clean up the pool
+    let (wctx, _) = test.next_epoch();
+    pool.advance_epoch(mint_balance(0), &wctx);
+
+    pool.request_withdraw_stake(&mut staked_wal_a, true, false, &wctx);
+
+    let (wctx, _) = test.next_epoch();
+    pool.advance_epoch(mint_balance(0), &wctx);
+
+    let balance_a = pool.withdraw_stake(staked_wal_a, true, false, &wctx);
+    let balance_b = pool.withdraw_stake(staked_wal_b, true, false, &wctx);
+
+    assert_eq!(balance_a.destroy_for_testing(), 1000);
+    assert_eq!(balance_b.destroy_for_testing(), 500);
+    assert_eq!(balance_c.destroy_for_testing(), 1000);
+
+    pool.destroy_empty()
+}
+
+#[test]
+// Check that wal_balance_at_epoch correctly updates if a stake is withdrawn
+// after two epochs.
+fun wal_balance_with_withdrawal_after_two_epochs() {
+    let mut test = context_runner();
+
+    let (wctx, ctx) = test.select_committee();
+    let mut pool = pool().build(&wctx, ctx);
+    assert_eq!(pool.wal_balance(), 0);
+    {
+        assert_eq!(pool.wal_balance(), 0);
+        assert_eq!(pool.wal_balance_at_epoch(E1), 0);
+        assert_eq!(pool.wal_balance_at_epoch(E2), 0);
+    };
+
+    // E0:
+    // A stakes 1000
+    let mut staked_wal_a = pool.stake(mint_balance(1000), &wctx, ctx);
+    {
+        assert_eq!(pool.wal_balance(), 0);
+        assert_eq!(pool.wal_balance_at_epoch(E1), 0);
+        assert_eq!(pool.wal_balance_at_epoch(E2), 1000);
+    };
+    test.next_epoch();
+    let (wctx, _) = test.select_committee();
+
+    // E1:
+    {
+        assert_eq!(pool.wal_balance_at_epoch(E1), 0);
+        assert_eq!(pool.wal_balance_at_epoch(E2), 1000);
+        assert_eq!(pool.wal_balance_at_epoch(E3), 1000);
+    };
+
+    pool.request_withdraw_stake(&mut staked_wal_a, true, true, &wctx);
+    {
+        assert_eq!(pool.wal_balance_at_epoch(E1), 0);
+        assert_eq!(pool.wal_balance_at_epoch(E2), 1000);
+        assert_eq!(pool.wal_balance_at_epoch(E3), 0);
+    };
+    test.next_epoch();
+    let (wctx, _) = test.select_committee();
+    pool.advance_epoch(mint_balance(0), &wctx);
+
+    // E2:
+    {
+        assert_eq!(pool.wal_balance_at_epoch(E2), 1000);
+        assert_eq!(pool.wal_balance_at_epoch(E3), 0);
+    };
+    let (_, _) = test.next_epoch();
+    let (wctx, _) = test.select_committee();
+    pool.advance_epoch(mint_balance(0), &wctx);
+
+    // E3:
+    {
+        assert_eq!(pool.wal_balance_at_epoch(E3), 0);
+    };
+
+    let balance_a = pool.withdraw_stake(staked_wal_a, true, true, &wctx);
+
+    assert_eq!(balance_a.destroy_for_testing(), 1000);
     pool.destroy_empty()
 }
 
@@ -449,7 +570,7 @@ fun correct_stake_with_withdrawals() {
     // E2: +1000 Rewards for E1; Alice requests withdrawal
     let (wctx, _) = test.next_epoch();
     pool.advance_epoch(mint_balance(1000), &wctx);
-    pool.request_withdraw_stake(&mut staked_a, &wctx);
+    pool.request_withdraw_stake(&mut staked_a, true, false, &wctx);
 
     // All rewards for the previous epoch go to Alice, Alice's stake does not count anymore.
     // Stake is 2000 (Bob + Chalie)
@@ -458,7 +579,7 @@ fun correct_stake_with_withdrawals() {
     // E3: +1000 Rewards for E2; Bob requests withdrawal
     let (wctx, _) = test.next_epoch();
     pool.advance_epoch(mint_balance(1000), &wctx);
-    pool.request_withdraw_stake(&mut staked_b, &wctx);
+    pool.request_withdraw_stake(&mut staked_b, true, false, &wctx);
 
     // Half of the rewards for the previous epoch go to Alice, a quarter to Bob and Charlie each.
     // Alice's and Bob's stakes does not count anymore.
@@ -512,7 +633,7 @@ fun pool_token_with_rewards_at_epochs() {
     assert_eq!(pool.wal_balance_at_epoch(wctx.epoch() + 1), 3000);
 
     // E+1, request withdraw stake A (to withdraw in E+2)
-    pool.request_withdraw_stake(&mut staked_wal_a, &wctx);
+    pool.request_withdraw_stake(&mut staked_wal_a, true, false, &wctx);
 
     assert!(staked_wal_a.is_withdrawing());
     assert_eq!(staked_wal_a.withdraw_epoch(), wctx.epoch() + 1);
@@ -524,17 +645,17 @@ fun pool_token_with_rewards_at_epochs() {
     pool.advance_epoch(mint_balance(0), &wctx);
 
     // E+2, withdraw stake A, request withdraw stake B
-    let balance = pool.withdraw_stake(staked_wal_a, &wctx);
+    let balance = pool.withdraw_stake(staked_wal_a, true, false, &wctx);
     assert_eq!(balance.destroy_for_testing(), 2000); // 1000 + 1000 rewards
 
-    pool.request_withdraw_stake(&mut staked_wal_b, &wctx);
+    pool.request_withdraw_stake(&mut staked_wal_b, true, false, &wctx);
 
     // E+3, withdraw stake B
     let (wctx, _) = test.next_epoch();
 
     pool.advance_epoch(mint_balance(0), &wctx);
 
-    let coin = pool.withdraw_stake(staked_wal_b, &wctx);
+    let coin = pool.withdraw_stake(staked_wal_b, true, false, &wctx);
     assert_eq!(coin.destroy_for_testing(), 1000);
 
     destroy(pool);
@@ -562,16 +683,16 @@ fun pool_token_split_rewards() {
     assert_eq!(pool.wal_balance_at_epoch(wctx.epoch()), 3000); // 1000 + 1000 rewards
 
     // E+1, request withdraw stake A and B (to withdraw in E+2)
-    pool.request_withdraw_stake(&mut staked_wal_a, &wctx);
-    pool.request_withdraw_stake(&mut staked_wal_b, &wctx);
+    pool.request_withdraw_stake(&mut staked_wal_a, true, false, &wctx);
+    pool.request_withdraw_stake(&mut staked_wal_b, true, false, &wctx);
 
     let (wctx, _) = test.next_epoch();
 
     pool.advance_epoch(mint_balance(0), &wctx);
 
     // E+2, withdraw stake A and B
-    let balance_a = pool.withdraw_stake(staked_wal_a, &wctx);
-    let balance_b = pool.withdraw_stake(staked_wal_b, &wctx);
+    let balance_a = pool.withdraw_stake(staked_wal_a, true, false, &wctx);
+    let balance_b = pool.withdraw_stake(staked_wal_b, true, false, &wctx);
 
     // due to rounding on low values, we cannot check the exact value, but
     // we check that the difference is less than 1%
@@ -588,23 +709,24 @@ fun test_advance_pool_epoch() {
     // create pool with commission rate 1000.
     let (wctx, ctx) = test.current();
     let mut pool = pool()
-        .commission_rate(1000)
+        .commission_rate(1_00)
         .write_price(1)
         .storage_price(1)
         .node_capacity(1)
         .build(&wctx, ctx);
 
     assert_eq!(pool.wal_balance(), 0);
-    assert_eq!(pool.commission_rate(), 1000);
+    assert_eq!(pool.commission_rate(), 1_00);
     assert_eq!(pool.write_price(), 1);
     assert_eq!(pool.storage_price(), 1);
     assert_eq!(pool.node_capacity(), 1);
 
-    // pool changes commission rate to 100 in epoch E+1
-    pool.set_next_commission(100);
     pool.set_next_node_capacity(1000);
     pool.set_next_storage_price(100);
     pool.set_next_write_price(100);
+
+    // pool changes commission rate to 10% in epoch E+2
+    pool.set_next_commission(10_00, &wctx);
 
     // TODO: commission rate should be applied in E+2
     //_eq assert!(pool.commission_rate(), 1000);
@@ -629,7 +751,7 @@ fun test_advance_pool_epoch() {
     pool.advance_epoch(mint_balance(0), &wctx);
 
     assert_eq!(pool.wal_balance(), 1000);
-    assert_eq!(pool.commission_rate(), 100);
+    assert_eq!(pool.commission_rate(), 1_00); // still the old value
     assert_eq!(pool.node_capacity(), 1000);
     assert_eq!(pool.write_price(), 100);
     assert_eq!(pool.storage_price(), 100);
@@ -645,8 +767,55 @@ fun test_advance_pool_epoch() {
     pool.advance_epoch(mint_balance(0), &wctx);
     assert_eq!(pool.wal_balance(), 2000);
     assert_eq!(pool.write_price(), 1000);
+    assert_eq!(pool.commission_rate(), 10_00);
 
     destroy(pool);
     destroy(sw1);
     destroy(sw2);
+}
+
+#[test]
+// Scenario:
+// - E0: Alice stakes
+// - E1: Bob stakes
+// - E2: Nothing
+// - E3: Alice requests withdrawal, so does Bob
+// - E4+: Join staked wal, withdraw
+fun staked_wal_join_different_activation_epochs() {
+    let mut test = context_runner();
+
+    // E0
+    let (wctx, ctx) = test.current();
+    let mut pool = pool().build(&wctx, ctx);
+    let mut sw1 = pool.stake(mint_balance(1000), &wctx, ctx);
+
+    // E1
+    let (wctx, ctx) = test.next_epoch();
+    pool.advance_epoch(mint_balance(0), &wctx);
+    let mut sw2 = pool.stake(mint_balance(1000), &wctx, ctx);
+
+    // E2, then E3
+    let (wctx, _) = test.next_epoch();
+    pool.advance_epoch(mint_balance(0), &wctx);
+    let (wctx, _) = test.next_epoch();
+    pool.advance_epoch(mint_balance(0), &wctx);
+
+    pool.request_withdraw_stake(&mut sw1, true, false, &wctx);
+    pool.request_withdraw_stake(&mut sw2, true, false, &wctx);
+
+    // E4
+    let (wctx, _) = test.next_epoch();
+    pool.advance_epoch(mint_balance(0), &wctx);
+
+    // Two different activation epochs, but the same withdraw epoch
+    assert!(sw1.activation_epoch() != sw2.activation_epoch());
+    assert_eq!(sw1.withdraw_epoch(), sw2.withdraw_epoch());
+    sw1.join(sw2);
+
+    // Make sure `join` works correctly
+    assert_eq!(sw1.value(), 2000);
+    assert!(sw1.is_withdrawing());
+    assert_eq!(pool.withdraw_stake(sw1, true, false, &wctx).destroy_for_testing(), 2000);
+
+    destroy(pool);
 }

--- a/testnet-contracts/walrus/tests/system/bls_tests.move
+++ b/testnet-contracts/walrus/tests/system/bls_tests.move
@@ -4,18 +4,18 @@
 #[test_only]
 module walrus::bls_tests;
 
-use sui::bls12381;
+use sui::bls12381::{Self, g1_to_uncompressed_g1};
 use walrus::{
-    bls_aggregate::{Self, BlsCommittee, new_bls_committee, verify_certificate},
+    bls_aggregate::{Self, BlsCommittee, new_bls_committee},
     messages,
     test_utils::{
         bls_aggregate_sigs,
         bls_min_pk_from_sk,
         bls_min_pk_sign,
-        bls_secret_keys_for_testing
+        bls_secret_keys_for_testing,
+        signers_to_bitmap
     }
 };
-
 
 #[test]
 public fun test_check_aggregate() {
@@ -29,17 +29,52 @@ public fun test_check_aggregate() {
     );
 }
 
-#[test, expected_failure(abort_code = bls_aggregate::ESigVerification)]
-public fun test_add_members_error() {
-    let (committee, agg_sig, mut signers, message) = create_committee_and_cert(option::none());
+#[test]
+public fun test_check_aggregate_short_bitmap() {
+    let (committee, agg_sig, signers, message) = create_committee_and_cert_short_bitmap(
+        option::none(),
+    );
 
-    // Add another signer to the set.
-    signers.push_back(7);
+    // Make sure that the signers bitmap is actually shorter than the maximum bitmap length.
+    assert!(signers.length() < committee.n_members().divide_and_round_up(8));
 
-    // Verify the aggregate signature with signers 0, .., 7. Test fails here.
+    // Verify the aggregate signature
     committee.verify_certificate(
         &agg_sig,
         &signers,
+        &message,
+    );
+}
+
+#[test, expected_failure(abort_code = bls_aggregate::EInvalidBitmap)]
+public fun test_check_aggregate_invalid_bitmap() {
+    let (committee, agg_sig, mut signers, message) = create_committee_and_cert(option::none());
+
+    // Add a byte to the signers bitmap to make it invalid.
+    signers.push_back(0);
+
+    // Verify the aggregate signature
+    committee.verify_certificate(
+        &agg_sig,
+        &signers,
+        &message,
+    );
+}
+
+#[test, expected_failure(abort_code = bls_aggregate::ESigVerification)]
+public fun test_add_members_error() {
+    let (committee, agg_sig, signers, message) = create_committee_and_cert(option::none());
+
+    // Add another signer to the set.
+    let mut other_signers = vector::empty();
+    // Add the 7th signer to the set.
+    other_signers.push_back(signers[0] | 64u8);
+    other_signers.push_back(signers[1]);
+
+    // Verify the aggregate signature with the new, modified set of signers. Test fails here.
+    committee.verify_certificate(
+        &agg_sig,
+        &other_signers,
         &message,
     );
 }
@@ -52,21 +87,6 @@ public fun test_incorrect_signature_error() {
     agg_sig.swap(0, 1);
 
     // Verify the aggregate signature with wrong signature. Test fails here.
-    committee.verify_certificate(
-        &agg_sig,
-        &signers,
-        &message,
-    );
-}
-
-#[test, expected_failure(abort_code = bls_aggregate::ETotalMemberOrder)]
-public fun test_duplicate_member_error() {
-    let (committee, agg_sig, mut signers, message) = create_committee_and_cert(option::none());
-
-    // Add a duplicate signer to the set.
-    signers.insert(3, 3);
-
-    // Verify the aggregate signature with the same signer listed twice. Test fails here.
     committee.verify_certificate(
         &agg_sig,
         &signers,
@@ -105,27 +125,50 @@ public fun test_cert_incorrect_epoch() {
 
 /// Returns a committee, a valid aggregate signature, the signers, and message that was signed.
 ///
-/// The signers are keys 0, .., 6 and the committee has 10 keys in total.
+/// The signers are keys 0, 1, 2, 3, 4, 7, 8 and the committee has 10 keys in total.
 fun create_committee_and_cert(
     weights: Option<vector<u16>>,
-): (BlsCommittee, vector<u8>, vector<u16>, vector<u8>) {
+): (BlsCommittee, vector<u8>, vector<u8>, vector<u8>) {
+    // Create the aggregate sig for keys 0, 1, 2, 3, 4, 7, 8
+    let signers = vector[0, 1, 2, 3, 4, 7, 8];
+    create_committee_and_cert_with_signer_indices(weights, signers)
+}
+
+/// Returns a committee, a valid aggregate signature, the signers as a short bitmap,
+/// and the message that was signed.
+///
+/// The signers are keys 0, 1, 2, 3, 4, 5, 6 and the committee has 10 keys in total.
+fun create_committee_and_cert_short_bitmap(
+    weights: Option<vector<u16>>,
+): (BlsCommittee, vector<u8>, vector<u8>, vector<u8>) {
+    // Create the aggregate sig for keys 0, 1, 2, 3, 4, 5, 6
+    let signers = vector[0, 1, 2, 3, 4, 5, 6];
+    create_committee_and_cert_with_signer_indices(weights, signers)
+}
+
+fun create_committee_and_cert_with_signer_indices(
+    weights: Option<vector<u16>>,
+    signers: vector<u16>,
+): (BlsCommittee, vector<u8>, vector<u8>, vector<u8>) {
     let sks = bls_secret_keys_for_testing();
     let pks = sks.map_ref!(|sk| bls12381::g1_from_bytes(&bls_min_pk_from_sk(sk)));
     let weights = weights.get_with_default(vector[1, 1, 1, 1, 1, 1, 1, 1, 1, 1]);
     let epoch = 5;
 
-    let message = messages::certified_message_bytes(epoch, 0xABC);
+    let message = messages::certified_permanent_message_bytes(epoch, 0xABC);
 
-    // Create the aggregate sig for keys 0, 1, 2, 3, 4, 5, 6
     let mut sigs = vector[];
-    7u64.do!(|i| sigs.push_back(bls_min_pk_sign(&message, &sks[i])));
+    signers.do!(|i| sigs.push_back(bls_min_pk_sign(&message, &sks[i as u64])));
+
+    let signers_bitmap = signers_to_bitmap(&signers);
+
     let agg_sig = bls_aggregate_sigs(&sigs);
 
     // Make a new committee with equal weight
     let members = pks.zip_map!(
         weights,
         |pk, weight| bls_aggregate::new_bls_committee_member(
-            pk,
+            g1_to_uncompressed_g1(&pk),
             weight,
             tx_context::dummy().fresh_object_address().to_id(),
         ),
@@ -134,6 +177,5 @@ fun create_committee_and_cert(
         epoch,
         members,
     );
-    let signers = vector[0, 1, 2, 3, 4, 5, 6];
-    (committee, agg_sig, signers, message)
+    (committee, agg_sig, signers_bitmap, message)
 }

--- a/testnet-contracts/walrus/tests/system/deny_list_tests.move
+++ b/testnet-contracts/walrus/tests/system/deny_list_tests.move
@@ -1,0 +1,67 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module walrus::deny_list_tests;
+
+use std::{bcs, unit_test::assert_eq};
+use walrus::messages;
+
+#[test]
+fun deny_list_update() {
+    let bytes = new_deny_list_update_message(@0x1.to_id(), 1, 1, 1u256);
+    let message = messages::new_certified_message(bytes, 1, 100);
+    let update_message = message.deny_list_update_message();
+
+    assert_eq!(update_message.storage_node_id(), @0x1.to_id());
+    assert_eq!(update_message.sequence_number(), 1);
+    assert_eq!(update_message.size(), 1);
+    assert_eq!(update_message.root(), 1u256);
+}
+
+#[test, expected_failure(abort_code = messages::EInvalidMsgType)]
+fun deny_list_update_invalid_message_type() {
+    let mut bytes = new_deny_list_update_message(@0x1.to_id(), 1, 1, 1u256);
+    *&mut bytes[0] = 1; // invalid message type
+    let message = messages::new_certified_message(bytes, 1, 100);
+    message.deny_list_update_message();
+}
+
+#[test]
+fun deny_list_blob_deleted() {
+    let bytes = new_deny_list_blob_deleted_message(1u256);
+    let message = messages::new_certified_message(bytes, 1, 100);
+    let delete_message = message.deny_list_blob_deleted_message();
+
+    assert_eq!(delete_message.blob_id(), 1u256);
+}
+
+#[test, expected_failure(abort_code = messages::EInvalidMsgType)]
+fun deny_list_blob_deleted_invalid_message_type() {
+    let mut bytes = new_deny_list_blob_deleted_message(1u256);
+    *&mut bytes[0] = 1; // invalid message type
+    let message = messages::new_certified_message(bytes, 1, 100);
+    message.deny_list_blob_deleted_message();
+}
+
+fun new_deny_list_blob_deleted_message(blob_id: u256): vector<u8> {
+    let mut bytes = vector[4, 0, 3]; // intent type, version, app id
+    bytes.append(bcs::to_bytes(&1u32)); // epoch
+    bytes.append(bcs::to_bytes(&blob_id));
+    bytes
+}
+
+fun new_deny_list_update_message(
+    id: ID,
+    deny_list_sequence_number: u64,
+    deny_list_size: u64,
+    deny_list_root: u256,
+): vector<u8> {
+    let mut bytes = vector[3, 0, 3]; // intent type, version, app id
+    bytes.append(bcs::to_bytes(&1u32)); // epoch
+    bytes.append(bcs::to_bytes(&id));
+    bytes.append(bcs::to_bytes(&deny_list_sequence_number));
+    bytes.append(bcs::to_bytes(&deny_list_size));
+    bytes.append(bcs::to_bytes(&deny_list_root));
+    bytes
+}

--- a/testnet-contracts/walrus/tests/system/event_blob_tests.move
+++ b/testnet-contracts/walrus/tests/system/event_blob_tests.move
@@ -4,12 +4,13 @@
 #[test_only]
 module walrus::event_blob_tests;
 
-use sui::test_utils::destroy;
-use walrus::blob::{Self};
-use walrus::storage_node;
-use walrus::system::{Self, System};
-use walrus::system_state_inner;
-use walrus::test_node::{test_nodes, TestStorageNode};
+use walrus::{
+    blob,
+    storage_node,
+    system::{Self, System},
+    system_state_inner,
+    test_node::{test_nodes, TestStorageNode}
+};
 
 const RED_STUFF: u8 = 0;
 
@@ -19,13 +20,11 @@ const SIZE: u64 = 5_000_000;
 #[test]
 public fun test_event_blob_certify_happy_path() {
     let ctx = &mut tx_context::dummy();
-    let mut system: system::System = system::new_for_testing_with_multiple_members(
-        ctx,
-    );
+    let mut system = system::new_for_testing_with_multiple_members(ctx);
     // Total of 10 nodes all with equal weights
     assert!(system.committee().to_vec_map().size() == 10);
     let mut nodes = test_nodes();
-    set_storage_node_caps(&system, ctx, &mut nodes);
+    set_storage_node_caps(&system, &mut nodes, ctx);
     let blob_id = blob::derive_blob_id(ROOT_HASH, RED_STUFF, SIZE);
     let mut index = 0;
     while (index < 10) {
@@ -39,7 +38,7 @@ public fun test_event_blob_certify_happy_path() {
             0,
             ctx,
         );
-        let state = system.inner().get_event_blob_certification_state();
+        let state = system.inner().event_blob_certification_state();
         if (index < 6) {
             assert!(state.get_latest_certified_checkpoint_sequence_number().is_none());
         } else {
@@ -49,66 +48,54 @@ public fun test_event_blob_certify_happy_path() {
         index = index + 1
     };
     nodes.destroy!(|node| node.destroy());
-    destroy(system);
+    system.destroy_for_testing()
 }
 
 #[test, expected_failure(abort_code = system_state_inner::ERepeatedAttestation)]
 public fun test_event_blob_certify_repeated_attestation() {
     let ctx = &mut tx_context::dummy();
-    let mut system: system::System = system::new_for_testing_with_multiple_members(
-        ctx,
-    );
+    let mut system = system::new_for_testing_with_multiple_members(ctx);
     // Total of 10 nodes
     assert!(system.committee().to_vec_map().size() == 10);
     let mut nodes = test_nodes();
-    set_storage_node_caps(&system, ctx, &mut nodes);
+    set_storage_node_caps(&system, &mut nodes, ctx);
     let blob_id = blob::derive_blob_id(ROOT_HASH, RED_STUFF, SIZE);
-    let mut index = 0;
-    while (index < 10) {
-        // Every node is going to attest the blob twice but their
-        // votes are only going to be counted once
-        system.certify_event_blob(
-            nodes.borrow_mut(index).cap_mut(),
-            blob_id,
-            ROOT_HASH,
-            SIZE,
-            RED_STUFF,
-            100,
-            0,
-            ctx,
-        );
-        system.certify_event_blob(
-            nodes.borrow_mut(index).cap_mut(),
-            blob_id,
-            ROOT_HASH,
-            SIZE,
-            RED_STUFF,
-            100,
-            0,
-            ctx,
-        );
-        let state = system.inner().get_event_blob_certification_state();
-        if (index < 6) {
-            assert!(state.get_latest_certified_checkpoint_sequence_number().is_none());
-        } else {
-            assert!(state.get_latest_certified_checkpoint_sequence_number().is_some());
-        };
-        index = index + 1
-    };
+
+    system.certify_event_blob(
+        nodes.borrow_mut(0).cap_mut(),
+        blob_id,
+        ROOT_HASH,
+        SIZE,
+        RED_STUFF,
+        100,
+        0,
+        ctx,
+    );
+
+    // Second attestation should fail
+    system.certify_event_blob(
+        nodes.borrow_mut(0).cap_mut(),
+        blob_id,
+        ROOT_HASH,
+        SIZE,
+        RED_STUFF,
+        100,
+        0,
+        ctx,
+    );
+
     nodes.destroy!(|node| node.destroy());
-    destroy(system);
+    system.destroy_for_testing();
 }
 
 #[test, expected_failure(abort_code = system_state_inner::EIncorrectAttestation)]
 public fun test_multiple_event_blobs_in_flight() {
     let ctx = &mut tx_context::dummy();
-    let mut system: system::System = system::new_for_testing_with_multiple_members(
-        ctx,
-    );
+    let mut system = system::new_for_testing_with_multiple_members(ctx);
     // Total of 10 nodes
     assert!(system.committee().to_vec_map().size() == 10);
     let mut nodes = test_nodes();
-    set_storage_node_caps(&system, ctx, &mut nodes);
+    set_storage_node_caps(&system, &mut nodes, ctx);
     let blob1 = blob::derive_blob_id(0xabc, RED_STUFF, SIZE);
     let blob2 = blob::derive_blob_id(0xdef, RED_STUFF, SIZE);
 
@@ -134,24 +121,22 @@ public fun test_multiple_event_blobs_in_flight() {
             0,
             ctx,
         );
-        let state = system.inner().get_event_blob_certification_state();
+        let state = system.inner().event_blob_certification_state();
         assert!(state.get_latest_certified_checkpoint_sequence_number().is_none());
         index = index + 1
     };
     nodes.destroy!(|node| node.destroy());
-    destroy(system);
+    system.destroy_for_testing();
 }
 
 #[test]
 public fun test_event_blob_certify_change_epoch() {
     let ctx = &mut tx_context::dummy();
-    let mut system: system::System = system::new_for_testing_with_multiple_members(
-        ctx,
-    );
+    let mut system = system::new_for_testing_with_multiple_members(ctx);
     // Total of 10 nodes
     assert!(system.committee().to_vec_map().size() == 10);
     let mut nodes = test_nodes();
-    set_storage_node_caps(&system, ctx, &mut nodes);
+    set_storage_node_caps(&system, &mut nodes, ctx);
     let blob_id = blob::derive_blob_id(ROOT_HASH, RED_STUFF, SIZE);
     let mut index = 0;
     while (index < 6) {
@@ -165,18 +150,18 @@ public fun test_event_blob_certify_change_epoch() {
             0,
             ctx,
         );
-        let state = system.inner().get_event_blob_certification_state();
+        let state = system.inner().event_blob_certification_state();
         assert!(state.get_latest_certified_checkpoint_sequence_number().is_none());
         index = index + 1
     };
     // increment epoch
     let mut new_committee = *system.committee();
     new_committee.increment_epoch_for_testing();
-    let balance = system.advance_epoch(
-        new_committee,
-        walrus::epoch_parameters::epoch_params_for_testing(),
-    );
-    balance.destroy_for_testing();
+    let (_, balances) = system
+        .advance_epoch(new_committee, &walrus::epoch_parameters::epoch_params_for_testing())
+        .into_keys_values();
+
+    balances.do!(|b| { b.destroy_for_testing(); });
     // 7th node attesting is not going to certify the blob as all other nodes
     // attested
     // the blob in previous epoch
@@ -190,7 +175,7 @@ public fun test_event_blob_certify_change_epoch() {
         1,
         ctx,
     );
-    let state = system.inner().get_event_blob_certification_state();
+    let state = system.inner().event_blob_certification_state();
     assert!(state.get_latest_certified_checkpoint_sequence_number().is_none());
     index = 0;
     // All nodes sign the blob in current epoch
@@ -210,7 +195,7 @@ public fun test_event_blob_certify_change_epoch() {
             1,
             ctx,
         );
-        let state = system.inner().get_event_blob_certification_state();
+        let state = system.inner().event_blob_certification_state();
         if (index < 5) {
             assert!(state.get_latest_certified_checkpoint_sequence_number().is_none());
         } else {
@@ -219,21 +204,148 @@ public fun test_event_blob_certify_change_epoch() {
         index = index + 1
     };
     nodes.destroy!(|node| node.destroy());
-    destroy(system);
+    system.destroy_for_testing();
+}
+
+#[test]
+public fun test_certify_invalid_blob_id() {
+    // Setup
+    let ctx = &mut tx_context::dummy();
+    let mut system = system::new_for_testing_with_multiple_members(ctx);
+    assert!(system.committee().to_vec_map().size() == 10);
+    let mut nodes = test_nodes();
+    set_storage_node_caps(&system, &mut nodes, ctx);
+
+    // Create a constant bad blob ID that will be used throughout the test
+    let bad_blob_id = blob::derive_blob_id(0xbeef, RED_STUFF, SIZE);
+
+    // Test multiple rounds of certification
+    let mut i: u256 = 0;
+    while (i < 30) {
+        // First, get 9 nodes to certify a valid blob
+        let good_blob_id = blob::derive_blob_id(i, RED_STUFF, SIZE);
+        let good_checkpoint = 100 * (i as u64);
+
+        // Get signatures from first 9 nodes
+        let mut index = 0;
+        while (index < 9) {
+            system.certify_event_blob(
+                nodes.borrow_mut(index).cap_mut(),
+                good_blob_id,
+                i,
+                SIZE,
+                RED_STUFF,
+                good_checkpoint,
+                0,
+                ctx,
+            );
+            index = index + 1
+        };
+
+        // Verify the good blob was certified
+        let state = system.inner().event_blob_certification_state();
+        assert!(
+            state.get_latest_certified_checkpoint_sequence_number() ==
+            option::some(good_checkpoint
+        ),
+        );
+
+        // Now try to get the 10th node to certify an invalid blob
+        let bad_checkpoint = good_checkpoint + 1;
+        system.certify_event_blob(
+            nodes.borrow_mut(9).cap_mut(),
+            bad_blob_id,
+            0xbeef,
+            SIZE,
+            RED_STUFF,
+            bad_checkpoint,
+            0,
+            ctx,
+        );
+
+        // Verify the bad blob didn't affect the certification state
+        let state = system.inner().event_blob_certification_state();
+        assert!(
+            state.get_latest_certified_checkpoint_sequence_number() ==
+            option::some(good_checkpoint),
+        );
+
+        i = i + 1
+    };
+    nodes.destroy!(|node| node.destroy());
+    system.destroy_for_testing();
+}
+
+#[test]
+public fun test_block_blob_events() {
+    let ctx = &mut tx_context::dummy();
+    // Initialize system with 10 nodes
+    let mut system = system::new_for_testing_with_multiple_members(ctx);
+    assert!(system.committee().to_vec_map().size() == 10);
+    let mut nodes = test_nodes();
+    set_storage_node_caps(&system, &mut nodes, ctx);
+
+    let mut i: u256 = 0;
+    while (i < 30) {
+        // Derive a good blob ID and certify it
+        let good_blob_id = blob::derive_blob_id(i as u256, RED_STUFF, SIZE);
+        let good_cp = 100 * (i as u64);
+        let mut index = 0;
+        while (index < 9) {
+            system.certify_event_blob(
+                nodes.borrow_mut(index).cap_mut(),
+                good_blob_id,
+                i as u256,
+                SIZE,
+                RED_STUFF,
+                good_cp,
+                0,
+                ctx,
+            );
+            index = index + 1;
+        };
+
+        let state = system.inner().event_blob_certification_state();
+        assert!(state.get_latest_certified_checkpoint_sequence_number() == option::some(good_cp));
+
+        // Derive a bad blob ID and attempt to certify it
+        let hash = 2000 * (i as u256);
+        let bad_blob_id = blob::derive_blob_id(hash, RED_STUFF, SIZE);
+        let bad_cp = 100 * (i as u64) + 1;
+
+        // Unique blob ID per call to fill up aggregate_weight_per_blob
+        system.certify_event_blob(
+            nodes.borrow_mut(9).cap_mut(),
+            bad_blob_id,
+            hash,
+            SIZE,
+            RED_STUFF,
+            bad_cp,
+            0,
+            ctx,
+        );
+
+        let state = system.inner().event_blob_certification_state();
+        // Ensure no more than one blob is being tracked
+        assert!(state.get_num_tracked_blobs() <= 1);
+        i = i + 1;
+    };
+    nodes.destroy!(|node| node.destroy());
+    system.destroy_for_testing();
 }
 
 // === Helper functions ===
 
 fun set_storage_node_caps(
     system: &System,
-    ctx: &mut TxContext,
     nodes: &mut vector<TestStorageNode>,
+    ctx: &mut TxContext,
 ) {
     let (node_ids, _values) = system.committee().to_vec_map().into_keys_values();
     let mut index = 0;
     node_ids.do!(|node_id| {
         let storage_cap = storage_node::new_cap(node_id, ctx);
-        nodes.borrow_mut(index).set_storage_node_cap(storage_cap);
+        nodes[index].set_storage_node_cap(storage_cap);
         index = index + 1;
     });
 }

--- a/testnet-contracts/walrus/tests/system/metadata_tests.move
+++ b/testnet-contracts/walrus/tests/system/metadata_tests.move
@@ -5,10 +5,7 @@
 module walrus::metadata_tests;
 
 use sui::vec_map::EKeyDoesNotExist;
-use walrus::{
-    metadata,
-};
-
+use walrus::metadata;
 
 #[test]
 public fun test_metadata_success() {

--- a/testnet-contracts/walrus/tests/system/ringbuffer_tests.move
+++ b/testnet-contracts/walrus/tests/system/ringbuffer_tests.move
@@ -4,10 +4,11 @@
 #[test_only]
 module walrus::ringbuffer_tests;
 
+use sui::test_utils::destroy;
 use walrus::storage_accounting::{Self as sa, FutureAccountingRingBuffer};
 
 #[test]
-public fun test_basic_ring_buffer(): FutureAccountingRingBuffer {
+public fun test_basic_ring_buffer() {
     let mut buffer: FutureAccountingRingBuffer = sa::ring_new(3);
 
     assert!(sa::epoch(sa::ring_lookup_mut(&mut buffer, 0)) == 0, 100);
@@ -26,14 +27,14 @@ public fun test_basic_ring_buffer(): FutureAccountingRingBuffer {
     assert!(sa::epoch(sa::ring_lookup_mut(&mut buffer, 1)) == 3, 100);
     assert!(sa::epoch(sa::ring_lookup_mut(&mut buffer, 2)) == 4, 100);
 
-    buffer
+    destroy(buffer)
 }
 
 #[test, expected_failure(abort_code = sa::ETooFarInFuture)]
-public fun test_oob_fail_ring_buffer(): FutureAccountingRingBuffer {
+public fun test_oob_fail_ring_buffer() {
     let mut buffer: FutureAccountingRingBuffer = sa::ring_new(3);
 
     sa::epoch(sa::ring_lookup_mut(&mut buffer, 3));
 
-    buffer
+    abort
 }

--- a/testnet-contracts/walrus/tests/system/storage_resource_tests.move
+++ b/testnet-contracts/walrus/tests/system/storage_resource_tests.move
@@ -55,8 +55,7 @@ public fun test_split_size() {
     destroy(new_storage);
 }
 
-#[test]
-#[expected_failure(abort_code = EInvalidEpoch)]
+#[test, expected_failure(abort_code = EInvalidEpoch)]
 public fun test_split_epoch_invalid_end() {
     let ctx = &mut tx_context::dummy();
     let mut storage = create_for_test(0, 10, 5_000_000, ctx);
@@ -65,8 +64,7 @@ public fun test_split_epoch_invalid_end() {
     destroy(new_storage);
 }
 
-#[test]
-#[expected_failure(abort_code = EInvalidEpoch)]
+#[test, expected_failure(abort_code = EInvalidEpoch)]
 public fun test_split_epoch_invalid_start() {
     let ctx = &mut tx_context::dummy();
     let mut storage = create_for_test(1, 10, 5_000_000, ctx);
@@ -104,22 +102,20 @@ public fun test_fuse_epochs() {
     destroy(second);
 }
 
-#[test]
-#[expected_failure(abort_code = EIncompatibleAmount)]
+#[test, expected_failure(abort_code = EIncompatibleAmount)]
 public fun test_fuse_incompatible_size() {
     let ctx = &mut tx_context::dummy();
     let mut first = create_for_test(0, 5, 1_000_000, ctx);
     let second = create_for_test(5, 10, 2_000_000, ctx);
     fuse(&mut first, second);
-    destroy(first);
+    abort
 }
 
-#[test]
-#[expected_failure(abort_code = EIncompatibleEpochs)]
+#[test, expected_failure(abort_code = EIncompatibleEpochs)]
 public fun test_fuse_incompatible_epochs() {
     let ctx = &mut tx_context::dummy();
     let mut first = create_for_test(0, 6, 1_000_000, ctx);
     let second = create_for_test(5, 10, 1_000_000, ctx);
     fuse(&mut first, second);
-    destroy(first);
+    abort
 }

--- a/testnet-contracts/walrus/tests/system/system_state_inner_tests.move
+++ b/testnet-contracts/walrus/tests/system/system_state_inner_tests.move
@@ -1,0 +1,81 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module walrus::system_state_inner_tests;
+
+use sui::test_utils::destroy;
+use walrus::{storage_accounting as sa, system_state_inner, test_utils::mint};
+
+fun add_subsidy_test(rewards: u64, epochs_ahead: u32) {
+    let ctx = &mut tx_context::dummy();
+    let mut system = system_state_inner::new_for_testing();
+    let base_reward = rewards / (epochs_ahead as u64);
+    let leftovers = rewards % (epochs_ahead as u64);
+
+    // Mint the subsidy and add it to the system.
+    let subsidy = mint(rewards, ctx);
+    system.add_subsidy(subsidy, epochs_ahead);
+
+    // Distribute the rewards across epochs.
+    epochs_ahead.do!(|i| {
+        let expected_reward = base_reward + if ((i as u64) < leftovers) { 1 } else { 0 };
+        let rb = sa::rewards_balance(sa::ring_lookup_mut(system.future_accounting_mut(), i));
+        assert!(rb.value() == expected_reward);
+    });
+
+    destroy(system);
+}
+
+#[test]
+fun test_add_subsidy_zero_rewards() {
+    add_subsidy_test(0, 2);
+}
+
+#[test]
+fun test_add_subsidy_one_epoch_ahead() {
+    add_subsidy_test(1000, 1);
+}
+
+#[test]
+fun test_add_subsidy_multiple_epochs_ahead() {
+    add_subsidy_test(1000, 4);
+}
+
+#[test]
+fun test_add_subsidy_uneven_distribution() {
+    let ctx = &mut tx_context::dummy();
+    let mut system = system_state_inner::new_for_testing();
+    let rewards = 1001u64;
+    let epochs_ahead = 3;
+    let reward_per_epoch = rewards / (epochs_ahead as u64);
+
+    // Test adding rewards 1,001 WAL for 3 epochs ahead.
+    let subsidy = mint(rewards, ctx);
+    system.add_subsidy(subsidy, epochs_ahead);
+
+    // Check rewards for the epochs ahead
+    // The first epoch should get 2 more rewards than the others. They are the leftover_rewards.
+    let first_epoch_rewards = reward_per_epoch + 2;
+
+    let rb0 = sa::rewards_balance(sa::ring_lookup_mut(system.future_accounting_mut(), 0));
+    assert!(rb0.value() == first_epoch_rewards);
+    let rb1 = sa::rewards_balance(sa::ring_lookup_mut(system.future_accounting_mut(), 1));
+    assert!(rb1.value() == reward_per_epoch);
+    let rb2 = sa::rewards_balance(sa::ring_lookup_mut(system.future_accounting_mut(), 2));
+    assert!(rb2.value() == reward_per_epoch);
+    destroy(system);
+}
+
+#[test, expected_failure(abort_code = system_state_inner::EInvalidEpochsAhead)]
+fun test_add_subsidy_zero_epochs_ahead_fail() {
+    let ctx = &mut tx_context::dummy();
+    let mut system = system_state_inner::new_for_testing();
+
+    let subsidy = mint(1000, ctx);
+
+    // Test adding rewards for 0 epochs ahead (should fail)
+    system.add_subsidy(subsidy, 0);
+
+    abort
+}

--- a/testnet-contracts/walrus/tests/upgrade_tests.move
+++ b/testnet-contracts/walrus/tests/upgrade_tests.move
@@ -1,0 +1,206 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// SPDX-License-Identifier: Apache-2.0
+
+#[allow(unused_mut_ref)]
+module walrus::upgrade_tests;
+
+use std::unit_test::assert_eq;
+use sui::{package, test_scenario};
+use walrus::{auth, e2e_runner, upgrade};
+
+#[test]
+public fun test_emergency_upgrade() {
+    use walrus::upgrade::EmergencyUpgradeCap;
+
+    let admin = @0xA11CE;
+    let mut runner = e2e_runner::prepare(admin).build();
+
+    let emergency_cap: EmergencyUpgradeCap = runner.scenario().take_from_address(admin);
+    runner.tx_with_upgrade_manager!(admin, |staking, system, upgrade_manager, _| {
+        // Check that the new package id is not set before the upgrade
+        assert!(system.new_package_id().is_none() && staking.new_package_id().is_none());
+
+        let upgrade_ticket = upgrade_manager.authorize_emergency_upgrade(
+            &emergency_cap,
+            vector<u8>[],
+        );
+        let receipt = package::test_upgrade(upgrade_ticket);
+        upgrade_manager.commit_upgrade(staking, system, receipt);
+
+        // Check that the new package id is set after the upgrade and is the same for both the
+        // system and staking objects.
+        assert!(system.new_package_id().is_some());
+        assert_eq!(system.new_package_id(), staking.new_package_id());
+    });
+    test_scenario::return_to_address(admin, emergency_cap);
+    runner.destroy();
+}
+
+#[test]
+public fun test_quorum_upgrade() {
+    let (mut runner, nodes) = e2e_runner::setup_committee_for_epoch_one();
+
+    // === vote for upgrade ===
+    // minimum number of votes needed since stake is equally distributed
+    let n_votes = nodes.length() * 2 / 3 + 1;
+    let digest = upgrade::digest_for_testing(runner.scenario().ctx());
+    n_votes.do!(|idx| {
+        let node = &nodes[idx];
+        runner.tx_with_upgrade_manager!(node.sui_address(), |staking, _, upgrade_manager, ctx| {
+            let auth = auth::authenticate_sender(ctx);
+            upgrade_manager.vote_for_upgrade(staking, auth, node.node_id(), digest)
+        });
+    });
+
+    // === commit upgrade ===
+
+    runner.tx_with_upgrade_manager!(nodes[0].sui_address(), |staking, system, upgrade_manager, _| {
+        // Check that the new package id is not set before the upgrade
+        assert!(system.new_package_id().is_none() && staking.new_package_id().is_none());
+
+        let upgrade_ticket = upgrade_manager.authorize_upgrade(staking, digest);
+        let receipt = package::test_upgrade(upgrade_ticket);
+        upgrade_manager.commit_upgrade(staking, system, receipt);
+
+        // Check that the new package id is set after the upgrade and is the same for both the
+        // system and staking objects.
+        assert!(system.new_package_id().is_some());
+        assert_eq!(system.new_package_id(), staking.new_package_id());
+    });
+
+    // === cleanup ===
+
+    runner.destroy();
+    nodes.destroy!(|node| node.destroy());
+}
+
+#[test, expected_failure(abort_code = upgrade::ENotEnoughVotes)]
+public fun test_upgrade_insufficient_votes() {
+    let (mut runner, nodes) = e2e_runner::setup_committee_for_epoch_one();
+
+    // === vote for upgrade ===
+    // just shy of a quorum since stake is equally distributed
+    let n_votes = nodes.length() * 2 / 3;
+
+    let digest = upgrade::digest_for_testing(runner.scenario().ctx());
+    n_votes.do!(|idx| {
+        let node = &nodes[idx];
+        runner.tx_with_upgrade_manager!(node.sui_address(), |staking, _, upgrade_manager, ctx| {
+            let auth = auth::authenticate_sender(ctx);
+            upgrade_manager.vote_for_upgrade(staking, auth, node.node_id(), digest)
+        });
+    });
+
+    // === try to commit upgrade ===
+
+    runner.tx_with_upgrade_manager!(nodes[0].sui_address(), |staking, _, upgrade_manager, _| {
+        // Test should fail here.
+        let _upgrade_ticket = upgrade_manager.authorize_upgrade(staking, digest);
+    });
+
+    // Unreachable
+    abort
+}
+
+#[test, expected_failure(abort_code = upgrade::EWrongEpoch)]
+public fun test_upgrade_wrong_epoch() {
+    let (mut runner, nodes) = e2e_runner::setup_committee_for_epoch_one();
+
+    // === vote for upgrade ===
+
+    let digest = upgrade::digest_for_testing(runner.scenario().ctx());
+    nodes.do_ref!(|node| {
+        runner.tx_with_upgrade_manager!(node.sui_address(), |staking, _, upgrade_manager, ctx| {
+            let auth = auth::authenticate_sender(ctx);
+            upgrade_manager.vote_for_upgrade(staking, auth, node.node_id(), digest)
+        });
+    });
+
+    // === advance clock and change epoch ===
+
+    runner.clock().increment_for_testing(e2e_runner::default_epoch_duration());
+    runner.tx!(nodes[0].sui_address(), |staking, system, _| {
+        staking.voting_end(runner.clock());
+        staking.initiate_epoch_change(system, runner.clock());
+        assert_eq!(system.epoch(), 2);
+    });
+
+    // === try to commit upgrade with the package voted for in the previous epoch ===
+
+    runner.tx_with_upgrade_manager!(nodes[0].sui_address(), |staking, _, upgrade_manager, _| {
+        // Test should fail here.
+        let _upgrade_ticket = upgrade_manager.authorize_upgrade(staking, digest);
+    });
+
+    // Unreachable
+    abort
+}
+
+#[test, expected_failure(abort_code = upgrade::EWrongVersion)]
+public fun test_upgrade_wrong_version() {
+    let (mut runner, nodes) = e2e_runner::setup_committee_for_epoch_one();
+
+    // === vote for upgrade 1 ===
+
+    let digest_1 = upgrade::digest_for_testing(runner.scenario().ctx());
+    nodes.do_ref!(|node| {
+        runner.tx_with_upgrade_manager!(node.sui_address(), |staking, _, upgrade_manager, ctx| {
+            let auth = auth::authenticate_sender(ctx);
+            upgrade_manager.vote_for_upgrade(staking, auth, node.node_id(), digest_1)
+        });
+    });
+
+    // === vote for upgrade 2 ===
+
+    let digest_2 = upgrade::digest_for_testing(runner.scenario().ctx());
+    nodes.do_ref!(|node| {
+        runner.tx_with_upgrade_manager!(node.sui_address(), |staking, _, upgrade_manager, ctx| {
+            let auth = auth::authenticate_sender(ctx);
+            upgrade_manager.vote_for_upgrade(staking, auth, node.node_id(), digest_2)
+        });
+    });
+    // === upgrade to digest 1 ===
+
+    runner.tx_with_upgrade_manager!(nodes[0].sui_address(), |staking, system, upgrade_manager, _| {
+        let upgrade_ticket = upgrade_manager.authorize_upgrade(staking, digest_1);
+        let receipt = package::test_upgrade(upgrade_ticket);
+        upgrade_manager.commit_upgrade(staking, system, receipt);
+    });
+
+    // === try to upgrade to digest 2 ===
+
+    runner.tx_with_upgrade_manager!(nodes[0].sui_address(), |staking, _, upgrade_manager, _| {
+        // Test should fail here.
+        let _upgrade_ticket = upgrade_manager.authorize_upgrade(staking, digest_2);
+    });
+
+    // Unreachable
+    abort
+}
+
+#[test, expected_failure(abort_code = upgrade::EDuplicateVote)]
+public fun test_upgrade_duplicate_vote() {
+    let (mut runner, nodes) = e2e_runner::setup_committee_for_epoch_one();
+
+    // === vote for upgrade 1 ===
+
+    let digest = upgrade::digest_for_testing(runner.scenario().ctx());
+    let node = &nodes[0];
+    runner.tx_with_upgrade_manager!(node.sui_address(), |staking, _, upgrade_manager, ctx| {
+        let auth = auth::authenticate_sender(ctx);
+        upgrade_manager.vote_for_upgrade(staking, auth, node.node_id(), digest)
+    });
+
+    // === vote for upgrade 2 ===
+
+    runner.tx_with_upgrade_manager!(node.sui_address(), |staking, _, upgrade_manager, ctx| {
+        let auth = auth::authenticate_sender(ctx);
+        // Test should fail here
+        upgrade_manager.vote_for_upgrade(staking, auth, node.node_id(), digest)
+    });
+
+    // Unreachable
+    abort
+}


### PR DESCRIPTION
## Description

Copies the contracts that were deployed for the Walrus Testnet v2 to the `testnet-contracts` directory, including the published object IDs.