### PR TITLE
ci: enable automatic updates for {bin,docs}.wal.app

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -23,6 +23,9 @@ on:
         type: boolean
         required: true
         default: false
+  schedule:
+    # Update Walrus Site every first day of the month at 03:14 UTC.
+    - cron: "14 3 1 * *"
 
 concurrency: ci-${{ github.ref }}
 
@@ -54,12 +57,13 @@ jobs:
   publish-walrus:
     name: Update Walrus Site
     runs-on: ubuntu-ghcloud
-    # TODO(WAL-698): enable this when Mainnet is live and we have finished the setup.
-    # if: ${{ github.event_name == 'push' || inputs.update-walrus-site == true }}
-    if: false
+    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || inputs.update-walrus-site == true }}
     env:
       # Colors don't seem to work properly with the multiline commands.
       NO_COLOR: 1
+      RUST_LOG: info
+      EPOCHS: 10
+      BUILD_DIR: docs/build/html
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
       - uses: ./.github/actions/build-mdbook
@@ -72,10 +76,17 @@ jobs:
           WALRUS_CONFIG: "${{ vars.WALRUS_CONFIG }}"
           SUI_NETWORK: mainnet
 
+      # TODO: Remove this step once the site-builder supports supports storing multiple blobs
+      # simultaneously.
+      - name: Store blobs on Walrus
+        run: >
+          walrus store
+          $(find ${{ env.BUILD_DIR }} -type f -exec echo -n ' {}' \;)
+          --deletable --epochs ${{ env.EPOCHS }}
+
       - name: Update Walrus Site
         run: >
-          RUST_LOG=site_builder=debug,walrus=debug,info
           site-builder
-          update docs/build/html ${{ vars.WALRUS_SITE_OBJECT }}
-          --epochs 183
+          update ${{ env.BUILD_DIR }} ${{ vars.WALRUS_SITE_OBJECT_DOCS }}
+          --epochs ${{ env.EPOCHS }}
           --force

--- a/.github/workflows/update-ws-binaries.yaml
+++ b/.github/workflows/update-ws-binaries.yaml
@@ -24,6 +24,9 @@ jobs:
     env:
       # Colors don't seem to work properly with the multiline commands.
       NO_COLOR: 1
+      RUST_LOG: info
+      EPOCHS: 10
+      BUILD_DIR: site
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
       - uses: ./.github/actions/set-up-walrus
@@ -34,20 +37,25 @@ jobs:
           SUI_NETWORK: mainnet
 
       - name: Create temporary directory
-        run: "mkdir -p site"
+        run: "mkdir -p ${{ env.BUILD_DIR }}"
       - name: Download latest mainnet and testnet binaries
         run: |
           for arch in ubuntu-x86_64 ubuntu-x86_64-generic macos-x86_64 macos-arm64 windows-x86_64.exe; do
           for env in mainnet testnet; do
           name=walrus-$env-latest-$arch
-          curl https://storage.googleapis.com/mysten-walrus-binaries/$name -o site/$name
+          curl https://storage.googleapis.com/mysten-walrus-binaries/$name -o ${{ env.BUILD_DIR }}/$name
           done
           done
 
+      # TODO: Remove this step once the site-builder supports supports storing multiple blobs
+      # simultaneously.
+      - name: Store blobs on Walrus
+        run: walrus store ${{ env.BUILD_DIR }}/* --epochs ${{ env.EPOCHS }}
+
       - name: Update Walrus Site
         run: >
-          RUST_LOG=site_builder=debug,walrus=debug,info
           site-builder
-          update --list-directory site ${{ vars.WALRUS_SITE_BIN_OBJECT }}
-          --epochs 183
+          update --list-directory ${{ env.BUILD_DIR }} ${{ vars.WALRUS_SITE_OBJECT_BIN }}
+          --epochs ${{ env.EPOCHS }}
+          --permanent
           --force


### PR DESCRIPTION
## Description

This updates and enables our CI jobs to automatically update the `docs.wal.app` and `bin.wal.app` sites. The relevant [variables](https://github.com/MystenLabs/walrus/settings/variables/actions) were added.

Closes WAL-698.

## Test plan

Run the workflows.
