### PR TITLE
test: turn off logs generated from Sui in Simtest CI

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -145,7 +145,8 @@ jobs:
     runs-on: ubuntu-ghcloud
     env:
       MSIM_TEST_NUM: 5
-      RUST_LOG: error
+      # Turn off Sui logging since it can be very distractive in CI
+      RUST_LOG: error,sui_=off
     steps:
       - uses: taiki-e/install-action@v2.47.18
         with:


### PR DESCRIPTION
## Description

Currently there are too many error logging generated from quorum driver to query transaction status after execution, which is very distractive and truncates logs in CI to see the actual error that causes the test to fail.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
