### PR TITLE
fix: reduce verbosity of some logs to debug

### DIFF
--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -814,7 +814,7 @@ impl LoadsFromPath for NetworkKeyPair {
             .context(format!("unable to read key from '{}'", path.display()))?;
 
         NetworkKeyPair::from_pkcs8_pem(&file_contents)
-            .inspect(|_| tracing::info!("loaded network private key in PKCS#8 format"))
+            .inspect(|_| tracing::debug!("loaded network private key in PKCS#8 format"))
             .or_else(|error| {
                 tracing::debug!(
                     ?error,
@@ -823,7 +823,7 @@ impl LoadsFromPath for NetworkKeyPair {
 
                 NetworkKeyPair::from_str(&file_contents)
                     .inspect(|_| {
-                        tracing::info!("loaded network private key in tagged format");
+                        tracing::debug!("loaded network private key in tagged format");
                     })
                     .map_err(|error2| {
                         anyhow!(

--- a/crates/walrus-service/src/node/contract_service.rs
+++ b/crates/walrus-service/src/node/contract_service.rs
@@ -252,7 +252,7 @@ impl SystemContractService for SuiSystemContractService {
                 return Err(SyncNodeConfigError::NodeNeedsReboot);
             }
         } else {
-            tracing::info!(
+            tracing::debug!(
                 node_name = config.name,
                 "node parameters are in sync with on-chain values"
             );

--- a/crates/walrus-sui/src/contracts.rs
+++ b/crates/walrus-sui/src/contracts.rs
@@ -16,6 +16,7 @@ use sui_sdk::{
 };
 use sui_types::TypeTag;
 use thiserror::Error;
+use tracing::Level;
 use walrus_core::ensure;
 
 /// Error returned when converting a Sui object or event to a rust struct.
@@ -49,7 +50,11 @@ pub trait AssociatedContractStruct: DeserializeOwned {
     const CONTRACT_STRUCT: StructTag<'static>;
 
     /// Converts a [`SuiObjectData`] to [`Self`].
-    #[tracing::instrument(err(Debug), skip_all, fields(object_id = %sui_object_data.object_id))]
+    #[tracing::instrument(
+        err(Debug, level = Level::DEBUG),
+        skip_all,
+        fields(object_id = %sui_object_data.object_id),
+    )]
     fn try_from_object_data(sui_object_data: &SuiObjectData) -> Result<Self, MoveConversionError> {
         tracing::trace!(
             target_struct = %Self::CONTRACT_STRUCT,


### PR DESCRIPTION
## Description

- Two log statements are emitted every time the `ConfigSynchronizer` runs (every 15 minutes by default); they don't provide any necessary information and thus mainly produce noise in the logs.
- The `try_from_object_data` function should not log errors by itself; instead, the caller should decide how to handle an error and whether to log anything.

## Test plan

Not needed.