### PR TITLE
fix(node): avoid spurious warnings during catchup

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -1050,9 +1050,9 @@ impl StorageNode {
         let start = tokio::time::Instant::now();
         let histogram_set = self.inner.metrics.recover_blob_duration_seconds.clone();
 
-        if self.inner.is_stored_at_all_shards(&event.blob_id)?
-            || !self.inner.is_blob_certified(&event.blob_id)?
+        if !self.inner.is_blob_certified(&event.blob_id)?
             || self.inner.storage.node_status()? == NodeStatus::RecoveryCatchUp
+            || self.inner.is_stored_at_all_shards(&event.blob_id)?
         {
             event_handle.mark_as_complete();
 


### PR DESCRIPTION
## Description

This changes the order of the checks in `process_blob_certified_event` to avoid spurious warnings like `"message":"failed to check if blob is stored at shard","error":"shard X does not exist ..."` during catchup.

## Test plan

Existing tests.
