### PR TITLE
feat: enable contract deployment with existing token

### DIFF
--- a/crates/walrus-orchestrator/src/protocol/target.rs
+++ b/crates/walrus-orchestrator/src/protocol/target.rs
@@ -169,6 +169,7 @@ impl ProtocolCommands for TargetProtocol {
             admin_wallet_path: None,
             do_not_copy_contracts: false,
             with_wal_exchange: true,
+            use_existing_wal_token: false,
         })
         .await
         .expect("Failed to create Walrus contract");

--- a/crates/walrus-service/bin/deploy.rs
+++ b/crates/walrus-service/bin/deploy.rs
@@ -138,6 +138,10 @@ struct DeploySystemContractArgs {
     /// If set, creates a WAL exchange.
     #[arg(long, action)]
     with_wal_exchange: bool,
+    /// If set, the deployment reuses the token deployed at the address specified in the `Move.lock`
+    /// file of the WAL contract. Otherwise, a new WAL token is created.
+    #[arg(long, action)]
+    use_existing_wal_token: bool,
 }
 
 #[derive(Debug, Clone, clap::Args)]
@@ -329,6 +333,7 @@ mod commands {
             admin_wallet_path,
             do_not_copy_contracts,
             with_wal_exchange,
+            use_existing_wal_token,
         }: DeploySystemContractArgs,
     ) -> anyhow::Result<()> {
         utils::init_tracing_subscriber()?;
@@ -359,6 +364,7 @@ mod commands {
             admin_wallet_path,
             do_not_copy_contracts,
             with_wal_exchange,
+            use_existing_wal_token,
         })
         .await
         .context("Failed to deploy system contract")?;

--- a/crates/walrus-service/src/testbed.rs
+++ b/crates/walrus-service/src/testbed.rs
@@ -240,6 +240,8 @@ pub struct DeployTestbedContractParameters<'a> {
     pub admin_wallet_path: Option<PathBuf>,
     /// Flag to create a WAL exchange.
     pub with_wal_exchange: bool,
+    /// Flag to use an existing WAL token deployment at the address specified in `Move.lock`.
+    pub use_existing_wal_token: bool,
 }
 
 /// Create and deploy a Walrus contract.
@@ -262,6 +264,7 @@ pub async fn deploy_walrus_contract(
         admin_wallet_path,
         do_not_copy_contracts,
         with_wal_exchange,
+        use_existing_wal_token,
     }: DeployTestbedContractParameters<'_>,
 ) -> anyhow::Result<TestbedConfig> {
     const WAL_AMOUNT_EXCHANGE: u64 = 10_000_000 * 1_000_000_000;
@@ -375,6 +378,7 @@ pub async fn deploy_walrus_contract(
         gas_budget,
         deploy_directory,
         with_wal_exchange,
+        use_existing_wal_token,
     )
     .await?;
 

--- a/crates/walrus-sui/src/test_utils/system_setup.rs
+++ b/crates/walrus-sui/src/test_utils/system_setup.rs
@@ -106,8 +106,6 @@ pub struct SystemContext {
     pub staking_object: ObjectID,
     /// The ID of the upgrade manager object.
     pub upgrade_manager_object: ObjectID,
-    /// The ID of the WAL package.
-    pub wal_pkg_id: ObjectID,
     /// The ID of the WAL exchange package.
     pub wal_exchange_pkg_id: Option<ObjectID>,
 }
@@ -154,6 +152,7 @@ pub async fn create_and_init_system_for_test(
         None,
         deploy_directory,
         true,
+        false,
     )
     .await
 }
@@ -172,18 +171,19 @@ pub async fn create_and_init_system(
     gas_budget: Option<u64>,
     deploy_directory: Option<PathBuf>,
     with_wal_exchange: bool,
+    use_existing_wal_token: bool,
 ) -> Result<SystemContext> {
     let PublishSystemPackageResult {
         walrus_pkg_id,
         init_cap_id,
         upgrade_cap_id,
         wal_exchange_pkg_id,
-        wal_pkg_id,
     } = system_setup::publish_coin_and_system_package(
         admin_wallet,
         contract_dir,
         deploy_directory,
         with_wal_exchange,
+        use_existing_wal_token,
         gas_budget,
     )
     .await?;
@@ -204,7 +204,6 @@ pub async fn create_and_init_system(
         system_object,
         staking_object,
         upgrade_manager_object,
-        wal_pkg_id,
         wal_exchange_pkg_id,
     })
 }


### PR DESCRIPTION
## Description

- adds a flag to the deployment that publishes the contracts without publishing `WAL`

## Test plan

- tested locally in testbed

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
