### PR TITLE
PinCushion: Pin crate-ci/typos to commit hash

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -71,7 +71,7 @@ jobs:
     name: Check spelling
     steps:
       - uses: actions/checkout@v4
-      - uses: crate-ci/typos@v1.30.1
+      - uses: crate-ci/typos@72f3776b6edc3a10a567b8e43fd0524b2a3f1419 # pin@v1.30.1
 
   shellcheck:
     name: ShellCheck


### PR DESCRIPTION
## Summary
This PR is to pin the GitHub Action `crate-ci/typos` to specific commit hash instead of using version tags or branch names. To do this we look at the references in the workflow files and resolve them to commit hashes.

## Files Changed
- `.github/workflows/lint.yml`

## Why?
Using commit hashes for GitHub Actions rather than version tags or branch references is good because:
- Prevents supply chain attacks where a tag could be moved to point to malicious code
- Ensures consistent CI/CD builds by pinning to a specific version
- Helps security sleep at night

## Testing
This PR only changes the action's references and doesn't modify any workflow logic. It should have no functional impact on the workflows. If it does, send a bug report to the PinCushion repo.

🚀 BUT STILL VERIFY THAT EVERYTHING WORKS AS EXPECTED! 🚀
