### PR TITLE
fix: present of `RUST_LOG` should not affect simtest execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13738,6 +13738,7 @@ dependencies = [
  "sui-macros",
  "sui-protocol-config",
  "sui-simulator",
+ "telemetry-subscribers",
  "tempfile",
  "tokio",
  "tokio-stream",

--- a/crates/walrus-e2e-tests/Cargo.toml
+++ b/crates/walrus-e2e-tests/Cargo.toml
@@ -16,6 +16,7 @@ serde_yaml.workspace = true
 sui-macros.workspace = true
 sui-protocol-config.workspace = true
 sui-simulator.workspace = true
+telemetry-subscribers.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true

--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -83,7 +83,7 @@ async fn test_store_and_read_blob_with_crash_failures(
     failed_shards_read: &[usize],
     expected_errors: &[ClientErrorKind],
 ) {
-    let _ = tracing_subscriber::fmt::try_init();
+    telemetry_subscribers::init_for_testing();
     let result =
         run_store_and_read_with_crash_failures(failed_shards_write, failed_shards_read, 31415)
             .await;
@@ -175,7 +175,7 @@ async_param_test! {
 }
 /// Stores a blob that is inconsistent in 1 shard
 async fn test_inconsistency(failed_nodes: &[usize]) -> TestResult {
-    let _ = tracing_subscriber::fmt::try_init();
+    telemetry_subscribers::init_for_testing();
 
     let (_sui_cluster_handle, mut cluster, mut client) = test_cluster::default_setup().await?;
 
@@ -305,7 +305,7 @@ async fn test_store_with_existing_blob_resource(
     epochs_ahead_required: EpochCount,
     should_match: bool,
 ) -> TestResult {
-    let _ = tracing_subscriber::fmt::try_init();
+    telemetry_subscribers::init_for_testing();
 
     let (_sui_cluster_handle, _cluster, client) = test_cluster::default_setup().await?;
 
@@ -390,7 +390,7 @@ async fn test_store_with_existing_storage_resource(
     epochs_ahead_required: EpochCount,
     should_match: bool,
 ) -> TestResult {
-    let _ = tracing_subscriber::fmt::try_init();
+    telemetry_subscribers::init_for_testing();
 
     let (_sui_cluster_handle, _cluster, client) = test_cluster::default_setup().await?;
 
@@ -455,7 +455,7 @@ async_param_test! {
 }
 /// Tests blob object deletion.
 async fn test_delete_blob(blobs_to_create: u32) -> TestResult {
-    let _ = tracing_subscriber::fmt::try_init();
+    telemetry_subscribers::init_for_testing();
     let (_sui_cluster_handle, _cluster, client) = test_cluster::default_setup().await?;
     let blob = walrus_test_utils::random_data(314);
     let blobs = vec![blob.as_slice()];
@@ -515,7 +515,7 @@ async fn test_delete_blob(blobs_to_create: u32) -> TestResult {
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_storage_nodes_delete_data_for_deleted_blobs() -> TestResult {
-    let _ = tracing_subscriber::fmt::try_init();
+    telemetry_subscribers::init_for_testing();
     let (_sui_cluster_handle, _cluster, client) = test_cluster::default_setup().await?;
     let client = client.as_ref();
     let blob = walrus_test_utils::random_data(314);
@@ -560,7 +560,7 @@ async fn test_storage_nodes_delete_data_for_deleted_blobs() -> TestResult {
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_blocklist() -> TestResult {
-    let _ = tracing_subscriber::fmt::try_init();
+    telemetry_subscribers::init_for_testing();
     let blocklist_dir = tempfile::tempdir().expect("temporary directory creation must succeed");
     let (_sui_cluster_handle, _cluster, client) =
         test_cluster::default_setup_with_epoch_duration_generic::<StorageNodeHandle>(
@@ -646,7 +646,7 @@ async fn test_blocklist() -> TestResult {
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_multiple_stores_same_blob() -> TestResult {
-    let _ = tracing_subscriber::fmt::try_init();
+    telemetry_subscribers::init_for_testing();
     let (_sui_cluster_handle, _cluster, client) = test_cluster::default_setup().await?;
     let client = client.as_ref();
     let blob = walrus_test_utils::random_data(314);
@@ -709,7 +709,7 @@ async fn test_multiple_stores_same_blob() -> TestResult {
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_repeated_shard_move() -> TestResult {
-    let _ = tracing_subscriber::fmt::try_init();
+    telemetry_subscribers::init_for_testing();
     let (_sui_cluster_handle, walrus_cluster, client) =
         test_cluster::default_setup_with_epoch_duration_generic::<StorageNodeHandle>(
             Duration::from_secs(20),
@@ -773,7 +773,7 @@ async fn test_repeated_shard_move() -> TestResult {
 async fn test_burn_blobs() -> TestResult {
     const N_BLOBS: usize = 3;
     const N_TO_DELETE: usize = 2;
-    let _ = tracing_subscriber::fmt::try_init();
+    telemetry_subscribers::init_for_testing();
 
     let (_sui_cluster_handle, _cluster, client) = test_cluster::default_setup().await?;
 
@@ -828,7 +828,7 @@ async fn test_burn_blobs() -> TestResult {
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_share_blobs() -> TestResult {
-    let _ = tracing_subscriber::fmt::try_init();
+    telemetry_subscribers::init_for_testing();
 
     let (_sui_cluster_handle, _cluster, client) = test_cluster::default_setup().await?;
 
@@ -921,7 +921,7 @@ async fn test_post_store_action(
     n_owned_blobs: usize,
     n_target_blobs: usize,
 ) -> TestResult {
-    let _ = tracing_subscriber::fmt::try_init();
+    telemetry_subscribers::init_for_testing();
     let (_sui_cluster_handle, _cluster, client) = test_cluster::default_setup().await?;
     let target_address: SuiAddress = SuiAddress::from_bytes(TARGET_ADDRESS).expect("valid address");
 

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -3120,7 +3120,7 @@ mod tests {
 
     #[walrus_simtest]
     async fn cancel_expired_blob_sync_upon_epoch_change() -> TestResult {
-        let _ = tracing_subscriber::fmt::try_init();
+        telemetry_subscribers::init_for_testing();
 
         let shards: &[&[u16]] = &[&[1], &[0, 2, 3, 4]];
 
@@ -4498,7 +4498,7 @@ mod tests {
 
         #[walrus_simtest]
         async fn finish_epoch_change_start_should_not_block_event_processing() -> TestResult {
-            let _ = tracing_subscriber::fmt::try_init();
+            telemetry_subscribers::init_for_testing();
 
             // It is important to only use one node in this test, so that no other node would
             // drive epoch change on chain, and send events to the nodes.
@@ -4594,7 +4594,7 @@ mod tests {
         // Tests that storage node lag check is not affected by the blob writer cursor.
         #[walrus_simtest]
         async fn event_blob_cursor_should_not_affect_node_state() -> TestResult {
-            let _ = tracing_subscriber::fmt::try_init();
+            telemetry_subscribers::init_for_testing();
 
             // Set the initial cursor to a high value to simulate a severe lag to
             // blob writer cursor.

--- a/crates/walrus-service/tests/epoch_change.rs
+++ b/crates/walrus-service/tests/epoch_change.rs
@@ -17,7 +17,7 @@ use walrus_test_utils::Result as TestResult;
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn nodes_drive_epoch_change() -> TestResult {
-    let _ = tracing_subscriber::fmt::try_init();
+    telemetry_subscribers::init_for_testing();
     let epoch_duration = Duration::from_secs(5);
     let (_sui, storage_nodes, _) =
         test_cluster::default_setup_with_epoch_duration_generic::<StorageNodeHandle>(


### PR DESCRIPTION
## Description

For some tests, with or without `RUST_LOG` produces different execution flow. This is because tracing_subscriber
runs different logic depending on whether `RUST_LOG` is set or not.

Switch to use Sui's telemetry_subscribers which is independent of whether `RUST_LOG` is set or not. Underneath,
telemetry_subscribers also uses tracing_subscriber to track trace logs.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
