### PR TITLE
chore: some cleanup sync shard task logic

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -4086,7 +4086,7 @@ mod tests {
         cluster.nodes[1]
             .storage_node
             .shard_sync_handler
-            .start_new_shard_sync(ShardIndex(0))
+            .start_sync_shards(vec![ShardIndex(0)], false)
             .await?;
 
         // Shard recovery should be completed, and all the data should be synced.
@@ -4171,7 +4171,7 @@ mod tests {
             cluster.nodes[1]
                 .storage_node
                 .shard_sync_handler
-                .start_new_shard_sync(ShardIndex(0))
+                .start_sync_shards(vec![ShardIndex(0)], false)
                 .await?;
 
             // Waits for the shard sync process to stop.
@@ -4230,7 +4230,7 @@ mod tests {
             cluster.nodes[1]
                 .storage_node
                 .shard_sync_handler
-                .start_new_shard_sync(ShardIndex(0))
+                .start_sync_shards(vec![ShardIndex(0)], false)
                 .await?;
 
             // Waits for the shard sync process to stop.
@@ -4315,7 +4315,7 @@ mod tests {
             cluster.nodes[1]
                 .storage_node
                 .shard_sync_handler
-                .start_new_shard_sync(ShardIndex(0))
+                .start_sync_shards(vec![ShardIndex(0)], false)
                 .await?;
 
             // Waits for the shard sync process to stop.
@@ -4381,7 +4381,7 @@ mod tests {
             cluster.nodes[1]
                 .storage_node
                 .shard_sync_handler
-                .start_new_shard_sync(ShardIndex(0))
+                .start_sync_shards(vec![ShardIndex(0)], false)
                 .await?;
             // Waits for the shard sync process to stop.
             wait_until_no_sync_tasks(&cluster.nodes[1].storage_node.shard_sync_handler).await?;


### PR DESCRIPTION
## Description

Trying to make `start_new_shard_sync` private, since its caller is private. Ended up with some other cleanup/refactor.
Should be a no-op.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
