### PR TITLE
fix: fix generation of Move errors

### DIFF
--- a/docker/walrus-service/Dockerfile
+++ b/docker/walrus-service/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y cmake clang
 
 COPY Cargo.toml Cargo.lock ./
 COPY crates crates
+COPY contracts contracts
 
 RUN cargo build --features walrus-service/backup \
     --profile $PROFILE \


### PR DESCRIPTION
## Description

- Make sure build script fails if `contracts` directory is missing.
- Copy contracts directory such that Move errors are generated correctly in Docker build.
- Fix `cargo::rerun-if-changed` directive.

## Test plan

Rerun the Docker build.