### PR TITLE
feat: add experimental flag for batch symbols

### DIFF
--- a/crates/walrus-service/node_config_example.yaml
+++ b/crates/walrus-service/node_config_example.yaml
@@ -71,6 +71,7 @@ blob_recovery:
   sliver_request_timeout_secs: 300
   invalidity_sync_timeout_secs: 300
   node_connect_timeout_secs: 1
+  experimental_batch_symbol_recovery: false
 tls:
   disable_tls: false
   pem_files: null

--- a/crates/walrus-service/src/node/committee/committee_service.rs
+++ b/crates/walrus-service/src/node/committee/committee_service.rs
@@ -63,11 +63,6 @@ use crate::{
     },
 };
 
-// TODO(jsmith): Set to false before merging to code base.
-// TODO(jsmith): Remove once all storage nodes have deployed this version, along with legacy code.
-// Avoids using [allow(unused)] for code that is currently deactivated.
-const USE_BATCHED_RECOVERY: bool = true;
-
 pub(crate) struct NodeCommitteeServiceBuilder<T> {
     service_factory: Box<dyn NodeServiceFactory<Service = T>>,
     local_identity: Option<PublicKey>,
@@ -528,7 +523,7 @@ where
         sliver_type: SliverType,
         certified_epoch: Epoch,
     ) -> Result<Sliver, InconsistencyProofEnum<MerkleProof>> {
-        if USE_BATCHED_RECOVERY {
+        if self.inner.config.experimental_batch_symbol_recovery {
             RecoverSliver::new(
                 metadata,
                 sliver_id,

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -370,6 +370,9 @@ pub struct CommitteeServiceConfig {
     #[serde_as(as = "DurationSeconds<u64>")]
     #[serde(rename = "node_connect_timeout_secs")]
     pub node_connect_timeout: Duration,
+    /// Use the experimental batch recovery service endpoint.
+    #[serde(skip_serializing_if = "defaults::is_default")]
+    pub experimental_batch_symbol_recovery: bool,
 }
 
 impl Default for CommitteeServiceConfig {
@@ -382,6 +385,7 @@ impl Default for CommitteeServiceConfig {
             invalidity_sync_timeout: Duration::from_secs(300),
             max_concurrent_metadata_requests: NonZeroUsize::new(1).unwrap(),
             node_connect_timeout: Duration::from_secs(1),
+            experimental_batch_symbol_recovery: false,
         }
     }
 }


### PR DESCRIPTION
## Description

Uses a config value, false by default, to enable the use of batch recovery.

Since other storage nodes need to be on a supported version, the feature must manually be switched on when other nodes have updated. A subsequent PR can remove the flag altogether.

## Test plan



---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
