### PR TITLE
PinCushion: Pin amannn/action-semantic-pull-request to commit hash

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Check PR title
-        uses: amannn/action-semantic-pull-request@v5.5.3
+        uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # pin@v5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
This PR is to pin the GitHub Action `amannn/action-semantic-pull-request` to specific commit hash instead of using version tags or branch names. To do this we look at the references in the workflow files and resolve them to commit hashes.

## Files Changed
- `.github/workflows/lint.yml`

## Why?
Using commit hashes for GitHub Actions rather than version tags or branch references is good because:
- Prevents supply chain attacks where a tag could be moved to point to malicious code
- Ensures consistent CI/CD builds by pinning to a specific version
- Helps security sleep at night

## Testing
This PR only changes the action's references and doesn't modify any workflow logic. It should have no functional impact on the workflows. If it does, send a bug report to the PinCushion repo.

🚀 BUT STILL VERIFY THAT EVERYTHING WORKS AS EXPECTED! 🚀
