### PR TITLE
fix(node): check that no storage-node cap exists during registration

### DIFF
--- a/crates/walrus-service/src/node/contract_service.rs
+++ b/crates/walrus-service/src/node/contract_service.rs
@@ -104,7 +104,7 @@ pub trait SystemContractService: std::fmt::Debug + Sync + Send {
     async fn get_node_capability_object(
         &self,
         node_capability_object_id: Option<ObjectID>,
-    ) -> Result<StorageNodeCap, anyhow::Error>;
+    ) -> Result<StorageNodeCap, SuiClientError>;
 }
 
 /// A [`SystemContractService`] that uses a [`SuiContractClient`] for chain interactions.
@@ -440,7 +440,7 @@ impl SystemContractService for SuiSystemContractService {
     async fn get_node_capability_object(
         &self,
         node_capability_object_id: Option<ObjectID>,
-    ) -> Result<StorageNodeCap, anyhow::Error> {
+    ) -> Result<StorageNodeCap, SuiClientError> {
         let node_capability = if let Some(node_cap) = node_capability_object_id {
             self.contract_client
                 .lock()

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -50,7 +50,12 @@ use walrus_core::{
 };
 use walrus_sdk::client::Client;
 use walrus_sui::{
-    client::{retry_client::RetriableRpcClient, BlobObjectMetadata, FixedSystemParameters},
+    client::{
+        retry_client::RetriableRpcClient,
+        BlobObjectMetadata,
+        FixedSystemParameters,
+        SuiClientError,
+    },
     test_utils::{system_setup::SystemContext, TestClusterHandle},
     types::{
         move_structs::{EpochState, VotingParams},
@@ -1398,7 +1403,7 @@ impl SystemContractService for StubContractService {
     async fn get_node_capability_object(
         &self,
         _node_capability_object_id: Option<ObjectID>,
-    ) -> Result<StorageNodeCap, anyhow::Error> {
+    ) -> Result<StorageNodeCap, SuiClientError> {
         Ok(self.node_capability_object.clone())
     }
 }
@@ -2049,7 +2054,7 @@ where
     async fn get_node_capability_object(
         &self,
         node_capability_object_id: Option<ObjectID>,
-    ) -> Result<StorageNodeCap, anyhow::Error> {
+    ) -> Result<StorageNodeCap, SuiClientError> {
         self.as_ref()
             .inner
             .get_node_capability_object(node_capability_object_id)


### PR DESCRIPTION
## Description

In addition to the check for the parameter in the config file, we now also ensure that the node wallet does not own any storage-node capability objects.

This protects nodes that were already registered but haven't set their (single) capability object in their config file.