### PR TITLE
chore: correctly enable backup feature in Docker and CI

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -99,7 +99,7 @@ jobs:
         with:
           save-if: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
       - name: Build Rust code
-        run: cargo build --workspace --verbose
+        run: cargo build --workspace --features "walrus-service/backup" --verbose
 
   test:
     name: Test Rust code
@@ -118,7 +118,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
           shared-key: v0-rust-test
       - name: Run tests
-        run: cargo nextest run --workspace --profile ci --run-ignored all
+        run: cargo nextest run --workspace --features "walrus-service/backup" --profile ci --run-ignored all
 
   test-coverage:
     name: Run all Rust tests and report coverage

--- a/docker/walrus-service/Dockerfile
+++ b/docker/walrus-service/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y cmake clang
 COPY Cargo.toml Cargo.lock ./
 COPY crates crates
 
-RUN cargo build --features="backup" \
+RUN cargo build --features walrus-service/backup \
     --profile $PROFILE \
     --bin walrus \
     --bin walrus-backup \


### PR DESCRIPTION
## Description

Fixes the Docker build properly (#1490 contained a mistake) and also enables the `backup` feature for CI build and test.

## Test plan

Automatic tests + run the [Walrus Scheduled CI workflow](https://github.com/MystenLabs/sui-operations/actions/workflows/walrus_scheduled_ci.yaml) again after merging this.
