### PR TITLE
feat: several small improvements for the `walrus-deploy` binary

### DIFF
--- a/crates/walrus-service/src/client/cli/args.rs
+++ b/crates/walrus-service/src/client/cli/args.rs
@@ -1259,8 +1259,8 @@ pub struct EpochArg {
     #[clap(long, value_parser = EpochCountOrMax::parse_epoch_count)]
     pub(crate) epochs: Option<EpochCountOrMax>,
 
-    /// The earliest time when the blob can expire, in RFC3339 format (e.g. "2024-03-20T15:00:00Z")
-    /// or a more relaxed format (e.g. "2024-03-20 15:00:00").
+    /// The earliest time when the blob can expire, in RFC3339 format (e.g., "2024-03-20T15:00:00Z")
+    /// or a more relaxed format (e.g., "2024-03-20 15:00:00").
     #[clap(long, value_parser = humantime::parse_rfc3339_weak)]
     pub(crate) earliest_expiry_time: Option<SystemTime>,
 


### PR DESCRIPTION
## Description

* Allow setting `mainnet` or a custom network without a faucet as the Sui network.
* If an admin wallet is provided, allow setting an amount of SUI to send to each created wallet.
* Allow setting an absolute end time for epoch 0 instead of a duration.

Contributes to WAL-518

## Test plan

- [x] Manual tests.