### PR TITLE
test: basic setup for walrus antithesis test

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -25,7 +25,7 @@ max_line_length = 150
 indent_size = unset
 
 # Ignore paths
-[{.git/**/*,**/*.lock,**/Move.toml,LICENSE,docs/devnet-public/glossary.md,crates/walrus-orchestrator/assets/*,.editorconfig,venv/**/*,crates/walrus-service/*.html,crates/walrus-service/*.yaml}]
+[{.git/**/*,**/*.lock,**/Move.toml,LICENSE,docs/devnet-public/glossary.md,crates/walrus-orchestrator/assets/*,.editorconfig,venv/**/*,crates/walrus-service/*.html,crates/walrus-service/*.yaml,docker/walrus-antithesis/build-walrus-image/update_move_toml.sh}]
 charset = unset
 end_of_line = unset
 indent_size = unset

--- a/crates/walrus-service/bin/deploy.rs
+++ b/crates/walrus-service/bin/deploy.rs
@@ -212,7 +212,7 @@ mod commands {
             DeployTestbedContractParameters,
             TestbedConfig,
         },
-        utils::load_from_yaml,
+        utils::{self, load_from_yaml},
     };
     use walrus_sui::utils::load_wallet;
 
@@ -303,7 +303,7 @@ mod commands {
             with_wal_exchange,
         }: DeploySystemContractArgs,
     ) -> anyhow::Result<()> {
-        tracing_subscriber::fmt::init();
+        utils::init_tracing_subscriber()?;
 
         fs::create_dir_all(&working_dir)
             .with_context(|| format!("Failed to create directory '{}'", working_dir.display()))?;
@@ -360,7 +360,7 @@ mod commands {
             admin_wallet_path,
         }: GenerateDryRunConfigsArgs,
     ) -> anyhow::Result<()> {
-        tracing_subscriber::fmt::init();
+        utils::init_tracing_subscriber()?;
 
         fs::create_dir_all(&working_dir)
             .with_context(|| format!("Failed to create directory '{}'", working_dir.display()))?;

--- a/docker/walrus-antithesis/build-test-config-image/Dockerfile
+++ b/docker/walrus-antithesis/build-test-config-image/Dockerfile
@@ -1,0 +1,22 @@
+FROM debian:bookworm-slim AS setup
+
+RUN apt update
+RUN apt install python3 python3-pip -y
+
+WORKDIR /
+
+RUN echo "SUI_RUST_LOG=$SUI_RUST_LOG" >> /.env
+
+# TODO(zhewu): update to use env variables
+RUN echo "WALRUS_IMAGE_NAME=walrus-service:walrus-service-zhe" >> /.env
+RUN echo "WALRUS_PLATFORM=linux/amd64" >> /.env
+RUN echo "SUI_IMAGE_NAME=mysten/sui-tools:mainnet-v1.40.3" >> /.env
+
+COPY ./docker-compose.yaml /docker-compose.yaml
+COPY ./files /files
+
+FROM scratch
+
+COPY --from=setup /docker-compose.yaml /docker-compose.yaml
+COPY --from=setup /.env /.env
+COPY --from=setup /files /files

--- a/docker/walrus-antithesis/build-test-config-image/docker-compose.yaml
+++ b/docker/walrus-antithesis/build-test-config-image/docker-compose.yaml
@@ -1,0 +1,142 @@
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# This docker-compose file sets up a test environment for Walrus with:
+# - A single-validator Sui network
+# - A Walrus deployment service
+# - A setup completion service
+# - 4 Walrus nodes for testing
+
+services:
+  # Runs a local Sui network with a single validator
+  sui-localnet:
+    networks:
+      testbed-network:
+        ipv4_address: 10.0.0.20
+    hostname: sui-node
+    image: mysten/sui-tools:mainnet-v1.40.3
+    platform: ${SUI_PLATFORM:-linux/amd64}
+    environment:
+      - NO_COLOR=1
+    command: >
+      /bin/sh -c "cp /usr/local/bin/sui /root/sui_bin/ && \
+      sui start --with-faucet --force-regenesis --committee-size 1 --epoch-duration-ms 86400000"
+    healthcheck:
+      test: ["CMD", "/bin/bash", "-c", "echo > /dev/tcp/127.0.0.1/9123 && echo > /dev/tcp/127.0.0.1/9000"]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+      start_period: 120s
+    volumes:
+      - sui-bin:/root/sui_bin
+
+  # Deploys the Walrus contracts and initializes the system
+  walrus-deploy:
+    restart: no
+    depends_on:
+      sui-localnet:
+        condition: service_healthy
+    networks:
+      testbed-network:
+    image: walrus-service:walrus-service-zhe
+    platform: ${WALRUS_PLATFORM:-linux/amd64}
+    hostname: walrus-deploy
+    container_name: walrus-deploy
+    environment:
+      - EPOCH_DURATION=1m
+      - NO_COLOR=1
+    volumes:
+      - ./files/deploy-walrus.sh:/root/deploy-walrus.sh
+      - walrus-deploy-outputs:/opt/walrus/outputs
+    command: >
+      /bin/bash -c "sleep 60 && /root/deploy-walrus.sh"
+
+  # Performs final setup steps after deployment
+  complete-setup:
+    depends_on:
+      sui-localnet:
+        condition: service_healthy
+      walrus-deploy:
+        condition: service_completed_successfully
+    image: walrus-service:walrus-service-zhe
+    platform: ${WALRUS_PLATFORM:-linux/amd64}
+    volumes:
+      - ./files/complete-setup.sh:/root/complete-setup.sh
+    command: >
+      /bin/bash -c "/root/complete-setup.sh"
+
+  # Template for Walrus nodes
+  walrus-node-0: &walrus-node
+    depends_on:
+      sui-localnet:
+        condition: service_healthy
+      walrus-deploy:
+        condition: service_completed_successfully
+    networks:
+      testbed-network:
+        ipv4_address: 10.0.0.10
+    image: walrus-service:walrus-service-zhe
+    platform: ${WALRUS_PLATFORM:-linux/amd64}
+    hostname: dryrun-node-0
+    container_name: dryrun-node-0
+    environment:
+      - NODE_NAME=dryrun-node-0
+      - NO_COLOR=1
+    volumes:
+      - sui-bin:/root/sui_bin
+      - walrus-deploy-outputs:/opt/walrus/outputs
+      - ./files/run-walrus.sh:/root/run-walrus.sh
+    command: >
+      /bin/bash -c "/root/run-walrus.sh"
+    logging:
+      driver: "json-file"
+      options:
+        max-file: "10"
+        max-size: "1g"
+
+  # Additional Walrus nodes using the template
+  walrus-node-1:
+    <<: *walrus-node
+    networks:
+      testbed-network:
+        ipv4_address: 10.0.0.11
+    hostname: dryrun-node-1
+    container_name: dryrun-node-1
+    environment:
+      - NODE_NAME=dryrun-node-1
+      - NO_COLOR=1
+
+  walrus-node-2:
+    <<: *walrus-node
+    networks:
+      testbed-network:
+        ipv4_address: 10.0.0.12
+    hostname: dryrun-node-2
+    container_name: dryrun-node-2
+    environment:
+      - NODE_NAME=dryrun-node-2
+      - NO_COLOR=1
+
+  walrus-node-3:
+    <<: *walrus-node
+    networks:
+      testbed-network:
+        ipv4_address: 10.0.0.13
+    hostname: dryrun-node-3
+    container_name: dryrun-node-3
+    environment:
+      - NODE_NAME=dryrun-node-3
+      - NO_COLOR=1
+
+# Persistent volumes for sharing data between containers
+volumes:
+  sui-bin:
+  walrus-deploy-outputs:
+
+# Network configuration for container communication
+networks:
+  testbed-network:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 10.0.0.0/24

--- a/docker/walrus-antithesis/build-test-config-image/files/complete-setup.sh
+++ b/docker/walrus-antithesis/build-test-config-image/files/complete-setup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+
+echo "about to signal complete setup"
+
+# Emit the JSONL message
+echo '{"antithesis_setup": { "status": "complete", "details": null }}' > "$ANTITHESIS_OUTPUT_DIR/sdk.jsonl"

--- a/docker/walrus-antithesis/build-test-config-image/files/deploy-walrus.sh
+++ b/docker/walrus-antithesis/build-test-config-image/files/deploy-walrus.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# use EPOCH_DURATION to set the epoch duration, default is 1h
+EPOCH_DURATION=${EPOCH_DURATION:-1h}
+
+cd /opt/walrus
+
+rm -rf /opt/walrus/outputs/*
+ls -al /opt/walrus/contracts
+
+/opt/walrus/bin/walrus-deploy deploy-system-contract \
+  --working-dir /opt/walrus/outputs \
+  --contract-dir /opt/walrus/contracts \
+  --do-not-copy-contracts \
+  --sui-network 'http://10.0.0.20:9000;http://10.0.0.20:9123/gas' \
+  --n-shards 10 \
+  --host-addresses 10.0.0.10 10.0.0.11 10.0.0.12 10.0.0.13 \
+  --storage-price 5 \
+  --write-price 1 \
+  --with-wal-exchange \
+  --epoch-duration $EPOCH_DURATION >/opt/walrus/outputs/deploy
+
+/opt/walrus/bin/walrus-deploy generate-dry-run-configs \
+  --working-dir /opt/walrus/outputs

--- a/docker/walrus-antithesis/build-test-config-image/files/run-walrus.sh
+++ b/docker/walrus-antithesis/build-test-config-image/files/run-walrus.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+## -----------------------------------------------------------------------------
+## Prepare the environment
+## -----------------------------------------------------------------------------
+
+HOSTNAME=$(hostname)
+
+# create directories
+mkdir -p /root/.sui/sui_config
+mkdir -p /root/.config/walrus
+mkdir -p /opt/walrus/outputs
+
+# copy from deploy outputs
+cp /opt/walrus/outputs/${HOSTNAME}-sui.yaml /root/.sui/sui_config/client.yaml
+cp /opt/walrus/outputs/${HOSTNAME}.aliases /root/.sui/sui_config/sui.aliases
+
+# extract object IDs from the deploy outputs
+SYSTEM_OBJECT=$(grep "system_object" /opt/walrus/outputs/deploy | awk '{print $2}')
+STAKING_OBJECT=$(grep "staking_object" /opt/walrus/outputs/deploy | awk '{print $2}')
+EXCHANGE_OBJECT=$(grep "exchange_object" /opt/walrus/outputs/deploy | awk '{print $2}')
+
+# copy binaries
+cp /root/sui_bin/sui /usr/local/bin/
+cp /opt/walrus/bin/walrus /usr/local/bin/
+
+cat <<EOF >/root/.config/walrus/client_config.yaml
+system_object: ${SYSTEM_OBJECT}
+staking_object: ${STAKING_OBJECT}
+exchange_objects: [${EXCHANGE_OBJECT}]
+EOF
+
+# get some sui tokens
+sui client faucet --url http://sui-localnet:9123/gas
+sleep 3
+
+# exchange for WAL tokens (500 WAL)
+walrus get-wal -a 500000000000
+sui client balance
+
+## -----------------------------------------------------------------------------
+## Start the node
+## -----------------------------------------------------------------------------
+RUST_LOG=info /opt/walrus/bin/walrus-node run --config-path /opt/walrus/outputs/${HOSTNAME}.yaml

--- a/docker/walrus-antithesis/build-walrus-image/Dockerfile
+++ b/docker/walrus-antithesis/build-walrus-image/Dockerfile
@@ -1,0 +1,89 @@
+# Build application
+#
+# Copy in all crates, Cargo.toml and Cargo.lock unmodified,
+# and build the application.
+FROM rust:1.84-bookworm AS base
+ARG PROFILE=release
+ARG GIT_REVISION
+ENV GIT_REVISION=$GIT_REVISION
+WORKDIR "$WORKDIR/walrus"
+RUN apt-get update && apt-get install -y cmake clang
+
+COPY Cargo.toml Cargo.lock ./
+COPY crates crates
+COPY contracts ./contracts
+COPY contracts /contracts
+COPY docker/walrus-antithesis/build-walrus-image/update_move_toml.sh /tmp/
+
+# Clone Sui repository at specific tag
+# TODO(zhewu): make this configurable to use the branch matching the current tag
+RUN git clone --depth 1 --branch testnet-v1.41.0 https://github.com/MystenLabs/sui /sui
+
+# We need to replace all the Sui dependencies with the local Sui repository.
+# When testing in antithesis, we cannot pull the Sui repository from the internet.
+RUN chmod +x /tmp/update_move_toml.sh
+RUN /tmp/update_move_toml.sh
+
+FROM base AS builder
+RUN cargo build --profile $PROFILE \
+    --bin walrus \
+    --bin walrus-node \
+    --bin walrus-deploy
+
+# Production Image for all binaries under walrus-service
+FROM debian:bookworm-slim AS walrus-service
+RUN apt-get update && apt-get install -y ca-certificates curl git
+ARG PROFILE=release
+WORKDIR "$WORKDIR/walrus"
+# Both bench and release profiles copy from release dir
+COPY --from=builder /walrus/target/release/walrus /opt/walrus/bin/walrus
+COPY --from=builder /walrus/target/release/walrus-node /opt/walrus/bin/walrus-node
+COPY --from=builder /walrus/target/release/walrus-deploy /opt/walrus/bin/walrus-deploy
+COPY --from=builder /contracts /opt/walrus/contracts
+COPY --from=builder /sui /opt/sui
+
+ARG BUILD_DATE
+ARG GIT_REVISION
+LABEL build-date=$BUILD_DATE
+LABEL git-revision=$GIT_REVISION
+
+# Production Image for walrus CLI
+FROM debian:bookworm-slim AS walrus-cli
+RUN apt-get update && apt-get install -y ca-certificates curl
+ARG PROFILE=release
+WORKDIR "$WORKDIR/walrus"
+# Both bench and release profiles copy from release dir
+COPY --from=builder /walrus/target/release/walrus /opt/walrus/bin/walrus
+
+ARG BUILD_DATE
+ARG GIT_REVISION
+LABEL build-date=$BUILD_DATE
+LABEL git-revision=$GIT_REVISION
+
+# Production Image for walrus node
+FROM debian:bookworm-slim AS walrus-node
+RUN apt-get update && apt-get install -y ca-certificates curl
+ARG PROFILE=release
+WORKDIR "$WORKDIR/walrus"
+# Both bench and release profiles copy from release dir
+COPY --from=builder /walrus/target/release/walrus-node /opt/walrus/bin/walrus-node
+
+ARG BUILD_DATE
+ARG GIT_REVISION
+LABEL build-date=$BUILD_DATE
+LABEL git-revision=$GIT_REVISION
+
+# Production Image for walrus deployment CLI
+FROM debian:bookworm-slim AS walrus-deploy
+RUN apt-get update && apt-get install -y ca-certificates curl
+ARG PROFILE=release
+WORKDIR "$WORKDIR/walrus"
+# Both bench and release profiles copy from release dir
+COPY --from=builder /walrus/target/release/walrus-deploy /opt/walrus/bin/walrus-deploy
+COPY --from=builder /contracts /opt/walrus/contracts
+COPY --from=builder /sui /opt/sui
+
+ARG BUILD_DATE
+ARG GIT_REVISION
+LABEL build-date=$BUILD_DATE
+LABEL git-revision=$GIT_REVISION

--- a/docker/walrus-antithesis/build-walrus-image/update_move_toml.sh
+++ b/docker/walrus-antithesis/build-walrus-image/update_move_toml.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+
+# List of contract directories to process
+contracts=("wal" "wal_exchange" "walrus" "subsidies")
+
+for contract in "${contracts[@]}"; do
+    toml_file="/contracts/${contract}/Move.toml"
+    sed 's|^Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework".*|Sui = { local = "/opt/sui/crates/sui-framework/packages/sui-framework" }|' \
+        < "$toml_file" > "${toml_file}.new"
+    mv "${toml_file}.new" "$toml_file"
+done


### PR DESCRIPTION
## Description

This PR creates a working directory containing docker files and scripts that can successfully starts an antithesis test.

It is currently very hacky and can only used be manually. However, it took me quite a bit of effort to reach to this point
and I also want to be able to check these out across multiple machines, so I wanted to check this in if possible.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
