### PR TITLE
chore(walrus-backup): retry writes that fail due to serializable transaction constraints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11799,6 +11799,7 @@ dependencies = [
  "ring 0.17.8",
  "rocksdb",
  "rustls 0.23.22",
+ "scoped-futures",
  "serde",
  "serde_json",
  "serde_with",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ reqwest = { version = "0.12.12", default-features = false, features = ["http2", 
 rocksdb = "0.21.0"
 rustls = { version = "0.23.22", default-features = false, features = ["logging", "ring", "tls12"] }
 rustls-native-certs = "0.8.1"
+scoped-futures = "0.1.4"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.138"
 serde_test = "1.0.177"

--- a/crates/walrus-service/Cargo.toml
+++ b/crates/walrus-service/Cargo.toml
@@ -33,6 +33,7 @@ backup = [
   "dep:diesel-async",
   "dep:diesel_migrations",
   "dep:object_store",
+  "dep:scoped-futures",
 ]
 client = [
   "dep:colored",
@@ -114,6 +115,7 @@ regex.workspace = true
 reqwest.workspace = true
 rocksdb = { workspace = true, optional = true }
 rustls.workspace = true
+scoped-futures = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
 serde_with.workspace = true

--- a/crates/walrus-service/src/backup/config.rs
+++ b/crates/walrus-service/src/backup/config.rs
@@ -64,6 +64,13 @@ pub struct BackupConfig {
         default = "defaults::idle_fetcher_sleep_time"
     )]
     pub idle_fetcher_sleep_time: Duration,
+    /// How long to sleep between PostgreSQL serializable transaction retries.
+    #[serde_as(as = "DurationMilliSeconds<u64>")]
+    #[serde(
+        rename = "db_serializability_retry_time_milliseconds",
+        default = "defaults::db_serializability_retry_time"
+    )]
+    pub db_serializability_retry_time: Duration,
 }
 
 impl BackupConfig {
@@ -83,6 +90,7 @@ impl BackupConfig {
             max_retries_per_blob: defaults::max_retries_per_blob(),
             retry_fetch_after_interval: defaults::retry_fetch_after_interval(),
             idle_fetcher_sleep_time: defaults::idle_fetcher_sleep_time(),
+            db_serializability_retry_time: defaults::db_serializability_retry_time(),
         }
     }
 }
@@ -134,5 +142,9 @@ pub mod defaults {
     /// can't find it to ensure there is always a database_url.
     pub fn database_url_from_env_var() -> String {
         std::env::var("DATABASE_URL").expect("missing DATABASE_URL env var")
+    }
+    /// Default wait time between PostgreSQL serializability error retries.
+    pub fn db_serializability_retry_time() -> Duration {
+        Duration::from_millis(100)
     }
 }

--- a/crates/walrus-service/src/backup/models.rs
+++ b/crates/walrus-service/src/backup/models.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
 use diesel::{
     ExpressionMethods,
     Insertable,
@@ -34,8 +33,8 @@ impl StreamEvent {
         event_index: u64,
         element_index: u64,
         element: &EventStreamElement,
-    ) -> Result<Self> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             element_index: element_index.try_into().expect("element_index overflow"),
             checkpoint_sequence_number: checkpoint_event_position
                 .checkpoint_sequence_number
@@ -47,8 +46,8 @@ impl StreamEvent {
                 .expect("counter overflow"),
             transaction_digest: transaction_digest.into(),
             event_index: event_index.try_into().expect("event_index overflow"),
-            element: serde_json::to_value(element)?,
-        })
+            element: serde_json::to_value(element).expect("failed to deserialize JSON"),
+        }
     }
 }
 


### PR DESCRIPTION
## Description

When multiple writers attempt to write simultaneously, it is possible (and expected) for transactions in isolation level SERIALIZABLE to fail. This change ensures that those transactions are retried.

## Test plan

CI, manual testing.

No release impact.