### PR TITLE
test: shorten epoch duration in antithesis test

### DIFF
--- a/docker/local-testbed/files/deploy-walrus.sh
+++ b/docker/local-testbed/files/deploy-walrus.sh
@@ -2,8 +2,10 @@
 # Copyright (c) Mysten Labs, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-# use EPOCH_DURATION to set the epoch duration, default is 1h
-EPOCH_DURATION=${EPOCH_DURATION:-1h}
+# use EPOCH_DURATION to set the epoch duration, default is 2 minutes
+# in antithesis test. The exhaustive behavior exploration in antithesis test requires
+# epoch duration to be as short as possible in order to explore more epoch change behaviors.
+EPOCH_DURATION=${EPOCH_DURATION:-2m}
 
 rm -rf walrus-docs
 git clone https://github.com/MystenLabs/walrus-docs.git

--- a/docker/walrus-antithesis/build-test-config-image/docker-compose.yaml
+++ b/docker/walrus-antithesis/build-test-config-image/docker-compose.yaml
@@ -45,7 +45,7 @@ services:
     hostname: walrus-deploy
     container_name: walrus-deploy
     environment:
-      - EPOCH_DURATION=10m
+      - EPOCH_DURATION=2m
       - NO_COLOR=1
     volumes:
       - ./files/deploy-walrus.sh:/root/deploy-walrus.sh


### PR DESCRIPTION
## Description

As discussed with the antithesis team, the shorter the epoch length, the more epoch related behaviors to be
exercised. Right now, the tests simulate about 800s, so having 2m epoch duration which allows us to reach at least
epoch 5.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
