### PR TITLE
chore: pin rossjrw/pr-preview-action to commit hash

### DIFF
--- a/.github/workflows/pages-preview.yaml
+++ b/.github/workflows/pages-preview.yaml
@@ -39,6 +39,6 @@ jobs:
           with_linkcheck: "false"
         if: github.event.action != 'closed'
       - name: Deploy preview
-        uses: rossjrw/pr-preview-action@v1.6.0
+        uses: rossjrw/pr-preview-action@df22037db54ab6ee34d3c1e2b8810ac040a530c6 # pin@v1.6.0
         with:
           source-dir: docs/build/html


### PR DESCRIPTION
## Summary
This PR is to pin the GitHub Action `rossjrw/pr-preview-action` to specific commit hash instead of using version tags or branch names. To do this we look at the references in the workflow files and resolve them to commit hashes.

## Files Changed
- `.github/workflows/pages-preview.yaml`

## Why?
Using commit hashes for GitHub Actions rather than version tags or branch references is good because:
- Prevents supply chain attacks where a tag could be moved to point to malicious code
- Ensures consistent CI/CD builds by pinning to a specific version
- Helps security sleep at night

## Testing
This PR only changes the action's references and doesn't modify any workflow logic. It should have no functional impact on the workflows. If it does, send a bug report to the PinCushion repo.

🚀 BUT STILL VERIFY THAT EVERYTHING WORKS AS EXPECTED! 🚀
