### PR TITLE
test: improve checks for example configs and OpenAPI specs

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -17,6 +17,10 @@ filter = 'package(walrus-e2e-tests) or package(walrus-sui) or test(nodes_drive_e
 slow-timeout = { period = "2m", terminate-after = 5 } # Mark E2E tests as slow only after 2 minutes
 threads-required = 4
 
+[[profile.ci.overrides]]
+filter = 'test(check_and_update_example_config) or test(check_and_update_openapi)'
+retries = 0 # Do not retry these tests as they always succeed on the second run
+
 [profile.simtest]
 slow-timeout = { period = "5m", terminate-after = 6 } # Timeout tests after 30 minutes
 test-threads = "num-cpus"

--- a/.github/actions/diffs/action.yml
+++ b/.github/actions/diffs/action.yml
@@ -25,6 +25,9 @@ outputs:
   isExampleConfig:
     description: True when changes happened in the example config files
     value: "${{ steps.diff.outputs.isExampleConfig }}"
+  isOpenapi:
+    description: True when changes happened in the OpenAPI files
+    value: "${{ steps.diff.outputs.isOpenapi }}"
 
 runs:
   using: composite
@@ -61,3 +64,6 @@ runs:
           isExampleConfig:
             - 'crates/walrus-service/node_config_example.yaml'
             - 'crates/walrus-service/client_config_example.yaml'
+          isOpenapi:
+            - 'crates/walrus-service/*_openapi.html'
+            - 'crates/walrus-service/*_openapi.yaml'

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -43,6 +43,7 @@ jobs:
       isMove: ${{ steps.diff.outputs.isMove }}
       isDenyConfig: ${{ steps.diff.outputs.isDenyConfig }}
       isTestConfig: ${{ steps.diff.outputs.isTestConfig }}
+      isOpenapi: ${{ steps.diff.outputs.isOpenapi }}
       isRelevantForRustTests: ${{ steps.diff.outputs.isRust == 'true' || steps.diff.outputs.isMove == 'true' || steps.diff.outputs.isTestConfig
         == 'true' }}
       isTestnetContracts: ${{ steps.diff.outputs.isTestnetContracts }}
@@ -244,6 +245,31 @@ jobs:
               `#[serde(default)]` on it, see `BlobRecoveryConfig` as an example.
             - You may need to update the [walrus-docs](https://github.com/MystenLabs/walrus-docs)
               repository to reflect the changes.
+
+  openapi-warning:
+    name: Check if the PR touches any of the OpenAPI files
+    runs-on: ubuntu-latest
+    needs: diff
+    if: ${{ needs.diff.outputs.isOpenapi == 'true' && github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'}}
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Post a warning if the PR touches an OpenAPI file
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          message: |
+            **Warning:** This PR modifies one of the OpenAPI files. Please consider the
+            following:
+
+            - Make sure the API changes are backwards compatible.
+            - Make sure to follow existing conventions for any added parameters, requests, and
+              responses.
+            - Make sure the generated HTML files do not contain errors.
+            - This probably requires release notes and maybe changes to the documentation.
+
+            cc @jpcsmith @mlegner
 
   check-all:
     name: Check if all code checks succeeded

--- a/crates/walrus-service/src/client/daemon/openapi.rs
+++ b/crates/walrus-service/src/client/daemon/openapi.rs
@@ -106,7 +106,14 @@ mod tests {
         spec.info.version = "<VERSION>".to_string();
 
         std::fs::write(html_path, Redoc::new(spec.clone()).to_html())?;
-        std::fs::write(spec_path, spec.clone().to_yaml()?)?;
+
+        let spec_yaml = spec.clone().to_yaml()?;
+        let spec_yaml_are_in_sync = std::fs::read_to_string(&spec_path)? == spec_yaml;
+        std::fs::write(spec_path, spec_yaml)?;
+        assert!(
+            spec_yaml_are_in_sync,
+            "OpenAPI specification was out of sync; was updated automatically"
+        );
 
         Ok(())
     }

--- a/crates/walrus-service/src/node/server/openapi.rs
+++ b/crates/walrus-service/src/node/server/openapi.rs
@@ -71,7 +71,14 @@ mod tests {
         spec.info.version = "<VERSION>".to_string();
 
         std::fs::write(NODE_OPENAPI_HTML_PATH, Redoc::new(spec.clone()).to_html())?;
-        std::fs::write(NODE_OPENAPI_SPEC_PATH, spec.clone().to_yaml()?)?;
+
+        let spec_yaml = spec.clone().to_yaml()?;
+        let spec_yaml_are_in_sync = std::fs::read_to_string(NODE_OPENAPI_SPEC_PATH)? == spec_yaml;
+        std::fs::write(NODE_OPENAPI_SPEC_PATH, spec_yaml)?;
+        assert!(
+            spec_yaml_are_in_sync,
+            "OpenAPI specification was out of sync; was updated automatically"
+        );
 
         Ok(())
     }


### PR DESCRIPTION
## Description

This improves checks for changes to example configs and OpenAPI specs in multiple ways:

- Make OpenAPI tests fail if the files are modified.
- Remove retries for the corresponding tests in CI such that they actually fail if the autogenerated files are out of sync.
- Automatically post warnings to PRs that modify any of the autogenerated OpenAPI specification files.

Closes #495 

## Test plan

Automatic tests.