### PR TITLE
fix: Ensure consistency between BlobInfo::to_blob_status() and is_registered()

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -1979,9 +1979,6 @@ impl ServiceState for StorageNodeInner {
         sliver_pair_index: SliverPairIndex,
         sliver_type: SliverType,
     ) -> Result<Sliver, RetrieveSliverError> {
-        if let Ok(BlobStatus::Nonexistent) = self.blob_status(blob_id) {
-            return Err(RetrieveSliverError::Unavailable);
-        }
         self.check_index(sliver_pair_index)?;
 
         ensure!(!self.is_blocked(blob_id), RetrieveSliverError::Forbidden);

--- a/crates/walrus-service/src/node/storage/blob_info.rs
+++ b/crates/walrus-service/src/node/storage/blob_info.rs
@@ -960,6 +960,7 @@ impl BlobInfoApi for BlobInfoV1 {
     fn is_registered(&self, current_epoch: Epoch) -> bool {
         let Self::Valid(ValidBlobInfoV1 {
             count_deletable_total,
+            count_deletable_certified,
             permanent_total,
             latest_seen_deletable_registered_epoch,
             permanent_certified,
@@ -984,7 +985,8 @@ impl BlobInfoApi for BlobInfoV1 {
 
             // TODO(mlegner): This is a temporary workaround due to a previous bug (#1163) with the
             // blob-status tracking. This is no longer needed after a full redeployment.
-            || latest_seen_deletable_certified_epoch.is_some_and(|l| l > current_epoch);
+            || *count_deletable_certified > 0
+                && latest_seen_deletable_certified_epoch.is_some_and(|l| l > current_epoch);
 
         exists_registered_permanent_blob || maybe_exists_registered_deletable_blob
     }


### PR DESCRIPTION
## Description

Ensure consistency between `BlobInfo::to_blob_status()` and `is_registered()`.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
