### PR TITLE
chore: backup service should use a different builder image

### DIFF
--- a/docker/walrus-service/Dockerfile
+++ b/docker/walrus-service/Dockerfile
@@ -14,18 +14,9 @@ COPY crates crates
 COPY contracts ./contracts
 COPY contracts /contracts
 
-FROM base AS backup-builder
-RUN cargo build --features walrus-service/backup \
-    --profile $PROFILE \
-    --bin walrus \
-    --bin walrus-backup \
-    --bin walrus-node \
-    --bin walrus-deploy
-
 FROM base AS builder
 RUN cargo build --profile $PROFILE \
     --bin walrus \
-    --bin walrus-backup \
     --bin walrus-node \
     --bin walrus-deploy
 
@@ -36,7 +27,6 @@ ARG PROFILE=release
 WORKDIR "$WORKDIR/walrus"
 # Both bench and release profiles copy from release dir
 COPY --from=builder /walrus/target/release/walrus /opt/walrus/bin/walrus
-COPY --from=builder /walrus/target/release/walrus-backup /opt/walrus/bin/walrus-backup
 COPY --from=builder /walrus/target/release/walrus-node /opt/walrus/bin/walrus-node
 COPY --from=builder /walrus/target/release/walrus-deploy /opt/walrus/bin/walrus-deploy
 COPY --from=builder /contracts /opt/walrus/contracts
@@ -85,6 +75,14 @@ ARG BUILD_DATE
 ARG GIT_REVISION
 LABEL build-date=$BUILD_DATE
 LABEL git-revision=$GIT_REVISION
+
+FROM base AS backup-builder
+RUN cargo build --features walrus-service/backup \
+    --profile $PROFILE \
+    --bin walrus \
+    --bin walrus-backup \
+    --bin walrus-node \
+    --bin walrus-deploy
 
 # Production Image for walrus backup CLI
 FROM debian:bookworm-slim AS walrus-backup


### PR DESCRIPTION
## Description

`walrus-backup` binary added dependencies of `libpg5.so`
in this case, binaries that does not need `libpg5.so` should use a different folder

## Test plan

built an image based on this branch: `us-central1-docker.pkg.dev/cryptic-bolt-398315/walrus/walrus-service:b49b90ac8a8f73ad3ee9183fe5baf61759b1ab68`

pulled and tried to run `walrus-node` and `walrus-deploy`, both are working fine without complaining missing `libpg.so.5`
<img width="585" alt="image" src="https://github.com/user-attachments/assets/9135cf94-cb1c-4453-adb8-f879c8bf0b26" />
