### PR TITLE
feat: Add fallback client for checkpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1821,6 +1821,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "checkpoint-downloader"
+version = "1.19.0"
+dependencies = [
+ "anyhow",
+ "async-channel",
+ "prometheus",
+ "rand 0.8.5",
+ "rocksdb",
+ "serde",
+ "serde_with",
+ "sui-rpc-api",
+ "sui-types",
+ "tempfile",
+ "tokio",
+ "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing",
+ "typed-store",
+ "walrus-sui",
+ "walrus-utils",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11841,6 +11863,7 @@ dependencies = [
  "bincode",
  "byteorder",
  "bytes",
+ "checkpoint-downloader",
  "chrono",
  "clap",
  "colored",
@@ -11977,6 +12000,7 @@ dependencies = [
  "async-trait",
  "bcs",
  "chrono",
+ "clap",
  "fastcrypto",
  "futures",
  "home",
@@ -11998,6 +12022,7 @@ dependencies = [
  "sui-rpc-api",
  "sui-sdk",
  "sui-simulator",
+ "sui-storage",
  "sui-types",
  "tempfile",
  "test-cluster",
@@ -12007,6 +12032,7 @@ dependencies = [
  "tonic 0.12.3",
  "tracing",
  "tracing-subscriber",
+ "url",
  "utoipa",
  "walkdir",
  "walrus-core",
@@ -12029,27 +12055,19 @@ name = "walrus-utils"
 version = "1.19.0"
 dependencies = [
  "anyhow",
- "async-channel",
  "bytes",
  "home",
  "http-body 1.0.1",
  "http-body-util",
  "pin-project",
- "prometheus",
  "rand 0.8.5",
- "reqwest",
- "rocksdb",
  "serde",
  "serde_json",
  "serde_with",
- "sui-rpc-api",
- "sui-types",
  "tempfile",
  "tokio",
  "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "tonic 0.12.3",
  "tracing",
- "typed-store",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 default-members = [
+  "crates/checkpoint-downloader",
   "crates/walrus-core",
   "crates/walrus-e2e-tests",
   "crates/walrus-proc-macros",
@@ -33,6 +34,7 @@ bcs = "0.1.6"
 bincode = "1.3.3"
 byteorder = "1.5.0"
 bytes = { version = "1.10.1", default-features = false, features = ["serde"] }
+checkpoint-downloader = { path = "crates/checkpoint-downloader" }
 chrono = "0.4"
 clap = { version = "4.5.32", features = ["derive"] }
 colored = "2.2.0"

--- a/crates/checkpoint-downloader/Cargo.toml
+++ b/crates/checkpoint-downloader/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "checkpoint-downloader"
+publish = false
+authors.workspace = true
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+async-channel.workspace = true
+prometheus.workspace = true
+rand.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_with.workspace = true
+sui-rpc-api.workspace = true
+sui-types.workspace = true
+tokio = { workspace = true, features = ["full"] }
+tokio-util.workspace = true
+tracing.workspace = true
+typed-store.workspace = true
+walrus-sui.workspace = true
+walrus-utils.workspace = true
+
+[dev-dependencies]
+rocksdb.workspace = true
+tempfile.workspace = true

--- a/crates/checkpoint-downloader/src/config.rs
+++ b/crates/checkpoint-downloader/src/config.rs
@@ -1,0 +1,152 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Checkpoint downloader configuration.
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DurationMilliSeconds, DurationSeconds};
+use sui_types::messages_checkpoint::TrustedCheckpoint;
+use typed_store::rocks::DBMap;
+use walrus_sui::client::retry_client::RetriableRpcClient;
+
+use crate::metrics::AdaptiveDownloaderMetrics;
+
+/// Fetcher configuration options for the parallel checkpoint fetcher.
+#[serde_as]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct ParallelDownloaderConfig {
+    /// Number of retries per checkpoint before giving up.
+    pub min_retries: u32,
+    /// Initial delay before the first retry.
+    #[serde_as(as = "DurationMilliSeconds")]
+    #[serde(rename = "initial_delay_millis")]
+    pub initial_delay: Duration,
+    /// Maximum delay between retries. Once this delay is reached, the
+    /// fetcher will keep retrying with this duration.
+    #[serde_as(as = "DurationMilliSeconds")]
+    #[serde(rename = "max_delay_millis")]
+    pub max_delay: Duration,
+}
+
+impl Default for ParallelDownloaderConfig {
+    fn default() -> Self {
+        // Checkpoint downloader configuration tuned for:
+        // - Checkpoint generation rate: 1 per 200ms (5 per second)
+        // - Network RTT: ~100-300ms
+        //
+        // Retry timing example with 100ms RTT:
+        // T+0ms:   Client requests checkpoint N
+        // T+100ms: Client learns checkpoint N unavailable
+        // T+200ms: Server generates checkpoint N
+        // T+250ms: Client retries after retry_delay
+        // T+350ms: Client gets response which should contain checkpoint N.
+
+        // Retry timing example with 300ms RTT:
+        // T+0ms:   Client requests checkpoint N
+        // T+200ms: Server generates checkpoint N
+        // T+300ms: Client learns checkpoint N unavailable
+        // T+450ms: Client retries after retry_delay
+        // T+750ms: Client gets response which should contain checkpoint N.
+        // The retry_delay of 150ms is chosen to balance in steady state with
+        // fully caught up client:
+        // - Not retrying too quickly (which could waste network resources)
+        // - Not waiting too long (which would cause us to fall behind)
+        // TODO: Use adaptive retry delay based on RTT and error type (#1123)
+        Self {
+            min_retries: 10,
+            initial_delay: Duration::from_millis(150),
+            max_delay: Duration::from_secs(2),
+        }
+    }
+}
+
+/// Configuration for the channel.
+///
+/// This is used to configure the size of the channel buffers for the worker pool.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ChannelConfig {
+    /// Additional buffer factor for work queue
+    /// Helps keep the worker busy in case of delays
+    /// in draining the checkpoint queue.
+    pub work_queue_buffer_factor: usize,
+    /// Buffer factor for result queue
+    /// Helps handle delays in processing the results.
+    pub result_queue_buffer_factor: usize,
+}
+
+impl Default for ChannelConfig {
+    fn default() -> Self {
+        Self {
+            work_queue_buffer_factor: 3,
+            result_queue_buffer_factor: 3,
+        }
+    }
+}
+
+/// Configuration for the adaptive worker pool.
+#[serde_as]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct AdaptiveDownloaderConfig {
+    /// Minimum number of workers.
+    pub min_workers: usize,
+    /// Maximum number of workers.
+    pub max_workers: usize,
+    /// Initial number of workers.
+    pub initial_workers: usize,
+    /// Checkpoint lag threshold for scaling up.
+    pub scale_up_lag_threshold: u64,
+    /// Checkpoint lag threshold for scaling down.
+    pub scale_down_lag_threshold: u64,
+    /// Minimum time between scaling operations.
+    #[serde(rename = "scale_cooldown_secs")]
+    #[serde_as(as = "DurationSeconds")]
+    pub scale_cooldown: Duration,
+    /// Base configuration.
+    pub base_config: ParallelDownloaderConfig,
+    /// Channel configuration.
+    pub channel_config: ChannelConfig,
+}
+
+impl Default for AdaptiveDownloaderConfig {
+    fn default() -> Self {
+        Self {
+            min_workers: 1,
+            max_workers: 10,
+            initial_workers: 5,
+            scale_up_lag_threshold: 100,
+            scale_down_lag_threshold: 10,
+            scale_cooldown: Duration::from_secs(10),
+            base_config: ParallelDownloaderConfig::default(),
+            channel_config: ChannelConfig::default(),
+        }
+    }
+}
+
+impl AdaptiveDownloaderConfig {
+    pub(crate) fn message_queue_size(&self) -> usize {
+        self.max_workers * self.channel_config.work_queue_buffer_factor
+    }
+
+    pub(crate) fn checkpoint_queue_size(&self) -> usize {
+        self.max_workers * self.channel_config.work_queue_buffer_factor
+    }
+
+    pub(crate) fn result_queue_size(&self) -> usize {
+        self.max_workers
+            * self.channel_config.work_queue_buffer_factor
+            * self.channel_config.result_queue_buffer_factor
+    }
+}
+
+/// Configuration for the pool monitor.
+#[derive(Clone)]
+pub(crate) struct PoolMonitorConfig {
+    pub(crate) downloader_config: AdaptiveDownloaderConfig,
+    pub(crate) checkpoint_store: DBMap<(), TrustedCheckpoint>,
+    pub(crate) client: RetriableRpcClient,
+    pub(crate) metrics: AdaptiveDownloaderMetrics,
+}

--- a/crates/checkpoint-downloader/src/lib.rs
+++ b/crates/checkpoint-downloader/src/lib.rs
@@ -1,0 +1,11 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+mod config;
+mod downloader;
+mod metrics;
+mod types;
+
+pub use config::{AdaptiveDownloaderConfig, ChannelConfig, ParallelDownloaderConfig};
+pub use downloader::ParallelCheckpointDownloader;
+pub use types::CheckpointEntry;

--- a/crates/checkpoint-downloader/src/metrics.rs
+++ b/crates/checkpoint-downloader/src/metrics.rs
@@ -1,0 +1,33 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Metrics for the checkpoint downloader.
+
+use prometheus::{register_int_gauge_with_registry, IntGauge, Registry};
+
+#[derive(Clone, Debug)]
+pub(crate) struct AdaptiveDownloaderMetrics {
+    /// The number of checkpoint downloader workers.
+    pub num_workers: IntGauge,
+    /// The current checkpoint lag between the local store and the full node.
+    pub checkpoint_lag: IntGauge,
+}
+
+impl AdaptiveDownloaderMetrics {
+    pub fn new(registry: &Registry) -> Self {
+        Self {
+            num_workers: register_int_gauge_with_registry!(
+                "checkpoint_downloader_num_workers",
+                "Number of workers active in the worker pool",
+                registry,
+            )
+            .expect("this is a valid metrics registration"),
+            checkpoint_lag: register_int_gauge_with_registry!(
+                "checkpoint_downloader_checkpoint_lag",
+                "Current checkpoint lag between local store and full node",
+                registry,
+            )
+            .expect("this is a valid metrics registration"),
+        }
+    }
+}

--- a/crates/checkpoint-downloader/src/types.rs
+++ b/crates/checkpoint-downloader/src/types.rs
@@ -1,0 +1,46 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Types for the checkpoint downloader.
+
+use anyhow::Result;
+use sui_types::{
+    full_checkpoint_content::CheckpointData,
+    messages_checkpoint::CheckpointSequenceNumber,
+};
+use tokio::sync::mpsc;
+
+/// Worker message types.
+pub(crate) enum WorkerMessage {
+    /// Download a checkpoint with the given sequence number.
+    Download(CheckpointSequenceNumber),
+    /// Shutdown the worker.
+    Shutdown,
+}
+
+/// Entry in the checkpoint fetcher queue.
+#[derive(Debug)]
+pub struct CheckpointEntry {
+    /// The sequence number of the checkpoint.
+    pub sequence_number: u64,
+    /// The result of the checkpoint download.
+    pub result: Result<CheckpointData>,
+}
+
+impl CheckpointEntry {
+    /// Creates a new checkpoint entry.
+    pub fn new(sequence_number: u64, result: Result<CheckpointData>) -> Self {
+        Self {
+            sequence_number,
+            result,
+        }
+    }
+}
+
+/// Channels for the pool monitor.
+#[derive(Clone)]
+pub(crate) struct PoolMonitorChannels {
+    pub(crate) message_sender: async_channel::Sender<WorkerMessage>,
+    pub(crate) message_receiver: async_channel::Receiver<WorkerMessage>,
+    pub(crate) checkpoint_sender: mpsc::Sender<CheckpointEntry>,
+}

--- a/crates/walrus-service/Cargo.toml
+++ b/crates/walrus-service/Cargo.toml
@@ -45,6 +45,7 @@ deploy = ["client", "node", "walrus-sui/test-utils"]
 node = [
   "dep:async-trait",
   "dep:bincode",
+  "dep:checkpoint-downloader",
   "dep:enum_dispatch",
   "dep:mime",
   "dep:mysten-metrics",
@@ -81,6 +82,7 @@ bcs.workspace = true
 bincode = { workspace = true, optional = true }
 byteorder.workspace = true
 bytes = { workspace = true, optional = true }
+checkpoint-downloader = { workspace = true, optional = true }
 chrono.workspace = true
 clap.workspace = true
 colored = { workspace = true, optional = true }
@@ -156,7 +158,7 @@ walrus-proc-macros = { workspace = true, features = ["derive-api-errors"] }
 walrus-sdk.workspace = true
 walrus-sui = { workspace = true, features = ["utoipa"] }
 walrus-test-utils = { workspace = true, optional = true }
-walrus-utils = { workspace = true, features = ["backoff", "checkpoints", "config", "http", "metrics"] }
+walrus-utils = { workspace = true, features = ["backoff", "config", "http", "metrics"] }
 
 [dev-dependencies]
 hex = "0.4.3"
@@ -167,6 +169,7 @@ tempfile.workspace = true
 walrus-core = { workspace = true, features = ["test-utils"] }
 walrus-proc-macros = { workspace = true, features = ["walrus-simtest"] }
 walrus-test-utils.workspace = true
+walrus-utils = { workspace = true, features = ["test-utils"] }
 
 [lints]
 workspace = true

--- a/crates/walrus-service/bin/deploy.rs
+++ b/crates/walrus-service/bin/deploy.rs
@@ -23,7 +23,10 @@ use walrus_service::{
     testbed,
     utils::version,
 };
-use walrus_sui::{client::UpgradeType, utils::SuiNetwork};
+use walrus_sui::{
+    client::{rpc_config::RpcFallbackConfigArgs, UpgradeType},
+    utils::SuiNetwork,
+};
 
 const VERSION: &str = version!();
 #[derive(Parser)]
@@ -216,6 +219,9 @@ struct GenerateDryRunConfigsArgs {
     /// The amount of SUI (in MIST) to send to all created wallets.
     #[clap(long, default_value_t = 1_000_000_000, requires = "admin_wallet_path")]
     sui_amount: u64,
+    /// The config for rpc fallback.
+    #[clap(flatten)]
+    rpc_fallback_config_args: Option<RpcFallbackConfigArgs>,
 }
 
 #[derive(Debug, Clone, clap::Args)]
@@ -430,6 +436,7 @@ mod commands {
             use_legacy_event_provider,
             disable_event_blob_writer,
             backup_database_url,
+            rpc_fallback_config_args,
             admin_wallet_path,
             sui_amount,
         }: GenerateDryRunConfigsArgs,
@@ -486,6 +493,9 @@ mod commands {
                 working_dir.as_path(),
                 database_url.as_str(),
                 testbed_config.sui_network.env().rpc,
+                rpc_fallback_config_args
+                    .as_ref()
+                    .and_then(|args| args.to_config()),
             )
             .await?;
             let serialized_backup_config = serde_yaml::to_string(&backup_config)
@@ -505,6 +515,9 @@ mod commands {
             set_config_dir.as_deref(),
             set_db_path.as_deref(),
             faucet_cooldown,
+            rpc_fallback_config_args
+                .as_ref()
+                .and_then(|args| args.to_config()),
             &mut admin_contract_client,
             use_legacy_event_provider,
             disable_event_blob_writer,

--- a/crates/walrus-service/src/common/config.rs
+++ b/crates/walrus-service/src/common/config.rs
@@ -8,7 +8,13 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DurationMilliSeconds};
 use walrus_sui::{
-    client::{contract_config::ContractConfig, SuiClientError, SuiContractClient, SuiReadClient},
+    client::{
+        contract_config::ContractConfig,
+        rpc_config::RpcFallbackConfig,
+        SuiClientError,
+        SuiContractClient,
+        SuiReadClient,
+    },
     config::WalletConfig,
 };
 use walrus_utils::backoff::ExponentialBackoffConfig;
@@ -39,6 +45,9 @@ pub struct SuiConfig {
     /// Gas budget for transactions.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gas_budget: Option<u64>,
+    /// The config for rpc fallback.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rpc_fallback_config: Option<RpcFallbackConfig>,
 }
 
 impl SuiConfig {
@@ -71,6 +80,7 @@ impl From<&SuiConfig> for SuiReaderConfig {
             contract_config: config.contract_config.clone(),
             event_polling_interval: config.event_polling_interval,
             backoff_config: config.backoff_config.clone(),
+            rpc_fallback_config: config.rpc_fallback_config.clone(),
         }
     }
 }
@@ -96,6 +106,9 @@ pub struct SuiReaderConfig {
     /// The configuration for the backoff strategy used for retries.
     #[serde(default, skip_serializing_if = "defaults::is_default")]
     pub backoff_config: ExponentialBackoffConfig,
+    /// The URL of the checkpoint download fallback endpoint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rpc_fallback_config: Option<RpcFallbackConfig>,
 }
 
 impl SuiReaderConfig {

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -400,6 +400,7 @@ impl StorageNodeBuilder {
                     rpc_address: sui_config.rpc.clone(),
                     event_polling_interval: sui_config.event_polling_interval,
                     db_path: config.storage_path.join("events"),
+                    rpc_fallback_config: sui_config.rpc_fallback_config.clone(),
                 };
                 let system_config = SystemConfig {
                     system_pkg_id: read_client.get_system_package_id(),

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -1011,6 +1011,7 @@ mod tests {
                 )),
                 backoff_config: Default::default(),
                 gas_budget: None,
+                rpc_fallback_config: None,
             }),
             config_synchronizer: ConfigSynchronizerConfig {
                 interval: Duration::from_secs(defaults::CONFIG_SYNCHRONIZER_INTERVAL_SECS),

--- a/crates/walrus-service/src/node/events.rs
+++ b/crates/walrus-service/src/node/events.rs
@@ -13,13 +13,13 @@ use std::{
 
 use anyhow::bail;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use checkpoint_downloader::AdaptiveDownloaderConfig;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DurationSeconds};
 use sui_rpc_api::Client;
 use sui_types::{event::EventID, messages_checkpoint::CheckpointSequenceNumber};
 use walrus_core::{BlobId, Epoch};
 use walrus_sui::types::{BlobEvent, ContractEvent};
-use walrus_utils::checkpoint_downloader::AdaptiveDownloaderConfig;
 
 pub mod event_blob;
 pub mod event_blob_writer;

--- a/crates/walrus-service/src/node/events/event_processor_runtime.rs
+++ b/crates/walrus-service/src/node/events/event_processor_runtime.rs
@@ -41,6 +41,7 @@ impl EventProcessorRuntime {
             rpc_address: sui_reader_config.rpc.clone(),
             event_polling_interval: sui_reader_config.event_polling_interval,
             db_path: db_path.join("events"),
+            rpc_fallback_config: sui_reader_config.rpc_fallback_config.clone(),
         };
         let system_config = SystemConfig {
             system_pkg_id: sui_reader_config

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -490,6 +490,7 @@ impl SimStorageNodeHandle {
                         .expect("temporary directory creation must succeed")
                         .path()
                         .to_path_buf()),
+                    rpc_fallback_config: None,
                 };
             let system_config = crate::node::events::event_processor::SystemConfig {
                 system_object_id: sui_config.contract_config.system_object,
@@ -1028,6 +1029,7 @@ impl StorageNodeHandleBuilder {
                 event_polling_interval: config::defaults::polling_interval(),
                 backoff_config: ExponentialBackoffConfig::default(),
                 gas_budget: None,
+                rpc_fallback_config: None,
             }),
             config_synchronizer: ConfigSynchronizerConfig {
                 interval: Duration::from_secs(5),
@@ -2541,6 +2543,7 @@ pub mod test_cluster {
                     .expect("temporary directory creation must succeed")
                     .path()
                     .to_path_buf()),
+                rpc_fallback_config: None,
             };
             let system_config = SystemConfig {
                 system_pkg_id: sui_read_client.get_system_package_id(),

--- a/crates/walrus-service/src/testbed.rs
+++ b/crates/walrus-service/src/testbed.rs
@@ -26,7 +26,7 @@ use walrus_core::{
     ShardIndex,
 };
 use walrus_sui::{
-    client::SuiContractClient,
+    client::{rpc_config::RpcFallbackConfig, SuiContractClient},
     config::{load_wallet_context_from_path, WalletConfig},
     system_setup::InitSystemParams,
     test_utils::system_setup::{
@@ -573,6 +573,7 @@ pub async fn create_backup_config(
     working_dir: &Path,
     database_url: &str,
     rpc: String,
+    rpc_fallback_config: Option<RpcFallbackConfig>,
 ) -> anyhow::Result<BackupConfig> {
     Ok(BackupConfig::new_with_defaults(
         working_dir.join("backup"),
@@ -581,6 +582,7 @@ pub async fn create_backup_config(
             contract_config: system_ctx.contract_config(),
             backoff_config: ExponentialBackoffConfig::default(),
             event_polling_interval: defaults::polling_interval(),
+            rpc_fallback_config,
         },
         database_url.to_string(),
     ))
@@ -597,6 +599,7 @@ pub async fn create_storage_node_configs(
     set_config_dir: Option<&Path>,
     set_db_path: Option<&Path>,
     faucet_cooldown: Option<Duration>,
+    rpc_fallback_config: Option<RpcFallbackConfig>,
     admin_contract_client: &mut SuiContractClient,
     use_legacy_event_provider: bool,
     disable_event_blob_writer: bool,
@@ -705,6 +708,7 @@ pub async fn create_storage_node_configs(
             wallet_config: WalletConfig::from_path(wallet_path),
             backoff_config: ExponentialBackoffConfig::default(),
             gas_budget: None,
+            rpc_fallback_config: rpc_fallback_config.clone(),
         });
 
         let storage_path = set_db_path

--- a/crates/walrus-sui/Cargo.toml
+++ b/crates/walrus-sui/Cargo.toml
@@ -23,6 +23,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 bcs.workspace = true
 chrono.workspace = true
+clap.workspace = true
 fastcrypto.workspace = true
 futures.workspace = true
 home.workspace = true
@@ -41,6 +42,7 @@ sui-move-build.workspace = true
 sui-package-management.workspace = true
 sui-rpc-api.workspace = true
 sui-sdk.workspace = true
+sui-storage.workspace = true
 sui-types.workspace = true
 tempfile = { workspace = true, optional = true }
 test-cluster = { workspace = true, optional = true }
@@ -49,6 +51,7 @@ tokio = { workspace = true, features = ["fs", "sync"] }
 tokio-stream.workspace = true
 tonic.workspace = true
 tracing.workspace = true
+url.workspace = true
 utoipa = { workspace = true, optional = true }
 walkdir = "2.5.0"
 walrus-core = { workspace = true, features = ["sui-types"] }

--- a/crates/walrus-sui/src/client.rs
+++ b/crates/walrus-sui/src/client.rs
@@ -90,6 +90,7 @@ pub use read_client::{
     SuiReadClient,
 };
 pub mod retry_client;
+pub mod rpc_config;
 
 pub mod transaction_builder;
 use crate::types::move_structs::EventBlob;

--- a/crates/walrus-sui/src/client/retry_client.rs
+++ b/crates/walrus-sui/src/client/retry_client.rs
@@ -5,13 +5,19 @@
 //!
 //! Wraps the [`SuiClient`] to introduce retries.
 
-use std::{collections::BTreeMap, fmt::Debug, future::Future, str::FromStr};
+use std::{collections::BTreeMap, fmt::Debug, future::Future, str::FromStr, time};
 
-use futures::{future, stream, Stream, StreamExt};
+use futures::{
+    future::{self},
+    stream,
+    Stream,
+    StreamExt,
+};
 use rand::{
     rngs::{StdRng, ThreadRng},
     Rng as _,
 };
+use reqwest::Url;
 use serde::{de::DeserializeOwned, Serialize};
 #[cfg(msim)]
 use sui_macros::fail_point_if;
@@ -39,6 +45,7 @@ use sui_sdk::{
     SuiClient,
     SuiClientBuilder,
 };
+use sui_storage::blob::Blob;
 #[cfg(msim)]
 use sui_types::transaction::TransactionDataAPI;
 use sui_types::{
@@ -52,11 +59,13 @@ use sui_types::{
     transaction::{Transaction, TransactionData, TransactionKind},
     TypeTag,
 };
+use thiserror::Error;
 use tracing::Level;
+use url::ParseError;
 use walrus_core::ensure;
 use walrus_utils::backoff::{BackoffStrategy, ExponentialBackoff, ExponentialBackoffConfig};
 
-use super::{SuiClientError, SuiClientResult};
+use super::{rpc_config::RpcFallbackConfig, SuiClientError, SuiClientResult};
 use crate::{
     contracts::{self, AssociatedContractStruct, TypeOriginMap},
     types::move_structs::{Key, Subsidies, SuiDynamicField, SystemObjectForDeserialization},
@@ -125,6 +134,30 @@ impl RetriableRpcError for SuiClientError {
 impl RetriableRpcError for tonic::Status {
     fn is_retriable_rpc_error(&self) -> bool {
         RETRIABLE_GRPC_ERRORS.contains(&self.code())
+    }
+}
+
+impl RetriableRpcError for CheckpointDownloadError {
+    fn is_retriable_rpc_error(&self) -> bool {
+        match self {
+            CheckpointDownloadError::RequestFailed(error) => error
+                .status()
+                .map(|status| status.is_server_error() || status.as_u16() == 429)
+                .unwrap_or(false),
+            _ => false,
+        }
+    }
+}
+
+impl RetriableRpcError for RetriableClientError {
+    fn is_retriable_rpc_error(&self) -> bool {
+        match self {
+            RetriableClientError::RpcError(status) => status.is_retriable_rpc_error(),
+            RetriableClientError::FallbackError(fallback_error) => {
+                fallback_error.is_retriable_rpc_error()
+            }
+            RetriableClientError::Other(_) => false,
+        }
     }
 }
 
@@ -780,46 +813,217 @@ impl RetriableSuiClient {
     }
 }
 
+/// Error type for checkpoint download errors.
+#[derive(Error, Debug)]
+pub enum CheckpointDownloadError {
+    /// Failed to construct URL.
+    #[error("Failed to construct URL: {0}")]
+    UrlConstruction(#[from] ParseError),
+
+    /// HTTP request failed.
+    #[error("HTTP request failed: {0}")]
+    RequestFailed(#[from] reqwest::Error),
+
+    /// Failed to deserialize checkpoint data.
+    #[error("Failed to deserialize checkpoint data: {0}")]
+    DeserializationError(String),
+}
+
+// Implement automatic conversion from CheckpointDownloadError to tonic::Status
+impl From<CheckpointDownloadError> for tonic::Status {
+    fn from(error: CheckpointDownloadError) -> Self {
+        tonic::Status::internal(format!("Checkpoint download failed: {}", error))
+    }
+}
+
+/// A client for downloading checkpoint data from a remote server.
+#[derive(Clone, Debug)]
+pub struct CheckpointBucketClient {
+    client: reqwest::Client,
+    base_url: Url,
+}
+
+impl CheckpointBucketClient {
+    /// Creates a new checkpoint download client.
+    pub fn new(base_url: Url) -> Self {
+        let client = reqwest::Client::new();
+        Self { client, base_url }
+    }
+
+    /// Downloads a checkpoint from the remote server.
+    pub async fn get_full_checkpoint(
+        &self,
+        sequence_number: u64,
+    ) -> Result<CheckpointData, CheckpointDownloadError> {
+        let url = self.base_url.join(&format!("{}.chk", sequence_number))?;
+        tracing::debug!("Downloading checkpoint from: {:?}", url);
+        let response = self.client.get(url).send().await?;
+        let bytes = response.bytes().await?;
+        let checkpoint = Blob::from_bytes::<CheckpointData>(&bytes)
+            .map_err(|e| CheckpointDownloadError::DeserializationError(e.to_string()))?;
+        tracing::debug!(
+            "Checkpoint download successful for sequence: {}",
+            sequence_number
+        );
+        Ok(checkpoint)
+    }
+}
+
+/// Custom error type for RetriableRpcClient operations
+#[derive(Error, Debug)]
+pub enum RetriableClientError {
+    /// RPC error from the primary client
+    #[error("RPC error: {0}")]
+    RpcError(#[from] tonic::Status),
+
+    /// Error from the fallback client
+    #[error("Fallback error: {0}")]
+    FallbackError(#[from] CheckpointDownloadError),
+
+    /// Generic error
+    #[error("Client error: {0}")]
+    Other(#[from] anyhow::Error),
+}
+
 /// A [`sui_rpc_api::Client`] that retries RPC calls with backoff in case of network errors.
 /// RpcClient is used primarily for retrieving checkpoint data from the Sui RPC server while
 /// SuiClient is used for all other RPC calls.
 #[derive(Clone)]
 pub struct RetriableRpcClient {
     client: RpcClient,
-    backoff_config: ExponentialBackoffConfig,
+    main_backoff_config: ExponentialBackoffConfig,
+    fallback_client: Option<CheckpointBucketClient>,
+    quick_retry_config: ExponentialBackoffConfig,
 }
 
 impl std::fmt::Debug for RetriableRpcClient {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("RetriableRpcClient")
-            .field("backoff_config", &self.backoff_config)
+            .field("main_backoff_config", &self.main_backoff_config)
             // Skip detailed client debug info since it's not typically useful
             .field("client", &"RpcClient")
+            .field("fallback_client", &"CheckpointDownloadClient")
             .finish()
     }
 }
 
 impl RetriableRpcClient {
     /// Creates a new retriable client.
-    pub fn new(client: RpcClient, backoff_config: ExponentialBackoffConfig) -> Self {
+    pub fn new(
+        client: RpcClient,
+        backoff_config: ExponentialBackoffConfig,
+        fallback_config: Option<RpcFallbackConfig>,
+    ) -> Self {
+        let fallback_client = fallback_config.as_ref().map(|config| {
+            let url = config.checkpoint_bucket.clone();
+            CheckpointBucketClient::new(url)
+        });
+
         Self {
             client,
-            backoff_config,
+            main_backoff_config: backoff_config,
+            fallback_client,
+            quick_retry_config: fallback_config
+                .map(|config| config.quick_retry_config)
+                .unwrap_or_else(|| {
+                    ExponentialBackoffConfig::new(
+                        time::Duration::from_millis(100),
+                        time::Duration::from_millis(300),
+                        Some(3),
+                    )
+                }),
         }
     }
 
     /// Gets a backoff strategy, seeded from the internal RNG.
     fn get_strategy(&self) -> ExponentialBackoff<StdRng> {
-        self.backoff_config.get_strategy(ThreadRng::default().gen())
+        self.main_backoff_config
+            .get_strategy(ThreadRng::default().gen())
+    }
+
+    /// Gets a quick retry strategy, seeded from the internal RNG.
+    fn get_quick_strategy(&self) -> ExponentialBackoff<StdRng> {
+        self.quick_retry_config
+            .get_strategy(ThreadRng::default().gen())
     }
 
     /// Gets the full checkpoint data for the given sequence number.
+    ///
+    /// This function will first try to fetch the checkpoint from the primary client. If that fails,
+    /// it will try to fetch the checkpoint from the fallback client if configured. If that also
+    /// fails, it will return the error from the primary client.
+    ///
+    /// When the primary client returns a "not found" or "missing event" error, it will use the
+    /// fallback client to fetch the checkpoint immediately. For all other errors, it will first
+    /// try a quick retry on the primary client before falling back to the fallback client.
+    ///
+    /// If fallback is not configured, it will retry the primary client with the main retry
+    /// strategy.
     pub async fn get_full_checkpoint(
         &self,
         sequence: u64,
-    ) -> Result<CheckpointData, tonic::Status> {
+    ) -> Result<CheckpointData, RetriableClientError> {
+        let primary_result = self.client.get_full_checkpoint(sequence).await;
+
+        let Err(err) = &primary_result else {
+            return Ok(primary_result.unwrap());
+        };
+
+        tracing::debug!("Primary client error while fetching checkpoint: {:?}", err);
+        let Some(ref fallback) = self.fallback_client else {
+            tracing::debug!("No fallback client configured, retrying primary client");
+            return retry_rpc_errors(self.get_strategy(), || async {
+                self.client
+                    .get_full_checkpoint(sequence)
+                    .await
+                    .map_err(RetriableClientError::from)
+            })
+            .await;
+        };
+
+        // For "not found" (pruned) and "missing event" errors, use fallback immediately as the
+        // events in full node get pruned by event digest and checkpoint sequence number and newer
+        // transactions could have events with the same digest (as the already pruned ones).
+        if err.code() == tonic::Code::NotFound
+            || (err.code() == tonic::Code::Internal && err.message().contains("missing event"))
+        {
+            tracing::debug!(
+                "Using fallback client to fetch checkpoint as error: {:?}",
+                err
+            );
+            return retry_rpc_errors(self.get_strategy(), || async {
+                fallback
+                    .get_full_checkpoint(sequence)
+                    .await
+                    .map_err(RetriableClientError::from)
+            })
+            .await;
+        }
+
+        // Try a quick retry on the primary client before falling back
+        tracing::debug!(
+            "Not a missing event or not found error, trying quick retry on primary client"
+        );
+        let quick_retry_result = retry_rpc_errors(self.get_quick_strategy(), || async {
+            self.client
+                .get_full_checkpoint(sequence)
+                .await
+                .map_err(RetriableClientError::from)
+        })
+        .await;
+
+        if quick_retry_result.is_ok() {
+            tracing::debug!("Quick retry on primary client succeeded");
+            return quick_retry_result;
+        }
+
+        // Fall back to the fallback client with the main retry strategy
+        tracing::debug!("Falling back to fallback client after quick retry failed");
         retry_rpc_errors(self.get_strategy(), || async {
-            self.client.get_full_checkpoint(sequence).await
+            fallback
+                .get_full_checkpoint(sequence)
+                .await
+                .map_err(RetriableClientError::from)
         })
         .await
     }
@@ -828,25 +1032,36 @@ impl RetriableRpcClient {
     pub async fn get_checkpoint_summary(
         &self,
         sequence: u64,
-    ) -> Result<CertifiedCheckpointSummary, tonic::Status> {
+    ) -> Result<CertifiedCheckpointSummary, RetriableClientError> {
         retry_rpc_errors(self.get_strategy(), || async {
-            self.client.get_checkpoint_summary(sequence).await
+            self.client
+                .get_checkpoint_summary(sequence)
+                .await
+                .map_err(RetriableClientError::from)
         })
         .await
     }
 
     /// Gets the latest checkpoint sequence number.
-    pub async fn get_latest_checkpoint(&self) -> Result<CertifiedCheckpointSummary, tonic::Status> {
+    pub async fn get_latest_checkpoint(
+        &self,
+    ) -> Result<CertifiedCheckpointSummary, RetriableClientError> {
         retry_rpc_errors(self.get_strategy(), || async {
-            self.client.get_latest_checkpoint().await
+            self.client
+                .get_latest_checkpoint()
+                .await
+                .map_err(RetriableClientError::from)
         })
         .await
     }
 
     /// Gets the object with the given ID.
-    pub async fn get_object(&self, id: ObjectID) -> Result<Object, tonic::Status> {
+    pub async fn get_object(&self, id: ObjectID) -> Result<Object, RetriableClientError> {
         retry_rpc_errors(self.get_strategy(), || async {
-            self.client.get_object(id).await
+            self.client
+                .get_object(id)
+                .await
+                .map_err(RetriableClientError::from)
         })
         .await
     }

--- a/crates/walrus-sui/src/client/rpc_config.rs
+++ b/crates/walrus-sui/src/client/rpc_config.rs
@@ -1,0 +1,81 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Configuration for the RPC client.
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use walrus_utils::backoff::ExponentialBackoffConfig;
+
+/// Configuration for the RPC endpoint fallback.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RpcFallbackConfig {
+    /// The endpoint of the checkpoint bucket that will be
+    /// used to download the checkpoint if the RPC endpoint
+    /// is not available.
+    pub checkpoint_bucket: reqwest::Url,
+    /// The configuration for the backoff strategy for the RPC
+    /// endpoint before falling back to the checkpoint bucket.
+    #[serde(default = "RpcFallbackConfig::default_quick_retry_config")]
+    pub quick_retry_config: ExponentialBackoffConfig,
+}
+
+impl RpcFallbackConfig {
+    fn default_quick_retry_config() -> ExponentialBackoffConfig {
+        ExponentialBackoffConfig {
+            min_backoff: Duration::from_millis(100),
+            max_backoff: Duration::from_millis(300),
+            max_retries: None,
+        }
+    }
+}
+
+/// Command line arguments for the RPC fallback configuration.
+#[derive(Debug, Clone, clap::Args)]
+pub struct RpcFallbackConfigArgs {
+    /// The fallback checkpoint bucket URL.
+    #[clap(long)]
+    pub checkpoint_bucket: Option<reqwest::Url>,
+
+    /// The minimum backoff interval in milliseconds
+    /// to retry the fullnode RPC before falling back
+    /// to the checkpoint bucket when available.
+    #[clap(long)]
+    pub min_backoff: Option<u64>,
+
+    /// The maximum backoff interval in milliseconds
+    /// to retry the fullnode RPC before falling back
+    /// to the checkpoint bucket when available.
+    #[clap(long)]
+    pub max_backoff: Option<u64>,
+
+    /// The maximum number of retries
+    /// to retry the fullnode RPC before falling back
+    /// to the checkpoint bucket when available.
+    #[clap(long)]
+    pub max_retries: Option<u32>,
+}
+
+impl RpcFallbackConfigArgs {
+    /// Converts the command line arguments to a [`RpcFallbackConfig`].
+    pub fn to_config(&self) -> Option<RpcFallbackConfig> {
+        self.checkpoint_bucket.as_ref().map(|url| {
+            let backoff = ExponentialBackoffConfig {
+                min_backoff: self
+                    .min_backoff
+                    .map(Duration::from_millis)
+                    .unwrap_or(Duration::from_millis(100)),
+                max_backoff: self
+                    .max_backoff
+                    .map(Duration::from_millis)
+                    .unwrap_or(Duration::from_millis(300)),
+                max_retries: self.max_retries,
+            };
+            RpcFallbackConfig {
+                checkpoint_bucket: url.clone(),
+                quick_retry_config: backoff,
+            }
+        })
+    }
+}

--- a/crates/walrus-utils/Cargo.toml
+++ b/crates/walrus-utils/Cargo.toml
@@ -7,23 +7,6 @@ license.workspace = true
 
 [features]
 backoff = ["dep:anyhow", "dep:rand", "dep:serde", "dep:serde_with", "dep:tracing", "tokio/time"]
-checkpoints = [
-  "backoff",
-  "dep:anyhow",
-  "dep:async-channel",
-  "dep:prometheus",
-  "dep:rand",
-  "dep:rocksdb",
-  "dep:serde",
-  "dep:serde_with",
-  "dep:sui-rpc-api",
-  "dep:sui-types",
-  "dep:tokio",
-  "dep:tokio-util",
-  "dep:tonic",
-  "dep:typed-store",
-  "test-utils",
-]
 config = ["dep:anyhow", "dep:home", "dep:serde", "dep:tracing"]
 default = []
 http = ["dep:bytes", "dep:http-body", "dep:pin-project"]
@@ -32,26 +15,18 @@ test-utils = ["dep:tempfile", "tokio/sync"]
 
 [dependencies]
 anyhow = { workspace = true, optional = true }
-async-channel = { workspace = true, optional = true }
 bytes = { workspace = true, optional = true }
 home = { workspace = true, optional = true }
 http-body = { version = "1", optional = true }
 pin-project = { workspace = true, optional = true }
-prometheus = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
-reqwest = { workspace = true, optional = true }
-rocksdb = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 serde_json = { workspace = true, optional = true }
 serde_with = { workspace = true, optional = true }
-sui-rpc-api = { workspace = true, optional = true }
-sui-types = { workspace = true, optional = true }
 tempfile = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"], optional = true }
 tokio-util = { workspace = true, optional = true }
-tonic = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
-typed-store = { workspace = true, optional = true }
 
 [dev-dependencies]
 http-body-util.workspace = true

--- a/crates/walrus-utils/src/lib.rs
+++ b/crates/walrus-utils/src/lib.rs
@@ -10,10 +10,6 @@ pub mod config;
 #[cfg(feature = "metrics")]
 pub mod metrics;
 
-// TODO(jsmith): Move this out of walrus-utils, as it's an entire service as opposed to a util
-#[cfg(feature = "checkpoints")]
-pub mod checkpoint_downloader;
-
 #[cfg(feature = "http")]
 pub mod http;
 


### PR DESCRIPTION
## Description

This PR adds code to read checkpoints from a fallback checkpoint bucket. One caveat is that `checkpoint_downlaoder.rs` now needs to use `RetriableRpcClient` which causes it (`walrus_util`) to take dependency on `walrus_sui` crate which already depends on `walrus_util`. So, in order to break this circular dependency, I've moved it to `walrus_service` which seems not a bad place for it (but as always open to suggestions).

## Test plan

Tested locally by running catchup on mainnet, and it downloads the checkpoints using fallback just fine using command: 
```
RUST_LOG=info,walrus_sui::client::retry_client=debug ./target/debug/walrus-node catchup --db-path /tmp/catchup --system-object-id 0x2134d52768ea07e8c43570ef975eb3e4c27a39fa6396bef985b5abc58d03ddd2 --staking-object-id 0x10b9d30c28448939ce6c4d6c6e0ffce4a7f8a4ada8248bdad09ef8b70e4a3904 --sui-rpc-url "https://mysten-rpc.mainnet.sui.io:443" --runtime-duration 1m --event-stream-catchup-min-checkpoint-lag 100000 --checkpoint-bucket https://checkpoints.mainnet.sui.io 2>&1 | tee /tmp/logs
```
```
2025-03-20T06:33:52.567676Z DEBUG walrus_sui::client::retry_client: Downloading checkpoint from: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("checkpoints.mainnet.sui.io")), port: None, path: "/122521999.chk", query: None, fragment: None }
2025-03-20T06:33:52.568676Z DEBUG walrus_sui::client::retry_client: Checkpoint download successful for sequence: 122521989
2025-03-20T06:33:52.570394Z DEBUG walrus_sui::client::retry_client: Checkpoint download successful for sequence: 122521995
2025-03-20T06:33:52.584979Z DEBUG walrus_sui::client::retry_client: Primary client error while fetching checkpoint: Status { code: NotFound, message: "data from requested checkpoint 122522000 has been pruned", details: b"\x08\x05\x128data from requested checkpoint 122522000 has been pruned", metadata: MetadataMap { headers: {"content-type": "application/grpc", "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000", "via": "1.1 google", "content-length": "0", "x-sui-chain-id": "35834a8a", "x-sui-chain": "mainnet", "x-sui-epoch": "707", "x-sui-checkpoint-height": "124635129", "x-sui-timestamp-ms": "1742452431897", "x-sui-timestamp": "2025-03-20T06:33:51.897Z", "x-sui-lowest-available-checkpoint": "123334496", "x-sui-lowest-available-checkpoint-objects": "123727549", "vary": "origin, access-control-request-method, access-control-request-headers", "access-control-allow-origin": "*", "server-timing": "finish_request;dur=0", "date": "Thu, 20 Mar 2025 06:33:52 GMT"} }, source: None }
2025-03-20T06:33:52.585017Z DEBUG walrus_sui::client::retry_client: Using fallback client to fetch checkpoint as error: Status { code: NotFound, message: "data from requested checkpoint 122522000 has been pruned", details: b"\x08\x05\x128data from requested checkpoint 122522000 has been pruned", metadata: MetadataMap { headers: {"content-type": "application/grpc", "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000", "via": "1.1 google", "content-length": "0", "x-sui-chain-id": "35834a8a", "x-sui-chain": "mainnet", "x-sui-epoch": "707", "x-sui-checkpoint-height": "124635129", "x-sui-timestamp-ms": "1742452431897", "x-sui-timestamp": "2025-03-20T06:33:51.897Z", "x-sui-lowest-available-checkpoint": "123334496", "x-sui-lowest-available-checkpoint-objects": "123727549", "vary": "origin, access-control-request-method, access-control-request-headers", "access-control-allow-origin": "*", "server-timing": "finish_request;dur=0", "date": "Thu, 20 Mar 2025 06:33:52 GMT"} }, source: None }
2025-03-20T06:33:52.585057Z DEBUG walrus_sui::client::retry_client: Downloading checkpoint from: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("checkpoints.mainnet.sui.io")), port: None, path: "/122522000.chk", query: None, fragment: None }
2025-03-20T06:33:52.589472Z DEBUG walrus_sui::client::retry_client: Checkpoint download successful for sequence: 122521997
2025-03-20T06:33:52.590492Z DEBUG walrus_sui::client::retry_client: Checkpoint download successful for sequence: 122521998
2025-03-20T06:33:52.590693Z DEBUG walrus_sui::client::retry_client: Checkpoint download successful for sequence: 122521999
```

---

## Release notes

- [x] Storage node: Support a fallback bucket from which to get checkpoints if they are unavailable from the main RPC node. Can be activated by adding the following to the node configuration file (example for Mainnet):
  ```
  sui:
    ...
    rpc_fallback_config:
      checkpoint_bucket: https://checkpoints.mainnet.sui.io
  ```