### PR TITLE
chore: copy contracts folder into walrus service image

### DIFF
--- a/docker/walrus-service/Dockerfile
+++ b/docker/walrus-service/Dockerfile
@@ -70,6 +70,7 @@ ARG PROFILE=release
 WORKDIR "$WORKDIR/walrus"
 # Both bench and release profiles copy from release dir
 COPY --from=builder /walrus/target/release/walrus-deploy /opt/walrus/bin/walrus-deploy
+COPY --from=builder contracts /opt/walrus/contracts
 
 ARG BUILD_DATE
 ARG GIT_REVISION


### PR DESCRIPTION
## Description

it's really hard to guarantee the contracts in `walrus-docs` is up-to-date. we should just bake the `contracts` folder into the image so that we can use it directly.

## Test plan

checked in the local built image

