### PR TITLE
fix: only update metadata is stored for event blob

### DIFF
--- a/crates/walrus-service/src/node/events/event_blob_writer.rs
+++ b/crates/walrus-service/src/node/events/event_blob_writer.rs
@@ -1170,11 +1170,6 @@ impl EventBlobWriter {
             return Ok(());
         };
 
-        self.node
-            .storage()
-            .update_blob_info_with_metadata(&blob_id)
-            .context("unable to update metadata")?;
-
         let attested = self.attested.clone();
         let failed_to_attest = self.failed_to_attest.clone();
         let metadata = self
@@ -1188,6 +1183,11 @@ impl EventBlobWriter {
         let Some(metadata) = metadata else {
             return Ok(());
         };
+
+        self.node
+            .storage()
+            .update_blob_info_with_metadata(&blob_id)
+            .context("unable to update metadata")?;
 
         self.metrics
             .latest_certified_event_index


### PR DESCRIPTION
## Description

It was updating for all blobs. We only need to do this for the event blob.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
