### PR TITLE
chore: avoid usize where u64 is adequate and improves legibility

### DIFF
--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -403,7 +403,7 @@ impl Storage {
     #[tracing::instrument(skip_all)]
     pub fn update_blob_info(
         &self,
-        event_index: usize,
+        event_index: u64,
         event: &BlobEvent,
     ) -> Result<(), TypedStoreError> {
         self.blob_info.update_blob_info(event_index, event)
@@ -412,11 +412,11 @@ impl Storage {
     /// Repositions the event cursor to the specified event index.
     pub(crate) fn reposition_event_cursor(
         &self,
-        event_index: usize,
+        event_index: u64,
         cursor: EventID,
     ) -> Result<(), TypedStoreError> {
         self.event_cursor
-            .reposition_event_cursor(cursor, event_index as u64)
+            .reposition_event_cursor(cursor, event_index)
     }
 
     /// Advances the event cursor to the most recent, sequential event observed.
@@ -432,7 +432,7 @@ impl Storage {
     #[tracing::instrument(skip_all)]
     pub(crate) fn maybe_advance_event_cursor(
         &self,
-        event_index: usize,
+        event_index: u64,
         cursor: &EventID,
     ) -> Result<EventProgress, TypedStoreError> {
         self.event_cursor
@@ -922,8 +922,8 @@ pub(crate) mod tests {
         ]
     }
     async fn maybe_advance_event_cursor_order(
-        sequence_ids: &[usize],
-        expected_sequence: &[usize],
+        sequence_ids: &[u64],
+        expected_sequence: &[u64],
     ) -> TestResult {
         let storage = empty_storage();
         let storage = storage.as_ref();

--- a/crates/walrus-service/src/node/storage/blob_info.rs
+++ b/crates/walrus-service/src/node/storage/blob_info.rs
@@ -109,10 +109,9 @@ impl BlobInfoTable {
     #[tracing::instrument(skip(self))]
     pub fn update_blob_info(
         &self,
-        event_index: usize,
+        event_index: u64,
         event: &BlobEvent,
     ) -> Result<(), TypedStoreError> {
-        let event_index = event_index.try_into().expect("assume 64-bit architecture");
         let latest_handled_event_index = self.latest_handled_event_index.lock().unwrap();
         if Self::has_event_been_handled(latest_handled_event_index.get(&())?, event_index) {
             tracing::debug!("skip updating blob info for already handled event");

--- a/crates/walrus-service/src/node/storage/event_sequencer.rs
+++ b/crates/walrus-service/src/node/storage/event_sequencer.rs
@@ -12,8 +12,8 @@ use sui_types::event::EventID;
 /// provides access to the `EventID`s sequentially starting from 0.
 #[derive(Debug, Default)]
 pub(super) struct EventSequencer {
-    head_index: usize,
-    queue: HashMap<usize, EventID>,
+    head_index: u64,
+    queue: HashMap<u64, EventID>,
 }
 
 impl EventSequencer {
@@ -23,16 +23,16 @@ impl EventSequencer {
     }
 
     /// Creates a new `EventSequencer`, that continues sequencing from the provided next index.
-    pub fn continue_from(next_index: usize) -> Self {
+    pub fn continue_from(head_index: u64) -> Self {
         Self {
-            head_index: next_index,
+            head_index,
             ..Self::default()
         }
     }
 
     /// The index of the next event to be observed. This is also the number of events that have been
     /// persisted.
-    pub fn head_index(&self) -> usize {
+    pub fn head_index(&self) -> u64 {
         self.head_index
     }
 
@@ -41,7 +41,7 @@ impl EventSequencer {
     /// # Panics
     ///
     /// Panics if the provided index has already been observed.
-    pub fn add(&mut self, index: usize, event_id: EventID) {
+    pub fn add(&mut self, index: u64, event_id: EventID) {
         if index < self.head_index || self.queue.insert(index, event_id).is_some() {
             // This class provides the invariant that we never advance unless we have seen all
             // prior sequence numbers, therefore anything less than the head_index or with a prior

--- a/crates/walrus-service/src/node/system_events.rs
+++ b/crates/walrus-service/src/node/system_events.rs
@@ -48,7 +48,7 @@ pub const EVENT_CHANNEL_CAPACITY: usize = 1024;
 // Important: Don't derive or implement `Clone` or `Copy`; every event should have a single handle
 // that is passed around until it is completely handled or the thread panics.
 pub(super) struct EventHandle {
-    index: usize,
+    index: u64,
     event_id: EventID,
     node: Arc<StorageNodeInner>,
     can_be_dropped: bool,
@@ -60,7 +60,7 @@ impl EventHandle {
         event_seq: 0,
     };
 
-    pub fn new(index: usize, event_id: Option<EventID>, node: Arc<StorageNodeInner>) -> Self {
+    pub fn new(index: u64, event_id: Option<EventID>, node: Arc<StorageNodeInner>) -> Self {
         Self {
             index,
             event_id: event_id.unwrap_or(Self::EVENT_ID_FOR_CHECKPOINT_EVENTS),
@@ -69,7 +69,7 @@ impl EventHandle {
         }
     }
 
-    pub fn index(&self) -> usize {
+    pub fn index(&self) -> u64 {
         self.index
     }
 


### PR DESCRIPTION
## Description

This is a code hygiene PR. I believe it is better to rely on the type system rather than utilizing machine-specific pointer/integer size checks at runtime. I did not see a clear reason that usize should be preferred in any of the affected locations. If we move to u32 or u128 in the future, this change will be compatible with such a refactoring by way of simple type checking.

## Test plan

CI Pipeline.

No release impact.
