### PR TITLE
feat: add tokio metrics to major storage node tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10749,6 +10749,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-metrics"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb2bb07a8451c4c6fa8b3497ad198510d8b8dffa5df5cfb97a64102a58b113c8"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio-stream",
+]
+
+[[package]]
 name = "tokio-postgres"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12088,6 +12099,7 @@ dependencies = [
  "serde_with",
  "tempfile",
  "tokio",
+ "tokio-metrics",
  "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
  "walrus-test-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10756,6 +10756,7 @@ checksum = "cb2bb07a8451c4c6fa8b3497ad198510d8b8dffa5df5cfb97a64102a58b113c8"
 dependencies = [
  "futures-util",
  "pin-project-lite",
+ "tokio",
  "tokio-stream",
 ]
 
@@ -11958,6 +11959,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.12",
  "tokio",
+ "tokio-metrics",
  "tokio-stream",
  "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower 0.5.2",

--- a/crates/walrus-service/Cargo.toml
+++ b/crates/walrus-service/Cargo.toml
@@ -159,7 +159,7 @@ walrus-proc-macros = { workspace = true, features = ["derive-api-errors"] }
 walrus-sdk.workspace = true
 walrus-sui = { workspace = true, features = ["utoipa"] }
 walrus-test-utils = { workspace = true, optional = true }
-walrus-utils = { workspace = true, features = ["backoff", "config", "http", "metrics"] }
+walrus-utils = { workspace = true, features = ["backoff", "config", "http", "metrics", "tokio-metrics"] }
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/crates/walrus-service/Cargo.toml
+++ b/crates/walrus-service/Cargo.toml
@@ -142,6 +142,7 @@ telemetry-subscribers.workspace = true
 tempfile = { workspace = true, optional = true }
 thiserror.workspace = true
 tokio.workspace = true
+tokio-metrics = "0.4.0"
 tokio-stream = { workspace = true, optional = true }
 tokio-util = { workspace = true, optional = true }
 tower = { workspace = true, features = ["buffer", "limit", "load-shed", "util"] }

--- a/crates/walrus-service/src/client/daemon.rs
+++ b/crates/walrus-service/src/client/daemon.rs
@@ -47,7 +47,7 @@ use crate::{
         config::AuthConfig,
         daemon::auth::verify_jwt_claim,
     },
-    common::telemetry::{metrics_middleware, HttpServerMetrics, MakeHttpSpan},
+    common::telemetry::{metrics_middleware, MakeHttpSpan, MetricsMiddlewareState},
 };
 
 pub mod auth;
@@ -140,7 +140,7 @@ impl WalrusWriteClient for Client<SuiContractClient> {
 pub struct ClientDaemon<T> {
     client: Arc<T>,
     network_address: SocketAddr,
-    metrics: HttpServerMetrics,
+    metrics: MetricsMiddlewareState,
     router: Router<Arc<T>>,
     allowed_headers: Arc<HashSet<String>>,
 }
@@ -166,7 +166,7 @@ impl<T: WalrusReadClient + Send + Sync + 'static> ClientDaemon<T> {
         ClientDaemon {
             client: Arc::new(client),
             network_address,
-            metrics: HttpServerMetrics::new(registry),
+            metrics: MetricsMiddlewareState::new(registry),
             router: Router::new()
                 .merge(Redoc::with_url(routes::API_DOCS, A::openapi()))
                 .route(STATUS_ENDPOINT, get(routes::status)),

--- a/crates/walrus-service/src/node/server.rs
+++ b/crates/walrus-service/src/node/server.rs
@@ -28,7 +28,7 @@ use utoipa::OpenApi as _;
 use utoipa_redoc::{Redoc, Servable as _};
 use walrus_core::{encoding, keys::NetworkKeyPair};
 
-use self::telemetry::HttpServerMetrics;
+use self::telemetry::MetricsMiddlewareState;
 use super::config::{defaults, Http2Config, PathOrInPlace, StorageNodeConfig, TlsConfig};
 use crate::{
     common::telemetry::{self, MakeHttpSpan},
@@ -146,7 +146,7 @@ pub enum TlsCertificateSource {
 pub struct RestApiServer<S> {
     state: Arc<S>,
     config: RestApiConfig,
-    metrics: HttpServerMetrics,
+    metrics: MetricsMiddlewareState,
     cancel_token: CancellationToken,
     handle: Mutex<Option<Handle>>,
 }
@@ -164,7 +164,7 @@ where
     ) -> Self {
         Self {
             state,
-            metrics: HttpServerMetrics::new(registry),
+            metrics: MetricsMiddlewareState::new(registry),
             cancel_token,
             handle: Default::default(),
             config,

--- a/crates/walrus-test-utils/src/lib.rs
+++ b/crates/walrus-test-utils/src/lib.rs
@@ -114,7 +114,7 @@ macro_rules! param_test {
         $( $(#[$outer:meta])* $case_name:ident:
             $(<$($type_args:ty),+>)?( $($args:expr),* $(,)? ) ),+$(,)?
     ]) => {
-        param_test!(
+        $crate::param_test!(
             $func_name -> ():
             [ $( $(#[$outer])* $case_name: $(<$($type_args),+>)?( $($args),* ) ),+ ]
         );

--- a/crates/walrus-utils/Cargo.toml
+++ b/crates/walrus-utils/Cargo.toml
@@ -12,6 +12,7 @@ default = []
 http = ["dep:bytes", "dep:http-body", "dep:pin-project"]
 metrics = ["dep:prometheus"]
 test-utils = ["dep:tempfile", "tokio/sync"]
+tokio-metrics = ["dep:tokio-metrics"]
 
 [dependencies]
 anyhow = { workspace = true, optional = true }
@@ -26,6 +27,7 @@ serde_json = { workspace = true, optional = true }
 serde_with = { workspace = true, optional = true }
 tempfile = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"], optional = true }
+tokio-metrics = { version = "0.4.0", optional = true, default-features = false }
 tokio-util = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 

--- a/crates/walrus-utils/src/metrics.rs
+++ b/crates/walrus-utils/src/metrics.rs
@@ -7,7 +7,7 @@ use prometheus::IntGauge;
 mod tokio;
 
 #[cfg(all(feature = "tokio-metrics", feature = "metrics"))]
-pub use tokio::TaskMonitorCollector;
+pub use tokio::{TaskMonitorCollector, TaskMonitorFamily};
 
 /// Defines a set of prometheus metrics.
 ///

--- a/crates/walrus-utils/src/metrics.rs
+++ b/crates/walrus-utils/src/metrics.rs
@@ -3,14 +3,20 @@
 
 use prometheus::IntGauge;
 
+#[cfg(all(feature = "tokio-metrics", feature = "metrics"))]
+mod tokio;
+
+#[cfg(all(feature = "tokio-metrics", feature = "metrics"))]
+pub use tokio::TaskMonitorCollector;
+
 /// Defines a set of prometheus metrics.
 ///
 /// # Example
 ///
-/// ```
-/// define_metric_set! {
-///     /// Docstring applied to the containing struct.
+/// ```ignore
+/// walrus_utils::define_metric_set! {
 ///     #[namespace = "walrus"]
+///     /// Docstring applied to the containing struct.
 ///     struct MyMetricSet {
 ///         // Gauges, counters, and histograms can be defined with an empty `[]`.
 ///         #[help = "Help text and docstring for this metric"]

--- a/crates/walrus-utils/src/metrics/tokio.rs
+++ b/crates/walrus-utils/src/metrics/tokio.rs
@@ -1,0 +1,331 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+
+use prometheus::{
+    core::{Collector, Desc},
+    proto::{Counter, LabelPair, Metric, MetricFamily, MetricType},
+};
+use tokio_metrics::TaskMonitor;
+
+const TASK_METRICS_NAMESPACE: &str = "tokio_task_metrics";
+
+/// Implements the [`prometheus::core::Collector`] interface for the [`TaskMonitor`]
+///
+/// This allows task metrics to be collected by Prometheus.
+///
+/// The exported metrics are within the namespace `tokio_task_metrics` and metrics corresponding to
+/// durations have the suffix `_seconds` appended to their name and are exported in floating-point
+/// seconds.
+///
+/// Attached to each metric is the constant label `task` which can be specified when
+/// creating the `TaskMonitorCollector`.
+#[derive(Debug, Clone)]
+pub struct TaskMonitorCollector {
+    inner: TaskMonitor,
+    const_labels: HashMap<String, String>,
+    descriptions: Vec<Desc>,
+    metric_families: Vec<MetricFamily>,
+}
+
+impl Collector for TaskMonitorCollector {
+    fn desc(&self) -> Vec<&Desc> {
+        self.descriptions.iter().collect()
+    }
+
+    fn collect(&self) -> Vec<MetricFamily> {
+        self.collect_metrics()
+    }
+}
+
+impl TaskMonitorCollector {
+    /// Create a new instance of [`TaskMonitorCollector`] with the specified task name.
+    pub fn new(monitor: TaskMonitor, task: String) -> Self {
+        let const_labels = [("task".to_owned(), task)].into_iter().collect();
+        let mut this = Self {
+            inner: monitor,
+            descriptions: vec![],
+            metric_families: vec![],
+            const_labels,
+        };
+
+        this.initialize_descriptions();
+        this.initialize_families();
+        this
+    }
+
+    #[cfg(test)]
+    fn monitor(&self) -> &TaskMonitor {
+        &self.inner
+    }
+
+    /// Initialize the metric families, so that each time metrics are collected, we only need to
+    /// clone the families and update their values.
+    fn initialize_families(&mut self) {
+        assert!(
+            !self.descriptions.is_empty(),
+            "initialize descriptions first"
+        );
+        let mut families = Vec::with_capacity(self.descriptions.len());
+
+        for description in &self.descriptions {
+            let mut family = MetricFamily::new();
+            family.set_name(description.fq_name.clone());
+            family.set_help(description.help.clone());
+
+            // We only record accumulating values, so everything is a counter.
+            family.set_field_type(MetricType::COUNTER);
+
+            // The only labels attached to each metric are the const labels, which means each
+            // family only has a single metric.
+            let mut metric = Metric::new();
+            let labels = self
+                .const_labels
+                .iter()
+                .map(|(name, value)| to_label_pair(name, value))
+                .collect();
+            metric.set_label(labels);
+            metric.set_counter(Counter::new());
+
+            family.set_metric(vec![metric].into());
+
+            families.push(family);
+        }
+
+        self.metric_families = families;
+    }
+}
+
+macro_rules! convert_metrics {
+    (
+        $name:ident: [
+            $(
+                #[help = $help_str:literal]
+                $metric_spec:tt
+            ),* $(,)?
+        ]
+    ) => {
+        impl $name {
+            /// Initialize the descriptions of the metrics to the values that will always be
+            /// returned.
+            fn initialize_descriptions(
+                &mut self,
+            )  {
+                self.descriptions = vec![
+                    $(
+                        Desc::new(
+                            convert_metrics!(@fq_name $metric_spec),
+                            $help_str.to_owned(),
+                            vec![],
+                            self.const_labels.clone(),
+                        )
+                        .expect("compile-time defined metric descriptions do not err")
+                    ),+
+                ];
+            }
+
+            fn collect_metrics(&self) -> Vec<MetricFamily> {
+                let tokio_metrics = self.inner.cumulative();
+                let mut metric_families = self.metric_families.clone();
+                let mut index = 0usize;
+
+                $(
+                    metric_families[index]
+                        .mut_metric()
+                        .first_mut()
+                        .expect("all families were defined with exactly 1 metric")
+                        .mut_counter()
+                        .set_value(convert_metrics!(@as_f64 $metric_spec tokio_metrics));
+
+                    // The very last assignment in the unrolled loop is unused.
+                    #[allow(unused_assignments)]
+                    {
+                        index += 1;
+                    }
+                )+
+
+                metric_families
+            }
+        }
+    };
+    (@fq_name ($_original_name:tt -> $name:ident)) => { convert_metrics!(@fq_name $name) };
+    (@fq_name $name:ident) => {
+        format!("{}_{}", TASK_METRICS_NAMESPACE, stringify!($name))
+    };
+
+    (@as_f64 (($name:ident in seconds) -> $_:tt) $tokio_metrics:ident) => {
+        ($tokio_metrics.$name).as_secs_f64()
+    };
+    (@as_f64 $name:ident $tokio_metrics:ident) => {
+        ($tokio_metrics.$name) as f64
+    };
+}
+
+convert_metrics! {
+    TaskMonitorCollector: [
+        #[help = "Total number of tasks instrumented."]
+        instrumented_count,
+
+        #[help = "Total number of tasks that were dropped."]
+        dropped_count,
+
+        #[help = "Total number of tasks that were polled for the first time."]
+        first_poll_count,
+
+        #[help = "Total duration (in seconds) elapsed between the instant tasks are instrumented \
+        and the instant they are first polled."]
+        ((total_first_poll_delay in seconds) -> total_first_poll_delay_seconds),
+
+        #[help = "Total number of times that tasks idled, waiting to be awoken"]
+        total_idled_count,
+
+        #[help = "Total duration (in seconds) that tasks idled"]
+        ((total_idle_duration in seconds) -> total_idle_duration_seconds),
+
+        #[help = "Total number of times that tasks were awoken (and then, presumably, \
+        scheduled for execution)"]
+        total_scheduled_count,
+
+        #[help = "Total duration (in seconds) that tasks spent waiting to be polled after \
+        awakening."]
+        ((total_scheduled_duration in seconds) -> total_scheduled_duration_seconds),
+
+        #[help = "Total number of times that tasks were polled."]
+        total_poll_count,
+
+        #[help = "Total duration (in seconds) elapsed during polls."]
+        ((total_poll_duration in seconds) -> total_poll_duration_seconds),
+
+        #[help = "Total number of times polling tasks completed swiftly."]
+        total_fast_poll_count,
+
+        #[help = "Total duration (in seconds) of fast polls."]
+        ((total_fast_poll_duration in seconds) -> total_fast_poll_duration_seconds),
+
+        #[help = "Total number of times polling tasks completed slowly."]
+        total_slow_poll_count,
+
+        #[help = "Total duration (in seconds) of slow polls."]
+        ((total_slow_poll_duration in seconds) -> total_slow_poll_duration_seconds),
+
+        #[help = "Total count of tasks with short scheduling delays."]
+        total_short_delay_count,
+
+        #[help = "Total count of tasks with long scheduling delays."]
+        total_long_delay_count,
+
+        #[help = "Total duration of tasks with short scheduling delays."]
+        ((total_short_delay_duration in seconds) -> total_short_delay_duration_seconds),
+
+        #[help = "Total duration of tasks with long scheduling delays."]
+        ((total_long_delay_duration in seconds) -> total_long_delay_duration_seconds),
+    ]
+}
+
+fn to_label_pair(name: &str, value: &str) -> LabelPair {
+    let mut pair = LabelPair::new();
+    pair.set_name(name.to_owned());
+    pair.set_value(value.to_owned());
+    pair
+}
+
+#[cfg(test)]
+mod test {
+    use prometheus::{proto::Counter, Registry};
+
+    use super::*;
+
+    fn task_monitor_collector() -> TaskMonitorCollector {
+        TaskMonitorCollector::new(TaskMonitor::default(), "test_monitor".to_owned())
+    }
+
+    walrus_test_utils::param_test! {
+        descriptions_are_present: [
+            instrumented_count: ("tokio_task_metrics_instrumented_count"),
+            total_long_delay_duration: ("tokio_task_metrics_total_long_delay_duration_seconds"),
+        ]
+    }
+    fn descriptions_are_present(fq_name: &str) {
+        let collector = task_monitor_collector();
+        let descriptions = collector.desc();
+
+        let desc = descriptions
+            .iter()
+            .find(|desc| desc.fq_name == fq_name)
+            .expect("description must be present");
+        assert_eq!(desc.const_label_pairs[0].get_name(), "task");
+        assert_eq!(desc.const_label_pairs[0].get_value(), "test_monitor");
+    }
+
+    fn find_by_fqname<'a>(metrics: &'a [MetricFamily], fq_name: &str) -> Option<&'a MetricFamily> {
+        metrics.iter().find(|metric| metric.get_name() == fq_name)
+    }
+
+    fn as_counter(family: &MetricFamily) -> &Counter {
+        family
+            .get_metric()
+            .first()
+            .expect("must have at least one metric in the family")
+            .get_counter()
+    }
+
+    #[tokio::test]
+    async fn sanity_test_counters() {
+        let monitor = task_monitor_collector();
+
+        let collected_metrics = monitor.collect();
+        let metric_family =
+            find_by_fqname(&collected_metrics, "tokio_task_metrics_instrumented_count")
+                .expect("metric must exist in collection");
+
+        // 0 tasks have been instrumented
+        assert_eq!(as_counter(metric_family).get_value(), 0.0);
+
+        monitor.monitor().instrument(async {});
+
+        let collected_metrics = monitor.collect();
+        let metric_family =
+            find_by_fqname(&collected_metrics, "tokio_task_metrics_instrumented_count")
+                .expect("metric must exist in collection");
+        // 1 task has been instrumented
+        assert_eq!(as_counter(metric_family).get_value(), 1.0);
+
+        monitor.monitor().instrument(async {});
+        monitor.monitor().instrument(async {});
+
+        let collected_metrics = monitor.collect();
+        let metric_family =
+            find_by_fqname(&collected_metrics, "tokio_task_metrics_instrumented_count")
+                .expect("metric must exist in collection");
+        // 3 tasks in total have been instrumented
+        assert_eq!(as_counter(metric_family).get_value(), 3.0);
+    }
+
+    #[test]
+    fn registers_successfully() {
+        let registry = Registry::default();
+        registry
+            .register(Box::new(task_monitor_collector()))
+            .expect("should successfully register");
+    }
+
+    #[test]
+    fn monitors_with_different_names_can_both_be_registered() {
+        let registry = Registry::default();
+
+        registry
+            .register(Box::new(TaskMonitorCollector::new(
+                TaskMonitor::default(),
+                "test_monitor1".to_owned(),
+            )))
+            .expect("first monitor should successfully register");
+
+        registry
+            .register(Box::new(TaskMonitorCollector::new(
+                TaskMonitor::default(),
+                "test_monitor2".to_owned(),
+            )))
+            .expect("second monitor should successfully register");
+    }
+}


### PR DESCRIPTION
## Description

This enables the use of the `tokio-metrics` crate with the `prometheus::Registry` and instruments HTTP routes, event processing, and blob sync tasks `tokio_metrics::TaskMonitor` to record metrics for when tasks are poll slowly or are scheduled but delayed to be run due to other tasks polling slowly.

## Test plan

Local testbed and a unit tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
