### PR TITLE
fix: ensure consensus on event blob checkpoint sequence numbers

### DIFF
--- a/contracts/walrus/sources/system/event_blob.move
+++ b/contracts/walrus/sources/system/event_blob.move
@@ -32,7 +32,7 @@ public struct EventBlobCertificationState has store {
     /// Latest certified event blob.
     latest_certified_blob: Option<EventBlob>,
     /// Current event blob being attested.
-    aggregate_weight_per_blob: VecMap<u256, u16>,
+    aggregate_weight_per_blob: VecMap<EventBlob, u16>,
 }
 
 // === Accessors related to event blob attestation ===
@@ -134,18 +134,25 @@ public(package) fun update_latest_certified_event_blob(
 public(package) fun update_aggregate_weight(
     self: &mut EventBlobCertificationState,
     blob_id: u256,
+    ending_checkpoint_sequence_number: u64,
     weight: u16,
 ): u16 {
-    let agg_weight = &mut self.aggregate_weight_per_blob[&blob_id];
+    let event_blob = new_event_blob(ending_checkpoint_sequence_number, blob_id);
+    let agg_weight = &mut self.aggregate_weight_per_blob[&event_blob];
     *agg_weight = *agg_weight + weight;
     *agg_weight
 }
 
 /// Start tracking which nodes are signing the event blob with given id for
 /// event blob certification
-public(package) fun start_tracking_blob(self: &mut EventBlobCertificationState, blob_id: u256) {
-    if (!self.aggregate_weight_per_blob.contains(&blob_id)) {
-        self.aggregate_weight_per_blob.insert(blob_id, 0);
+public(package) fun start_tracking_blob(
+    self: &mut EventBlobCertificationState,
+    blob_id: u256,
+    ending_checkpoint_sequence_number: u64,
+) {
+    let event_blob = new_event_blob(ending_checkpoint_sequence_number, blob_id);
+    if (!self.aggregate_weight_per_blob.contains(&event_blob)) {
+        self.aggregate_weight_per_blob.insert(event_blob, 0);
     };
 }
 

--- a/contracts/walrus/sources/system/system_state_inner.move
+++ b/contracts/walrus/sources/system/system_state_inner.move
@@ -455,9 +455,20 @@ public(package) fun certify_event_blob(
         return
     };
 
-    self.event_blob_certification_state.start_tracking_blob(blob_id);
+    self
+        .event_blob_certification_state
+        .start_tracking_blob(
+            blob_id,
+            ending_checkpoint_sequence_num,
+        );
     let weight = self.committee().get_member_weight(&cap.node_id());
-    let agg_weight = self.event_blob_certification_state.update_aggregate_weight(blob_id, weight);
+    let agg_weight = self
+        .event_blob_certification_state
+        .update_aggregate_weight(
+            blob_id,
+            ending_checkpoint_sequence_num,
+            weight,
+        );
     let certified = self.committee().is_quorum(agg_weight);
     if (!certified) {
         return

--- a/crates/walrus-sui/src/types/move_structs.rs
+++ b/crates/walrus-sui/src/types/move_structs.rs
@@ -513,7 +513,7 @@ pub struct EventBlobCertificationState {
     /// Latest certified blob
     pub latest_certified_blob: Option<EventBlob>,
     /// Total weight of the blobs undergoing certification.
-    pub aggregate_weight_per_blob: Vec<(BlobId, u16)>,
+    pub aggregate_weight_per_blob: Vec<(EventBlob, u16)>,
 }
 
 /// Sui type for staking object


### PR DESCRIPTION
## Description

Previously, event blob certification only tracked consensus based on blob IDs, allowing the last attesting node to set an arbitrary checkpoint sequence number that would become the official sequence number for the certified blob. This
could lead to inconsistencies in the event blob timeline.

The fix modifies the event blob certification process to require consensus on both the blob ID and checkpoint sequence number by:
- Tracking attestations using a composite key of (blob_id, checkpoint_seq_num)
- Aggregating weights specific to each blob+checkpoint combination
- Only certifying when quorum is reached for a specific checkpoint sequence number and blob id

This ensures that nodes must agree on both the blob content (via blob ID) and its position in the checkpoint sequence before certification can occur.


## Test plan

Existing tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
