### PR TITLE
fix: correctly update initial certified epoch

### DIFF
--- a/crates/walrus-sui/src/test_utils.rs
+++ b/crates/walrus-sui/src/test_utils.rs
@@ -69,11 +69,11 @@ pub fn event_id_for_testing() -> EventID {
     }
 }
 
-/// Returns an arbitrary (fixed) `EventID` for testing.
-pub fn fixed_event_id_for_testing() -> EventID {
+/// Returns an arbitrary (fixed) `EventID` for testing with a variable sequence number.
+pub fn fixed_event_id_for_testing(event_seq: u64) -> EventID {
     EventID {
         tx_digest: TransactionDigest::new([42; 32]),
-        event_seq: 314,
+        event_seq,
     }
 }
 


### PR DESCRIPTION
## Description

We need to update the `initial_certified_epoch` every time there is a period where the blob is not certified. This is important at the moment, because we do not clean up expired blob data yet, but will also be relevant afterwards, because the cleanup process will probably run in the background, such that there are periods where the blob is no longer certified but the data hasn't been cleaned up yet.

Closes WAL-632
Contributes to WAL-258

## Test plan

Added unit tests (checked that they failed before and succeed after).

---

## Release notes

- [x] Storage node: Fixes a bug in the blob info tracking, where the initial certified epoch was not updated correctly.
