### PR TITLE
fix: Reset local state of event blob writer

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -145,7 +145,7 @@ jobs:
     if: ${{ needs.diff.outputs.isRelevantForRustTests == 'true' }}
     runs-on: ubuntu-ghcloud
     env:
-      MSIM_TEST_NUM: 5
+      MSIM_TEST_NUM: 3
       # Turn off Sui logging since it can be very distractive in CI
       RUST_LOG: simtest=info,error,sui_=off,consensus_core=off
     steps:

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -632,6 +632,7 @@ impl StorageNode {
             num_checkpoints_per_blob
         );
 
+        let last_certified_event_blob = contract_service.last_certified_event_blob().await?;
         let event_blob_writer_factory = if !config.disable_event_blob_writer {
             Some(EventBlobWriterFactory::new(
                 &config.storage_path,
@@ -640,6 +641,8 @@ impl StorageNode {
                 node_params
                     .num_checkpoints_per_blob
                     .or(num_checkpoints_per_blob),
+                last_certified_event_blob,
+                config.num_uncertified_blob_threshold,
             )?)
         } else {
             None
@@ -811,7 +814,10 @@ impl StorageNode {
             return Ok(None);
         };
         let read_client = config.new_read_client().await?;
-        let system_package_id = read_client.get_system_package_id();
+        let retriable_client = read_client.sui_client();
+        let system_package_id = retriable_client
+            .get_package_id_from_object(read_client.get_system_object_id())
+            .await?;
         let on_public_testnet = system_package_id
             == ObjectID::from_str(
                 "0x795ddbc26b8cfff2551f45e198b87fc19473f2df50f995376b924ac80e56f88b",
@@ -5383,6 +5389,9 @@ mod tests {
         contract_service
             .expect_get_epoch_and_state()
             .returning(move || Ok((0, EpochState::EpochChangeDone(Utc::now()))));
+        contract_service
+            .expect_last_certified_event_blob()
+            .returning(|| Ok(None));
         let node = StorageNodeHandle::builder()
             .with_system_event_provider(vec![ContractEvent::EpochChangeEvent(
                 EpochChangeEvent::EpochChangeStart(EpochChangeStart {

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -161,6 +161,10 @@ pub struct StorageNodeConfig {
     /// The capability object ID of the storage node.
     #[serde(default, skip_serializing_if = "defaults::is_none")]
     pub storage_node_cap: Option<ObjectID>,
+    /// The number of uncertified blobs before the node will reset the local
+    /// state in event blob writer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub num_uncertified_blob_threshold: Option<u32>,
 }
 
 impl Default for StorageNodeConfig {
@@ -196,6 +200,7 @@ impl Default for StorageNodeConfig {
             metadata: Default::default(),
             config_synchronizer: Default::default(),
             storage_node_cap: None,
+            num_uncertified_blob_threshold: None,
         }
     }
 }

--- a/crates/walrus-service/src/node/contract_service.rs
+++ b/crates/walrus-service/src/node/contract_service.rs
@@ -23,7 +23,11 @@ use walrus_sui::{
         SuiClientError,
         SuiContractClient,
     },
-    types::{move_structs::EpochState, StorageNodeCap, UpdatePublicKeyParams},
+    types::{
+        move_structs::{EpochState, EventBlob},
+        StorageNodeCap,
+        UpdatePublicKeyParams,
+    },
 };
 use walrus_utils::backoff::{self, ExponentialBackoff};
 
@@ -107,6 +111,9 @@ pub trait SystemContractService: std::fmt::Debug + Sync + Send {
 
     /// Returns the system object version.
     async fn get_system_object_version(&self) -> Result<u64, SuiClientError>;
+
+    /// Returns the last certified event blob.
+    async fn last_certified_event_blob(&self) -> Result<Option<EventBlob>, SuiClientError>;
 }
 
 /// A [`SystemContractService`] that uses a [`SuiContractClient`] for chain interactions.
@@ -411,6 +418,14 @@ impl SystemContractService for SuiSystemContractService {
             .lock()
             .await
             .system_object_version()
+            .await
+    }
+
+    async fn last_certified_event_blob(&self) -> Result<Option<EventBlob>, SuiClientError> {
+        self.contract_client
+            .lock()
+            .await
+            .last_certified_event_blob()
             .await
     }
 }

--- a/crates/walrus-service/src/node/events/event_blob_writer.rs
+++ b/crates/walrus-service/src/node/events/event_blob_writer.rs
@@ -36,6 +36,7 @@ use walrus_sui::{
     client::SuiClientError,
     types::{
         move_errors::{MoveExecutionError, SystemStateInnerError},
+        move_structs::EventBlob as SuiEventBlob,
         BlobEvent,
         ContractEvent,
         EpochChangeEvent,
@@ -61,6 +62,7 @@ const PENDING: &str = "pending_blob_store";
 const FAILED_TO_ATTEST: &str = "failed_to_attest_blob_store";
 const MAX_BLOB_SIZE: usize = 100 * 1024 * 1024;
 pub(crate) const NUM_CHECKPOINTS_PER_BLOB: u32 = 216_000;
+const DEFAULT_NUM_UNATTESTED_BLOBS_THRESHOLD: u32 = 3;
 
 /// Metadata for event blobs.
 #[derive(Eq, PartialEq, Debug, Clone, Deserialize, Serialize)]
@@ -245,6 +247,8 @@ impl EventBlobWriterFactory {
         node: Arc<StorageNodeInner>,
         registry: &Registry,
         num_checkpoints_per_blob: Option<u32>,
+        last_certified_event_blob: Option<SuiEventBlob>,
+        num_uncertified_blob_threshold: Option<u32>,
     ) -> Result<EventBlobWriterFactory> {
         let db_path = Self::db_path(root_dir_path);
         fs::create_dir_all(db_path.as_path())?;
@@ -308,6 +312,15 @@ impl EventBlobWriterFactory {
             &ReadWriteOptions::default(),
             false,
         )?;
+
+        Self::reset_uncertified_blobs(
+            &pending,
+            &attested,
+            &failed_to_attest,
+            num_uncertified_blob_threshold,
+            last_certified_event_blob,
+        )?;
+
         let event_cursor = pending
             .unbounded_iter()
             .last()
@@ -419,6 +432,94 @@ impl EventBlobWriterFactory {
                 .unwrap_or(NUM_CHECKPOINTS_PER_BLOB),
         )
         .await
+    }
+
+    /// Resets the state of unattested blobs when the system detects potential network
+    /// synchronization issues.
+    ///
+    /// This function helps recover from network-wide synchronization issues by resetting
+    /// uncertified blobs when their count exceeds a threshold. It's specifically designed
+    /// to handle cases where:
+    /// - The entire network is out of sync for an extended period
+    /// - The cluster is unable to achieve quorum for certifying new blobs
+    /// - There's a need to reset currently formed blobsand retry blob attestation
+    ///
+    /// # Note
+    /// This is a network-level recovery mechanism and would not be helpful with handling local
+    /// node corruption.
+    ///
+    /// # Process
+    /// 1. Gets the last certified blob in system object as an argument
+    /// 2. Counts local uncertified blobs (pending, attested, failed) after the last certified
+    ///    checkpoint
+    /// 3. if there are more total blobs than after the last certified checkpoint, it means that
+    ///    the node is still processing blobs before the last certified checkpoint, and hence there
+    ///    is no need to reset.
+    /// 4. If that count exceeds the threshold, resets all local uncertified blobs
+    fn reset_uncertified_blobs(
+        pending_db: &DBMap<u64, PendingEventBlobMetadata>,
+        attested_db: &DBMap<(), AttestedEventBlobMetadata>,
+        failed_to_attest_db: &DBMap<(), FailedToAttestEventBlobMetadata>,
+        num_uncertified_blob_threshold: Option<u32>,
+        last_certified_event_blob: Option<SuiEventBlob>,
+    ) -> Result<()> {
+        let Some(last_certified_event_blob) = last_certified_event_blob else {
+            return Ok(());
+        };
+        let num_uncertified_blob_threshold =
+            num_uncertified_blob_threshold.unwrap_or(DEFAULT_NUM_UNATTESTED_BLOBS_THRESHOLD);
+        let pending = pending_db
+            .unbounded_iter()
+            .filter(|(_, metadata)| {
+                metadata.end > last_certified_event_blob.ending_checkpoint_sequence_number
+            })
+            .collect::<Vec<_>>();
+        let attested = attested_db
+            .unbounded_iter()
+            .filter(|(_, metadata)| {
+                metadata.end > last_certified_event_blob.ending_checkpoint_sequence_number
+            })
+            .collect::<Vec<_>>();
+        let failed_to_attest = failed_to_attest_db
+            .unbounded_iter()
+            .filter(|(_, metadata)| {
+                metadata.end > last_certified_event_blob.ending_checkpoint_sequence_number
+            })
+            .collect::<Vec<_>>();
+        let total_uncertified_blobs = pending_db.unbounded_iter().count()
+            + failed_to_attest_db.unbounded_iter().count()
+            + attested_db.unbounded_iter().count();
+        let uncertified_blobs_after_last_certified =
+            pending.len() + failed_to_attest.len() + attested.len();
+
+        let should_reset = total_uncertified_blobs == uncertified_blobs_after_last_certified
+            && uncertified_blobs_after_last_certified as u32 >= num_uncertified_blob_threshold;
+        if !should_reset {
+            tracing::info!(
+                "No need to reset as number of uncertified blobs {} is less than the threshold {}",
+                uncertified_blobs_after_last_certified,
+                num_uncertified_blob_threshold
+            );
+            return Ok(());
+        }
+        tracing::info!(
+            "Resetting current event blob writer state as number of uncertified blobs {} \
+            is greater than the threshold {}",
+            uncertified_blobs_after_last_certified,
+            num_uncertified_blob_threshold
+        );
+        let mut wb = pending_db.batch();
+        for (k, _) in pending {
+            wb.delete_batch(pending_db, std::iter::once(k))?;
+        }
+        if !attested.is_empty() {
+            wb.delete_batch(attested_db, std::iter::once(()))?;
+        }
+        if !failed_to_attest.is_empty() {
+            wb.delete_batch(failed_to_attest_db, std::iter::once(()))?;
+        }
+        wb.write()?;
+        Ok(())
     }
 }
 
@@ -1375,6 +1476,8 @@ mod tests {
             node.storage_node.inner().clone(),
             &registry,
             Some(10),
+            None,
+            None,
         )?;
         let mut blob_writer = blob_writer_factory.create().await?;
         let num_checkpoints: u64 = NUM_BLOBS * blob_writer.num_checkpoints_per_blob() as u64;
@@ -1425,6 +1528,8 @@ mod tests {
             node.storage_node.inner().clone(),
             &registry,
             Some(10),
+            None,
+            None,
         )?;
         let mut blob_writer = blob_writer_factory.create().await?;
         let num_checkpoints: u64 = NUM_BLOBS * blob_writer.num_checkpoints_per_blob() as u64;
@@ -1502,6 +1607,8 @@ mod tests {
             node.storage_node.inner().clone(),
             &registry,
             Some(10),
+            None,
+            None,
         )?;
         let mut blob_writer = blob_writer_factory.create().await?;
         let num_checkpoints: u64 = NUM_BLOBS * blob_writer.num_checkpoints_per_blob() as u64;

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -57,7 +57,7 @@ use walrus_sui::{
     },
     test_utils::{system_setup::SystemContext, TestClusterHandle},
     types::{
-        move_structs::{EpochState, NodeMetadata, VotingParams},
+        move_structs::{EpochState, EventBlob, NodeMetadata, VotingParams},
         Committee,
         ContractEvent,
         NetworkAddress,
@@ -1461,6 +1461,10 @@ impl SystemContractService for StubContractService {
     async fn get_system_object_version(&self) -> Result<u64, SuiClientError> {
         Ok(1)
     }
+
+    async fn last_certified_event_blob(&self) -> Result<Option<EventBlob>, SuiClientError> {
+        Ok(None)
+    }
 }
 
 /// Returns a socket address that is not currently in use on the system.
@@ -2127,6 +2131,10 @@ where
     async fn get_system_object_version(&self) -> Result<u64, SuiClientError> {
         self.as_ref().inner.get_system_object_version().await
     }
+
+    async fn last_certified_event_blob(&self) -> Result<Option<EventBlob>, SuiClientError> {
+        self.as_ref().inner.last_certified_event_blob().await
+    }
 }
 
 /// Returns a test-committee with members with the specified number of shards ehortach.
@@ -2603,6 +2611,7 @@ pub fn storage_node_config() -> WithTempDir<StorageNodeConfig> {
             metadata: Default::default(),
             config_synchronizer: Default::default(),
             storage_node_cap: None,
+            num_uncertified_blob_threshold: Some(u32::MAX),
         },
         temp_dir,
     }

--- a/crates/walrus-service/src/testbed.rs
+++ b/crates/walrus-service/src/testbed.rs
@@ -730,6 +730,7 @@ pub async fn create_storage_node_configs(
             metadata: Default::default(),
             config_synchronizer: Default::default(),
             storage_node_cap: None,
+            num_uncertified_blob_threshold: Some(10),
         });
     }
 

--- a/crates/walrus-sui/src/client/retry_client.rs
+++ b/crates/walrus-sui/src/client/retry_client.rs
@@ -621,7 +621,7 @@ impl RetriableSuiClient {
     /// Returns the package ID from the type of the given object.
     ///
     /// Note: This returns the package address from the object type, not the newest package ID.
-    pub(crate) async fn get_package_id_from_object(
+    pub async fn get_package_id_from_object(
         &self,
         object_id: ObjectID,
     ) -> SuiClientResult<ObjectID> {


### PR DESCRIPTION
## Description

During startup, reset all pending, attested and failed to attest blobs once we realize we have accumulated quite a few of them since the last event blob was certified. This lets storage nodes generate new blobs after a code change and re-attest again upon epoch change.
