### PR TITLE
fix: Don't submit event blob certiy txn if node has no storage cap

### DIFF
--- a/crates/walrus-service/src/node/contract_service.rs
+++ b/crates/walrus-service/src/node/contract_service.rs
@@ -230,6 +230,10 @@ impl SystemContractService for SuiSystemContractService {
                     .await
                 {
                     Ok(()) => Some(()),
+                    Err(SuiClientError::StorageNodeCapabilityObjectNotSet) => {
+                        tracing::debug!("Storage node capability object not set");
+                        Some(())
+                    }
                     Err(SuiClientError::TransactionExecutionError(e)) => {
                         tracing::debug!(
                             walrus.epoch = epoch,


### PR DESCRIPTION
## Description

Fixes the issue found in https://linear.app/mysten-labs/issue/WAL-545/nodes-that-are-not-registered-get-stuck-processing-events-at-first. 


