### PR TITLE
chore: bump Rust to 1.85

### DIFF
--- a/crates/walrus-service/src/node/storage/blob_info.rs
+++ b/crates/walrus-service/src/node/storage/blob_info.rs
@@ -707,7 +707,7 @@ impl ValidBlobInfoV1 {
         if force
             || self
                 .initial_certified_epoch
-                .map_or(true, |existing_epoch| existing_epoch > new_certified_epoch)
+                .is_none_or(|existing_epoch| existing_epoch > new_certified_epoch)
         {
             self.initial_certified_epoch = Some(new_certified_epoch);
         }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.84"
+channel = "1.85"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Description

Bump Rust to latest stable release.

## Test plan

Test suite.