### PR TITLE
chore: disable RaptorQ encoding type in write path

### DIFF
--- a/crates/walrus-core/Cargo.toml
+++ b/crates/walrus-core/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 license.workspace = true
 
 [features]
-default = ["raptorq", "rs2"]
+default = ["rs2"]
 raptorq = []
 rs2 = []
 sui-types = ["dep:sui-types"]

--- a/crates/walrus-service/src/client/cli/args.rs
+++ b/crates/walrus-service/src/client/cli/args.rs
@@ -235,7 +235,7 @@ pub enum CliCommands {
         #[serde(default)]
         share: bool,
         /// The encoding type to use for encoding the files.
-        #[clap(long)]
+        #[clap(long, hide = true)]
         #[serde(default)]
         encoding_type: Option<EncodingType>,
     },
@@ -279,7 +279,7 @@ pub enum CliCommands {
         #[serde(default = "default::status_timeout")]
         timeout: Duration,
         /// The encoding type to use for encoding the file.
-        #[clap(long)]
+        #[clap(long, hide = true)]
         #[serde(default)]
         encoding_type: Option<EncodingType>,
         /// The URL of the Sui RPC node to use.
@@ -344,7 +344,7 @@ pub enum CliCommands {
         #[serde(flatten)]
         rpc_arg: RpcArg,
         /// The encoding type to use for computing the blob ID.
-        #[clap(long)]
+        #[clap(long, hide = true)]
         #[serde(default)]
         encoding_type: Option<EncodingType>,
     },
@@ -382,7 +382,7 @@ pub enum CliCommands {
         /// The encoding type to use for computing the blob ID.
         ///
         /// This is only used when running the command with the `--file` target.
-        #[clap(long)]
+        #[clap(long, hide = true)]
         #[serde(default)]
         encoding_type: Option<EncodingType>,
     },


### PR DESCRIPTION
## Description

Also hide the `--encoding-type` CLI option.

The binary still supports the original RedStuff encoding type for *reading* just not for *writing*. Complete removal of RaptorQ needs to wait until we redeploy Walrus Testnet.

## Test plan

CI + manual testing:

```
$ walrus store ~/hello --encoding-type RedStuffRaptorQ --epochs 1
Error: unsupported encoding type: RedStuff/RaptorQ

$ walrus read eUyCBl9h0he57BNP2VaWT8SdtCMOo_ZxhyIorC_KKf8 # encoded with RaptorQ
Hello Walrus!
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [x] Storage node: No longer accept blobs encoded with the `RedStuff/RaptorQ` encoding type.
- [x] Publisher: Remove support the `RedStuff/RaptorQ` encoding type.
- [x] CLI: Remove support for *writing* blobs using the `RedStuff/RaptorQ` encoding type.
