### PR TITLE
test: fix tests for example and OpenAPI files on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11858,6 +11858,7 @@ dependencies = [
 name = "walrus-test-utils"
 version = "1.12.0"
 dependencies = [
+ "anyhow",
  "rand 0.8.5",
  "tempfile",
  "tokio",

--- a/crates/walrus-service/src/client/config.rs
+++ b/crates/walrus-service/src/client/config.rs
@@ -545,13 +545,10 @@ mod tests {
             communication_config: Default::default(),
         };
 
-        let serialized = serde_yaml::to_string(&config).unwrap();
-        let configs_are_in_sync = std::fs::read_to_string(EXAMPLE_CONFIG_PATH)? == serialized;
-        std::fs::write(EXAMPLE_CONFIG_PATH, serialized.clone()).unwrap();
-        assert!(
-            configs_are_in_sync,
-            "example configuration was out of sync; was updated automatically"
-        );
+        walrus_test_utils::overwrite_file_and_fail_if_not_equal(
+            EXAMPLE_CONFIG_PATH,
+            serde_yaml::to_string(&config)?,
+        )?;
 
         Ok(())
     }

--- a/crates/walrus-service/src/client/daemon/openapi.rs
+++ b/crates/walrus-service/src/client/daemon/openapi.rs
@@ -107,13 +107,7 @@ mod tests {
 
         std::fs::write(html_path, Redoc::new(spec.clone()).to_html())?;
 
-        let spec_yaml = spec.clone().to_yaml()?;
-        let spec_yaml_are_in_sync = std::fs::read_to_string(&spec_path)? == spec_yaml;
-        std::fs::write(spec_path, spec_yaml)?;
-        assert!(
-            spec_yaml_are_in_sync,
-            "OpenAPI specification was out of sync; was updated automatically"
-        );
+        walrus_test_utils::overwrite_file_and_fail_if_not_equal(spec_path, spec.to_yaml()?)?;
 
         Ok(())
     }

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -710,13 +710,10 @@ mod tests {
             ..Default::default()
         };
 
-        let serialized = serde_yaml::to_string(&config).unwrap();
-        let configs_are_in_sync = std::fs::read_to_string(EXAMPLE_CONFIG_PATH)? == serialized;
-        std::fs::write(EXAMPLE_CONFIG_PATH, serialized.clone()).unwrap();
-        assert!(
-            configs_are_in_sync,
-            "example configuration was out of sync; was updated automatically"
-        );
+        walrus_test_utils::overwrite_file_and_fail_if_not_equal(
+            EXAMPLE_CONFIG_PATH,
+            serde_yaml::to_string(&config)?,
+        )?;
 
         Ok(())
     }

--- a/crates/walrus-service/src/node/server/openapi.rs
+++ b/crates/walrus-service/src/node/server/openapi.rs
@@ -72,13 +72,10 @@ mod tests {
 
         std::fs::write(NODE_OPENAPI_HTML_PATH, Redoc::new(spec.clone()).to_html())?;
 
-        let spec_yaml = spec.clone().to_yaml()?;
-        let spec_yaml_are_in_sync = std::fs::read_to_string(NODE_OPENAPI_SPEC_PATH)? == spec_yaml;
-        std::fs::write(NODE_OPENAPI_SPEC_PATH, spec_yaml)?;
-        assert!(
-            spec_yaml_are_in_sync,
-            "OpenAPI specification was out of sync; was updated automatically"
-        );
+        walrus_test_utils::overwrite_file_and_fail_if_not_equal(
+            NODE_OPENAPI_SPEC_PATH,
+            spec.to_yaml()?,
+        )?;
 
         Ok(())
     }

--- a/crates/walrus-test-utils/Cargo.toml
+++ b/crates/walrus-test-utils/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 version.workspace = true
 
 [dependencies]
+anyhow.workspace = true
 rand.workspace = true
 tempfile.workspace = true
 


### PR DESCRIPTION
## Description

Compare files in tests line-by-line to account for different line endings on Windows.

## Test plan

Temporarily add a CI job on Windows, see [here](https://github.com/MystenLabs/walrus/actions/runs/13016362866/job/36306449643?pr=1488).