### PR TITLE
fix(docker): update Rust version and enable 'backup' feature

### DIFF
--- a/docker/walrus-orchestrator/Dockerfile
+++ b/docker/walrus-orchestrator/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.83-bookworm AS builder
+FROM rust:1.84-bookworm AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/docker/walrus-proxy/Dockerfile
+++ b/docker/walrus-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.83-bookworm as build
+FROM rust:1.84-bookworm as build
 
 ARG PROFILE=release
 WORKDIR /work

--- a/docker/walrus-service/Dockerfile
+++ b/docker/walrus-service/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.83-bookworm AS builder
+FROM rust:1.84-bookworm AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION
@@ -12,7 +12,8 @@ RUN apt-get update && apt-get install -y cmake clang
 COPY Cargo.toml Cargo.lock ./
 COPY crates crates
 
-RUN cargo build --profile $PROFILE \
+RUN cargo build --features="backup" \
+    --profile $PROFILE \
     --bin walrus \
     --bin walrus-backup \
     --bin walrus-node \

--- a/docker/walrus-stress/Dockerfile
+++ b/docker/walrus-stress/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.83-bookworm AS builder
+FROM rust:1.84-bookworm AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION


### PR DESCRIPTION
## Description

Removing the `backup` feature from the default features (#1483), caused building the Docker image to fail (e.g., [here](https://github.com/MystenLabs/sui-operations/actions/runs/13019461306/job/36317603198)).

## Test plan

Run the [Walrus Scheduled CI workflow](https://github.com/MystenLabs/sui-operations/actions/workflows/walrus_scheduled_ci.yaml) again after merging this.
