### PR TITLE
fix: missing state metrics due to sql query

### DIFF
--- a/crates/walrus-service/src/backup/service.rs
+++ b/crates/walrus-service/src/backup/service.rs
@@ -405,7 +405,7 @@ fn start_db_metrics_loop(metrics_runtime: &MetricsAndLoggingRuntime, config: &Ba
                     UNION
                     SELECT
                         'total_bytes_archived' AS name,
-                        SUM(coalesce(size, 0))::bigint AS value
+                        COALESCE(SUM(size), 0)::bigint AS value
                     FROM blob_state
                     WHERE state = 'archived';
                     ",


### PR DESCRIPTION
## Description

Rearrange a COALESCE to avoid a NULL value in the output of a backup state metrics query.

## Test plan

Manually tested new query.

---

No release impact.