### PR TITLE
fix: check that activation epochs match when joining stake

### DIFF
--- a/contracts/walrus/sources/staking/staked_wal.move
+++ b/contracts/walrus/sources/staking/staked_wal.move
@@ -149,12 +149,12 @@ public fun withdraw_epoch(sw: &StakedWal): u32 {
 /// Aborts if the `node_id` or `activation_epoch` of the staked WALs do not match.
 public fun join(sw: &mut StakedWal, other: StakedWal) {
     assert!(sw.node_id == other.node_id, EMetadataMismatch);
+    assert!(sw.activation_epoch == other.activation_epoch, EMetadataMismatch);
 
     // Simple scenario - staked wal is in `Staked` state. We guarantee that the
     // metadata is identical: same activation epoch and both are in the same state.
     if (sw.is_staked()) {
         assert!(other.is_staked(), EMetadataMismatch);
-        assert!(sw.activation_epoch == other.activation_epoch, EMetadataMismatch);
 
         let StakedWal { id, principal, .. } = other;
         sw.principal.join(principal);

--- a/contracts/walrus/tests/staking/staked_wal_tests.move
+++ b/contracts/walrus/tests/staking/staked_wal_tests.move
@@ -116,6 +116,21 @@ fun unable_to_join_activation_epoch() {
 }
 
 #[test, expected_failure(abort_code = staked_wal::EMetadataMismatch)]
+// Scenario: Join a staked WAL with a different activation epoch
+fun unable_to_join_activation_epoch_withdrawing() {
+    let ctx = &mut tx_context::dummy();
+    let node_id = ctx.fresh_object_address().to_id();
+    let mut sw1 = staked_wal::mint(node_id, mint_wal_balance(100), 1, ctx);
+    sw1.set_withdrawing(4);
+    let mut sw2 = staked_wal::mint(node_id, mint_wal_balance(100), 2, ctx);
+    sw2.set_withdrawing(4);
+
+    sw1.join(sw2);
+
+    abort
+}
+
+#[test, expected_failure(abort_code = staked_wal::EMetadataMismatch)]
 // Scenario: Join a staked WAL with a different pool ID
 fun unable_to_join_different_pool() {
     let ctx = &mut tx_context::dummy();

--- a/contracts/walrus/tests/staking/staking_pool/staking_pool_tests.move
+++ b/contracts/walrus/tests/staking/staking_pool/staking_pool_tests.move
@@ -780,7 +780,7 @@ fun test_advance_pool_epoch() {
     destroy(sw2);
 }
 
-#[test]
+#[test, expected_failure(abort_code = walrus::staked_wal::EMetadataMismatch)]
 // Scenario:
 // - E0: Alice stakes
 // - E1: Bob stakes
@@ -818,13 +818,5 @@ fun staked_wal_join_different_activation_epochs() {
     assert_eq!(sw1.withdraw_epoch(), sw2.withdraw_epoch());
     sw1.join(sw2);
 
-    // Make sure `join` works correctly
-    assert_eq!(sw1.value(), 2000 * frost_per_wal());
-    assert!(sw1.is_withdrawing());
-    assert_eq!(
-        pool.withdraw_stake(sw1, true, false, &wctx).destroy_for_testing(),
-        2000 * frost_per_wal(),
-    );
-
-    destroy(pool);
+    abort 0
 }


### PR DESCRIPTION
## Description

Checks that the activation epoch matches when joining StakedWal, even if in withdrawing state.

## Test plan

- Added test, changed expected outcome of previous test

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
