### PR TITLE
feat(client): support multiple node IDs and URLs for health command

### DIFF
--- a/crates/walrus-service/src/client/cli/runner.rs
+++ b/crates/walrus-service/src/client/cli/runner.rs
@@ -646,6 +646,7 @@ impl ClientCommandRunner {
         node_selection: NodeSelection,
         detail: bool,
     ) -> Result<()> {
+        node_selection.exactly_one_is_set()?;
         let config = self.config?;
         let sui_read_client = get_sui_read_client_from_rpc_node_or_wallet(
             &config,
@@ -654,9 +655,13 @@ impl ClientCommandRunner {
             self.wallet_path.is_none(),
         )
         .await?;
-        ServiceHealthInfoOutput::get_health_info(&sui_read_client, node_selection, detail)
-            .await?
-            .print_output(self.json)
+
+        ServiceHealthInfoOutput::new_for_nodes(
+            node_selection.get_nodes(&sui_read_client).await?,
+            detail,
+        )
+        .await?
+        .print_output(self.json)
     }
 
     pub(crate) async fn blob_id(

--- a/crates/walrus-sui/src/client.rs
+++ b/crates/walrus-sui/src/client.rs
@@ -135,9 +135,6 @@ pub enum SuiClientError {
     /// The sender is not authorized to perform the action on the pool.
     #[error("the sender is not authorized to perform the action on the pool with node ID {0}")]
     NotAuthorizedForPool(ObjectID),
-    /// The storage node is not found.
-    #[error("the storage node {0} is not found")]
-    StorageNodeNotFound(ObjectID),
     /// Transaction execution was cancelled due to shared object congestion
     #[error("execution cancelled due to shared object congestion on objects {0:?}")]
     SharedObjectCongestion(Vec<ObjectID>),
@@ -848,7 +845,7 @@ impl SuiContractClientInner {
             expected_num_blobs
         );
 
-        self.sui_client().get_sui_objects(blob_obj_ids).await
+        self.sui_client().get_sui_objects(&blob_obj_ids).await
     }
 
     /// Purchases blob storage for the next `epochs_ahead` Walrus epochs and uses the resulting
@@ -894,7 +891,7 @@ impl SuiContractClientInner {
             expected_num_blobs
         );
 
-        self.sui_client().get_sui_objects(blob_obj_ids).await
+        self.sui_client().get_sui_objects(&blob_obj_ids).await
     }
 
     /// Certifies the specified blob on Sui, given a certificate that confirms its storage and
@@ -966,7 +963,7 @@ impl SuiContractClientInner {
             // to shared blob object id.
             let shared_blobs = self
                 .sui_client()
-                .get_sui_objects::<SharedBlob>(object_ids)
+                .get_sui_objects::<SharedBlob>(&object_ids)
                 .await?;
             Ok(shared_blobs
                 .into_iter()
@@ -1106,7 +1103,7 @@ impl SuiContractClientInner {
             cap_ids.len(),
         );
 
-        self.sui_client().get_sui_objects(cap_ids).await
+        self.sui_client().get_sui_objects(&cap_ids).await
     }
 
     /// For each entry in `node_ids_with_amounts`, stakes the amount of WAL specified by the second
@@ -1136,7 +1133,7 @@ impl SuiContractClientInner {
             count
         );
 
-        self.sui_client().get_sui_objects(staked_wal).await
+        self.sui_client().get_sui_objects(&staked_wal).await
     }
 
     /// Call to end voting and finalize the next epoch parameters.
@@ -1675,7 +1672,7 @@ impl ReadClient for SuiContractClient {
         self.read_client.next_committee().await
     }
 
-    async fn get_storage_nodes_from_active_set(&self) -> SuiClientResult<Vec<StorageNode>> {
+    async fn get_storage_nodes_from_active_set(&self) -> Result<Vec<StorageNode>> {
         self.read_client.get_storage_nodes_from_active_set().await
     }
 
@@ -1683,8 +1680,8 @@ impl ReadClient for SuiContractClient {
         self.read_client.get_storage_nodes_from_committee().await
     }
 
-    async fn get_storage_node_by_id(&self, node_id: ObjectID) -> SuiClientResult<StorageNode> {
-        self.read_client.get_storage_node_by_id(node_id).await
+    async fn get_storage_nodes_by_ids(&self, node_ids: &[ObjectID]) -> Result<Vec<StorageNode>> {
+        self.read_client.get_storage_nodes_by_ids(node_ids).await
     }
 
     async fn epoch_state(&self) -> SuiClientResult<EpochState> {

--- a/crates/walrus-sui/src/client/retry_client.rs
+++ b/crates/walrus-sui/src/client/retry_client.rs
@@ -420,7 +420,7 @@ impl RetriableSuiClient {
     #[tracing::instrument(level = Level::DEBUG, skip_all)]
     pub(crate) async fn get_sui_objects<U>(
         &self,
-        object_ids: Vec<ObjectID>,
+        object_ids: &[ObjectID],
     ) -> SuiClientResult<Vec<U>>
     where
         U: AssociatedContractStruct,


### PR DESCRIPTION
## Description

Adds the ability to provide a list of node IDs or URLs for the `walrus health` command. This is a breaking change for the JSON mode because `nodeId` and `nodeUrl` are changed to `nodeIds` and `nodeUrls`, respectively. Through the alias this is backwards-compatible for the "normal" CLI.

Includes some simplifications and refactoring within `walrus_service::client` and `walrus_sui::client`.

Currently, if a node ID is not found, the error message is not very useful, as it doesn't contain the concrete ID that was not found.

Closes WAL-562.

## Test plan

Manually running some variants of the `walrus health` command:

```sh
cargo run --bin walrus -- health --node-ids 0xb763f0defd9d23eb6f6bd98371c4d6559749c264d0ddbcad0b1ba9bc917119f9 0x81dae13f34dfe76170901f9f24a920c3b361acee7136bbc2ef6a0a15bfa085c8
cargo run --bin walrus -- health --node-urls mia-tnt-sto-00.walrus-testnet.walrus.space:9185 uc1-tnt-sto-00.walrus-testnet.walrus.space:9185
cargo run --bin walrus -- health --committee
```

---

## Release notes

- [x] CLI: Adds the ability to provide a list of node IDs or URLs for the `walrus health` command. This is a breaking change for the JSON mode because `nodeId` and `nodeUrl` are changed to `nodeIds` and `nodeUrls`, respectively. The "normal" CLI is backwards-compatible because `--node-id` and `--node-url` are set as aliases for the new options.
