### PR TITLE
test: turn on event blob recovery simtest, also fix a race condition in event blob certification and reset

### DIFF
--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -2627,7 +2627,7 @@ pub fn storage_node_config() -> WithTempDir<StorageNodeConfig> {
             metadata: Default::default(),
             config_synchronizer: Default::default(),
             storage_node_cap: None,
-            num_uncertified_blob_threshold: Some(u32::MAX),
+            num_uncertified_blob_threshold: Some(3),
             balance_check: Default::default(),
         },
         temp_dir,


### PR DESCRIPTION
## Description

This PR enables the event blob recovery simtest, cleans up the test a bit, and fixed a race condition discovered by the test.

The race condition is found by the simtest where the following situation could cause the event blob progress to stuck
forever in the system, assuming 4 nodes cluster:

- node 1 certify event blob A
- node 2 certify event blob A
- node1 node2 crash
- node 3 certify event blob 1, blob 1 is now certified on chain
- node 1 and node 2 restart, their local last certified is different from the last certified onchain, which makes them stuck forever.
- Since node 1 and node 2 are all stuck, which cause the quorum cannot be formed, the event blob progress stuck.

The fix is to check that the local last certified is either the same as the global certified, or 1 blob before the global certified.

After the change, 100 tests passed.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
