### PR TITLE
fix: a few minor improvements for encoding types

### DIFF
--- a/crates/walrus-core/Cargo.toml
+++ b/crates/walrus-core/Cargo.toml
@@ -7,8 +7,8 @@ edition.workspace = true
 license.workspace = true
 
 [features]
+default = ["raptorq", "rs2"]
 raptorq = []
-raptorq-and-rs2 = ["raptorq", "rs2"]
 rs2 = []
 sui-types = ["dep:sui-types"]
 test-utils = ["walrus-test-utils"]

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -1999,6 +1999,12 @@ impl ServiceState for StorageNodeInner {
             return Ok(false);
         }
 
+        // Check if encoding type is supported
+        let encoding_type = metadata.metadata().encoding_type();
+        if !encoding_type.is_supported() {
+            return Err(StoreMetadataError::UnsupportedEncodingType(encoding_type));
+        }
+
         let verified_metadata_with_id = metadata.verify(&self.encoding_config)?;
         self.storage
             .put_verified_metadata(&verified_metadata_with_id)
@@ -3265,7 +3271,7 @@ mod tests {
                 object_id,
                 event_id,
                 size: 0,
-                encoding_type: walrus_core::EncodingType::RedStuffRaptorQ,
+                encoding_type: DEFAULT_ENCODING,
             }
             .into(),
         )?;

--- a/crates/walrus-service/src/node/errors.rs
+++ b/crates/walrus-service/src/node/errors.rs
@@ -184,6 +184,10 @@ pub enum StoreMetadataError {
     #[rest_api_error(reason = "INVALID_BLOB", status = ApiStatusCode::FailedPrecondition)]
     InvalidBlob(EventID),
 
+    #[error("unsupported encoding type {0}, supported types are: {SUPPORTED_ENCODING_TYPES:?}")]
+    #[rest_api_error(reason = "UNSUPPORTED_ENCODING_TYPE", status = ApiStatusCode::InvalidArgument)]
+    UnsupportedEncodingType(EncodingType),
+
     #[error(transparent)]
     #[rest_api_error(delegate)]
     Internal(#[from] InternalError),

--- a/crates/walrus-sui/src/test_utils.rs
+++ b/crates/walrus-sui/src/test_utils.rs
@@ -46,8 +46,8 @@ use walrus_core::{
         InvalidBlobIdMsg,
     },
     BlobId,
-    EncodingType,
     Epoch,
+    DEFAULT_ENCODING,
 };
 use walrus_test_utils::WithTempDir;
 
@@ -516,7 +516,7 @@ impl EventForTesting for BlobRegistered {
             epoch: 1,
             blob_id,
             size: 10000,
-            encoding_type: EncodingType::RedStuffRaptorQ,
+            encoding_type: DEFAULT_ENCODING,
             end_epoch: 42,
             deletable: false,
             object_id: ObjectID::random(),

--- a/crates/walrus-sui/tests/test_walrus_sui.rs
+++ b/crates/walrus-sui/tests/test_walrus_sui.rs
@@ -121,13 +121,13 @@ async fn test_register_certify_blob(encoding_type: EncodingType) -> anyhow::Resu
         1, 2, 3, 4, 5, 6, 7, 8,
     ];
 
-    let blob_id = BlobId::from_metadata(Node::from(root_hash), EncodingType::RedStuffRaptorQ, size);
+    let blob_id = BlobId::from_metadata(Node::from(root_hash), encoding_type, size);
     let blob_metadata = BlobObjectMetadata {
         blob_id,
         root_hash: Node::from(root_hash),
         unencoded_size: size,
         encoded_size: resource_size,
-        encoding_type: EncodingType::RedStuffRaptorQ,
+        encoding_type,
     };
 
     let blob_obj = walrus_client
@@ -208,13 +208,13 @@ async fn test_register_certify_blob(encoding_type: EncodingType) -> anyhow::Resu
         1, 2, 3, 4, 5, 6, 7, 0,
         1, 2, 3, 4, 5, 6, 7, 0,
     ];
-    let blob_id = BlobId::from_metadata(Node::from(root_hash), EncodingType::RedStuffRaptorQ, size);
+    let blob_id = BlobId::from_metadata(Node::from(root_hash), encoding_type, size);
     let blob_metadata = BlobObjectMetadata {
         blob_id,
         root_hash: Node::from(root_hash),
         unencoded_size: size,
         encoded_size: resource_size,
-        encoding_type: EncodingType::RedStuffRaptorQ,
+        encoding_type,
     };
 
     let blob_obj = walrus_client


### PR DESCRIPTION
## Description

- Don't use `EncodingType::RedStuffRaptorQ` explicitly outside of `walrus-core`.
- Remove `raptorq-and-rs2` feature, it's not needed.
- Define default feature in `walrus-core` that enables both raptorq and rs2.
- Nodes already reject metadata for unsupported encoding types.

Contributes to WAL-633.

## Test plan

Existing tests.