### PR TITLE
fix: only assert no direct shard recovery in test_new_node_joining_cluster

### DIFF
--- a/crates/walrus-service/src/node/storage/shard.rs
+++ b/crates/walrus-service/src/node/storage/shard.rs
@@ -500,6 +500,15 @@ impl ShardStorage {
         directly_recover_shard: bool,
     ) -> Result<(), SyncShardClientError> {
         tracing::info!(walrus.epoch = epoch, %directly_recover_shard, "syncing shard");
+
+        #[cfg(msim)]
+        {
+            // This fail point is used to signal that direct shard sync recovery is triggered.
+            if directly_recover_shard {
+                fail_point!("fail_point_direct_shard_sync_recovery");
+            }
+        }
+
         if self.status()? == ShardStatus::None {
             self.shard_status.insert(&(), &ShardStatus::ActiveSync)?
         }

--- a/crates/walrus-simtest/tests/simtest.rs
+++ b/crates/walrus-simtest/tests/simtest.rs
@@ -807,7 +807,7 @@ mod tests {
     #[ignore = "ignore E2E tests by default"]
     #[walrus_simtest]
     async fn test_new_node_joining_cluster() {
-        register_fail_point("fail_point_shard_sync_recovery", move || {
+        register_fail_point("fail_point_direct_shard_sync_recovery", move || {
             panic!("shard sync should not enter recovery mode in this test");
         });
 
@@ -963,7 +963,7 @@ mod tests {
             }
             tokio::time::sleep(Duration::from_secs(1)).await;
         }
-        clear_fail_point("fail_point_shard_sync_recovery");
+        clear_fail_point("fail_point_direct_shard_sync_recovery");
     }
 
     #[walrus_simtest]


### PR DESCRIPTION
## Description

Because pending blob sync in the source storage node may still cause individual blob recovery. The old assertion
was incorrect.

100 seeds passed locally.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
