### PR TITLE
feat: add an `OwnedGaugeGuard` and unique metric registrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12060,6 +12060,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "pin-project",
+ "prometheus",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -12068,6 +12069,7 @@ dependencies = [
  "tokio",
  "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
+ "walrus-test-utils",
 ]
 
 [[package]]

--- a/crates/walrus-service/src/backup/metrics.rs
+++ b/crates/walrus-service/src/backup/metrics.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use prometheus::{Gauge, GaugeVec, Histogram, IntCounter, IntCounterVec, Opts};
+use prometheus::{Gauge, GaugeVec, Histogram, IntCounter, IntCounterVec};
 
 walrus_utils::metrics::define_metric_set! {
     #[namespace = "walrus"]

--- a/crates/walrus-service/src/common/telemetry.rs
+++ b/crates/walrus-service/src/common/telemetry.rs
@@ -92,7 +92,7 @@ walrus_utils::metrics::define_metric_set! {
                 "error_type",
                 "http_response_status_code",
             ],
-            buckets: default_buckets_for_bytes()
+            buckets: walrus_utils::metrics::default_buckets_for_bytes()
         },
 
         #[help = "The size in bytes of the (compressed) response body."]
@@ -105,16 +105,9 @@ walrus_utils::metrics::define_metric_set! {
                 "error_type",
                 "http_response_status_code",
             ],
-            buckets: default_buckets_for_bytes()
+            buckets: walrus_utils::metrics::default_buckets_for_bytes()
         }
     }
-}
-
-/// Returns 21 buckets from <= 128 bytes to approx. <= 134 MB.
-///
-/// As prometheus includes a bucket to +Inf, values over 134 MB are still counted.
-fn default_buckets_for_bytes() -> Vec<f64> {
-    prometheus::exponential_buckets(128.0, 2.0, 21).expect("count, start, and factor are valid")
 }
 
 /// Struct to generate new [`tracing::Span`]s for HTTP requests.

--- a/crates/walrus-service/src/node/events/event_processor.rs
+++ b/crates/walrus-service/src/node/events/event_processor.rs
@@ -23,7 +23,7 @@ use move_core_types::{
     account_address::AccountAddress,
     annotated_value::{MoveDatatypeLayout, MoveTypeLayout},
 };
-use prometheus::{IntCounter, IntCounterVec, IntGauge, Opts, Registry};
+use prometheus::{IntCounter, IntCounterVec, IntGauge, Registry};
 use rocksdb::Options;
 use sui_package_resolver::{
     error::Error as PackageResolverError,

--- a/crates/walrus-service/src/node/metrics.rs
+++ b/crates/walrus-service/src/node/metrics.rs
@@ -9,7 +9,6 @@ use prometheus::{
     IntCounterVec,
     IntGauge,
     IntGaugeVec,
-    Opts,
 };
 use walrus_sui::types::{
     BlobCertified,

--- a/crates/walrus-utils/Cargo.toml
+++ b/crates/walrus-utils/Cargo.toml
@@ -10,7 +10,7 @@ backoff = ["dep:anyhow", "dep:rand", "dep:serde", "dep:serde_with", "dep:tracing
 config = ["dep:anyhow", "dep:home", "dep:serde", "dep:tracing"]
 default = []
 http = ["dep:bytes", "dep:http-body", "dep:pin-project"]
-metrics = []
+metrics = ["dep:prometheus"]
 test-utils = ["dep:tempfile", "tokio/sync"]
 
 [dependencies]
@@ -19,6 +19,7 @@ bytes = { workspace = true, optional = true }
 home = { workspace = true, optional = true }
 http-body = { version = "1", optional = true }
 pin-project = { workspace = true, optional = true }
+prometheus = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 serde_json = { workspace = true, optional = true }
@@ -32,3 +33,4 @@ tracing = { workspace = true, optional = true }
 http-body-util.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
+walrus-test-utils.workspace = true

--- a/crates/walrus-utils/src/metrics.rs
+++ b/crates/walrus-utils/src/metrics.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use prometheus::IntGauge;
+
 /// Defines a set of prometheus metrics.
 ///
 /// # Example
@@ -67,9 +69,21 @@ macro_rules! define_metric_set {
 
             /// Creates a new instance of the metric set.
             pub fn new(registry: &prometheus::Registry) -> Self {
+                // Create a unique ID for this instance of the defined metric set, which will be
+                // used to separate multiple instantiations of the metric, so that they can be
+                // registered together.
+                static TYPE_LOCAL_ID: std::sync::atomic::AtomicUsize =
+                    std::sync::atomic::AtomicUsize::new(0);
+                let metric_set_instance_id = format!(
+                    "{:?}::{}",
+                    std::any::TypeId::of::<Self>(),
+                    TYPE_LOCAL_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+                );
+
                 Self { $(
                     $field_name: {
-                        let opts = Opts::new(stringify!($field_name), $help_str)
+                        let opts = prometheus::Opts::new(stringify!($field_name), $help_str)
+                            .const_label("metric_set_instance_id", &metric_set_instance_id)
                             .namespace($namespace);
                         let metric = $crate::create_metric!($field_type, opts, $field_def);
                         registry
@@ -99,10 +113,6 @@ macro_rules! create_metric {
         <$field_type>::with_opts($opts.into())
             .expect("this must be called with valid metrics type and options")
     }};
-    ($field_type:ty, $opts:expr, [$($label_names:tt)+]) => {{
-        <$field_type>::new($opts.into(), &[$($label_names)+])
-            .expect("this must be called with valid metrics type and options")
-    }};
     (Histogram, $opts:expr, {buckets: $buckets:expr $(,)?}) => {{
         let mut opts: prometheus::HistogramOpts = $opts.into();
         opts.buckets = $buckets.into();
@@ -110,11 +120,15 @@ macro_rules! create_metric {
         prometheus::Histogram::with_opts(opts)
             .expect("this must be called with valid metrics type and options")
     }};
-    (HistogramVec, $opts:expr, {labels: [$($label_names:tt)+], buckets: $buckets:expr $(,)?}) => {{
+    (HistogramVec, $opts:expr, {labels: $label_names:expr, buckets: $buckets:expr $(,)?}) => {{
         let mut opts: prometheus::HistogramOpts = $opts.into();
         opts.buckets = $buckets.into();
 
-        prometheus::HistogramVec::new(opts, &[$($label_names)+])
+        prometheus::HistogramVec::new(opts, &$label_names)
+            .expect("this must be called with valid metrics type and options")
+    }};
+    ($field_type:ty, $opts:expr, $label_names:expr) => {{
+        <$field_type>::new($opts.into(), &$label_names)
             .expect("this must be called with valid metrics type and options")
     }};
 }
@@ -132,4 +146,36 @@ macro_rules! with_label {
     ($metric:expr, $label1:expr, $label2:expr, $label3:expr) => {
         $metric.with_label_values(&[$label1.as_ref(), $label2.as_ref(), $label3.as_ref()])
     };
+}
+
+/// Returns 21 buckets from <= 128 bytes to approx. <= 134 MB.
+///
+/// As prometheus includes a bucket to +Inf, values over 134 MB are still counted.
+pub fn default_buckets_for_bytes() -> Vec<f64> {
+    prometheus::exponential_buckets(128.0, 2.0, 21).expect("count, start, and factor are valid")
+}
+
+/// Concatenates to the two label lists into a vector.
+pub fn concat_labels<'a>(first: &[&'a str], second: &[&'a str]) -> Vec<&'a str> {
+    let mut output = Vec::with_capacity(first.len() + second.len());
+    output.extend_from_slice(first);
+    output.extend_from_slice(second);
+    output
+}
+
+/// Increments gauge when acquired, decrements when guard drops
+pub struct OwnedGaugeGuard(IntGauge);
+
+impl OwnedGaugeGuard {
+    /// Increment and take ownership of the gauge.
+    pub fn acquire(gauge: IntGauge) -> Self {
+        gauge.inc();
+        Self(gauge)
+    }
+}
+
+impl Drop for OwnedGaugeGuard {
+    fn drop(&mut self) {
+        self.0.dec();
+    }
 }


### PR DESCRIPTION
## Description

In addition to adding an owned variant of the `GaugeGuard`, this allows multiple instantiations of a struct created with `define_metric_set` to register their metrics to the same prometheus registry by adding a const-label derived from the struct and instance.

## Test plan

Existing tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
