### PR TITLE
fix(node): set `current_node_status` metric during startup

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -1548,8 +1548,10 @@ impl StorageNodeInner {
 
     fn init_gauges(&self) -> Result<(), TypedStoreError> {
         let persisted = self.storage.get_sequentially_processed_event_count()?;
+        let node_status = self.storage.node_status()?;
 
         metrics::with_label!(self.metrics.event_cursor_progress, "persisted").set(persisted);
+        self.metrics.current_node_status.set(node_status.to_i64());
 
         Ok(())
     }


### PR DESCRIPTION
## Description

This makes sure we set the metric for the node status correctly during startup.

---

## Release notes

- [x] Storage node: Correctly set `walrus_current_node_status` metric during startup.