### PR TITLE
fix: prevent returning metadata for blobs that are not certified

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -1921,7 +1921,7 @@ impl ServiceState for StorageNodeInner {
         ensure!(!self.is_blocked(blob_id), RetrieveMetadataError::Forbidden);
 
         ensure!(
-            self.is_blob_registered(blob_id)?,
+            self.is_blob_certified(blob_id)?,
             RetrieveMetadataError::Unavailable,
         );
 


### PR DESCRIPTION
## Description

Fixes WAL-147. "Only return slivers and metadata after the blob has been certified"

## Test plan

CI pipeline, but otherwise none. This requires some investigation.

---

## Release notes

- [x] Storage node: Storage nodes will no longer return metadata for blobs that are only registered. Now, they will need to be certified.
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
