### PR TITLE
fix(node): add missing `serde(default)` for config

### DIFF
--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -47,6 +47,7 @@ use crate::{
 /// Configuration for the config synchronizer.
 #[serde_as]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
 pub struct ConfigSynchronizerConfig {
     /// Interval between config monitoring checks.
     #[serde_as(as = "DurationSeconds<u64>")]
@@ -1107,6 +1108,8 @@ mod tests {
                     scale_down_lag_threshold: 10
                     base_config:
                         max_delay_millis: 1000
+            config_synchronizer:
+                enabled: false
         "};
 
         let _: StorageNodeConfig = serde_yaml::from_str(yaml)?;


### PR DESCRIPTION
## Description

Without this attribute, it is necessary to specify the *full* `config_synchronizer` config, even if one only wants to change one field (e.g., to disable it).

## Test plan

Extended existing unit test.
