### PR TITLE
fix: correct Subsidies struct, prevent empty transactions

### DIFF
--- a/crates/walrus-sui/src/client/read_client.rs
+++ b/crates/walrus-sui/src/client/read_client.rs
@@ -1055,6 +1055,7 @@ impl ReadClient for SuiReadClient {
             .await?;
         self.refresh_package_id_with_id(walrus_package_id).await
     }
+
     async fn refresh_subsidies_package_id(&self) -> SuiClientResult<()> {
         let subsidies = self
             .subsidies

--- a/crates/walrus-sui/src/client/transaction_builder.rs
+++ b/crates/walrus-sui/src/client/transaction_builder.rs
@@ -236,7 +236,7 @@ impl WalrusPtbBuilder {
         function: FunctionTag<'_>,
         arguments: Vec<Argument>,
     ) -> SuiClientResult<Argument> {
-        tracing::debug!(
+        tracing::trace!(
             package_id = package_id.to_canonical_string(true),
             ?function,
             ?arguments,

--- a/crates/walrus-sui/src/contracts.rs
+++ b/crates/walrus-sui/src/contracts.rs
@@ -51,7 +51,7 @@ pub trait AssociatedContractStruct: DeserializeOwned {
     /// Converts a [`SuiObjectData`] to [`Self`].
     #[tracing::instrument(err(Debug), skip_all, fields(object_id = %sui_object_data.object_id))]
     fn try_from_object_data(sui_object_data: &SuiObjectData) -> Result<Self, MoveConversionError> {
-        tracing::debug!(
+        tracing::trace!(
             target_struct = %Self::CONTRACT_STRUCT,
             "converting Move object to Rust struct",
         );

--- a/crates/walrus-sui/src/types/move_structs.rs
+++ b/crates/walrus-sui/src/types/move_structs.rs
@@ -800,10 +800,10 @@ pub struct Subsidies {
     pub system_subsidy_rate: u16,
     /// The total amount of WAL available for subsidies
     pub subsidy_pool: u64,
-    /// The version of the subsidies object
-    pub version: u64,
     /// The package ID of the subsidies contract
     pub package_id: ObjectID,
+    /// The version of the subsidies object
+    pub version: u64,
 }
 
 impl AssociatedContractStruct for Subsidies {

--- a/scripts/local-testbed.sh
+++ b/scripts/local-testbed.sh
@@ -174,7 +174,8 @@ if ! $use_existing_config; then
     --write-price 1 \
     --epoch-duration "$epoch_duration" \
     --contract-dir "$contract_dir" \
-    --with-wal-exchange
+    --with-wal-exchange \
+    --with-subsidies
 
   # Generate configs
   generate_dry_run_args=( --working-dir "$working_dir" )


### PR DESCRIPTION
## Description

- fixes the Rust version of the `Subsidies` move struct (`version` and `package_id` were swapped)
- returns early for contract operations that take a vector as input and do nothing for empty vectors

## Test plan

- existing tests
- manual tests in local testbed & PTN

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
