### PR TITLE
fix(node): enable batch symbol recovery by default

### DIFF
--- a/crates/walrus-service/node_config_example.yaml
+++ b/crates/walrus-service/node_config_example.yaml
@@ -72,7 +72,7 @@ blob_recovery:
   sliver_request_timeout_secs: 300
   invalidity_sync_timeout_secs: 300
   node_connect_timeout_secs: 1
-  experimental_batch_symbol_recovery: false
+  experimental_batch_symbol_recovery: true
 tls:
   disable_tls: false
   certificate_path: null

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -476,7 +476,6 @@ pub struct CommitteeServiceConfig {
     #[serde(rename = "node_connect_timeout_secs")]
     pub node_connect_timeout: Duration,
     /// Use the experimental batch recovery service endpoint.
-    #[serde(skip_serializing_if = "defaults::is_default")]
     pub experimental_batch_symbol_recovery: bool,
 }
 
@@ -490,7 +489,7 @@ impl Default for CommitteeServiceConfig {
             invalidity_sync_timeout: Duration::from_secs(300),
             max_concurrent_metadata_requests: NonZeroUsize::new(1).unwrap(),
             node_connect_timeout: Duration::from_secs(1),
-            experimental_batch_symbol_recovery: false,
+            experimental_batch_symbol_recovery: true,
         }
     }
 }


### PR DESCRIPTION
## Description

This enables the new batch sliver recovery by default.

## Test plan

The recovery itself was already tested.

---

## Release notes

- [x] Storage node: The new batch symbol recovery is enabled by default.