### PR TITLE
fix: various minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,9 @@ A decentralized blob store using [Sui](https://github.com/MystenLabs/sui) for co
 
 ## Documentation
 
-General Walrus documentation is available at
-[mystenlabs.github.io/walrus-docs](https://mystenlabs.github.io/walrus-docs), which is built from
-the [MystenLabs/walrus-docs](https://github.com/MystenLabs/walrus-docs) repository. That repository
-also contains usage examples for Walrus.
+General Walrus documentation is available at [docs.walrus.site](https://docs.walrus.site), which is
+built from the [MystenLabs/walrus-docs](https://github.com/MystenLabs/walrus-docs) repository. That
+repository also contains usage examples for Walrus.
 
 Our encoding system, which we call *Red Stuff*, is described in detail in
 [docs/red-stuff.md](docs/red-stuff.md).

--- a/crates/walrus-core/src/encoding/blob_encoding.rs
+++ b/crates/walrus-core/src/encoding/blob_encoding.rs
@@ -549,7 +549,7 @@ impl<'a, T: EncodingAxis> BlobDecoder<'a, T> {
         }
 
         if !decoding_successful {
-            tracing::warn!("decoding unsuccessful");
+            tracing::debug!("decoding attempt unsuccessful");
             return None;
         }
 

--- a/crates/walrus-service/src/client.rs
+++ b/crates/walrus-service/src/client.rs
@@ -1288,6 +1288,9 @@ impl<T> Client<T> {
         } else {
             // We were not able to decode. Keep requesting slivers and try decoding as soon as every
             // new sliver is received.
+            tracing::info!(
+                "blob decoding with initial set of slivers failed; requesting additional slivers"
+            );
             self.decode_sliver_by_sliver(
                 &mut requests,
                 &mut decoder,

--- a/crates/walrus-service/src/client/cli/args.rs
+++ b/crates/walrus-service/src/client/cli/args.rs
@@ -343,7 +343,7 @@ pub enum CliCommands {
         /// If this is a single value, this amount is staked at all nodes. Otherwise, the number of
         /// values must be equal to the number of node IDs, and each amount is staked at the node
         /// with the same index.
-        #[clap(long, alias("amount"), default_value = "1000000000")]
+        #[clap(long, alias("amount"), num_args=1.., default_value = "1000000000")]
         #[serde(default = "default::staking_amounts_frost")]
         amounts: Vec<u64>,
     },

--- a/crates/walrus-service/src/client/cli/cli_output.rs
+++ b/crates/walrus-service/src/client/cli/cli_output.rs
@@ -820,7 +820,7 @@ impl CliOutput for NodeHealthOutput {
                     event_heading = "Event Progress".bold().walrus_teal(),
                     highest_finished_event_index_output = highest_finished_event_index
                         .map_or("".to_string(), |index| format!(
-                            "\nHighest finished event index: {index}\n"
+                            "\nHighest finished event index: {index}"
                         )),
                     shard_heading = "Shard Summary".bold().walrus_teal(),
                     owned = health_info.shard_summary.owned,

--- a/crates/walrus-service/src/common/utils.rs
+++ b/crates/walrus-service/src/common/utils.rs
@@ -427,7 +427,7 @@ async fn push_metrics(
     registry: &Registry,
     labels: Option<HashMap<String, String>>,
 ) -> Result<(), anyhow::Error> {
-    tracing::info!(push_url, "pushing metrics to remote");
+    tracing::debug!(push_url, "pushing metrics to remote");
 
     // now represents a collection timestamp for all of the metrics we send to the proxy.
     let now = SystemTime::now()


### PR DESCRIPTION
## Description

- Don't log a warning for when a decoding attempt fails.
- Link to `docs.walrus.site` in README.
- Fix the `--amounts` option for the `walrus stake` command.
- Remove an extraneous newline in the `walrus health` output.
- Reduce the log level for metrics push to DEBUG.

## Test plan

Existing tests.