### PR TITLE
fix(docker): clean up Dockerfiles and bump Rust version

### DIFF
--- a/docker/walrus-antithesis/build-walrus-image-for-antithesis/Dockerfile
+++ b/docker/walrus-antithesis/build-walrus-image-for-antithesis/Dockerfile
@@ -6,9 +6,9 @@
 # - walrus-node: Node binary only
 # - walrus-deploy: Deployment tool with contracts
 
-# Stage 1: Base Build Environment
+# Stage 1: Base Build Environment + Builder
 # -------------------------------------
-FROM rust:1.84-bookworm AS base
+FROM rust:1.85-bookworm AS builder
 ARG PROFILE=release-antithesis
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION
@@ -42,9 +42,6 @@ ENV RUSTFLAGS="-C target-feature=-crt-static -C codegen-units=1 -C passes=sancov
 -C link-args=-Wl,--build-id -Ccodegen-units=1 \
 -L/usr/lib/libvoidstar.so -lvoidstar"
 
-# Stage 2: Builder
-# -------------------------------------
-FROM base AS builder
 # Build all binaries with Antithesis instrumentation
 RUN LD_LIBRARY_PATH=/usr/lib/libvoidstar.so \
     cargo build --profile $PROFILE \
@@ -52,7 +49,7 @@ RUN LD_LIBRARY_PATH=/usr/lib/libvoidstar.so \
     --bin walrus-node \
     --bin walrus-deploy
 
-# Stage 3: Production Images
+# Stage 2: Production Images
 # -------------------------------------
 
 # walrus-service: Complete service image

--- a/docker/walrus-orchestrator/Dockerfile
+++ b/docker/walrus-orchestrator/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.84-bookworm AS builder
+FROM rust:1.85-bookworm AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/docker/walrus-proxy/Dockerfile
+++ b/docker/walrus-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.84-bookworm as build
+FROM rust:1.85-bookworm as builder
 
 ARG PROFILE=release
 WORKDIR /work
@@ -14,4 +14,4 @@ RUN cargo build --profile ${PROFILE} --bin walrus-proxy
 
 FROM gcr.io/distroless/cc-debian12 as deploy
 
-COPY --from=build --chmod=755 /work/target/release/walrus-proxy /opt/walrus/bin/walrus-proxy
+COPY --from=builder --chmod=755 /work/target/release/walrus-proxy /opt/walrus/bin/walrus-proxy

--- a/docker/walrus-service/Dockerfile
+++ b/docker/walrus-service/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.84-bookworm AS base
+FROM rust:1.85-bookworm AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION
@@ -14,7 +14,6 @@ COPY crates crates
 COPY contracts ./contracts
 COPY contracts /contracts
 
-FROM base AS builder
 RUN cargo build --profile $PROFILE \
     --bin walrus \
     --bin walrus-node \

--- a/docker/walrus-service/Dockerfile.walrus-backup
+++ b/docker/walrus-service/Dockerfile.walrus-backup
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.84-bookworm AS base
+FROM rust:1.85-bookworm AS builder
 ARG PROFILE=release
 ARG RUST_LOG=info,walrus_service::common::event_blob_downloader=warn
 ARG GIT_REVISION
@@ -15,7 +15,6 @@ COPY crates crates
 COPY contracts ./contracts
 COPY contracts /contracts
 
-FROM base AS backup-builder
 RUN cargo build \
     --features walrus-service/backup \
     --profile $PROFILE \
@@ -29,7 +28,7 @@ ARG PROFILE=release
 ENV RUST_LOG=$RUST_LOG
 WORKDIR "$WORKDIR/walrus"
 # Both bench and release profiles copy from release dir
-COPY --from=backup-builder /walrus/target/release/walrus-backup /opt/walrus/bin/walrus-backup
+COPY --from=builder /walrus/target/release/walrus-backup /opt/walrus/bin/walrus-backup
 
 ARG BUILD_DATE
 ARG GIT_REVISION

--- a/docker/walrus-stress/Dockerfile
+++ b/docker/walrus-stress/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.84-bookworm AS builder
+FROM rust:1.85-bookworm AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION


### PR DESCRIPTION
## Description

- Bump Rust version in Dockerfiles to 1.85 (aligned with the toolchain we use everywhere else).
- Don't create a separate `base` image if it is not actually reused.
- Use name `builder` consistently.

## Test plan

Would be good to have some basic lints/tests for our Docker setup... 🤔 