### PR TITLE
fix(node): add fallback for checkpoint summary

### DIFF
--- a/crates/checkpoint-downloader/src/downloader.rs
+++ b/crates/checkpoint-downloader/src/downloader.rs
@@ -172,7 +172,7 @@ impl ParallelCheckpointDownloaderInner {
         let Ok(Some(current_checkpoint)) = checkpoint_store.get(&()) else {
             return Err(anyhow!("Failed to get current checkpoint"));
         };
-        let latest_checkpoint = client.get_latest_checkpoint().await?;
+        let latest_checkpoint = client.get_latest_checkpoint_summary().await?;
         let current_lag =
             latest_checkpoint.sequence_number - current_checkpoint.inner().sequence_number;
         Ok(current_lag)

--- a/crates/walrus-service/src/common/event_blob_downloader.rs
+++ b/crates/walrus-service/src/common/event_blob_downloader.rs
@@ -55,8 +55,7 @@ impl EventBlobDownloader {
         };
 
         tracing::info!(
-            "Starting downloading event blobs using event blobs from latest blob ID {:?} \
-            and going backwards",
+            "starting download of event blobs from latest blob ID {} and going backwards",
             prev_event_blob
         );
 
@@ -125,14 +124,13 @@ impl EventBlobDownloader {
                     - event_blob.start_checkpoint_sequence_number()
                     + 1;
                 tracing::info!(
-                    "Storing event blob {:?} with {} checkpoints",
+                    "storing event blob {} with {} checkpoints",
                     prev_event_blob,
                     num_checkpoints_stored
                 );
             } else {
                 tracing::info!(
-                    "Skipping event blob {:?} as it contains events only before the next \
-                    checkpoint",
+                    "skipping event blob {} as it contains events only before the next checkpoint",
                     prev_event_blob
                 );
                 break;

--- a/crates/walrus-service/src/common/utils.rs
+++ b/crates/walrus-service/src/common/utils.rs
@@ -769,6 +769,8 @@ pub async fn collect_event_blobs_for_catchup(
     let blob_ids = blob_downloader
         .download(upto_checkpoint, None, recovery_path, metrics)
         .await?;
+
+    tracing::info!("successfully downloaded {} event blobs", blob_ids.len());
     Ok(blob_ids)
 }
 

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -2647,7 +2647,7 @@ async fn wait_for_event_processor_to_start(
 ) -> anyhow::Result<()> {
     // Wait until event processor is actually running and downloaded a few checkpoints
     tokio::time::sleep(Duration::from_secs(5)).await;
-    let checkpoint = client.get_latest_checkpoint().await?;
+    let checkpoint = client.get_latest_checkpoint_summary().await?;
     while let Some(event_processor_checkpoint) = event_processor.stores.checkpoint_store.get(&())? {
         if event_processor_checkpoint.inner().sequence_number >= checkpoint.sequence_number {
             break;


### PR DESCRIPTION
## Description

- Get checkpoint summary from fallback bucket if primary RPC fails.
- Add/improve some logging for event-blob handling.
- Minor refactoring.

Closes WAL-721

## Test plan

Compare catchup (`NO_COLOR=1 RUST_LOG=info,walrus_sui::client::retry_client=debug ./target/release/walrus-node catchup --db-path /tmp/catchup --system-object-id 0x2134d52768ea07e8c43570ef975eb3e4c27a39fa6396bef985b5abc58d03ddd2 --staking-object-id 0x10b9d30c28448939ce6c4d6c6e0ffce4a7f8a4ada8248bdad09ef8b70e4a3904 --sui-rpc-url "https://mysten-rpc.mainnet.sui.io:443" --event-stream-catchup-min-checkpoint-lag 100000 --checkpoint-bucket https://checkpoints.mainnet.sui.io 2>&1 | tee /tmp/logs`) on Mainnet with and without this change.

<details><summary>Before</summary>
<pre><code>
2025-03-26T16:31:13.594624Z DEBUG wal_type_from_package{package_id=0xfdc88f7d7cf30afab2f82e8380d11ee8f70efb90e863d1de8616fae1bb09ea77}: walrus_sui::client::retry_client: WAL type wal_type="0x356a26eb9e012a68958082340d4c4116e7f55615cf27affcff209cf0ae544f59::wal::WAL"
2025-03-26T16:31:13.705389Z  INFO walrus_service::node::events: the configured full node provides the required REST endpoint for event processing
2025-03-26T16:31:14.033386Z  INFO walrus_service::node::events::event_processor: Starting event catchup using event blobs
2025-03-26T16:31:14.154393Z DEBUG wal_type_from_package{package_id=0xfdc88f7d7cf30afab2f82e8380d11ee8f70efb90e863d1de8616fae1bb09ea77}: walrus_sui::client::retry_client: WAL type wal_type="0x356a26eb9e012a68958082340d4c4116e7f55615cf27affcff209cf0ae544f59::wal::WAL"
2025-03-26T16:31:14.840720Z  INFO walrus_service::common::event_blob_downloader: Starting downloading event blobs using event blobs from latest blob ID BlobId(s4TUb-hL032SBjyWGuUqJ8IkfZhlnT9jHY03raV1-tA) and going backwards
2025-03-26T16:31:16.659258Z  INFO walrus_service::common::event_blob_downloader: finished reading event blob blob_id=s4TUb-hL032SBjyWGuUqJ8IkfZhlnT9jHY03raV1-tA
2025-03-26T16:31:16.659275Z  INFO walrus_service::common::event_blob_downloader: Storing event blob BlobId(s4TUb-hL032SBjyWGuUqJ8IkfZhlnT9jHY03raV1-tA) with 216000 checkpoints

[Similar lines removed...]

2025-03-26T16:31:43.733040Z  INFO walrus_service::common::event_blob_downloader: finished reading event blob blob_id=Ma7oTabS9HNwNPhxQPREtCA6QENQmAqKPJzRAgFBf0c
2025-03-26T16:31:43.733051Z  INFO walrus_service::common::event_blob_downloader: Storing event blob BlobId(Ma7oTabS9HNwNPhxQPREtCA6QENQmAqKPJzRAgFBf0c) with 216000 checkpoints
2025-03-26T16:31:43.734626Z  INFO walrus_service::client::refresh: the channel is closed, stopping the refresher
2025-03-26T16:31:43.840266Z DEBUG walrus_sui::client::retry_client: non-retriable error, returning last failure value
2025-03-26T16:31:43.843249Z ERROR walrus_service::node::events::event_processor: Failed to catch up using event blobs e=RPC error: status: NotFound, message: "data from requested checkpoint 122735926 has been pruned", details: [8, 5, 18, 56, 100, 97, 116, 97, 32, 102, 114, 111, 109, 32, 114, 101, 113, 117, 101, 115, 116, 101, 100, 32, 99, 104, 101, 99, 107, 112, 111, 105, 110, 116, 32, 49, 50, 50, 55, 51, 53, 57, 50, 54, 32, 104, 97, 115, 32, 98, 101, 101, 110, 32, 112, 114, 117, 110, 101, 100], metadata: MetadataMap { headers: {"content-type": "application/grpc", "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000", "via": "1.1 google", "content-length": "0", "x-sui-chain-id": "35834a8a", "x-sui-chain": "mainnet", "x-sui-epoch": "713", "x-sui-checkpoint-height": "126955417", "x-sui-timestamp-ms": "1743006703276", "x-sui-timestamp": "2025-03-26T16:31:43.276Z", "x-sui-lowest-available-checkpoint": "125422366", "x-sui-lowest-available-checkpoint-objects": "125807816", "vary": "origin, access-control-request-method, access-control-request-headers", "access-control-allow-origin": "*", "server-timing": "finish_request;dur=0", "date": "Wed, 26 Mar 2025 16:31:43 GMT"} }

Caused by:
    status: NotFound, message: "data from requested checkpoint 122735926 has been pruned", details: [8, 5, 18, 56, 100, 97, 116, 97, 32, 102, 114, 111, 109, 32, 114, 101, 113, 117, 101, 115, 116, 101, 100, 32, 99, 104, 101, 99, 107, 112, 111, 105, 110, 116, 32, 49, 50, 50, 55, 51, 53, 57, 50, 54, 32, 104, 97, 115, 32, 98, 101, 101, 110, 32, 112, 114, 117, 110, 101, 100], metadata: MetadataMap { headers: {"content-type": "application/grpc", "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000", "via": "1.1 google", "content-length": "0", "x-sui-chain-id": "35834a8a", "x-sui-chain": "mainnet", "x-sui-epoch": "713", "x-sui-checkpoint-height": "126955417", "x-sui-timestamp-ms": "1743006703276", "x-sui-timestamp": "2025-03-26T16:31:43.276Z", "x-sui-lowest-available-checkpoint": "125422366", "x-sui-lowest-available-checkpoint-objects": "125807816", "vary": "origin, access-control-request-method, access-control-request-headers", "access-control-allow-origin": "*", "server-timing": "finish_request;dur=0", "date": "Wed, 26 Mar 2025 16:31:43 GMT"} }

Stack backtrace:
   0: std::backtrace::Backtrace::create
2025-03-26T16:31:44.316348Z DEBUG get_full_checkpoint{sequence=122519926}: walrus_sui::client::retry_client: primary client error while fetching checkpoint: RpcError(Status { code: NotFound, message: "data from requested checkpoint 122519926 has been pruned", details: b"\x08\x05\x128data from requested checkpoint 122519926 has been pruned", metadata: MetadataMap { headers: {"content-type": "application/grpc", "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000", "via": "1.1 google", "content-length": "0", "x-sui-chain-id": "35834a8a", "x-sui-chain": "mainnet", "x-sui-epoch": "713", "x-sui-checkpoint-height": "126955419", "x-sui-timestamp-ms": "1743006703784", "x-sui-timestamp": "2025-03-26T16:31:43.784Z", "x-sui-lowest-available-checkpoint": "125422366", "x-sui-lowest-available-checkpoint-objects": "125807816", "vary": "origin, access-control-request-method, access-control-request-headers", "access-control-allow-origin": "*", "server-timing": "finish_request;dur=0", "date": "Wed, 26 Mar 2025 16:31:43 GMT"} }, source: None })
</code></pre>
</details>


<details><summary>After</summary>
<pre><code>
2025-03-26T16:36:21.152050Z DEBUG wal_type_from_package{package_id=0xfdc88f7d7cf30afab2f82e8380d11ee8f70efb90e863d1de8616fae1bb09ea77}: walrus_sui::client::retry_client: WAL type wal_type="0x356a26eb9e012a68958082340d4c4116e7f55615cf27affcff209cf0ae544f59::wal::WAL"
2025-03-26T16:36:21.255302Z  INFO walrus_service::node::events: the configured full node provides the required REST endpoint for event processing
2025-03-26T16:36:21.619532Z  INFO walrus_service::node::events::event_processor: Starting event catchup using event blobs
2025-03-26T16:36:21.771517Z DEBUG wal_type_from_package{package_id=0xfdc88f7d7cf30afab2f82e8380d11ee8f70efb90e863d1de8616fae1bb09ea77}: walrus_sui::client::retry_client: WAL type wal_type="0x356a26eb9e012a68958082340d4c4116e7f55615cf27affcff209cf0ae544f59::wal::WAL"
2025-03-26T16:36:22.440480Z  INFO walrus_service::common::event_blob_downloader: starting download of event blobs from latest blob ID s4TUb-hL032SBjyWGuUqJ8IkfZhlnT9jHY03raV1-tA and going backwards
2025-03-26T16:36:24.626541Z  INFO walrus_service::common::event_blob_downloader: finished reading event blob blob_id=s4TUb-hL032SBjyWGuUqJ8IkfZhlnT9jHY03raV1-tA
2025-03-26T16:36:24.626560Z  INFO walrus_service::common::event_blob_downloader: storing event blob s4TUb-hL032SBjyWGuUqJ8IkfZhlnT9jHY03raV1-tA with 216000 checkpoints

[Similar lines removed...]

2025-03-26T16:36:52.790290Z  INFO walrus_service::common::event_blob_downloader: finished reading event blob blob_id=Ma7oTabS9HNwNPhxQPREtCA6QENQmAqKPJzRAgFBf0c
2025-03-26T16:36:52.790304Z  INFO walrus_service::common::event_blob_downloader: storing event blob Ma7oTabS9HNwNPhxQPREtCA6QENQmAqKPJzRAgFBf0c with 216000 checkpoints
2025-03-26T16:36:52.791831Z  INFO walrus_service::common::utils: successfully downloaded 20 event blobs
2025-03-26T16:36:52.791849Z  INFO walrus_service::client::refresh: the channel is closed, stopping the refresher
2025-03-26T16:36:52.803502Z  INFO walrus_service::node::events::event_processor: starting to process event blobs
2025-03-26T16:36:52.905818Z DEBUG walrus_sui::client::retry_client: non-retriable error, returning last failure value
2025-03-26T16:36:52.905827Z  INFO walrus_sui::client::retry_client: falling back to fallback client to fetch checkpoint summary
2025-03-26T16:36:52.905829Z  INFO walrus_sui::client::retry_client: fetching checkpoint from fallback client sequence_number=122735926
2025-03-26T16:36:52.905836Z DEBUG walrus_sui::client::retry_client: downloading checkpoint from fallback bucket url=https://checkpoints.mainnet.sui.io/122735926.chk
2025-03-26T16:36:52.990985Z DEBUG walrus_sui::client::retry_client: checkpoint download successful sequence_number=122735926
2025-03-26T16:36:53.050815Z  INFO walrus_service::node::events::event_processor: processed event blob Ma7oTabS9HNwNPhxQPREtCA6QENQmAqKPJzRAgFBf0c with 216000 events, last event index: 215999

[Similar lines removed...]

2025-03-26T16:36:57.971308Z DEBUG walrus_sui::client::retry_client: non-retriable error, returning last failure value
2025-03-26T16:36:57.971316Z  INFO walrus_sui::client::retry_client: falling back to fallback client to fetch checkpoint summary
2025-03-26T16:36:57.971317Z  INFO walrus_sui::client::retry_client: fetching checkpoint from fallback client sequence_number=125327926
2025-03-26T16:36:57.971324Z DEBUG walrus_sui::client::retry_client: downloading checkpoint from fallback bucket url=https://checkpoints.mainnet.sui.io/125327926.chk
2025-03-26T16:36:58.355169Z DEBUG walrus_sui::client::retry_client: checkpoint download successful sequence_number=125327926
2025-03-26T16:36:58.421918Z  INFO walrus_service::node::events::event_processor: processed event blob f8uMA1tzmCzhZhlc7ASGCYc2Txtom_8GyHYwJ835wnc with 216000 events, last event index: 2807999
2025-03-26T16:36:58.589863Z  INFO walrus_service::node::events::event_processor: processed event blob cVW1Y3ziqs0jO5x2QuSteJ0Y6dmQZLHVglBComQ5GyQ with 216000 events, last event index: 3023999
2025-03-26T16:36:58.789507Z  INFO walrus_service::node::events::event_processor: processed event blob m8AInF5eu4ELopMub4XwsNz_U7pZyZdTu9FwpQm9GYo with 216000 events, last event index: 3239999
2025-03-26T16:36:58.952818Z  INFO walrus_service::node::events::event_processor: processed event blob -zpRCIdhM8mbs6Q8ODuLuPvhqMnJ2sJhIbJU86I7TaQ with 216000 events, last event index: 3455999
2025-03-26T16:36:59.169680Z  INFO walrus_service::node::events::event_processor: processed event blob PTC9TufWbyX2R-U3FwYqkNGz5UykHtcUc5YYp67Aq0c with 216000 events, last event index: 3671999
2025-03-26T16:36:59.352643Z  INFO walrus_service::node::events::event_processor: processed event blob p-4kVr54Snz9_YhQnmn_KEedEm7UgG8h9aDjFPXNQTk with 216000 events, last event index: 3887999
2025-03-26T16:36:59.516077Z  INFO walrus_service::node::events::event_processor: processed event blob y-MbHbvop15AvVNs-o9QoLOgskplJu0d6ZjAwQyKuWE with 216234 events, last event index: 4104233
2025-03-26T16:36:59.684188Z  INFO walrus_service::node::events::event_processor: processed event blob s4TUb-hL032SBjyWGuUqJ8IkfZhlnT9jHY03raV1-tA with 221929 events, last event index: 4326162
2025-03-26T16:36:59.686666Z  INFO walrus_service::node::events::event_processor: recovered 4326163 events from event blobs
2025-03-26T16:36:59.686676Z  INFO walrus_service::node::events::event_processor: successfully caught up using event blobs
2025-03-26T16:36:59.686830Z  INFO walrus_service::node::events::event_processor: Starting event processor
</code></pre>
</details>