### PR TITLE
fix: minor output/logging improvements

### DIFF
--- a/crates/walrus-service/src/client/cli/args.rs
+++ b/crates/walrus-service/src/client/cli/args.rs
@@ -376,12 +376,13 @@ pub enum CliCommands {
         #[serde(default = "default::faucet_timeout")]
         faucet_timeout: Duration,
     },
-    /// Exchange SUI for WAL through the configured exchange.
+    /// Exchange SUI for WAL through the configured exchange. This command is only available on
+    /// Testnet.
     GetWal {
         #[clap(long)]
         /// The object ID of the exchange to use.
         ///
-        /// This takes precedence over the value in the config file.
+        /// This takes precedence over any values set in the configuration file.
         exchange_id: Option<ObjectID>,
         #[clap(long, default_value_t = default::exchange_amount_mist())]
         #[serde(default = "default::exchange_amount_mist")]
@@ -546,7 +547,7 @@ pub struct PublisherArgs {
     pub max_concurrent_requests: usize,
     /// The number of clients to use for the publisher.
     ///
-    /// The publisher uses this number of clients to publish blobs concurrenty.
+    /// The publisher uses this number of clients to publish blobs concurrently.
     #[clap(long, default_value_t = default::n_publisher_clients())]
     #[serde(default = "default::n_publisher_clients")]
     pub n_clients: usize,
@@ -556,6 +557,7 @@ pub struct PublisherArgs {
     pub refill_interval: Duration,
     /// The directory where the publisher will store the sub-wallets used for client multiplexing.
     #[clap(long)]
+    #[serde(deserialize_with = "crate::utils::resolve_home_dir")]
     pub sub_wallets_dir: PathBuf,
     /// The amount of MIST transferred at every refill.
     #[clap(long, default_value_t = default::gas_refill_amount())]

--- a/crates/walrus-service/src/client/cli/runner.rs
+++ b/crates/walrus-service/src/client/cli/runner.rs
@@ -927,8 +927,9 @@ impl ClientCommandRunner {
                     .copied()
             })
             .context(
-                "Object ID of exchange object must be specified either in the config file or as a \
-            command-line argument.",
+                "The object ID of an exchange object must be specified either in the config file \
+                or as a command-line argument.\n\
+                Note that this command is only available on Testnet.",
             )?;
         let client = get_contract_client(config, self.wallet, self.gas_budget, &None).await?;
         tracing::info!(

--- a/crates/walrus-sui/src/contracts.rs
+++ b/crates/walrus-sui/src/contracts.rs
@@ -22,13 +22,13 @@ use walrus_core::ensure;
 #[derive(Debug, Error)]
 pub enum MoveConversionError {
     #[error("object data does not contain bcs")]
-    /// Error if the object data we are trying to convert does not contain bcs.
+    /// Error if the object data we are trying to convert does not contain BCS.
     NoBcs,
-    #[error("not a move object")]
-    /// Error if the object data is not a move object.
+    #[error("not a Move object")]
+    /// Error if the object data is not a Move object.
     NotMoveObject,
     /// Error resulting if the object or event does not have the expected type.
-    #[error("the move struct {actual} does not match the expected type {expected}")]
+    #[error("the Move struct {actual} does not match the expected type {expected}")]
     TypeMismatch {
         /// Expected type of the struct.
         expected: String,
@@ -49,11 +49,11 @@ pub trait AssociatedContractStruct: DeserializeOwned {
     const CONTRACT_STRUCT: StructTag<'static>;
 
     /// Converts a [`SuiObjectData`] to [`Self`].
-    #[tracing::instrument(err, skip_all)]
+    #[tracing::instrument(err(Debug), skip_all, fields(object_id = %sui_object_data.object_id))]
     fn try_from_object_data(sui_object_data: &SuiObjectData) -> Result<Self, MoveConversionError> {
         tracing::debug!(
-            "converting move object to rust struct {:?}",
-            Self::CONTRACT_STRUCT,
+            target_struct = %Self::CONTRACT_STRUCT,
+            "converting Move object to Rust struct",
         );
         let raw = sui_object_data
             .bcs


### PR DESCRIPTION
## Description

- Add object ID to log messages when converting Move structs.
- Clarify that `get-wal` command only works on Testnet.
- Support `~` for the `subWalletsDir` in JSON mode.
- Fix some typos.

Closes WAL-427

## Test plan

Not required.