### PR TITLE
refactor(publisher): some cleanup of errors and logs

### DIFF
--- a/crates/walrus-service/src/client/daemon/routes.rs
+++ b/crates/walrus-service/src/client/daemon/routes.rs
@@ -345,12 +345,12 @@ fn check_blob_size(
         Ok(claim) => {
             if let Some(max_size) = claim.max_size {
                 if blob_size as u64 > max_size {
-                    return Err(PublisherAuthError::SizeIncorrect);
+                    return Err(PublisherAuthError::InvalidSize);
                 }
             }
             if let Some(size) = claim.size {
                 if blob_size as u64 != size {
-                    return Err(PublisherAuthError::SizeIncorrect);
+                    return Err(PublisherAuthError::InvalidSize);
                 }
             }
             Ok(())


### PR DESCRIPTION
## Description

Clean up some errors and log statements in the authentication layer of the publisher (follow-up on #1613). Essentially, this differentiates between an inconsistent token (`InconsistentToken`) and requests that don't match the token (`InvalidSize`, `InvalidEpochs`, ...).

## Test plan

Automatic tests.
