### PR TITLE
feat(cli): minor improvements to health output

### DIFF
--- a/crates/walrus-service/src/client/cli/cli_output.rs
+++ b/crates/walrus-service/src/client/cli/cli_output.rs
@@ -832,14 +832,15 @@ impl CliOutput for NodeHealthOutput {
     fn print_cli_output(&self) {
         printdoc! {"
 
-            {heading}: {node_name}
+            {heading}
             Node ID: {node_id}
             Node URL: {node_url}
+            Network public key: {network_public_key}
             ",
-            heading = "Node Information".bold().walrus_purple(),
-            node_name = self.node_name,
+            heading = self.node_name.bold().walrus_purple(),
             node_id = self.node_id,
-            node_url = self.node_url
+            node_url = self.node_url,
+            network_public_key = self.network_public_key,
         };
         match &self.health_info {
             Err(error) => {
@@ -1017,7 +1018,7 @@ fn create_node_health_table() -> Table {
         b->"Name",
         b->"Node ID",
         b->"Address",
-        b->"# Owned Shards",
+        bc->"# Shards\n(Ready / Owned)",
         b->"Status",
     ]);
     table
@@ -1026,12 +1027,16 @@ fn create_node_health_table() -> Table {
 fn add_node_health_to_table(table: &mut Table, node: &NodeHealthOutput, node_idx: usize) {
     match &node.health_info {
         Ok(health_info) => {
+            let shards_str = format!(
+                "{} / {}",
+                health_info.shard_summary.owned_shard_status.ready, health_info.shard_summary.owned
+            );
             table.add_row(row![
-                node_idx,
+                r->node_idx,
                 node.node_name,
                 node.node_id,
                 node.node_url,
-                r->health_info.shard_summary.owned,
+                c->shards_str,
                 health_info.node_status,
             ]);
         }
@@ -1045,11 +1050,11 @@ fn add_node_health_to_table(table: &mut Table, node: &NodeHealthOutput, node_idx
             };
 
             table.add_row(row![
-                node_idx,
+                r->node_idx,
                 node.node_name,
                 node.node_id,
                 node.node_url,
-                r->"N/A",
+                c->"N/A",
                 Fr->truncated_error,
             ]);
         }

--- a/crates/walrus-service/src/client/responses.rs
+++ b/crates/walrus-service/src/client/responses.rs
@@ -770,7 +770,7 @@ pub(crate) struct NodeHealthOutput {
     pub node_id: ObjectID,
     pub node_url: String,
     pub node_name: String,
-    /// The health information of the service.
+    pub network_public_key: NetworkPublicKey,
     pub health_info: Result<ServiceHealthInfo, String>,
 }
 
@@ -793,6 +793,7 @@ impl NodeHealthOutput {
             node_id: node.node_id,
             node_url: node.network_address.0.clone(),
             node_name: node.name,
+            network_public_key: node.network_public_key,
             health_info,
         }
     }


### PR DESCRIPTION
## Description

- add network public key
- add # ready shards to table
- use node name itself as heading
- minor formatting changes for table

## Test plan

Manual run. Top of the table:

```
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Idx  Name                             Node ID                                                             Address                                                     # Shards      Status 
                                                                                                                                                                    (Ready / Owned)   
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   0  4EVERLAND                        0x4aa91c8118aa80af50691e821d47d1515431d2a35410372f65a708ec17fac4aa  walrus-storage.4everland.org:9185                             0 / 1       Active 
   1  AlphaFi                          0xdcc5aa1cd704e86924539ad1d96338611a8c6c29462cb03a7927f5c31dc22f12  walrus.testnet.alphafi.xyz:9185                               0 / 1       Active 
   2  ankr-walrus-storage-node2        0xb7ff96c135908b90e30899200c55e2cf12074b6a6a018fd3230fd524898699e9  walrus-node-testnet.ankr.com:19185                           18 / 18      Active 
   3  Astro-Stakers                    0x4b261ec305b63533fb962aab18ff827700c8417ccb1345e47e13c22662f630fe  walrus.astrostakers.com:9185                                 18 / 18      Active 
   4  atalma.io                        0x4e3d73bad89ef7641af79e3cfb7db303fc5fd1851c063800ee4b78002c443fa1  testnet.walrus.atalma.io:9185                                 1 / 1       Active 
```
