### PR TITLE
PinCushion: Pin julbme/gh-action-manage-tag to commit hash

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # Pin v4.1.1
 
       - name: Tag
-        uses: julbme/gh-action-manage-tag@v1
+        uses: julbme/gh-action-manage-tag@8daf6387badea2c6b8f989bd0f82b5a9ef1d84e6 # pin@v1
         with:
           name: ${{ env.TAG_NAME }}
           state: present


### PR DESCRIPTION
## Summary
This PR is to pin the GitHub Action `julbme/gh-action-manage-tag` to specific commit hash instead of using version tags or branch names. To do this we look at the references in the workflow files and resolve them to commit hashes.

## Files Changed
- `.github/workflows/tag.yml`

## Why?
Using commit hashes for GitHub Actions rather than version tags or branch references is good because:
- Prevents supply chain attacks where a tag could be moved to point to malicious code
- Ensures consistent CI/CD builds by pinning to a specific version
- Helps security sleep at night

## Testing
This PR only changes the action's references and doesn't modify any workflow logic. It should have no functional impact on the workflows. If it does, send a bug report to the PinCushion repo.

🚀 BUT STILL VERIFY THAT EVERYTHING WORKS AS EXPECTED! 🚀
