### PR TITLE
chore: make CheckpointEventPosition copyable

### DIFF
--- a/crates/walrus-service/src/node/events.rs
+++ b/crates/walrus-service/src/node/events.rs
@@ -58,7 +58,7 @@ impl Default for EventProcessorConfig {
 
 /// The position of an event in the event stream. This is a combination of the sequence
 /// number of the Sui checkpoint the event belongs to and the index of the event in the checkpoint.
-#[derive(Eq, PartialEq, Default, Clone, Debug, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Default, Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct CheckpointEventPosition {
     /// The sequence number of the Sui checkpoint an event belongs to.
     pub checkpoint_sequence_number: CheckpointSequenceNumber,

--- a/crates/walrus-service/src/node/events/event_processor.rs
+++ b/crates/walrus-service/src/node/events/event_processor.rs
@@ -506,7 +506,7 @@ impl EventProcessor {
                         counter,
                     );
                     let walrus_event =
-                        PositionedStreamEvent::new(contract_event, event_sequence_number.clone());
+                        PositionedStreamEvent::new(contract_event, event_sequence_number);
                     write_batch
                         .insert_batch(
                             &self.stores.event_store,


### PR DESCRIPTION
## Description

Allow CheckpointEventPosition (16 bytes) to be copyable.

No release impact.