### PR TITLE
PinCushion: Pin marocchino/sticky-pull-request-comment to commit hash

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -134,7 +134,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/run_tarpaulin
       - name: Add coverage PR comment
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # pin@v2
         if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
         with:
           path: code-coverage-results.md
@@ -213,7 +213,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Post a warning if the PR touches the testnet-contracts directory
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # pin@v2
         with:
           message: >
             **Warning:** This PR touches the `testnet-contracts` directory. This should only be
@@ -234,7 +234,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Post a warning if the PR touches an example config file
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # pin@v2
         with:
           message: |
             **Warning:** This PR modifies one of the example config files. Please consider the
@@ -261,7 +261,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Post a warning if the PR touches an OpenAPI file
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # pin@v2
         with:
           message: |
             **Warning:** This PR modifies one of the OpenAPI files. Please consider the


### PR DESCRIPTION
## Summary
This PR is to pin the GitHub Action `marocchino/sticky-pull-request-comment` to specific commit hash instead of using version tags or branch names. To do this we look at the references in the workflow files and resolve them to commit hashes.

## Files Changed
- `.github/workflows/code.yml`

## Why?
Using commit hashes for GitHub Actions rather than version tags or branch references is good because:
- Prevents supply chain attacks where a tag could be moved to point to malicious code
- Ensures consistent CI/CD builds by pinning to a specific version
- Helps security sleep at night

## Testing
This PR only changes the action's references and doesn't modify any workflow logic. It should have no functional impact on the workflows. If it does, send a bug report to the PinCushion repo.

🚀 BUT STILL VERIFY THAT EVERYTHING WORKS AS EXPECTED! 🚀
