### PR TITLE
fix: don't set the full subsidies configuration directly in tests

### DIFF
--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -2139,7 +2139,7 @@ pub mod test_cluster {
     use futures::future;
     use tokio::sync::Mutex;
     use walrus_sui::{
-        client::{Subsidies as ClientSubsidies, SuiContractClient, SuiReadClient},
+        client::{SuiContractClient, SuiReadClient},
         test_utils::{
             self,
             system_setup::{
@@ -2333,7 +2333,7 @@ pub mod test_cluster {
             .await?;
 
         if let Some(subsidies_pkg_id) = system_ctx.subsidies_pkg_id {
-            let (subsidies_id, _) = admin_contract_client
+            let (subsidies_object_id, _) = admin_contract_client
                 .as_ref()
                 .create_and_fund_subsidies(
                     subsidies_pkg_id,
@@ -2342,8 +2342,12 @@ pub mod test_cluster {
                     DEFAULT_SUBSIDY_FUNDS,
                 )
                 .await?;
-            let subsidies = ClientSubsidies::new(subsidies_pkg_id, subsidies_id);
-            *admin_contract_client.inner.read_client().subsidies_mut() = Some(subsidies);
+
+            admin_contract_client
+                .inner
+                .read_client()
+                .set_subsidies_object(subsidies_object_id)
+                .await?;
         }
 
         let amounts_to_stake = test_nodes_config

--- a/crates/walrus-sui/src/client/read_client.rs
+++ b/crates/walrus-sui/src/client/read_client.rs
@@ -510,7 +510,7 @@ impl SuiReadClient {
     }
 
     /// Returns a mutable reference to the subsidies object.
-    pub fn subsidies_mut(&self) -> RwLockWriteGuard<Option<Subsidies>> {
+    fn subsidies_mut(&self) -> RwLockWriteGuard<Option<Subsidies>> {
         self.subsidies.write().expect("lock should not be poisoned")
     }
 
@@ -742,6 +742,20 @@ impl SuiReadClient {
             inner,
         };
         Ok(staking_object)
+    }
+
+    /// Sets a subsidies object to be used by the client.
+    pub async fn set_subsidies_object(&self, subsidies_object_id: ObjectID) -> SuiClientResult<()> {
+        let subsidies_package_id = self
+            .sui_client
+            .get_subsidies_package_id_from_subsidies_object(subsidies_object_id)
+            .await?;
+        *self.subsidies_mut() = Some(Subsidies {
+            package_id: subsidies_package_id,
+            object_id: subsidies_object_id,
+            subsidies_obj_initial_version: OnceCell::new(),
+        });
+        Ok(())
     }
 
     async fn refresh_package_id_with_id(&self, walrus_package_id: ObjectID) -> SuiClientResult<()> {


### PR DESCRIPTION
## Description

- Sets the subsidies object by object ID only for tests. This would catch issues as the one fixed by #1617 directly.

Context: https://github.com/MystenLabs/walrus/pull/1617#discussion_r1967764248

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
