### PR TITLE
fix: Fix rocksdb params for blob column families

### DIFF
--- a/crates/walrus-service/node_config_example.yaml
+++ b/crates/walrus-service/node_config_example.yaml
@@ -26,8 +26,8 @@ db_config:
     blob_garbage_collection_force_threshold: 0.5
     blob_compaction_read_ahead_size: 10485760
     write_buffer_size: 268435456
-    target_file_size_base: 4194304
-    max_bytes_for_level_base: 33554432
+    target_file_size_base: 67108864
+    max_bytes_for_level_base: 536870912
   node_status: null
   metadata: null
   blob_info: null

--- a/crates/walrus-service/src/node/storage/database_config.rs
+++ b/crates/walrus-service/src/node/storage/database_config.rs
@@ -67,8 +67,8 @@ impl DatabaseTableOptions {
             blob_garbage_collection_force_threshold: Some(0.5),
             blob_compaction_read_ahead_size: Some(10 << 20),
             write_buffer_size: Some(256 << 20),
-            target_file_size_base: Some(4 << 20),
-            max_bytes_for_level_base: Some(32 << 20),
+            target_file_size_base: Some(64 << 20),
+            max_bytes_for_level_base: Some(512 << 20),
         }
     }
 


### PR DESCRIPTION
## Description

Current settings will create a lot of small sst files which cause db.open() to take a long time. 
