### PR TITLE
chore: walrus-proxy rust build needs contracts folder now

### DIFF
--- a/docker/walrus-proxy/Dockerfile
+++ b/docker/walrus-proxy/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y cmake clang
 COPY .git/ .git/
 COPY Cargo.toml Cargo.lock ./
 COPY crates crates
+COPY contracts contracts
 
 RUN cargo build --profile ${PROFILE} --bin walrus-proxy
 


### PR DESCRIPTION
## Description

walrus-proxy rust build needs contracts folder now, adding that to dockerfile

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
