### PR TITLE
fix: increase the maximum number of allowed pending-accept resets on a connection

### DIFF
--- a/crates/walrus-service/node_config_example.yaml
+++ b/crates/walrus-service/node_config_example.yaml
@@ -50,6 +50,7 @@ rest_server:
   http2_max_concurrent_streams: 1000
   http2_initial_stream_window_size: null
   http2_initial_connection_window_size: null
+  http2_max_pending_accept_reset_streams: 100
   http2_adaptive_window: true
 rest_graceful_shutdown_period_secs: 60
 sui:

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -961,6 +961,8 @@ pub struct Http2Config {
     /// Sets the max connection-level flow control for HTTP2.
     #[serde(skip_serializing_if = "defaults::is_none")]
     pub http2_initial_connection_window_size: Option<u32>,
+    /// Sets the maximum number of pending-accept remotely-reset streams.
+    pub http2_max_pending_accept_reset_streams: usize,
     /// Use adaptive flow control, overriding the `http2_initial_stream_window_size` and
     /// `http2_initial_connection_window_size` settings.
     pub http2_adaptive_window: bool,
@@ -970,6 +972,7 @@ impl Default for Http2Config {
     fn default() -> Self {
         Self {
             http2_max_concurrent_streams: 1000,
+            http2_max_pending_accept_reset_streams: 100,
             http2_initial_stream_window_size: None,
             http2_initial_connection_window_size: None,
             http2_adaptive_window: true,

--- a/crates/walrus-service/src/node/server.rs
+++ b/crates/walrus-service/src/node/server.rs
@@ -230,6 +230,7 @@ where
         let mut http2_builder = server.http_builder().http2();
         http2_builder
             .max_concurrent_streams(config.http2_max_concurrent_streams)
+            .max_pending_accept_reset_streams(config.http2_max_pending_accept_reset_streams)
             .initial_connection_window_size(config.http2_initial_connection_window_size)
             .initial_stream_window_size(config.http2_initial_stream_window_size)
             .adaptive_window(config.http2_adaptive_window);


### PR DESCRIPTION
## Description

This increases the default limit [`max_pending_accept_reset_streams`](https://docs.rs/h2/latest/h2/server/struct.Builder.html#method.max_pending_accept_reset_streams) from 20 to 100, for storage node REST APIs, since we often drop requests before they are complete with a storage node.

## Test plan

- 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
