### PR TITLE
fix: address recent regression in test_repeated_shard_move_with_workload simtest

### DIFF
--- a/crates/walrus-service/src/client.rs
+++ b/crates/walrus-service/src/client.rs
@@ -647,7 +647,10 @@ impl Client<SuiContractClient> {
             .sui_client
             .certify_blobs(&blobs_with_certificates, post_store)
             .await
-            .map_err(|e| ClientError::from(ClientErrorKind::CertificationFailed(e)))?;
+            .map_err(|e| {
+                tracing::warn!(error = %e, "failed to certify blobs on Sui");
+                ClientError::from(ClientErrorKind::CertificationFailed(e))
+            })?;
         tracing::info!(
             duration = ?sui_cert_timer.elapsed(),
             "certified {} blobs on Sui",


### PR DESCRIPTION
## Description

We see cases where a single upload's two consecutive attempts are all cross epoch boundaries, which cause the test
to fail. This PR reduces the simulated network latency to make communication faster among nodes.

Also added more logging for easier debugging next time.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
