### PR TITLE
fix: don't overwrite configured metrics and REST API addresses

### DIFF
--- a/crates/walrus-service/bin/node.rs
+++ b/crates/walrus-service/bin/node.rs
@@ -7,7 +7,7 @@ use std::{
     fmt::Display,
     fs,
     io::{self, Write},
-    net::{IpAddr, Ipv4Addr, SocketAddr},
+    net::SocketAddr,
     path::{Path, PathBuf},
     sync::Arc,
     time::Duration,
@@ -1188,8 +1188,6 @@ impl StorageNodeRuntime {
             RestApiConfig::from(node_config),
             &metrics_runtime.registry,
         );
-        let mut rest_api_address = node_config.rest_api_address;
-        rest_api_address.set_ip(IpAddr::V4(Ipv4Addr::UNSPECIFIED));
         let rest_api_handle = tokio::spawn(async move {
             let result = rest_api
                 .run()

--- a/crates/walrus-service/src/common/utils.rs
+++ b/crates/walrus-service/src/common/utils.rs
@@ -9,7 +9,7 @@ use std::{
     fmt::Debug,
     future::Future,
     mem,
-    net::{IpAddr, Ipv4Addr, SocketAddr},
+    net::SocketAddr,
     path::Path,
     pin::Pin,
     str::FromStr,
@@ -240,8 +240,7 @@ impl MetricsAndLoggingRuntime {
     }
 
     /// Create a new runtime for metrics and logging.
-    pub fn new(mut metrics_address: SocketAddr, runtime: Option<Runtime>) -> anyhow::Result<Self> {
-        metrics_address.set_ip(IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+    pub fn new(metrics_address: SocketAddr, runtime: Option<Runtime>) -> anyhow::Result<Self> {
         let registry_service = mysten_metrics::start_prometheus_server(metrics_address);
         let walrus_registry = registry_service.default_registry();
 


### PR DESCRIPTION
## Description

There was a bug where the metrics runtime always bound to `0.0.0.0` instead of the configured address. This PR changes this so the configured address is actually used.

This *may* break metrics collection in some deployments that so far relied on the current bug.

## Test plan

- [ ] Make sure metrics collection works on PTN. 
- [ ] Communicate change to node operators?

---

## Release notes

- [x] Storage node: Use the metrics and REST API address from the configuration file instead of always binding to `0.0.0.0`. Note that this bugfix may break some setups that relied on the previous incorrect behavior. To get the old behavior, set the `metrics_address` and `rest_api_address` to `0.0.0.0:<port>` explicitly.
- [x] Aggregator: Use the metrics address specified through the CLI options file instead of always binding to `0.0.0.0`. Note that this bugfix may break some setups that relied on the previous incorrect behavior. To get the old behavior, use `--metrics-address 0.0.0.0:<port>` when starting the aggregator.
- [x] Publisher: Use the metrics address specified through the CLI options file instead of always binding to `0.0.0.0`. Note that this bugfix may break some setups that relied on the previous incorrect behavior. To get the old behavior, use `--metrics-address 0.0.0.0:<port>` when starting the aggregator.
