### PR TITLE
fix(node): return slivers for registered blobs

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -1984,7 +1984,7 @@ impl ServiceState for StorageNodeInner {
         ensure!(!self.is_blocked(blob_id), RetrieveSliverError::Forbidden);
 
         ensure!(
-            self.is_blob_certified(blob_id)?,
+            self.is_blob_registered(blob_id)?,
             RetrieveSliverError::Unavailable,
         );
 


### PR DESCRIPTION
## Description

So far, we were only returning slivers for *certified* blobs. This can cause a delay between the certification of a blob and the point where reads succeed as nodes may receive or process the certification event with some delay.

With the new behavior a blob is guaranteed to be available immediately after certification as all nodes check for it to be registered before they certify it.

Replaces #1526.

## Test plan

All interactions should still succeed as the new node behavior is more permissive.