### PR TITLE
fix: fix flaky sync_shard_recovery_metadata_restart::simtest_fail_during_fetching

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -4627,10 +4627,12 @@ mod tests {
             } else {
                 let total_blobs = blob_details.len() as u64;
                 // Randomly pick a blob index to inject failure.
-                let break_index = rand::thread_rng().gen_range(0..total_blobs);
+                // Note that the scan count starts from 1.
+                let break_scan_count = rand::thread_rng().gen_range(1..=total_blobs);
+
                 register_fail_point_arg(
                     "fail_point_shard_sync_recovery_metadata_error_during_fetch",
-                    move || -> Option<u64> { Some(break_index) },
+                    move || -> Option<u64> { Some(break_scan_count) },
                 );
             }
 


### PR DESCRIPTION
## Description

The test was flaky because when break_index is 0, it doesn't inject any failure due that in the checking side, it is the number of blobs scanned, so it starts from 1.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
