### PR TITLE
feat(walrus-sui): Add fallback to direct calls when subsidies contract is outdated

### DIFF
--- a/crates/walrus-simtest/tests/simtest.rs
+++ b/crates/walrus-simtest/tests/simtest.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Contains dedicated Walrus simulation tests.
+#![recursion_limit = "256"]
+
 #[cfg(msim)]
 mod tests {
     use std::{

--- a/crates/walrus-sui/src/client/transaction_builder.rs
+++ b/crates/walrus-sui/src/client/transaction_builder.rs
@@ -251,26 +251,7 @@ impl WalrusPtbBuilder {
     }
 
     /// Adds a call to `reserve_space` to the `pt_builder` and returns the result [`Argument`].
-    pub async fn reserve_space(
-        &mut self,
-        encoded_size: u64,
-        epochs_ahead: EpochCount,
-    ) -> SuiClientResult<Argument> {
-        let subsidies_package_id = self.read_client.get_subsidies_package_id();
-        match subsidies_package_id {
-            Some(pkg_id) => {
-                self.reserve_space_with_subsidies(encoded_size, epochs_ahead, pkg_id)
-                    .await
-            }
-            None => {
-                self.reserve_space_without_subsidies(encoded_size, epochs_ahead)
-                    .await
-            }
-        }
-    }
-
-    /// Adds a call to `reserve_space` to the `pt_builder` and returns the result [`Argument`].
-    async fn reserve_space_without_subsidies(
+    pub async fn reserve_space_without_subsidies(
         &mut self,
         encoded_size: u64,
         epochs_ahead: EpochCount,
@@ -294,7 +275,7 @@ impl WalrusPtbBuilder {
     }
 
     /// Adds a call to `reserve_space` to the `pt_builder` and returns the result [`Argument`].
-    async fn reserve_space_with_subsidies(
+    pub async fn reserve_space_with_subsidies(
         &mut self,
         encoded_size: u64,
         epochs_ahead: EpochCount,
@@ -613,7 +594,7 @@ impl WalrusPtbBuilder {
     }
 
     /// Adds a call to extend an owned blob without subsidies.
-    async fn extend_blob_without_subsidies(
+    pub async fn extend_blob_without_subsidies(
         &mut self,
         blob_object: ArgumentOrOwnedObject,
         epochs_extended: EpochCount,
@@ -636,28 +617,8 @@ impl WalrusPtbBuilder {
         Ok(())
     }
 
-    /// Adds a call to extend an owned blob.
-    pub async fn extend_blob(
-        &mut self,
-        blob_object: ArgumentOrOwnedObject,
-        epochs_ahead: EpochCount,
-        encoded_size: u64,
-    ) -> SuiClientResult<()> {
-        let subsidies_package_id = self.read_client.get_subsidies_package_id();
-        match subsidies_package_id {
-            Some(pkg_id) => {
-                self.extend_blob_with_subsidies(blob_object, epochs_ahead, encoded_size, pkg_id)
-                    .await
-            }
-            None => {
-                self.extend_blob_without_subsidies(blob_object, epochs_ahead, encoded_size)
-                    .await
-            }
-        }
-    }
-
     /// Adds a call to extend an owned blob with subsidies.
-    async fn extend_blob_with_subsidies(
+    pub async fn extend_blob_with_subsidies(
         &mut self,
         blob_object: ArgumentOrOwnedObject,
         epochs_ahead: EpochCount,


### PR DESCRIPTION
## Description

When the main Walrus contracts are upgraded but the subsidies contract hasn't been updated yet, calls through the subsidies contract will fail with EWrongVersion errors. This change adds fallback logic to bypass the subsidies 
contract and call the main contracts directly in such cases.

The fallback is triggered specifically when we get an EWrongVersion error from the Walrus package (which the subsidies package depends on), indicating that the Walrus package was upgraded but the subsidies package hasn't been updated 
yet.

However, if the calls to walrus package also fail with EWrongVersion, the packages would be refreshed and contract call to packages retried (first to subsidies and then walrus if subsidies is not updated but walrus is)

closes WAL-639