### PR TITLE
chore: run diesel migrations on walrus-backup boot or bust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11765,6 +11765,7 @@ dependencies = [
  "colored",
  "diesel",
  "diesel-async",
+ "diesel_migrations",
  "enum_dispatch",
  "fastcrypto",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ colored = "2.2.0"
 criterion = "0.5.1"
 diesel = { version = "2.2", features = ["chrono", "postgres", "uuid"] }
 diesel-async = { version = "0.5", features = ["postgres"] }
+diesel_migrations = { version = "2.2.0", features = ["postgres"] }
 enum_dispatch = "0.3"
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9" }
 futures = { version = "0.3.31", default-features = false, features = ["async-await", "std"] }

--- a/crates/walrus-service/Cargo.toml
+++ b/crates/walrus-service/Cargo.toml
@@ -31,6 +31,7 @@ backup = [
   "dep:bytes",
   "dep:diesel",
   "dep:diesel-async",
+  "dep:diesel_migrations",
   "dep:object_store",
 ]
 client = [
@@ -83,6 +84,7 @@ clap.workspace = true
 colored = { workspace = true, optional = true }
 diesel = { workspace = true, optional = true }
 diesel-async = { workspace = true, optional = true }
+diesel_migrations = { workspace = true, optional = true }
 enum_dispatch = { workspace = true, optional = true }
 fastcrypto.workspace = true
 futures.workspace = true

--- a/crates/walrus-service/bin/backup.rs
+++ b/crates/walrus-service/bin/backup.rs
@@ -7,7 +7,14 @@ use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
 use walrus_service::{
-    backup::{start_backup_fetcher, start_backup_orchestrator, VERSION},
+    backup::{
+        run_backup_database_migrations,
+        start_backup_fetcher,
+        start_backup_orchestrator,
+        BackupConfig,
+        VERSION,
+    },
+    common::utils::MetricsAndLoggingRuntime,
     utils::load_from_yaml,
 };
 
@@ -33,20 +40,36 @@ enum BackupCommands {
     RunFetcher,
 }
 
-#[tokio::main]
-async fn main() {
-    let args = Args::parse();
-    let config = load_from_yaml(args.config).expect("failed to load config");
-    let _ = match args.command {
-        BackupCommands::RunOrchestrator => start_backup_orchestrator(config).await,
-        BackupCommands::RunFetcher => start_backup_fetcher(config).await,
+fn exit_process_on_return(result: anyhow::Result<()>, context: &str) {
+    if let Err(error) = result {
+        tracing::error!(?error, context, "encountered error");
     }
-    .inspect(|_| {
-        tracing::error!("backup node exited prematurely without an explicit error");
-    })
-    .inspect_err(|error| {
-        tracing::error!(?error, "backup node exited prematurely");
-    });
-    // Exit immediately with an error code if either backup node exits prematurely.
+    tracing::error!(context, "exited prematurely");
     std::process::exit(1);
+}
+
+fn main() {
+    let args = Args::parse();
+    let config: BackupConfig = load_from_yaml(&args.config).expect("loading config from yaml");
+
+    let rt = tokio::runtime::Runtime::new().expect("creating tokio runtime");
+    let _guard = rt.enter();
+
+    let metrics_runtime = MetricsAndLoggingRuntime::new(config.metrics_address, None)
+        .expect("starting metrics runtime");
+
+    // Run migrations before starting the backup node.
+    run_backup_database_migrations(&config);
+
+    rt.block_on(async move {
+        exit_process_on_return(
+            match args.command {
+                BackupCommands::RunOrchestrator => {
+                    start_backup_orchestrator(config, &metrics_runtime).await
+                }
+                BackupCommands::RunFetcher => start_backup_fetcher(config, &metrics_runtime).await,
+            },
+            "backup node",
+        )
+    });
 }

--- a/crates/walrus-service/build.rs
+++ b/crates/walrus-service/build.rs
@@ -1,0 +1,8 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Build script for the walrus-service crate.
+fn main() {
+    #[cfg(feature = "backup")]
+    println!("cargo:rerun-if-changed=migrations");
+}

--- a/crates/walrus-service/src/backup.rs
+++ b/crates/walrus-service/src/backup.rs
@@ -16,4 +16,9 @@ mod schema;
 mod service;
 
 #[cfg(feature = "backup")]
-pub use service::{start_backup_fetcher, start_backup_orchestrator, VERSION};
+pub use service::{
+    run_backup_database_migrations,
+    start_backup_fetcher,
+    start_backup_orchestrator,
+    VERSION,
+};

--- a/scripts/local-testbed.sh
+++ b/scripts/local-testbed.sh
@@ -101,8 +101,9 @@ echo "$0: Using backup_database_url: $backup_database_url"
 
 if ! $use_existing_config; then
   if [[ -n "$backup_database_url" ]]; then
-    echo "Migrating database to ensure it's starting fresh... [backup_database_url=$backup_database_url]"
-    diesel migration --database-url "$backup_database_url" redo
+    echo "Reverting database migrations to ensure walrus-backup is starting fresh... [backup_database_url=$backup_database_url]"
+    diesel migration --database-url "$backup_database_url" revert --all ||:
+    diesel migration --database-url "$backup_database_url" run
 
     # shellcheck disable=SC2207
     schema_files=( $(git ls-files '**/schema.rs') )


### PR DESCRIPTION
## Description

Ensure that walrus-backup database migrations are run upon boot of any walrus-backup process.

## Test plan

Manual testing locally, manual testing in testnet.

No release impact.
