### PR TITLE
PinCushion: Pin google-github-actions/setup-gcloud to commit hash

### DIFF
--- a/.github/workflows/attach-binaries-to-release.yml
+++ b/.github/workflows/attach-binaries-to-release.yml
@@ -71,7 +71,7 @@ jobs:
           ref: ${{ env.walrus_tag }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a # pin@v2
         with:
           version: ">= 363.0.0"
 


### PR DESCRIPTION
## Summary
This PR is to pin the GitHub Action `google-github-actions/setup-gcloud` to specific commit hash instead of using version tags or branch names. To do this we look at the references in the workflow files and resolve them to commit hashes.

## Files Changed
- `.github/workflows/attach-binaries-to-release.yml`

## Why?
Using commit hashes for GitHub Actions rather than version tags or branch references is good because:
- Prevents supply chain attacks where a tag could be moved to point to malicious code
- Ensures consistent CI/CD builds by pinning to a specific version
- Helps security sleep at night

## Testing
This PR only changes the action's references and doesn't modify any workflow logic. It should have no functional impact on the workflows. If it does, send a bug report to the PinCushion repo.

🚀 BUT STILL VERIFY THAT EVERYTHING WORKS AS EXPECTED! 🚀
