### PR TITLE
feat(node): allow setting metrics push config in setup command

### DIFF
--- a/crates/walrus-service/src/common/utils.rs
+++ b/crates/walrus-service/src/common/utils.rs
@@ -349,7 +349,7 @@ impl MetricPushRuntime {
             .worker_threads(1)
             .enable_all()
             .build()
-            .context("meteric push runtime creation failed")?;
+            .context("metric push runtime creation failed")?;
         let _guard = runtime.enter();
 
         let metric_push_handle = tokio::spawn(async move {

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -254,8 +254,8 @@ pub struct MetricsPushConfig {
     #[serde_as(as = "DurationSeconds<u64>")]
     #[serde(
         rename = "push_interval_secs",
-        default = "push_interval_default",
-        skip_serializing_if = "defaults::is_default"
+        default = "defaults::push_interval",
+        skip_serializing_if = "defaults::is_push_interval_default"
     )]
     pub push_interval: Duration,
     /// The URL that we will push metrics to.
@@ -265,37 +265,36 @@ pub struct MetricsPushConfig {
     pub labels: Option<HashMap<String, String>>,
 }
 
-/// MetricsPushConfig impls to set name and host labels
-/// we accept a name to use from node config and will attempt to fetch the hostname
-/// if that fetch fails, we will default to the node name from the config.
-/// these manifest as labels in metric data.
 impl MetricsPushConfig {
-    /// set metric label name = foo
-    pub fn set_name(&mut self, name: &str) {
+    /// Creates a new `MetricsPushConfig` with the provided URL and otherwise default values.
+    pub fn new_for_url(url: String) -> Self {
+        Self {
+            push_interval: defaults::push_interval(),
+            push_url: url,
+            labels: None,
+        }
+    }
+
+    /// Sets the 'name' label to `name` and the 'host' label to the machine's hostname; if the
+    /// hostname cannot be determined, `name` is used as a fallback.
+    pub fn set_name_and_host_label(&mut self, name: &str) {
         self.labels
             .get_or_insert_with(HashMap::new)
             .entry("name".into())
             .or_insert_with(|| name.into());
 
-        // also set the host label and try to get the hostname to do it.  if we cannot
-        // use name as a fallback.
         let host =
             hostname::get().map_or_else(|_| name.into(), |v| v.to_string_lossy().to_string());
         self.set_host(host);
     }
 
-    /// set metric label host = bar
+    /// Sets the 'host' label to `host`.
     fn set_host(&mut self, host: String) {
         self.labels
             .get_or_insert_with(HashMap::new)
             .entry("host".into())
             .or_insert_with(|| host);
     }
-}
-
-/// Configure the default push interval for metrics.
-fn push_interval_default() -> Duration {
-    Duration::from_secs(60)
 }
 
 /// Configuration for TLS of the rest API.
@@ -486,6 +485,16 @@ pub mod defaults {
     /// The default vote for the write price.
     pub fn write_price() -> u64 {
         2000
+    }
+
+    /// Configure the default push interval for metrics.
+    pub fn push_interval() -> Duration {
+        Duration::from_secs(60)
+    }
+
+    /// Returns true if the `duration` is equal to the default push interval for metrics.
+    pub fn is_push_interval_default(duration: &Duration) -> bool {
+        duration == &push_interval()
     }
 
     /// Returns true iff the value is `None` and we don't run in test mode.


### PR DESCRIPTION
## Description

Allow setting the metrics push configuration directly in the `walrus-node` setup command.

This includes some refactoring and cleanup.

## Test plan

Run the `walrus-node setup` command manually and inspect the resulting configuration.

---

## Release notes

- [x] Storage node: Allow setting the metrics push configuration directly in the `walrus-node` setup command.