### PR TITLE
fix: make blob encodings parallel instead of concurrent

### DIFF
--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -681,8 +681,7 @@ async fn test_store_with_existing_storage_resource(
     let encoding_type = DEFAULT_ENCODING;
     let pairs_and_metadata = client
         .as_ref()
-        .encode_blobs_to_pairs_and_metadata(&blobs, encoding_type)
-        .await?;
+        .encode_blobs_to_pairs_and_metadata(&blobs, encoding_type)?;
     let encoded_sizes = pairs_and_metadata
         .iter()
         .map(|(_, metadata)| metadata.metadata().encoded_size().unwrap())

--- a/crates/walrus-service/src/client/cli/runner.rs
+++ b/crates/walrus-service/src/client/cli/runner.rs
@@ -603,9 +603,8 @@ impl ClientCommandRunner {
 
         for file in files {
             let blob = read_blob_from_file(&file)?;
-            let (_, metadata) = client
-                .encode_pairs_and_metadata(&blob, encoding_type, &MultiProgress::new())
-                .await?;
+            let (_, metadata) =
+                client.encode_pairs_and_metadata(&blob, encoding_type, &MultiProgress::new())?;
             let unencoded_size = metadata.metadata().unencoded_length();
             let encoded_size = encoded_blob_length_for_n_shards(
                 encoding_config.n_shards(),


### PR DESCRIPTION
## Description

Fix the encoding of multiple blobs such that it is parallel, not just concurrent. 

The prior approach created multiple blocking units of work within a single future (join_all), which is then polled by a single thread at any given time. This fix uses rayon to distribute the work to worker threads and collect the results.

Note that as before, this runs on a tokio core thread. Moving this onto a background thread will require more changes due to the lifetime of the blobs.

## Test plan

Used the cli to encode multiple blobs and swa tht 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
