### PR TITLE
fix: fix regression in local testbed script

### DIFF
--- a/scripts/local-testbed.sh
+++ b/scripts/local-testbed.sh
@@ -125,7 +125,7 @@ if ! $existing; then
     echo Generating configuration...
     ./target/release/walrus-deploy generate-dry-run-configs --working-dir $working_dir
 
-    echo "---
+    echo "
 event_processor_config:
   adaptive_downloader_config:
   max_workers: 2


### PR DESCRIPTION
## Description

Remove extraneous document delimiter line '---' from echoed yaml in local-testbed.sh.

## Test plan

Manually tested.

No release impact.