### PR TITLE
docs: added section on storage costs

### DIFF
--- a/docs/book/SUMMARY.md
+++ b/docs/book/SUMMARY.md
@@ -31,7 +31,7 @@
 - [Developer guide](./dev-guide/dev-guide.md)
   - [Components](./dev-guide/components.md)
   - [Operations](./dev-guide/dev-operations.md)
-  - [Storage Costs](./dev-guide/costs.md)
+  - [Storage costs](./dev-guide/costs.md)
   - [Sui structures](./dev-guide/sui-struct.md)
 - [Operator guide](./operator-guide/operator-guide.md)
   - [Storage node](./operator-guide/storage-node.md)


### PR DESCRIPTION
## Description

Added a section explaining storage costs and how to minimise them.

Closes WAL-623.

## Test plan

Proof read and linter appeasement.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
