### PR TITLE
fix: Make event blob writer non blocking

### DIFF
--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -17,7 +17,6 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use anyhow::Error;
 use async_trait::async_trait;
 use chrono::Utc;
 use futures::{stream::FuturesUnordered, StreamExt};
@@ -1392,8 +1391,8 @@ impl SystemContractService for StubContractService {
         _ending_checkpoint_seq_num: u64,
         _epoch: u32,
         _node_capability_object_id: ObjectID,
-    ) -> Result<(), Error> {
-        anyhow::bail!("stub service cannot certify event blob")
+    ) -> Result<(), SuiClientError> {
+        Ok(())
     }
 
     async fn refresh_contract_package(&self) -> Result<(), anyhow::Error> {
@@ -2037,7 +2036,7 @@ where
         ending_checkpoint_seq_num: u64,
         epoch: u32,
         node_capability_object_id: ObjectID,
-    ) -> Result<(), Error> {
+    ) -> Result<(), SuiClientError> {
         self.as_ref()
             .inner
             .certify_event_blob(


### PR DESCRIPTION
## Description

Currently, when attestation fails due to errors, the event blob writer continues to retry indefinitely for some type of errors, blocking progress for the storage node. This change de-couples event blob writing from event processing and:

1. Adds state management to pause attestations until the next epoch when invalid epoch errors occur
2. Adds logging for attestation state changes
3. Adds finite number of retries for the `certify_event_blob` contract call

This ensures event processing continues even when attestations fail, and attestations automatically resume in the next epoch. The change prevents unnecessary load from failed attestation attempts and ensures smoother epoch transitions.
