### PR TITLE
fix(test): Batch requests to register nodes to prevent congestion error

### DIFF
--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -2403,6 +2403,7 @@ pub mod test_cluster {
             &protocol_keypairs,
             &contract_clients_refs,
             &amounts_to_stake,
+            None,
         )
         .await?;
 

--- a/crates/walrus-service/src/testbed.rs
+++ b/crates/walrus-service/src/testbed.rs
@@ -751,6 +751,7 @@ pub async fn create_storage_node_configs(
         &protocol_keypairs,
         &contract_clients.iter().collect::<Vec<_>>(),
         &amounts_to_stake,
+        Some(10),
     )
     .await?;
 

--- a/crates/walrus-sui/tests/test_walrus_sui.rs
+++ b/crates/walrus-sui/tests/test_walrus_sui.rs
@@ -683,6 +683,7 @@ async fn publish_with_default_system_with_epoch_duration(
         &[protocol_keypair],
         &[&admin_contract_client],
         &[1_000_000_000],
+        None,
     )
     .await?;
 


### PR DESCRIPTION
## Description

Batch these requests otherwise when running ad-hoc network for throughput testing, we run into congestion errors like:
```
Mar 12 22:37:48 wah-sui-sadhan3-9cfc131 google_metadata_script_runner[2171]: startup-script: 2025-03-12T22:37:48.323373Z ERROR create_storage_node_configs:register_committee_and_stake: walrus_sui::test_utils::system_setup: error=>
Mar 12 22:37:48 wah-sui-sadhan3-9cfc131 google_metadata_script_runner[2171]: startup-script: 2025-03-12T22:37:48.329682Z ERROR create_storage_node_configs: walrus_service::testbed: error=execution cancelled due to shared object c>
Mar 12 22:37:48 wah-sui-sadhan3-9cfc131 google_metadata_script_runner[2171]: startup-script: Error: execution cancelled due to shared object congestion on objects [0xbcd36fba497116b1f661ae6abde1d5b8a60023ea33d60a2a161e5190ced25e5>

```
## Test plan

PR fixes the congestion error on adhoc network.