### PR TITLE
feat(client): support for multiple environments (Testnet/Mainnet) in client config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11720,6 +11720,7 @@ dependencies = [
  "walrus-core",
  "walrus-service",
  "walrus-sui",
+ "walrus-utils",
 ]
 
 [[package]]
@@ -11949,6 +11950,7 @@ dependencies = [
  "chrono",
  "fastcrypto",
  "futures",
+ "home",
  "inflections",
  "jsonrpsee",
  "move-core-types",
@@ -11999,6 +12001,7 @@ version = "1.16.0"
 dependencies = [
  "anyhow",
  "async-channel",
+ "home",
  "prometheus",
  "rand 0.8.5",
  "reqwest",

--- a/crates/walrus-orchestrator/Cargo.toml
+++ b/crates/walrus-orchestrator/Cargo.toml
@@ -29,6 +29,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 walrus-core.workspace = true
 walrus-service = { workspace = true, features = ["deploy", "node"] }
 walrus-sui.workspace = true
+walrus-utils.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/walrus-orchestrator/src/settings.rs
+++ b/crates/walrus-orchestrator/src/settings.rs
@@ -79,12 +79,12 @@ pub struct Settings {
     /// The ssh private key to access the instances.
     #[serde(
         skip_serializing,
-        deserialize_with = "walrus_service::utils::resolve_home_dir"
+        deserialize_with = "walrus_utils::config::resolve_home_dir"
     )]
     pub ssh_private_key_file: PathBuf,
     /// The corresponding ssh public key registered on the instances. If not specified. the
     /// public key defaults the same path as the private key with an added extension 'pub'.
-    #[serde(deserialize_with = "walrus_service::utils::resolve_home_dir_option")]
+    #[serde(deserialize_with = "walrus_utils::config::resolve_home_dir_option")]
     pub ssh_public_key_file: Option<PathBuf>,
     /// The list of cloud provider regions to deploy the testbed.
     pub regions: Vec<String>,

--- a/crates/walrus-service/bin/client.rs
+++ b/crates/walrus-service/bin/client.rs
@@ -35,7 +35,13 @@ fn client() -> Result<()> {
     app.extract_json_command()?;
 
     tracing::info!("client version: {VERSION}");
-    let runner = ClientCommandRunner::new(&app.config, &app.wallet, app.gas_budget, app.json);
+    let runner = ClientCommandRunner::new(
+        &app.config,
+        app.context.as_deref(),
+        &app.wallet,
+        app.gas_budget,
+        app.json,
+    );
 
     // Drop the temporary tracing subscriber, as the global ones are about to be initialized.
     drop(subscriber_guard);

--- a/crates/walrus-service/bin/deploy.rs
+++ b/crates/walrus-service/bin/deploy.rs
@@ -251,7 +251,7 @@ mod commands {
     };
     use walrus_sui::{
         client::{contract_config::ContractConfig, SuiContractClient, UpgradeType},
-        utils::load_wallet,
+        config::load_wallet_context_from_path,
     };
     use walrus_utils::backoff::ExponentialBackoffConfig;
 
@@ -423,7 +423,8 @@ mod commands {
         let admin_wallet_path = admin_wallet_path.or(Some(
             working_dir.join(format!("{ADMIN_CONFIG_PREFIX}.yaml")),
         ));
-        let admin_wallet = load_wallet(admin_wallet_path).context("unable to load admin wallet")?;
+        let admin_wallet = load_wallet_context_from_path(admin_wallet_path)
+            .context("unable to load admin wallet")?;
         let mut admin_contract_client = testbed_config
             .system_ctx
             .new_contract_client(admin_wallet, ExponentialBackoffConfig::default(), None)
@@ -503,7 +504,7 @@ mod commands {
     ) -> anyhow::Result<()> {
         utils::init_tracing_subscriber()?;
 
-        let wallet = load_wallet(wallet_path).context("unable to load wallet")?;
+        let wallet = load_wallet_context_from_path(wallet_path).context("unable to load wallet")?;
         let contract_config = ContractConfig::new(system_object_id, staking_object_id);
 
         let contract_client =

--- a/crates/walrus-service/src/backup/config.rs
+++ b/crates/walrus-service/src/backup/config.rs
@@ -8,10 +8,7 @@ use std::{net::SocketAddr, path::PathBuf, time::Duration};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DurationMilliSeconds, DurationSeconds};
 
-use crate::{
-    common::{config::SuiReaderConfig, utils},
-    node::events::EventProcessorConfig,
-};
+use crate::{common::config::SuiReaderConfig, node::events::EventProcessorConfig};
 
 /// The subdirectory in which to store the backup blobs when running without remote storage.
 pub const BACKUP_BLOB_ARCHIVE_SUBDIR: &str = "archive";
@@ -46,7 +43,7 @@ pub struct BackupDbConfig {
 pub struct BackupConfig {
     /// Directory in which to persist the event processor database and downloaded blob archives if
     /// no backup_bucket is specified.
-    #[serde(deserialize_with = "utils::resolve_home_dir")]
+    #[serde(deserialize_with = "walrus_utils::config::resolve_home_dir")]
     pub backup_storage_path: PathBuf,
     /// Database configuration. Split apart to ease passing these values to db-specific routines.
     #[serde(flatten)]

--- a/crates/walrus-service/src/client/cli/args.rs
+++ b/crates/walrus-service/src/client/cli/args.rs
@@ -52,8 +52,15 @@ pub struct App {
     /// 4. In `~/.walrus/`.
     // NB: Keep this in sync with `crate::cli`.
     #[clap(long, verbatim_doc_comment, global = true)]
-    #[serde(default, deserialize_with = "crate::utils::resolve_home_dir_option")]
+    #[serde(
+        default,
+        deserialize_with = "walrus_utils::config::resolve_home_dir_option"
+    )]
     pub config: Option<PathBuf>,
+    /// The configuration context to use for the client, if omitted the default_context is used.
+    #[clap(long, global = true)]
+    #[serde(default)]
+    pub context: Option<String>,
     /// The path to the Sui wallet configuration file.
     ///
     /// The wallet configuration is taken from the following locations:
@@ -67,7 +74,10 @@ pub struct App {
     /// is returned.
     // NB: Keep this in sync with `crate::cli`.
     #[clap(long, verbatim_doc_comment, global = true)]
-    #[serde(default, deserialize_with = "crate::utils::resolve_home_dir_option")]
+    #[serde(
+        default,
+        deserialize_with = "walrus_utils::config::resolve_home_dir_option"
+    )]
     pub wallet: Option<PathBuf>,
     /// The gas budget for transactions.
     ///
@@ -186,7 +196,7 @@ pub enum CliCommands {
     Store {
         /// The files containing the blob to be published to Walrus.
         #[clap(required = true, value_name = "FILES")]
-        #[serde(deserialize_with = "crate::utils::resolve_home_dir_vec")]
+        #[serde(deserialize_with = "walrus_utils::config::resolve_home_dir_vec")]
         files: Vec<PathBuf>,
         /// The epoch argument to specify either the number of epochs to store the blob, or the
         /// end epoch, or the earliest expiry time in rfc3339 format.
@@ -239,7 +249,10 @@ pub enum CliCommands {
         ///
         /// If unset, prints the blob to stdout.
         #[clap(long)]
-        #[serde(default, deserialize_with = "crate::utils::resolve_home_dir_option")]
+        #[serde(
+            default,
+            deserialize_with = "walrus_utils::config::resolve_home_dir_option"
+        )]
         out: Option<PathBuf>,
         /// The URL of the Sui RPC node to use.
         #[clap(flatten)]
@@ -318,7 +331,7 @@ pub enum CliCommands {
     /// Encode the specified file to obtain its blob ID.
     BlobId {
         /// The file containing the blob for which to compute the blob ID.
-        #[serde(deserialize_with = "crate::utils::resolve_home_dir")]
+        #[serde(deserialize_with = "walrus_utils::config::resolve_home_dir")]
         file: PathBuf,
         /// The number of shards for which to compute the blob ID.
         ///
@@ -737,7 +750,7 @@ pub struct PublisherArgs {
     pub refill_interval: Duration,
     /// The directory where the publisher will store the sub-wallets used for client multiplexing.
     #[clap(long)]
-    #[serde(deserialize_with = "crate::utils::resolve_home_dir")]
+    #[serde(deserialize_with = "walrus_utils::config::resolve_home_dir")]
     pub sub_wallets_dir: PathBuf,
     /// The amount of MIST transferred at every refill.
     #[clap(long, default_value_t = default::gas_refill_amount())]
@@ -889,7 +902,10 @@ pub struct DaemonArgs {
     pub(crate) metrics_address: SocketAddr,
     /// Path to a blocklist file containing a list (in YAML syntax) of blocked blob IDs.
     #[clap(long)]
-    #[serde(default, deserialize_with = "crate::utils::resolve_home_dir_option")]
+    #[serde(
+        default,
+        deserialize_with = "walrus_utils::config::resolve_home_dir_option"
+    )]
     pub(crate) blocklist: Option<PathBuf>,
 }
 
@@ -1457,6 +1473,7 @@ mod tests {
     fn test_json_string_extraction(json: &str, command: Commands) -> TestResult {
         let mut app = App {
             config: None,
+            context: None,
             wallet: None,
             gas_budget: None,
             json: false,

--- a/crates/walrus-service/src/client/multiplexer.rs
+++ b/crates/walrus-service/src/client/multiplexer.rs
@@ -27,6 +27,7 @@ use walrus_sui::{
         SuiContractClient,
         SuiReadClient,
     },
+    config::load_wallet_context_from_path,
     types::move_structs::BlobWithAttribute,
     utils::create_wallet,
 };
@@ -358,7 +359,7 @@ impl<'a> SubClientLoader<'a> {
 
         if wallet_config_path.exists() {
             tracing::debug!(?wallet_config_path, "loading sub-wallet from file");
-            WalletContext::new(&wallet_config_path, None, None)
+            load_wallet_context_from_path(Some(&wallet_config_path))
         } else {
             tracing::debug!(?wallet_config_path, "creating new sub-wallet");
             create_wallet(

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -74,7 +74,7 @@ pub struct StorageNodeConfig {
     #[serde(deserialize_with = "utils::deserialize_node_name")]
     pub name: String,
     /// Directory in which to persist the database.
-    #[serde(deserialize_with = "utils::resolve_home_dir")]
+    #[serde(deserialize_with = "walrus_utils::config::resolve_home_dir")]
     pub storage_path: PathBuf,
     /// File path to the blocklist.
     #[serde(default, skip_serializing_if = "defaults::is_none")]
@@ -663,7 +663,10 @@ pub enum PathOrInPlace<T> {
     /// A value that is not present in the config, but at a path on the filesystem.
     Path {
         /// The path from which the value can be loaded.
-        #[serde(rename = "path", deserialize_with = "utils::resolve_home_dir")]
+        #[serde(
+            rename = "path",
+            deserialize_with = "walrus_utils::config::resolve_home_dir"
+        )]
         path: PathBuf,
         /// The value loaded from the specified path.
         #[serde(skip, default = "Option::default")]
@@ -904,7 +907,7 @@ mod tests {
     use sui_types::base_types::ObjectID;
     use tempfile::{NamedTempFile, TempDir};
     use walrus_core::test_utils;
-    use walrus_sui::client::contract_config::ContractConfig;
+    use walrus_sui::{client::contract_config::ContractConfig, config::WalletConfig};
     use walrus_test_utils::Result as TestResult;
 
     use super::*;
@@ -928,7 +931,9 @@ mod tests {
                 rpc: "https://fullnode.testnet.sui.io:443".to_string(),
                 contract_config,
                 event_polling_interval: defaults::polling_interval(),
-                wallet_config: PathBuf::from("/opt/walrus/config/sui_config.yaml"),
+                wallet_config: WalletConfig::from_path(PathBuf::from(
+                    "/opt/walrus/config/sui_config.yaml",
+                )),
                 backoff_config: Default::default(),
                 gas_budget: None,
             }),

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -1011,7 +1011,9 @@ impl StorageNodeHandleBuilder {
                     system_context.system_object,
                     system_context.staking_object,
                 ),
-                wallet_config: self.node_wallet_dir.unwrap().join("wallet_config.yaml"),
+                wallet_config: walrus_sui::config::WalletConfig::from_path(
+                    self.node_wallet_dir.unwrap().join("wallet_config.yaml"),
+                ),
                 event_polling_interval: config::defaults::polling_interval(),
                 backoff_config: ExponentialBackoffConfig::default(),
                 gas_budget: None,

--- a/crates/walrus-service/src/testbed.rs
+++ b/crates/walrus-service/src/testbed.rs
@@ -27,6 +27,7 @@ use walrus_core::{
 };
 use walrus_sui::{
     client::SuiContractClient,
+    config::{load_wallet_context_from_path, WalletConfig},
     system_setup::InitSystemParams,
     test_utils::system_setup::{
         create_and_init_system,
@@ -351,7 +352,7 @@ pub async fn deploy_walrus_contract(
             "Loading existing admin wallet from path: {}",
             admin_wallet_path.display()
         );
-        WalletContext::new(&admin_wallet_path, None, None)?
+        load_wallet_context_from_path(Some(&admin_wallet_path))?
     } else {
         tracing::debug!("Creating new admin wallet in working directory");
         let mut admin_wallet = create_wallet(
@@ -544,7 +545,7 @@ pub async fn create_client_config(
     let client_config = client::Config {
         contract_config,
         exchange_objects,
-        wallet_config: Some(wallet_path),
+        wallet_config: Some(WalletConfig::from_path(wallet_path)),
         communication_config: Default::default(),
         refresh_config: Default::default(),
     };
@@ -685,7 +686,7 @@ pub async fn create_storage_node_configs(
             rpc: rpc.clone(),
             contract_config,
             event_polling_interval: defaults::polling_interval(),
-            wallet_config: wallet_path,
+            wallet_config: WalletConfig::from_path(wallet_path),
             backoff_config: ExponentialBackoffConfig::default(),
             gas_budget: None,
         });

--- a/crates/walrus-stress/src/main.rs
+++ b/crates/walrus-stress/src/main.rs
@@ -15,9 +15,9 @@ use anyhow::Context;
 use clap::Parser;
 use walrus_service::{
     client::{metrics::ClientMetrics, Config, Refiller},
-    utils::{load_from_yaml, load_wallet_context},
+    utils::load_from_yaml,
 };
-use walrus_sui::utils::SuiNetwork;
+use walrus_sui::{config::load_wallet_context_from_path, utils::SuiNetwork};
 
 use crate::generator::LoadGenerator;
 
@@ -98,7 +98,7 @@ async fn main() -> anyhow::Result<()> {
     // Start the write transaction generator.
     let gas_refill_period = Duration::from_millis(args.gas_refill_period_millis.get());
 
-    let wallet = load_wallet_context(&args.wallet_path)?;
+    let wallet = load_wallet_context_from_path(args.wallet_path)?;
     let contract_client = config.new_contract_client(wallet, None).await?;
 
     let refiller = Refiller::new(

--- a/crates/walrus-sui/Cargo.toml
+++ b/crates/walrus-sui/Cargo.toml
@@ -25,6 +25,7 @@ bcs.workspace = true
 chrono.workspace = true
 fastcrypto.workspace = true
 futures.workspace = true
+home.workspace = true
 move-core-types.workspace = true
 move-package.workspace = true
 rand.workspace = true

--- a/crates/walrus-sui/src/config.rs
+++ b/crates/walrus-sui/src/config.rs
@@ -1,0 +1,121 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Wallet configuration utilities.
+use std::{
+    fmt::Debug,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
+use sui_sdk::wallet_context::WalletContext;
+use sui_types::base_types::SuiAddress;
+use walrus_utils::config::{path_or_defaults_if_exist, resolve_home_dir};
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(untagged)]
+/// The wallet configuration is a mechanism for specifying the sui wallet config, with a potential
+/// override for the active environment.
+pub enum WalletConfig {
+    /// The path to the wallet configuration file. The wallet context will use the active
+    /// environment from the given configuration file.
+    Path(#[serde(default, deserialize_with = "resolve_home_dir")] PathBuf),
+    /// The path to the wallet configuration file with some optional overrides `active_env`, and
+    /// `active_address`. The wallet context will use the specified `active_env` or `active_address`
+    /// if it is non-null. Loading of the `WalletContext` will fail if an invalid `active_...`
+    /// parameter is used. Specifying a null `active_..` parameter will use its prespecified value
+    /// from the related configuration file.
+    PathWithOverride {
+        /// The path to the wallet configuration file.
+        #[serde(default, deserialize_with = "resolve_home_dir")]
+        path: PathBuf,
+        /// The optional `active_env` to use to override whatever `active_env` is listed in the
+        /// configuration file.
+        #[serde(default)]
+        active_env: Option<String>,
+        /// The optional `active_address` to use to override whatever `active_address` is listed in
+        /// the configuration file.
+        #[serde(default)]
+        active_address: Option<SuiAddress>,
+    },
+}
+
+/// Helper function to load the wallet context from the given optional wallet path.
+pub fn load_wallet_context_from_path(
+    wallet_path: Option<impl AsRef<Path>>,
+) -> Result<WalletContext> {
+    WalletConfig::load_wallet_context(wallet_path.map(WalletConfig::from_path).as_ref())
+}
+
+impl WalletConfig {
+    /// Construct a simple pass-through wallet configuration from a path.
+    pub fn from_path(path: impl AsRef<Path>) -> Self {
+        WalletConfig::Path(path.as_ref().to_path_buf())
+    }
+
+    /// Retrieves the path to the wallet configuration file.
+    pub fn path(&self) -> &Path {
+        match self {
+            WalletConfig::Path(path) => path,
+            WalletConfig::PathWithOverride { path, .. } => path,
+        }
+    }
+
+    /// Retrieves the `active_env`, if it was specified.
+    pub fn active_env(&self) -> Option<&str> {
+        match self {
+            WalletConfig::Path(_) => None,
+            WalletConfig::PathWithOverride { active_env, .. } => active_env.as_deref(),
+        }
+    }
+
+    /// Retrieves the `active_address`, if it was specified.
+    pub fn active_address(&self) -> Option<SuiAddress> {
+        match self {
+            WalletConfig::Path(_) => None,
+            WalletConfig::PathWithOverride { active_address, .. } => *active_address,
+        }
+    }
+
+    /// Loads the wallet context from the given optional wallet config (optional path and optional
+    /// Sui env).
+    ///
+    /// If no path is provided, tries to load the configuration first from the local folder, and
+    /// then from the standard Sui configuration directory.
+    // NB: When making changes to the logic, make sure to update the argument docs in
+    // `crates/walrus-service/bin/client.rs`.
+    pub fn load_wallet_context(wallet_config: Option<&WalletConfig>) -> Result<WalletContext> {
+        let mut default_paths = vec!["./sui_config.yaml".into()];
+        if let Some(home_dir) = home::home_dir() {
+            default_paths.push(home_dir.join(".sui").join("sui_config").join("client.yaml"))
+        }
+
+        let path = path_or_defaults_if_exist(wallet_config.map(|c| c.path()), &default_paths)
+            .ok_or(anyhow!("could not find a valid wallet config file"))?;
+        tracing::info!("using Sui wallet configuration from '{}'", path.display());
+        let mut wallet_context: WalletContext = WalletContext::new(&path, None, None)?;
+        if let Some(active_env) = wallet_config.and_then(|wallet_config| wallet_config.active_env())
+        {
+            if !wallet_context
+                .config
+                .envs
+                .iter()
+                .any(|env| env.alias == active_env)
+            {
+                return Err(anyhow!(
+                    "Env '{}' not found in wallet config file '{}'.",
+                    active_env,
+                    path.display()
+                ));
+            }
+            wallet_context.config.active_env = Some(active_env.to_string());
+        }
+        if let Some(active_address) =
+            wallet_config.and_then(|wallet_config| wallet_config.active_address())
+        {
+            wallet_context.config.active_address = Some(active_address);
+        }
+        Ok(wallet_context)
+    }
+}

--- a/crates/walrus-sui/src/lib.rs
+++ b/crates/walrus-sui/src/lib.rs
@@ -6,6 +6,7 @@
 #[macro_use]
 pub mod utils;
 pub mod client;
+pub mod config;
 pub mod contracts;
 pub mod system_setup;
 

--- a/crates/walrus-sui/src/test_utils.rs
+++ b/crates/walrus-sui/src/test_utils.rs
@@ -41,6 +41,7 @@ use walrus_test_utils::WithTempDir;
 
 use crate::{
     client::SuiContractClient,
+    config::load_wallet_context_from_path,
     types::{
         BlobCertified,
         BlobDeleted,
@@ -345,7 +346,7 @@ pub async fn create_and_fund_wallets_on_cluster(
     // Load the cluster's wallet from file instead of using the wallet stored in the cluster.
     // This prevents tasks from being spawned in the current runtime that are expected by
     // the wallet to continue running.
-    let mut cluster_wallet = WalletContext::new(&path_guard, None, None)?;
+    let mut cluster_wallet = load_wallet_context_from_path(Some(path_guard.as_path()))?;
 
     let mut wallets = vec![];
     let mut addresses = vec![];
@@ -374,7 +375,7 @@ pub async fn new_wallet_on_sui_test_cluster(
     // Load the cluster's wallet from file instead of using the wallet stored in the cluster.
     // This prevents tasks from being spawned in the current runtime that are expected by
     // the wallet to continue running.
-    let mut cluster_wallet = WalletContext::new(&path_guard, None, None)?;
+    let mut cluster_wallet = load_wallet_context_from_path(Some(path_guard.as_path()))?;
     let wallet = wallet_for_testing(&mut cluster_wallet, true).await?;
     drop(path_guard);
     Ok(wallet)

--- a/crates/walrus-sui/src/utils.rs
+++ b/crates/walrus-sui/src/utils.rs
@@ -7,7 +7,7 @@ use std::{
     collections::HashSet,
     future::Future,
     num::NonZeroU16,
-    path::{Path, PathBuf},
+    path::Path,
     str::FromStr,
     time::Duration,
 };
@@ -16,7 +16,7 @@ use anyhow::{anyhow, Result};
 use move_core_types::language_storage::StructTag as MoveStructTag;
 use move_package::{source_package::layout::SourcePackageLayout, BuildConfig as MoveBuildConfig};
 use serde::{Deserialize, Serialize};
-use sui_config::{sui_config_dir, Config, SUI_CLIENT_CONFIG, SUI_KEYSTORE_FILENAME};
+use sui_config::{sui_config_dir, Config, SUI_KEYSTORE_FILENAME};
 use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use sui_sdk::{
     rpc_types::{ObjectChange, Page, SuiObjectResponse, SuiTransactionBlockResponse},
@@ -42,6 +42,7 @@ use walrus_core::{
 
 use crate::{
     client::{SuiClientResult, SuiContractClient},
+    config::load_wallet_context_from_path,
     contracts::AssociatedContractStruct,
 };
 
@@ -279,13 +280,6 @@ impl std::fmt::Display for SuiNetwork {
     }
 }
 
-/// Loads a sui wallet from `config_path`.
-pub fn load_wallet(config_path: Option<PathBuf>) -> Result<WalletContext> {
-    let config_path =
-        config_path.map_or_else(|| anyhow::Ok(sui_config_dir()?.join(SUI_CLIENT_CONFIG)), Ok)?;
-    WalletContext::new(&config_path, None, None)
-}
-
 /// Creates a wallet on `network` and stores its config at `config_path`.
 ///
 /// The keystore will be stored in the same directory as the wallet config and named
@@ -315,7 +309,7 @@ pub fn create_wallet(
     }
     .persisted(config_path)
     .save()?;
-    load_wallet(Some(config_path.to_owned()))
+    load_wallet_context_from_path(Some(config_path))
 }
 
 /// Sends a request to the faucet to request coins for `address`.

--- a/crates/walrus-utils/Cargo.toml
+++ b/crates/walrus-utils/Cargo.toml
@@ -12,6 +12,7 @@ test-utils = ["dep:tempfile"]
 [dependencies]
 anyhow.workspace = true
 async-channel.workspace = true
+home.workspace = true
 prometheus.workspace = true
 rand.workspace = true
 reqwest.workspace = true

--- a/crates/walrus-utils/src/config.rs
+++ b/crates/walrus-utils/src/config.rs
@@ -1,0 +1,71 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{de::Error, Deserialize, Deserializer};
+
+/// Can be used to deserialize optional paths such that the `~` is resolved to the user's home
+/// directory.
+pub fn resolve_home_dir<'de, D>(deserializer: D) -> Result<PathBuf, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let path: PathBuf = Deserialize::deserialize(deserializer)?;
+    path_with_resolved_home_dir(path).map_err(D::Error::custom)
+}
+
+/// Can be used to deserialize optional paths such that the `~` is resolved to the user's home
+/// directory.
+pub fn resolve_home_dir_vec<'de, D>(deserializer: D) -> Result<Vec<PathBuf>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let paths: Vec<PathBuf> = Deserialize::deserialize(deserializer)?;
+    paths
+        .into_iter()
+        .map(|p| path_with_resolved_home_dir(p).map_err(D::Error::custom))
+        .collect()
+}
+
+/// Can be used to deserialize optional paths such that the `~` is resolved to the user's home
+/// directory.
+pub fn resolve_home_dir_option<'de, D>(deserializer: D) -> Result<Option<PathBuf>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let path: Option<PathBuf> = Deserialize::deserialize(deserializer)?;
+    let Some(path) = path else { return Ok(None) };
+    Ok(Some(
+        path_with_resolved_home_dir(path).map_err(D::Error::custom)?,
+    ))
+}
+
+fn path_with_resolved_home_dir(path: PathBuf) -> Result<PathBuf> {
+    if path.starts_with("~/") {
+        let home = home::home_dir().context("unable to resolve home directory")?;
+        Ok(home.join(
+            path.strip_prefix("~")
+                .expect("we just checked for this prefix"),
+        ))
+    } else {
+        Ok(path)
+    }
+}
+
+/// Returns the path if it is `Some` or any of the default paths if they exist (attempt in order).
+pub fn path_or_defaults_if_exist(
+    path: Option<impl AsRef<Path>>,
+    defaults: &[PathBuf],
+) -> Option<PathBuf> {
+    let mut path = path.map(|p| p.as_ref().to_path_buf());
+    tracing::debug!(?path, ?defaults, "looking for configuration file");
+    for default in defaults {
+        if path.is_some() {
+            break;
+        }
+        path = default.exists().then_some(default.clone());
+    }
+    path.map(|p| p.to_path_buf())
+}

--- a/crates/walrus-utils/src/lib.rs
+++ b/crates/walrus-utils/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod backoff;
 pub mod checkpoint_downloader;
+pub mod config;
 pub mod metrics;
 
 pub mod tests {


### PR DESCRIPTION
## Description

Add support for multiple contexts within Walrus client config.

## Test plan

Added new unit tests around the new scenarios. Manual testing.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [x] CLI: support has been introduced for multiple contexts, and a default_context for walrus client invocations. Context can be overriden with the new --context <context> argument.

Here is an example (with some fake addresses) multi-context config file.

```
---
contexts:
  testnet:
    system_object: 0x98ebc47370603fe81d9e15491b2f1443d619d1dab720d586e429ed233e1255c1
    staking_object: 0x20266a17b4f1a216727f3eef5772f8d486a9e3b5e319af80a5b75809c035561d
    exchange_objects:
      - 0x59ab926eb0d94d0d6d6139f11094ea7861914ad2ecffc7411529c60019133997
      - 0x89127f53890840ab6c52fca96b4a5cf853d7de52318d236807ad733f976eef7b
      - 0x9f9b4f113862e8b1a3591d7955fadd7c52ecc07cf24be9e3492ce56eb8087805
      - 0xb60118f86ecb38ec79e74586f1bb184939640911ee1d63a84138d080632ee28a
    wallet_config:
      path: ~/.sui/sui_config/client.yaml
      active_env: testnet
  devnet:
    system_object: 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
    staking_object: 0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
    exchange_objects:
      - 0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
      - 0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
      - 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
      - 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
    wallet_config:
      path: ~/.sui/sui_config/client.yaml
      active_env: devnet

default_context: testnet

```