### PR TITLE
feat: Add metrics to track network throughput for different http endpoints

### DIFF
--- a/crates/walrus-service/src/client/daemon.rs
+++ b/crates/walrus-service/src/client/daemon.rs
@@ -20,7 +20,7 @@ use axum_extra::{
     TypedHeader,
 };
 use openapi::{AggregatorApiDoc, DaemonApiDoc, PublisherApiDoc};
-use prometheus::{HistogramVec, Registry};
+use prometheus::Registry;
 use reqwest::StatusCode;
 use routes::{PublisherQuery, BLOB_GET_ENDPOINT, BLOB_PUT_ENDPOINT, STATUS_ENDPOINT};
 use tower::{
@@ -38,7 +38,7 @@ use walrus_sui::client::{BlobPersistence, PostStoreAction, ReadClient, SuiContra
 use super::{responses::BlobStoreResult, Client, ClientResult, StoreWhen};
 use crate::{
     client::{config::AuthConfig, daemon::auth::verify_jwt_claim},
-    common::telemetry::{metrics_middleware, register_http_metrics, MakeHttpSpan},
+    common::telemetry::{metrics_middleware, register_http_metrics, HttpMetrics, MakeHttpSpan},
 };
 
 pub mod auth;
@@ -117,7 +117,7 @@ impl WalrusWriteClient for Client<SuiContractClient> {
 pub struct ClientDaemon<T> {
     client: Arc<T>,
     network_address: SocketAddr,
-    metrics: HistogramVec,
+    metrics: HttpMetrics,
     router: Router<Arc<T>>,
 }
 

--- a/crates/walrus-service/src/common/telemetry.rs
+++ b/crates/walrus-service/src/common/telemetry.rs
@@ -14,6 +14,7 @@ use std::{
 };
 
 use axum::{
+    body::Body,
     extract::{ConnectInfo, MatchedPath, State},
     http::{
         self,
@@ -22,6 +23,7 @@ use axum::{
     },
     middleware,
 };
+use futures::StreamExt;
 use opentelemetry::propagation::Extractor;
 use prometheus::{
     core::{AtomicU64, Collector, GenericGauge},
@@ -41,6 +43,28 @@ use super::active_committees::ActiveCommittees;
 
 /// Route string used in metrics for invalid routes.
 pub(crate) const UNMATCHED_ROUTE: &str = "invalid-route";
+
+/// HTTP metrics for tracking request/response statistics
+#[derive(Debug, Clone)]
+pub(crate) struct HttpMetrics {
+    pub(crate) duration: HistogramVec,
+    pub(crate) request_size: HistogramVec,
+    pub(crate) response_size: HistogramVec,
+}
+
+impl HttpMetrics {
+    pub(crate) fn new(
+        duration: HistogramVec,
+        request_size: HistogramVec,
+        response_size: HistogramVec,
+    ) -> Self {
+        Self {
+            duration,
+            request_size,
+            response_size,
+        }
+    }
+}
 
 /// Struct to generate new [`tracing::Span`]s for HTTP requests.
 #[derive(Debug, Clone, Default)]
@@ -244,7 +268,7 @@ fn get_header_as_str<B, K: AsHeaderName>(request: &Request<B>, key: K) -> Option
 
 /// Middleware that records the elapsed time, HTTP method, and status of requests.
 pub(crate) async fn metrics_middleware(
-    State(metrics): State<HistogramVec>,
+    State(metrics): State<HttpMetrics>,
     request: axum::extract::Request,
     next: middleware::Next,
 ) -> axum::response::Response {
@@ -259,30 +283,91 @@ pub(crate) async fn metrics_middleware(
         // for each rest to an invalid URI. Use a
         UNMATCHED_ROUTE.into()
     };
+    // Track request size by reading the body
+    let method_clone = method.clone();
+    let route_clone = route.clone();
+    let (parts, body) = request.into_parts();
+    let counted_body = Body::from_stream(body.into_data_stream().map(move |chunk| {
+        chunk.inspect(|c| {
+            metrics
+                .request_size
+                .with_label_values(&[method_clone.as_str(), &route_clone])
+                .observe(c.len() as f64);
+        })
+    }));
+    let request = Request::from_parts(parts, counted_body);
 
     let response = next.run(request).await;
 
-    let histogram =
-        metrics.with_label_values(&[method.as_str(), &route, response.status().as_str()]);
-    histogram.observe(start.elapsed().as_secs_f64());
+    // Record response metrics
+    let method_clone = method.clone();
+    let route_clone = route.clone();
+    let status = response.status();
+    let (parts, body) = response.into_parts();
+    let counted_body = Body::from_stream(body.into_data_stream().map(move |chunk| {
+        chunk.inspect(|c| {
+            metrics
+                .response_size
+                .with_label_values(&[method_clone.as_str(), &route_clone, status.as_str()])
+                .observe(c.len() as f64);
+        })
+    }));
+    let response = http::Response::from_parts(parts, counted_body);
+
+    metrics
+        .duration
+        .with_label_values(&[method.as_str(), &route, status.as_str()])
+        .observe(start.elapsed().as_secs_f64());
 
     response
 }
 
 /// Registers the HTTP request method, route, status, and durations metrics.
-pub(crate) fn register_http_metrics(registry: &Registry) -> HistogramVec {
-    let opts = prometheus::Opts::new(
+pub(crate) fn register_http_metrics(registry: &Registry) -> HttpMetrics {
+    let duration_opts = prometheus::Opts::new(
         "request_duration_seconds",
         "Time (in seconds) spent serving HTTP requests.",
     )
     .namespace("http");
 
-    register_histogram_vec_with_registry!(
-        opts.into(),
+    let request_size_opts = prometheus::Opts::new(
+        "request_size_bytes_total",
+        "Total size of HTTP requests in bytes.",
+    )
+    .namespace("http");
+
+    let response_size_opts = prometheus::Opts::new(
+        "response_size_bytes_total",
+        "Total size of HTTP responses in bytes.",
+    )
+    .namespace("http");
+
+    let duration_histogram = register_histogram_vec_with_registry!(
+        duration_opts.into(),
         &["method", "route", "status_code"],
         registry
     )
-    .expect("metric registration must not fail")
+    .expect("metric registration must not fail");
+
+    let request_size_histogram = register_histogram_vec_with_registry!(
+        request_size_opts.into(),
+        &["method", "route"],
+        registry
+    )
+    .expect("metric registration must not fail");
+
+    let response_size_histogram = register_histogram_vec_with_registry!(
+        response_size_opts.into(),
+        &["method", "route", "status_code"],
+        registry
+    )
+    .expect("metric registration must not fail");
+
+    HttpMetrics::new(
+        duration_histogram,
+        request_size_histogram,
+        response_size_histogram,
+    )
 }
 
 macro_rules! with_label {

--- a/crates/walrus-service/src/node/server.rs
+++ b/crates/walrus-service/src/node/server.rs
@@ -17,7 +17,7 @@ use fastcrypto::{secp256r1::Secp256r1PrivateKey, traits::ToFromBytes};
 use futures::{future::Either, FutureExt};
 use openapi::RestApiDoc;
 use p256::{elliptic_curve::pkcs8::EncodePrivateKey as _, SecretKey};
-use prometheus::{HistogramVec, Registry};
+use prometheus::Registry;
 use rcgen::{CertificateParams, CertifiedKey, DnType, KeyPair as RcGenKeyPair};
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
@@ -30,7 +30,7 @@ use walrus_core::{encoding::max_sliver_size_for_n_shards, keys::NetworkKeyPair};
 
 use super::config::{defaults, Http2Config, PathOrInPlace, StorageNodeConfig, TlsConfig};
 use crate::{
-    common::telemetry::{metrics_middleware, register_http_metrics, MakeHttpSpan},
+    common::telemetry::{metrics_middleware, register_http_metrics, HttpMetrics, MakeHttpSpan},
     node::ServiceState,
 };
 
@@ -145,7 +145,7 @@ pub enum TlsCertificateSource {
 pub struct RestApiServer<S> {
     state: Arc<S>,
     config: RestApiConfig,
-    metrics: HistogramVec,
+    metrics: HttpMetrics,
     cancel_token: CancellationToken,
     handle: Mutex<Option<Handle>>,
 }


### PR DESCRIPTION
## Description

This lets us track response throughput of client requests vs recovery and would be useful in debugging issues in the future hopefully.

## Test plan

Deployed on private testnet and verified the results.

[
<img width="1376" alt="Screenshot 2025-01-23 at 11 12 18 PM" src="https://github.com/user-attachments/assets/20aaef8b-e3a7-4c6d-b9da-53ac855155a9" />
](url)
