### PR TITLE
fix(client): improve native TLS certificate handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11858,6 +11858,7 @@ dependencies = [
  "ring 0.17.13",
  "rocksdb",
  "rustls 0.23.23",
+ "rustls-native-certs 0.8.1",
  "scoped-futures",
  "serde",
  "serde_json",

--- a/crates/walrus-sdk/src/client.rs
+++ b/crates/walrus-sdk/src/client.rs
@@ -414,6 +414,14 @@ impl ClientBuilder {
         self
     }
 
+    /// Add a custom DER-encoded root certificate.
+    ///
+    /// It is the responsibility of the caller to check the certificate for validity.
+    pub fn add_root_certificates(mut self, certificates: &[CertificateDer<'static>]) -> Self {
+        self.roots.extend(certificates.iter().cloned());
+        self
+    }
+
     /// Controls the use of built-in/preloaded certificates during certificate validation.
     ///
     /// Defaults to true – built-in system certs will be used.

--- a/crates/walrus-service/Cargo.toml
+++ b/crates/walrus-service/Cargo.toml
@@ -119,6 +119,7 @@ regex.workspace = true
 reqwest.workspace = true
 rocksdb = { workspace = true, optional = true }
 rustls.workspace = true
+rustls-native-certs.workspace = true
 scoped-futures = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/walrus-service/client_config_example.yaml
+++ b/crates/walrus-service/client_config_example.yaml
@@ -24,7 +24,7 @@ communication_config:
       max_backoff_millis: 30000
       max_retries: 5
   disable_proxy: false
-  disable_native_certs: true
+  disable_native_certs: false
   sliver_write_extra_time:
     factor: 0.5
     base_millis: 500

--- a/crates/walrus-service/src/client.rs
+++ b/crates/walrus-service/src/client.rs
@@ -194,7 +194,7 @@ impl Client<()> {
             communication_factory: NodeCommunicationFactory::new(
                 config.communication_config.clone(),
                 encoding_config,
-            ),
+            )?,
             config,
         })
     }

--- a/crates/walrus-service/src/client/cli/runner.rs
+++ b/crates/walrus-service/src/client/cli/runner.rs
@@ -8,6 +8,7 @@ use std::{
     iter,
     num::NonZeroU16,
     path::{Path, PathBuf},
+    sync::Arc,
     time::Duration,
 };
 
@@ -83,6 +84,7 @@ use crate::{
             HumanReadableFrost,
             HumanReadableMist,
         },
+        communication::NodeCommunicationFactory,
         error::ClientErrorKind,
         multiplexer::ClientMultiplexer,
         responses::{
@@ -761,9 +763,16 @@ impl ClientCommandRunner {
             !self.wallet_set_explicitly,
         )
         .await?;
+        let communication_factory = NodeCommunicationFactory::new(
+            config.communication_config.clone(),
+            Arc::new(EncodingConfig::new(
+                sui_read_client.current_committee().await?.n_shards(),
+            )),
+        )?;
 
         ServiceHealthInfoOutput::new_for_nodes(
             node_selection.get_nodes(&sui_read_client).await?,
+            &communication_factory,
             detail,
             sort,
         )

--- a/crates/walrus-service/src/client/config.rs
+++ b/crates/walrus-service/src/client/config.rs
@@ -280,7 +280,7 @@ pub struct ClientCommunicationConfig {
 impl Default for ClientCommunicationConfig {
     fn default() -> Self {
         Self {
-            disable_native_certs: true,
+            disable_native_certs: false,
             max_concurrent_writes: Default::default(),
             max_concurrent_sliver_reads: Default::default(),
             max_concurrent_metadata_reads: default::max_concurrent_metadata_reads(),

--- a/crates/walrus-service/src/client/error.rs
+++ b/crates/walrus-service/src/client/error.rs
@@ -170,6 +170,9 @@ pub enum ClientErrorKind {
         FROST for staking"
     )]
     StakeBelowThreshold(u64),
+    /// Unable to load trusted certificates from the OS.
+    #[error("unable to load trusted certificates from the OS: {0:?}")]
+    FailedToLoadCerts(Vec<rustls_native_certs::Error>),
     /// A failure internal to the node.
     #[error("client internal error: {0}")]
     Other(Box<dyn std::error::Error + Send + Sync + 'static>),

--- a/crates/walrus-service/src/node/metrics.rs
+++ b/crates/walrus-service/src/node/metrics.rs
@@ -242,6 +242,7 @@ impl TelemetryLabel for ClientErrorKind {
             ClientErrorKind::UnsupportedEncodingType(_) => "unsupported-encoding-type",
             ClientErrorKind::CommitteeChangeNotified => "committee-change-notified",
             ClientErrorKind::StakeBelowThreshold(_) => "stake-below-threshold",
+            ClientErrorKind::FailedToLoadCerts(_) => "failed-to-load-certs",
             ClientErrorKind::Other(_) => "unknown",
         }
     }


### PR DESCRIPTION
## Description

* load native TLS certificates from the system trust store by default
* only load native certificates once and keep them in the `NodeCommunicationFactory`
* respect `disable_native_certs` configuration parameter for `walrus health` command

On MacOS, running against the ~100 node Testnet, caching the native certificates substantially reduces the time for various operations:

* `walrus read <blob-id>`: before ~16s, after ~2.5s
* `walrus blob-status --blob-id <blob-id>`: before ~15s, after ~2s
* `walrus health --committee`: before ~19s, after ~11s

Closes WAL-275

## Test plan

Existing tests + manual testing.
