### PR TITLE
refactor: allow cancelling the wait for a permit during recovery and parallelize cancellation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11850,6 +11850,7 @@ dependencies = [
  "prettytable",
  "prometheus",
  "rand 0.8.5",
+ "rayon",
  "rcgen",
  "regex",
  "reqwest",

--- a/crates/walrus-service/Cargo.toml
+++ b/crates/walrus-service/Cargo.toml
@@ -110,6 +110,7 @@ pin-project.workspace = true
 prettytable = { workspace = true, optional = true }
 prometheus.workspace = true
 rand.workspace = true
+rayon = "1.10.0"
 rcgen.workspace = true
 regex.workspace = true
 reqwest.workspace = true

--- a/crates/walrus-service/src/node/blob_sync.rs
+++ b/crates/walrus-service/src/node/blob_sync.rs
@@ -16,6 +16,7 @@ use futures::{
     TryFutureExt,
 };
 use mysten_metrics::{GaugeGuard, GaugeGuardFutureExt};
+use rayon::prelude::*;
 use tokio::{
     sync::{Notify, Semaphore},
     task::{JoinHandle, JoinSet},
@@ -194,7 +195,7 @@ impl BlobSyncHandler {
             tracing::info!("acquired lock on the in-progress blob recoveries");
 
             in_progress_guard
-                .iter_mut()
+                .par_iter_mut()
                 .filter_map(|(blob_id, sync)| {
                     self.node
                         .is_blob_certified(blob_id)


### PR DESCRIPTION
## Description

Fixes a bug where it was not possible to cancel a blob recovery that is awaiting a permit to perform the recovery. This meant that waiting for the cancellation of expired blobs to complete would require also waiting for each blob to first acquire a semaphore.

Additionally, this uses the `rayon` crate to parallelise the checks of whether a blob is certified or not. While it's currently unclear whether the former bug, or the latter serial implementation was responsible for the slow handling of epoch change events, there is at least some evidence that the slowdown was happening even when no recoveries were cancelled (which would invalidate the bug from being the issue). 

This also adds a bit of info-logging around the cancellation during epoch-change, which should highlight any long delays when during cancellation on epoch-change.

## Test plan

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
