### PR TITLE
chore: fix dockerfile contracts location

### DIFF
--- a/docker/walrus-service/Dockerfile
+++ b/docker/walrus-service/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y cmake clang
 COPY Cargo.toml Cargo.lock ./
 COPY crates crates
 COPY contracts ./contracts
-COPY contracts /tmp/contracts
+COPY contracts /contracts
 
 RUN cargo build --features walrus-service/backup \
     --profile $PROFILE \
@@ -31,7 +31,7 @@ COPY --from=builder /walrus/target/release/walrus /opt/walrus/bin/walrus
 COPY --from=builder /walrus/target/release/walrus-backup /opt/walrus/bin/walrus-backup
 COPY --from=builder /walrus/target/release/walrus-node /opt/walrus/bin/walrus-node
 COPY --from=builder /walrus/target/release/walrus-deploy /opt/walrus/bin/walrus-deploy
-COPY --from=builder /tmp/contracts /opt/walrus/contracts
+COPY --from=builder /contracts /opt/walrus/contracts
 
 ARG BUILD_DATE
 ARG GIT_REVISION
@@ -71,7 +71,7 @@ ARG PROFILE=release
 WORKDIR "$WORKDIR/walrus"
 # Both bench and release profiles copy from release dir
 COPY --from=builder /walrus/target/release/walrus-deploy /opt/walrus/bin/walrus-deploy
-COPY --from=builder /tmp/contracts /opt/walrus/contracts
+COPY --from=builder /contracts /opt/walrus/contracts
 
 ARG BUILD_DATE
 ARG GIT_REVISION


### PR DESCRIPTION
## Description

kaniko is a little bit particular about relative folder location, so we use a absolute path for that

## Test plan

pulled the image and inspected, the `contracts/` folder is in the right place