### PR TITLE
chore: add walrus-backup to Dockerfile for deployment

### DIFF
--- a/docker/walrus-service/Dockerfile
+++ b/docker/walrus-service/Dockerfile
@@ -14,6 +14,7 @@ COPY crates crates
 
 RUN cargo build --profile $PROFILE \
     --bin walrus \
+    --bin walrus-backup \
     --bin walrus-node \
     --bin walrus-deploy
 
@@ -24,6 +25,7 @@ ARG PROFILE=release
 WORKDIR "$WORKDIR/walrus"
 # Both bench and release profiles copy from release dir
 COPY --from=builder /walrus/target/release/walrus /opt/walrus/bin/walrus
+COPY --from=builder /walrus/target/release/walrus-backup /opt/walrus/bin/walrus-backup
 COPY --from=builder /walrus/target/release/walrus-node /opt/walrus/bin/walrus-node
 COPY --from=builder /walrus/target/release/walrus-deploy /opt/walrus/bin/walrus-deploy
 
@@ -65,6 +67,19 @@ ARG PROFILE=release
 WORKDIR "$WORKDIR/walrus"
 # Both bench and release profiles copy from release dir
 COPY --from=builder /walrus/target/release/walrus-deploy /opt/walrus/bin/walrus-deploy
+
+ARG BUILD_DATE
+ARG GIT_REVISION
+LABEL build-date=$BUILD_DATE
+LABEL git-revision=$GIT_REVISION
+
+# Production Image for walrus backup CLI
+FROM debian:bookworm-slim AS walrus-backup
+RUN apt-get update && apt-get install -y ca-certificates curl
+ARG PROFILE=release
+WORKDIR "$WORKDIR/walrus"
+# Both bench and release profiles copy from release dir
+COPY --from=builder /walrus/target/release/walrus-backup /opt/walrus/bin/walrus-backup
 
 ARG BUILD_DATE
 ARG GIT_REVISION


### PR DESCRIPTION
## Description

Add walrus-backup to walrus-service Dockerfile for backup deployment purposes.

## Test plan

Manual testing.

No release impact.