### PR TITLE
chore: add a metrics_address parameter to walrus-backup

### DIFF
--- a/crates/walrus-service/bin/backup.rs
+++ b/crates/walrus-service/bin/backup.rs
@@ -27,6 +27,12 @@ use walrus_service::{
 struct Args {
     #[clap(long, short, help = "Specify the config file path to use")]
     config: PathBuf,
+    #[clap(
+        long,
+        short,
+        help = "Override the metrics address to use (ie: 127.0.0.1:9184)"
+    )]
+    metrics_address: Option<std::net::SocketAddr>,
     #[command(subcommand)]
     command: BackupCommands,
 }
@@ -50,7 +56,10 @@ fn exit_process_on_return(result: anyhow::Result<()>, context: &str) {
 
 fn main() {
     let args = Args::parse();
-    let config: BackupConfig = load_from_yaml(&args.config).expect("loading config from yaml");
+    let mut config: BackupConfig = load_from_yaml(&args.config).expect("loading config from yaml");
+    if let Some(metrics_address) = args.metrics_address {
+        config.metrics_address = metrics_address;
+    }
 
     let rt = tokio::runtime::Runtime::new().expect("creating tokio runtime");
     let _guard = rt.enter();

--- a/scripts/local-testbed.sh
+++ b/scripts/local-testbed.sh
@@ -6,18 +6,30 @@ set -euo pipefail
 
 trap ctrl_c INT
 
-function kill_tmux_sessions() {
+join_by() {
+  delim_save="$1"
+  delim=""
+  shift
+  str=""
+  for arg in "$@"; do
+    str="$str$delim$arg"
+    delim="$delim_save"
+  done
+  echo "$str"
+}
+
+kill_tmux_sessions() {
   { tmux ls || true; } | { grep -o "dryrun-node-\d*" || true; } | xargs -n1 tmux kill-session -t
 }
 
-function ctrl_c() {
+ctrl_c() {
   kill_tmux_sessions
   exit 0
 }
 
 kill_tmux_sessions
 
-function usage() {
+usage() {
   echo "Usage: $0 [OPTIONS]"
   echo "OPTIONS:"
   echo "  -b <database_url>     Specify a backup database url (ie: postgresql://postgres:postgres@localhost/postgres, default: none)"
@@ -31,7 +43,7 @@ function usage() {
   echo "  -t                    Use testnet contracts"
 }
 
-function run_node() {
+run_node() {
   cmd="./target/release/walrus-node run --config-path $working_dir/$1.yaml ${2:-} \
     |& tee $working_dir/$1.log"
   echo "Running within tmux: '$cmd'..."
@@ -114,10 +126,20 @@ if ! $use_existing_config; then
   fi
 fi
 
-echo Building walrus, walrus-node, and walrus-deploy binaries...
 
-features="deploy"
-cargo build --release --bin walrus --bin walrus --bin walrus-node --bin walrus-deploy --features "$features"
+features=( deploy )
+binaries=( walrus walrus-node walrus-deploy )
+if [[ -n "$backup_database_url" ]]; then
+  features+=( backup )
+  binaries+=( walrus-backup )
+fi
+
+echo "Building $(join_by ', ' "${binaries[@]}") binaries..."
+# shellcheck disable=SC2046
+cargo build \
+  --release \
+  $(printf -- "--bin %s " "${binaries[@]}") \
+  --features "$(join_by , "${features[@]}")"
 
 # Set working directory
 working_dir="./working_dir"


### PR DESCRIPTION
## Description

Allow metrics_address to be changed for walrus-backup via the command line. This is to ensure that the orchestrator and fetcher can be run on the same machine easily for local testing purposes.

## Test plan

Manual testing.

No release impact.