### PR TITLE
fix: temporarily disable logs emitted by TraceLayer

### DIFF
--- a/crates/walrus-service/src/node/server.rs
+++ b/crates/walrus-service/src/node/server.rs
@@ -185,6 +185,10 @@ where
             .layer(
                 TraceLayer::new_for_http()
                     .make_span_with(MakeHttpSpan::new())
+                    // TODO(jsmith): This silences logs being emitted by TraceLayer.
+                    // Until we've resolved too may 503's or customized this further to not log
+                    // specifically this error, we disable it.
+                    .on_failure(())
                     .on_response(MakeHttpSpan::new()),
             );
 


### PR DESCRIPTION
## Description

Temporarily disable logs emitted by TraceLayer (we have our own failure logging throughout our code), until we're able to find a satisfactory solution to the frequency with which it emits 503 errors.

## Test plan

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
