### PR TITLE
feat: add metrics to track recovery-symbol cache hit rate

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -599,6 +599,7 @@ impl StorageNode {
                     .max_concurrent(config.thread_pool.max_concurrent_tasks)
                     .metrics_registry(registry.clone())
                     .build_bounded(),
+                registry,
             ),
             encoding_config,
         });


### PR DESCRIPTION
## Description

Adds metrics to count the total and number of times that recovery symbol service requests hit the cache.

## Test plan

Local testbed.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
