### PR TITLE
feat: add the 'role' label to exported storage node metrics

### DIFF
--- a/crates/walrus-service/bin/node.rs
+++ b/crates/walrus-service/bin/node.rs
@@ -431,6 +431,7 @@ mod commands {
         LoadsFromPath,
         MetricsPushConfig,
         NodeRegistrationParamsForThirdPartyRegistration,
+        ServiceRole,
     };
     use sui_sdk::SuiClientBuilder;
     #[cfg(not(msim))]
@@ -533,6 +534,7 @@ mod commands {
         let metrics_push_runtime = match config.metrics_push.take() {
             Some(mut mc) => {
                 mc.set_name_and_host_label(&config.name);
+                mc.set_role_label(ServiceRole::StorageNode);
                 let network_key_pair = network_key_pair.0.clone();
                 let mp_config = EnableMetricsPush {
                     cancel: cancel_token.child_token(),


### PR DESCRIPTION
## Description

Adds the label "role = walrus-node" to metrics exported by walrus-proxy.

## Test plan



---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
