### PR TITLE
PinCushion: Pin actions/setup-node to commit hash

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # pin@v4
       - run: npm install @mysten/prettier-plugin-move@0.2.2
       - run: npx prettier-move -c **/*.move
 


### PR DESCRIPTION
## Summary
This PR is to pin the GitHub Action `actions/setup-node` to specific commit hash instead of using version tags or branch names. To do this we look at the references in the workflow files and resolve them to commit hashes.

## Files Changed
- `.github/workflows/lint.yml`

## Why?
Using commit hashes for GitHub Actions rather than version tags or branch references is good because:
- Prevents supply chain attacks where a tag could be moved to point to malicious code
- Ensures consistent CI/CD builds by pinning to a specific version
- Helps security sleep at night

## Testing
This PR only changes the action's references and doesn't modify any workflow logic. It should have no functional impact on the workflows. If it does, send a bug report to the PinCushion repo.

🚀 BUT STILL VERIFY THAT EVERYTHING WORKS AS EXPECTED! 🚀
