### PR TITLE
chore: make EventStreamCursor copyable to avoid clutter

### DIFF
--- a/crates/walrus-service/src/node/events.rs
+++ b/crates/walrus-service/src/node/events.rs
@@ -272,7 +272,7 @@ impl InitState {
 }
 
 /// A cursor that points to a specific element in the event stream.
-#[derive(Default, Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct EventStreamCursor {
     /// The event ID of the event the cursor points to.
     pub event_id: Option<EventID>,


### PR DESCRIPTION
## Description

This is code cleanup to make EventStreamCursor copyable. It is a small value that can simply be copied but code currently clones it. This change makes using this structure cleaner.

## Test plan

CI Pipeline.

No release impact.
