### PR TITLE
chore: `v1.18.1` cherry-picks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11666,7 +11666,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-core"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11690,7 +11690,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-e2e-tests"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "anyhow",
  "futures",
@@ -11719,7 +11719,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-orchestrator"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "aws-config",
  "aws-runtime",
@@ -11748,7 +11748,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-proc-macros"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",
@@ -11759,7 +11759,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-proxy"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "anyhow",
  "axum 0.8.1",
@@ -11798,7 +11798,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-sdk"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "axum 0.8.1",
  "axum-server 0.7.2",
@@ -11830,7 +11830,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-service"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11926,7 +11926,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-simtest"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "anyhow",
  "futures",
@@ -11949,7 +11949,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-stress"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -11971,7 +11971,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-sui"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12016,7 +12016,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-test-utils"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -12026,7 +12026,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-utils"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "2"
 authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2021"
 license = "Apache-2.0"
-version = "1.18.0"
+version = "1.18.1"
 
 [workspace.dependencies]
 anyhow = "1.0.97"


### PR DESCRIPTION
## Description

Merge an important PR into the `v1.18` release:

- [ ] #1735 

## Test plan

Manual tests.

---

## Release notes

- [x] Storage node: Support a fallback bucket from which to get checkpoints if they are unavailable from the main RPC node. Can be activated by adding the following to the node configuration file (example for Mainnet):
  ```
  sui:
    ...
    rpc_fallback_config:
      checkpoint_bucket: https://checkpoints.mainnet.sui.io
  ```
