### PR TITLE
chore: change copyright header to Walrus Foundation

### DIFF
--- a/.licensesnip
+++ b/.licensesnip
@@ -1,2 +1,2 @@
-Copyright (c) Mysten Labs, Inc.
+Copyright (c) Walrus Foundation
 SPDX-License-Identifier: Apache-2.0

--- a/contracts/subsidies/sources/subsidies.move
+++ b/contracts/subsidies/sources/subsidies.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// Module: `subsidies`

--- a/contracts/subsidies/tests/subsidies_tests.move
+++ b/contracts/subsidies/tests/subsidies_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[test_only]

--- a/contracts/wal/sources/wal.move
+++ b/contracts/wal/sources/wal.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// The WAL token is the native token for the Walrus Protocol.

--- a/contracts/wal_exchange/sources/wal_exchange.move
+++ b/contracts/wal_exchange/sources/wal_exchange.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// Module: wal_exchange

--- a/contracts/walrus/docs/msg_formats.txt
+++ b/contracts/walrus/docs/msg_formats.txt
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 

--- a/contracts/walrus/sources/display.move
+++ b/contracts/walrus/sources/display.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// Implements Sui Object Display for user-owned objects.

--- a/contracts/walrus/sources/init.move
+++ b/contracts/walrus/sources/init.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::init;

--- a/contracts/walrus/sources/staking.move
+++ b/contracts/walrus/sources/staking.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[allow(unused_variable, unused_function, unused_field, unused_mut_parameter)]

--- a/contracts/walrus/sources/staking/active_set.move
+++ b/contracts/walrus/sources/staking/active_set.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// Contains an active set of storage nodes. The active set is a smart collection

--- a/contracts/walrus/sources/staking/apportionment_queue.move
+++ b/contracts/walrus/sources/staking/apportionment_queue.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// A custom priority queue implementation for use in the apportionment algorithm.

--- a/contracts/walrus/sources/staking/auth.move
+++ b/contracts/walrus/sources/staking/auth.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::auth;

--- a/contracts/walrus/sources/staking/committee.move
+++ b/contracts/walrus/sources/staking/committee.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// This module defines the `Committee` struct which stores the current

--- a/contracts/walrus/sources/staking/exchange_rate.move
+++ b/contracts/walrus/sources/staking/exchange_rate.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// A utility module which implements an `ExchangeRate` struct and its methods.

--- a/contracts/walrus/sources/staking/node_metadata.move
+++ b/contracts/walrus/sources/staking/node_metadata.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// Metadata that describes a Storage Node. Attached to the `StakingPool`

--- a/contracts/walrus/sources/staking/pending_values.move
+++ b/contracts/walrus/sources/staking/pending_values.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::pending_values;

--- a/contracts/walrus/sources/staking/staked_wal.move
+++ b/contracts/walrus/sources/staking/staked_wal.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// Module: `staked_wal`

--- a/contracts/walrus/sources/staking/staking_inner.move
+++ b/contracts/walrus/sources/staking/staking_inner.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::staking_inner;

--- a/contracts/walrus/sources/staking/staking_pool.move
+++ b/contracts/walrus/sources/staking/staking_pool.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// Module: staking_pool

--- a/contracts/walrus/sources/staking/storage_node.move
+++ b/contracts/walrus/sources/staking/storage_node.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[allow(unused_field, unused_function, unused_variable, unused_use)]

--- a/contracts/walrus/sources/staking/walrus_context.move
+++ b/contracts/walrus/sources/staking/walrus_context.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// Module: `walrus_context`

--- a/contracts/walrus/sources/system.move
+++ b/contracts/walrus/sources/system.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[allow(unused_variable, unused_function, unused_field, unused_mut_parameter)]

--- a/contracts/walrus/sources/system/blob.move
+++ b/contracts/walrus/sources/system/blob.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::blob;

--- a/contracts/walrus/sources/system/bls_aggregate.move
+++ b/contracts/walrus/sources/system/bls_aggregate.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::bls_aggregate;

--- a/contracts/walrus/sources/system/encoding.move
+++ b/contracts/walrus/sources/system/encoding.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::encoding;

--- a/contracts/walrus/sources/system/epoch_parameters.move
+++ b/contracts/walrus/sources/system/epoch_parameters.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::epoch_parameters;

--- a/contracts/walrus/sources/system/event_blob.move
+++ b/contracts/walrus/sources/system/event_blob.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// Module to certify event blobs.

--- a/contracts/walrus/sources/system/events.move
+++ b/contracts/walrus/sources/system/events.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// Module to emit events. Used to allow filtering all events in the

--- a/contracts/walrus/sources/system/messages.move
+++ b/contracts/walrus/sources/system/messages.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::messages;

--- a/contracts/walrus/sources/system/metadata.move
+++ b/contracts/walrus/sources/system/metadata.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// Contains the metadata for Blobs on Walrus.

--- a/contracts/walrus/sources/system/redstuff.move
+++ b/contracts/walrus/sources/system/redstuff.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::redstuff;

--- a/contracts/walrus/sources/system/shared_blob.move
+++ b/contracts/walrus/sources/system/shared_blob.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::shared_blob;

--- a/contracts/walrus/sources/system/storage_accounting.move
+++ b/contracts/walrus/sources/system/storage_accounting.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::storage_accounting;

--- a/contracts/walrus/sources/system/storage_resource.move
+++ b/contracts/walrus/sources/system/storage_resource.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::storage_resource;

--- a/contracts/walrus/sources/system/system_state_inner.move
+++ b/contracts/walrus/sources/system/system_state_inner.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[allow(unused_variable, unused_mut_parameter, unused_field)]

--- a/contracts/walrus/sources/upgrade.move
+++ b/contracts/walrus/sources/upgrade.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// Module to manage Walrus contract upgrades.

--- a/contracts/walrus/sources/utils/extended_field.move
+++ b/contracts/walrus/sources/utils/extended_field.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// Module: extended_field

--- a/contracts/walrus/sources/utils/sort.move
+++ b/contracts/walrus/sources/utils/sort.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// Implements sorting macros for commonly used data structures.

--- a/contracts/walrus/tests/e2e_runner.move
+++ b/contracts/walrus/tests/e2e_runner.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::e2e_runner;

--- a/contracts/walrus/tests/e2e_tests.move
+++ b/contracts/walrus/tests/e2e_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[allow(unused_mut_ref)]

--- a/contracts/walrus/tests/staking/active_set_tests.move
+++ b/contracts/walrus/tests/staking/active_set_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// Contains an active set of storage nodes. The active set is a smart collection

--- a/contracts/walrus/tests/staking/committee_tests.move
+++ b/contracts/walrus/tests/staking/committee_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::committee_tests;

--- a/contracts/walrus/tests/staking/staked_wal_tests.move
+++ b/contracts/walrus/tests/staking/staked_wal_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::staked_wal_tests;

--- a/contracts/walrus/tests/staking/staking_inner_compute_tests.move
+++ b/contracts/walrus/tests/staking/staking_inner_compute_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::staking_inner_compute_tests;

--- a/contracts/walrus/tests/staking/staking_inner_tests.move
+++ b/contracts/walrus/tests/staking/staking_inner_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::staking_inner_tests;

--- a/contracts/walrus/tests/staking/staking_pool/pool_commission_tests.move
+++ b/contracts/walrus/tests/staking/staking_pool/pool_commission_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::pool_commission_tests;

--- a/contracts/walrus/tests/staking/staking_pool/pool_direct_withdraw_tests.move
+++ b/contracts/walrus/tests/staking/staking_pool/pool_direct_withdraw_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[allow(unused_use, unused_const)]

--- a/contracts/walrus/tests/staking/staking_pool/pool_early_withdraw_tests.move
+++ b/contracts/walrus/tests/staking/staking_pool/pool_early_withdraw_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 // Early withdrawal mechanics (for E0, E0', E1, E1', E2, E2'):

--- a/contracts/walrus/tests/staking/staking_pool/pool_rounding_tests.move
+++ b/contracts/walrus/tests/staking/staking_pool/pool_rounding_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::pool_rounding_tests;

--- a/contracts/walrus/tests/staking/staking_pool/staking_pool_tests.move
+++ b/contracts/walrus/tests/staking/staking_pool/staking_pool_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::staking_pool_tests;

--- a/contracts/walrus/tests/staking/walrus_context_tests.move
+++ b/contracts/walrus/tests/staking/walrus_context_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::walrus_context_tests;

--- a/contracts/walrus/tests/system/blob_tests.move
+++ b/contracts/walrus/tests/system/blob_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[test_only]

--- a/contracts/walrus/tests/system/bls_tests.move
+++ b/contracts/walrus/tests/system/bls_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[test_only]

--- a/contracts/walrus/tests/system/deny_list_tests.move
+++ b/contracts/walrus/tests/system/deny_list_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[test_only]

--- a/contracts/walrus/tests/system/event_blob_tests.move
+++ b/contracts/walrus/tests/system/event_blob_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[test_only]

--- a/contracts/walrus/tests/system/invalid_tests.move
+++ b/contracts/walrus/tests/system/invalid_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[test_only]

--- a/contracts/walrus/tests/system/metadata_tests.move
+++ b/contracts/walrus/tests/system/metadata_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[test_only]

--- a/contracts/walrus/tests/system/ringbuffer_tests.move
+++ b/contracts/walrus/tests/system/ringbuffer_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[test_only]

--- a/contracts/walrus/tests/system/storage_resource_tests.move
+++ b/contracts/walrus/tests/system/storage_resource_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[test_only]

--- a/contracts/walrus/tests/system/system_state_inner_tests.move
+++ b/contracts/walrus/tests/system/system_state_inner_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[test_only]

--- a/contracts/walrus/tests/test_node.move
+++ b/contracts/walrus/tests/test_node.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::test_node;

--- a/contracts/walrus/tests/test_utils.move
+++ b/contracts/walrus/tests/test_utils.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 // editorconfig-checker-disable-file
 

--- a/contracts/walrus/tests/upgrade_tests.move
+++ b/contracts/walrus/tests/upgrade_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 // SPDX-License-Identifier: Apache-2.0

--- a/crates/checkpoint-downloader/src/config.rs
+++ b/crates/checkpoint-downloader/src/config.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Checkpoint downloader configuration.

--- a/crates/checkpoint-downloader/src/downloader.rs
+++ b/crates/checkpoint-downloader/src/downloader.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Checkpoint downloader.

--- a/crates/checkpoint-downloader/src/lib.rs
+++ b/crates/checkpoint-downloader/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 mod config;

--- a/crates/checkpoint-downloader/src/metrics.rs
+++ b/crates/checkpoint-downloader/src/metrics.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Metrics for the checkpoint downloader.

--- a/crates/checkpoint-downloader/src/types.rs
+++ b/crates/checkpoint-downloader/src/types.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Types for the checkpoint downloader.

--- a/crates/walrus-core/benches/basic_encoding.rs
+++ b/crates/walrus-core/benches/basic_encoding.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Benchmarks for the basic encoding and decoding.

--- a/crates/walrus-core/benches/blob_encoding.rs
+++ b/crates/walrus-core/benches/blob_encoding.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Benchmarks for the blob encoding and decoding with and without authentication.

--- a/crates/walrus-core/src/bft.rs
+++ b/crates/walrus-core/src/bft.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Definitions and computations related to Byzantine fault tolerance (BFT).

--- a/crates/walrus-core/src/by_axis.rs
+++ b/crates/walrus-core/src/by_axis.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Structs related to the encoding axis.

--- a/crates/walrus-core/src/encoding.rs
+++ b/crates/walrus-core/src/encoding.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Blob encoding functionality, using the RedStuff algorithm.

--- a/crates/walrus-core/src/encoding/basic_encoding.rs
+++ b/crates/walrus-core/src/encoding/basic_encoding.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use alloc::vec::Vec;

--- a/crates/walrus-core/src/encoding/basic_encoding/raptorq.rs
+++ b/crates/walrus-core/src/encoding/basic_encoding/raptorq.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use alloc::vec::Vec;

--- a/crates/walrus-core/src/encoding/basic_encoding/reed_solomon.rs
+++ b/crates/walrus-core/src/encoding/basic_encoding/reed_solomon.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use alloc::vec::Vec;

--- a/crates/walrus-core/src/encoding/blob_encoding.rs
+++ b/crates/walrus-core/src/encoding/blob_encoding.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use alloc::{vec, vec::Vec};

--- a/crates/walrus-core/src/encoding/common.rs
+++ b/crates/walrus-core/src/encoding/common.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};

--- a/crates/walrus-core/src/encoding/config.rs
+++ b/crates/walrus-core/src/encoding/config.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use alloc::vec::Vec;

--- a/crates/walrus-core/src/encoding/errors.rs
+++ b/crates/walrus-core/src/encoding/errors.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use core::num::NonZeroU16;

--- a/crates/walrus-core/src/encoding/mapping.rs
+++ b/crates/walrus-core/src/encoding/mapping.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! The mapping between the encoded sliver pairs and shards.

--- a/crates/walrus-core/src/encoding/slivers.rs
+++ b/crates/walrus-core/src/encoding/slivers.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use alloc::vec::Vec;

--- a/crates/walrus-core/src/encoding/symbols.rs
+++ b/crates/walrus-core/src/encoding/symbols.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! The representation on encoded symbols.

--- a/crates/walrus-core/src/encoding/utils.rs
+++ b/crates/walrus-core/src/encoding/utils.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use alloc::vec::Vec;

--- a/crates/walrus-core/src/inconsistency.rs
+++ b/crates/walrus-core/src/inconsistency.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Proofs for inconsistent encoding.

--- a/crates/walrus-core/src/keys.rs
+++ b/crates/walrus-core/src/keys.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Keys used with Walrus.

--- a/crates/walrus-core/src/lib.rs
+++ b/crates/walrus-core/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Core functionality for Walrus.

--- a/crates/walrus-core/src/merkle.rs
+++ b/crates/walrus-core/src/merkle.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Merkle tree implementation for Walrus.

--- a/crates/walrus-core/src/messages.rs
+++ b/crates/walrus-core/src/messages.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Signed off-chain messages.

--- a/crates/walrus-core/src/messages/certificate.rs
+++ b/crates/walrus-core/src/messages/certificate.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use alloc::vec::Vec;

--- a/crates/walrus-core/src/messages/invalid_blob_id.rs
+++ b/crates/walrus-core/src/messages/invalid_blob_id.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};

--- a/crates/walrus-core/src/messages/proof_of_possession.rs
+++ b/crates/walrus-core/src/messages/proof_of_possession.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::Serialize;

--- a/crates/walrus-core/src/messages/storage_confirmation.rs
+++ b/crates/walrus-core/src/messages/storage_confirmation.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[allow(unused)]

--- a/crates/walrus-core/src/messages/sync_shard.rs
+++ b/crates/walrus-core/src/messages/sync_shard.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use alloc::vec::Vec;

--- a/crates/walrus-core/src/metadata.rs
+++ b/crates/walrus-core/src/metadata.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Metadata associated with a Blob and stored by storage nodes.

--- a/crates/walrus-core/src/test_utils.rs
+++ b/crates/walrus-core/src/test_utils.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 //! Utility functions for tests.
 

--- a/crates/walrus-core/src/utils.rs
+++ b/crates/walrus-core/src/utils.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Utilities used throughout Walrus.

--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Contains end-to-end tests for the Walrus client interacting with a Walrus test cluster.

--- a/crates/walrus-e2e-tests/tests/test_event_blobs.rs
+++ b/crates/walrus-e2e-tests/tests/test_event_blobs.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! End-to-end tests for event blobs.

--- a/crates/walrus-orchestrator/src/benchmark.rs
+++ b/crates/walrus-orchestrator/src/benchmark.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fmt::{Debug, Display};

--- a/crates/walrus-orchestrator/src/client.rs
+++ b/crates/walrus-orchestrator/src/client.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{

--- a/crates/walrus-orchestrator/src/client/aws.rs
+++ b/crates/walrus-orchestrator/src/client/aws.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{

--- a/crates/walrus-orchestrator/src/client/vultr.rs
+++ b/crates/walrus-orchestrator/src/client/vultr.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{fmt::Display, net::Ipv4Addr};

--- a/crates/walrus-orchestrator/src/display.rs
+++ b/crates/walrus-orchestrator/src/display.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{fmt::Display, io::stdout};

--- a/crates/walrus-orchestrator/src/error.rs
+++ b/crates/walrus-orchestrator/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::net::SocketAddr;

--- a/crates/walrus-orchestrator/src/faults.rs
+++ b/crates/walrus-orchestrator/src/faults.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{

--- a/crates/walrus-orchestrator/src/logs.rs
+++ b/crates/walrus-orchestrator/src/logs.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::cmp::max;

--- a/crates/walrus-orchestrator/src/main.rs
+++ b/crates/walrus-orchestrator/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Orchestrator entry point.

--- a/crates/walrus-orchestrator/src/measurements.rs
+++ b/crates/walrus-orchestrator/src/measurements.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{

--- a/crates/walrus-orchestrator/src/monitor.rs
+++ b/crates/walrus-orchestrator/src/monitor.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::net::SocketAddr;

--- a/crates/walrus-orchestrator/src/orchestrator.rs
+++ b/crates/walrus-orchestrator/src/orchestrator.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{

--- a/crates/walrus-orchestrator/src/protocol.rs
+++ b/crates/walrus-orchestrator/src/protocol.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{

--- a/crates/walrus-orchestrator/src/protocol/target.rs
+++ b/crates/walrus-orchestrator/src/protocol/target.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{

--- a/crates/walrus-orchestrator/src/settings.rs
+++ b/crates/walrus-orchestrator/src/settings.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{

--- a/crates/walrus-orchestrator/src/ssh.rs
+++ b/crates/walrus-orchestrator/src/ssh.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{

--- a/crates/walrus-orchestrator/src/testbed.rs
+++ b/crates/walrus-orchestrator/src/testbed.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::time::Duration;

--- a/crates/walrus-proc-macros/src/derive_api_errors.rs
+++ b/crates/walrus-proc-macros/src/derive_api_errors.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 //! Implementation of the [`RestApiError`] derive macro.
 //!

--- a/crates/walrus-proc-macros/src/lib.rs
+++ b/crates/walrus-proc-macros/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 //! Proc-macros used within various walrus crates.
 //!

--- a/crates/walrus-proc-macros/src/walrus_simtest.rs
+++ b/crates/walrus-proc-macros/src/walrus_simtest.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use proc_macro::TokenStream;

--- a/crates/walrus-proxy/src/admin.rs
+++ b/crates/walrus-proxy/src/admin.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{sync::Arc, time::Duration};

--- a/crates/walrus-proxy/src/config.rs
+++ b/crates/walrus-proxy/src/config.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 use core::time::Duration;
 use std::{collections::HashMap, net::SocketAddr, path::PathBuf};

--- a/crates/walrus-proxy/src/consumer.rs
+++ b/crates/walrus-proxy/src/consumer.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::io::Read;

--- a/crates/walrus-proxy/src/handlers.rs
+++ b/crates/walrus-proxy/src/handlers.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 use axum::{extract::Extension, http::StatusCode};
 use once_cell::sync::Lazy;

--- a/crates/walrus-proxy/src/histogram_relay.rs
+++ b/crates/walrus-proxy/src/histogram_relay.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 use std::{
     collections::VecDeque,

--- a/crates/walrus-proxy/src/lib.rs
+++ b/crates/walrus-proxy/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! # Walrus Proxy

--- a/crates/walrus-proxy/src/main.rs
+++ b/crates/walrus-proxy/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 //! - walrus-proxy service
 //!

--- a/crates/walrus-proxy/src/metrics.rs
+++ b/crates/walrus-proxy/src/metrics.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{

--- a/crates/walrus-proxy/src/middleware.rs
+++ b/crates/walrus-proxy/src/middleware.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 use std::{collections::HashMap, sync::Arc};
 

--- a/crates/walrus-proxy/src/prom_to_mimir.rs
+++ b/crates/walrus-proxy/src/prom_to_mimir.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 use itertools::Itertools;
 use prometheus::proto::{Counter, Gauge, Histogram, Metric, MetricFamily, MetricType};

--- a/crates/walrus-proxy/src/providers.rs
+++ b/crates/walrus-proxy/src/providers.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// walrus specific provider implementation for nodes in committee

--- a/crates/walrus-proxy/src/providers/walrus.rs
+++ b/crates/walrus-proxy/src/providers/walrus.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// walrus node provider implementation

--- a/crates/walrus-proxy/src/providers/walrus/provider.rs
+++ b/crates/walrus-proxy/src/providers/walrus/provider.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{

--- a/crates/walrus-proxy/src/providers/walrus/query.rs
+++ b/crates/walrus-proxy/src/providers/walrus/query.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{

--- a/crates/walrus-proxy/src/remote_write.rs
+++ b/crates/walrus-proxy/src/remote_write.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 #![allow(clippy::all)]
 #![allow(warnings)]

--- a/crates/walrus-sdk/src/api.rs
+++ b/crates/walrus-sdk/src/api.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! API types.

--- a/crates/walrus-sdk/src/api/errors.rs
+++ b/crates/walrus-sdk/src/api/errors.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Error status and codes.

--- a/crates/walrus-sdk/src/client.rs
+++ b/crates/walrus-sdk/src/client.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Client for interacting with the StorageNode API.

--- a/crates/walrus-sdk/src/error.rs
+++ b/crates/walrus-sdk/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Errors that may be encountered while interacting with a storage node.

--- a/crates/walrus-sdk/src/lib.rs
+++ b/crates/walrus-sdk/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Code for interacting with the Walrus system.

--- a/crates/walrus-sdk/src/node_response.rs
+++ b/crates/walrus-sdk/src/node_response.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use reqwest::{

--- a/crates/walrus-sdk/src/tls.rs
+++ b/crates/walrus-sdk/src/tls.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{

--- a/crates/walrus-service/bin/backup.rs
+++ b/crates/walrus-service/bin/backup.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Walrus Backup Nodes entry points.

--- a/crates/walrus-service/bin/client.rs
+++ b/crates/walrus-service/bin/client.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! A client for the Walrus blob store.

--- a/crates/walrus-service/bin/deploy.rs
+++ b/crates/walrus-service/bin/deploy.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! CLI tool to generate Walrus configurations and deploy testbeds.

--- a/crates/walrus-service/bin/node.rs
+++ b/crates/walrus-service/bin/node.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Walrus Storage Node entry point.

--- a/crates/walrus-service/build.rs
+++ b/crates/walrus-service/build.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Build script for the walrus-service crate.

--- a/crates/walrus-service/src/backup.rs
+++ b/crates/walrus-service/src/backup.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Walrus blob backup service.

--- a/crates/walrus-service/src/backup/config.rs
+++ b/crates/walrus-service/src/backup/config.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Configuration for the blob backup service.

--- a/crates/walrus-service/src/backup/garbage_collector.rs
+++ b/crates/walrus-service/src/backup/garbage_collector.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{panic::Location, time::Duration};

--- a/crates/walrus-service/src/backup/metrics.rs
+++ b/crates/walrus-service/src/backup/metrics.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use prometheus::{Gauge, GaugeVec, Histogram, IntCounter, IntCounterVec};

--- a/crates/walrus-service/src/backup/models.rs
+++ b/crates/walrus-service/src/backup/models.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use diesel::{

--- a/crates/walrus-service/src/backup/schema.rs
+++ b/crates/walrus-service/src/backup/schema.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 // @generated automatically by Diesel CLI.

--- a/crates/walrus-service/src/backup/service.rs
+++ b/crates/walrus-service/src/backup/service.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Backup service implementation.

--- a/crates/walrus-service/src/client.rs
+++ b/crates/walrus-service/src/client.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Client for the Walrus service.

--- a/crates/walrus-service/src/client/cli.rs
+++ b/crates/walrus-service/src/client/cli.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Utilities for running the walrus cli tools.

--- a/crates/walrus-service/src/client/cli/args.rs
+++ b/crates/walrus-service/src/client/cli/args.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! The arguments to the Walrus client binary.

--- a/crates/walrus-service/src/client/cli/cli_output.rs
+++ b/crates/walrus-service/src/client/cli/cli_output.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{io::stdout, num::NonZeroU16, path::PathBuf};

--- a/crates/walrus-service/src/client/cli/runner.rs
+++ b/crates/walrus-service/src/client/cli/runner.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Helper struct to run the Walrus client binary commands.

--- a/crates/walrus-service/src/client/communication.rs
+++ b/crates/walrus-service/src/client/communication.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Logic to handle the communication between the client and the storage nodes.

--- a/crates/walrus-service/src/client/communication/factory.rs
+++ b/crates/walrus-service/src/client/communication/factory.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Create the vectors of node communications objects.

--- a/crates/walrus-service/src/client/communication/node.rs
+++ b/crates/walrus-service/src/client/communication/node.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{num::NonZeroU16, sync::Arc};

--- a/crates/walrus-service/src/client/config.rs
+++ b/crates/walrus-service/src/client/config.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{

--- a/crates/walrus-service/src/client/daemon.rs
+++ b/crates/walrus-service/src/client/daemon.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! A client daemon who serves a set of simple HTTP endpoints to store, encode, or read blobs.

--- a/crates/walrus-service/src/client/daemon/auth.rs
+++ b/crates/walrus-service/src/client/daemon/auth.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use axum::{body::Body, extract::Query, http::Response};

--- a/crates/walrus-service/src/client/daemon/cache.rs
+++ b/crates/walrus-service/src/client/daemon/cache.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Implementation of a simple value cache with element expiration.

--- a/crates/walrus-service/src/client/daemon/openapi.rs
+++ b/crates/walrus-service/src/client/daemon/openapi.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use utoipa::OpenApi;

--- a/crates/walrus-service/src/client/daemon/routes.rs
+++ b/crates/walrus-service/src/client/daemon/routes.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{collections::HashSet, str::FromStr, sync::Arc};

--- a/crates/walrus-service/src/client/error.rs
+++ b/crates/walrus-service/src/client/error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! The errors for the storage client and the communication with storage nodes.

--- a/crates/walrus-service/src/client/metrics.rs
+++ b/crates/walrus-service/src/client/metrics.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Metrics for the client and daemon.

--- a/crates/walrus-service/src/client/multiplexer.rs
+++ b/crates/walrus-service/src/client/multiplexer.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! A client mulitplexer, that allows to submit requests using multiple clients in the background.

--- a/crates/walrus-service/src/client/refill.rs
+++ b/crates/walrus-service/src/client/refill.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Utilities to refill gas for the stress clients.

--- a/crates/walrus-service/src/client/refresh.rs
+++ b/crates/walrus-service/src/client/refresh.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! A cache for the active committee and the price computation, that refreshed them periodically

--- a/crates/walrus-service/src/client/resource.rs
+++ b/crates/walrus-service/src/client/resource.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Manages the storage and blob resources in the Wallet on behalf of the client.

--- a/crates/walrus-service/src/client/responses.rs
+++ b/crates/walrus-service/src/client/responses.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Structures of client results returned by the daemon or through the JSON API.

--- a/crates/walrus-service/src/client/utils.rs
+++ b/crates/walrus-service/src/client/utils.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{

--- a/crates/walrus-service/src/common.rs
+++ b/crates/walrus-service/src/common.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Service functionality for Walrus shared by client and storage node.

--- a/crates/walrus-service/src/common/active_committees.rs
+++ b/crates/walrus-service/src/common/active_committees.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{cmp::Ordering, collections::HashSet, mem, num::NonZeroU16, sync::Arc};

--- a/crates/walrus-service/src/common/api.rs
+++ b/crates/walrus-service/src/common/api.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Formats and tools for success and error messages of our REST APIs.

--- a/crates/walrus-service/src/common/blocklist.rs
+++ b/crates/walrus-service/src/common/blocklist.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{

--- a/crates/walrus-service/src/common/config.rs
+++ b/crates/walrus-service/src/common/config.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Common configuration module.

--- a/crates/walrus-service/src/common/event_blob_downloader.rs
+++ b/crates/walrus-service/src/common/event_blob_downloader.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Responsible for downloading and managing event blobs

--- a/crates/walrus-service/src/common/telemetry.rs
+++ b/crates/walrus-service/src/common/telemetry.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Telemetry utilities for instrumenting walrus services.

--- a/crates/walrus-service/src/common/utils.rs
+++ b/crates/walrus-service/src/common/utils.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Utility functions for the Walrus service.

--- a/crates/walrus-service/src/lib.rs
+++ b/crates/walrus-service/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Walrus client, server, and associated utilities.

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Walrus storage node.

--- a/crates/walrus-service/src/node/blob_retirement_notifier.rs
+++ b/crates/walrus-service/src/node/blob_retirement_notifier.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{

--- a/crates/walrus-service/src/node/blob_sync.rs
+++ b/crates/walrus-service/src/node/blob_sync.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{

--- a/crates/walrus-service/src/node/committee.rs
+++ b/crates/walrus-service/src/node/committee.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Walrus committee service and associated types.

--- a/crates/walrus-service/src/node/committee/committee_service.rs
+++ b/crates/walrus-service/src/node/committee/committee_service.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 #![allow(clippy::mutable_key_type)]
 

--- a/crates/walrus-service/src/node/committee/node_service.rs
+++ b/crates/walrus-service/src/node/committee/node_service.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 //! Services for communicating with Storage Nodes.
 //!

--- a/crates/walrus-service/src/node/committee/request_futures.rs
+++ b/crates/walrus-service/src/node/committee/request_futures.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{

--- a/crates/walrus-service/src/node/committee/test_committee_service.rs
+++ b/crates/walrus-service/src/node/committee/test_committee_service.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Storage client configuration module.

--- a/crates/walrus-service/src/node/config_synchronizer.rs
+++ b/crates/walrus-service/src/node/config_synchronizer.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{path::PathBuf, sync::Arc, time::Duration};

--- a/crates/walrus-service/src/node/contract_service.rs
+++ b/crates/walrus-service/src/node/contract_service.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Service to handle write interactions with the system contract for storage nodes.

--- a/crates/walrus-service/src/node/dbtool.rs
+++ b/crates/walrus-service/src/node/dbtool.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Tools for inspecting and maintaining the RocksDB database.

--- a/crates/walrus-service/src/node/epoch_change_driver.rs
+++ b/crates/walrus-service/src/node/epoch_change_driver.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Drive voting end and epoch change.

--- a/crates/walrus-service/src/node/errors.rs
+++ b/crates/walrus-service/src/node/errors.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;

--- a/crates/walrus-service/src/node/events.rs
+++ b/crates/walrus-service/src/node/events.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Service functionality for downloading and processing events from the full node.

--- a/crates/walrus-service/src/node/events/event_blob.rs
+++ b/crates/walrus-service/src/node/events/event_blob.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Event blob file format.

--- a/crates/walrus-service/src/node/events/event_blob_writer.rs
+++ b/crates/walrus-service/src/node/events/event_blob_writer.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Event blob writer.

--- a/crates/walrus-service/src/node/events/event_processor.rs
+++ b/crates/walrus-service/src/node/events/event_processor.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Event processor for processing events from the full node.

--- a/crates/walrus-service/src/node/events/event_processor_runtime.rs
+++ b/crates/walrus-service/src/node/events/event_processor_runtime.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Walrus event processor runtime.

--- a/crates/walrus-service/src/node/metrics.rs
+++ b/crates/walrus-service/src/node/metrics.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use prometheus::{

--- a/crates/walrus-service/src/node/node_recovery.rs
+++ b/crates/walrus-service/src/node/node_recovery.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::sync::{Arc, Mutex};

--- a/crates/walrus-service/src/node/recovery_symbol_service.rs
+++ b/crates/walrus-service/src/node/recovery_symbol_service.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{

--- a/crates/walrus-service/src/node/server.rs
+++ b/crates/walrus-service/src/node/server.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Server for the Walrus service.

--- a/crates/walrus-service/src/node/server/extract.rs
+++ b/crates/walrus-service/src/node/server/extract.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::anyhow;

--- a/crates/walrus-service/src/node/server/openapi.rs
+++ b/crates/walrus-service/src/node/server/openapi.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use walrus_core::{messages::SignedMessage, EpochSchema, SliverPairIndex, SliverType, SymbolId};

--- a/crates/walrus-service/src/node/server/responses.rs
+++ b/crates/walrus-service/src/node/server/responses.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::{BTreeMap, HashMap};

--- a/crates/walrus-service/src/node/server/routes.rs
+++ b/crates/walrus-service/src/node/server/routes.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{num::NonZeroU16, sync::Arc};

--- a/crates/walrus-service/src/node/shard_sync.rs
+++ b/crates/walrus-service/src/node/shard_sync.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{

--- a/crates/walrus-service/src/node/start_epoch_change_finisher.rs
+++ b/crates/walrus-service/src/node/start_epoch_change_finisher.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use core::fmt::{self, Display};

--- a/crates/walrus-service/src/node/storage/blob_info.rs
+++ b/crates/walrus-service/src/node/storage/blob_info.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Keeping track of the status of blob IDs and on-chain `Blob` objects.

--- a/crates/walrus-service/src/node/storage/constants.rs
+++ b/crates/walrus-service/src/node/storage/constants.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use walrus_core::ShardIndex;

--- a/crates/walrus-service/src/node/storage/database_config.rs
+++ b/crates/walrus-service/src/node/storage/database_config.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use rocksdb::{DBCompressionType, Options};

--- a/crates/walrus-service/src/node/storage/event_cursor_table.rs
+++ b/crates/walrus-service/src/node/storage/event_cursor_table.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::sync::{

--- a/crates/walrus-service/src/node/storage/event_sequencer.rs
+++ b/crates/walrus-service/src/node/storage/event_sequencer.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;

--- a/crates/walrus-service/src/node/storage/metrics.rs
+++ b/crates/walrus-service/src/node/storage/metrics.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::time::Duration;

--- a/crates/walrus-service/src/node/storage/shard.rs
+++ b/crates/walrus-service/src/node/storage/shard.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Walrus shard storage.

--- a/crates/walrus-service/src/node/system_events.rs
+++ b/crates/walrus-service/src/node/system_events.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Walrus events observed by the storage node.

--- a/crates/walrus-service/src/node/thread_pool.rs
+++ b/crates/walrus-service/src/node/thread_pool.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Test utilities for using storage nodes in tests.

--- a/crates/walrus-service/src/testbed.rs
+++ b/crates/walrus-service/src/testbed.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Facilities to deploy a Walrus testbed.

--- a/crates/walrus-service/tests/epoch_change.rs
+++ b/crates/walrus-service/tests/epoch_change.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Contains end-to-end tests for the epoch change mechanism.

--- a/crates/walrus-simtest/tests/simtest.rs
+++ b/crates/walrus-simtest/tests/simtest.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Contains dedicated Walrus simulation tests.

--- a/crates/walrus-stress/src/generator.rs
+++ b/crates/walrus-stress/src/generator.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Generate writes and reads for stress tests.

--- a/crates/walrus-stress/src/generator/blob.rs
+++ b/crates/walrus-stress/src/generator/blob.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use rand::{rngs::StdRng, thread_rng, Rng, SeedableRng};

--- a/crates/walrus-stress/src/generator/write_client.rs
+++ b/crates/walrus-stress/src/generator/write_client.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{

--- a/crates/walrus-stress/src/main.rs
+++ b/crates/walrus-stress/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Load generators for stress testing the Walrus nodes.

--- a/crates/walrus-sui/build.rs
+++ b/crates/walrus-sui/build.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Walrus Sui build script. Currently only used to generate error definitions based on the

--- a/crates/walrus-sui/src/client.rs
+++ b/crates/walrus-sui/src/client.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Client to call Walrus move functions from rust.

--- a/crates/walrus-sui/src/client/contract_config.rs
+++ b/crates/walrus-sui/src/client/contract_config.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Module for the configuration of contract packages and shared objects.

--- a/crates/walrus-sui/src/client/read_client.rs
+++ b/crates/walrus-sui/src/client/read_client.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Client to call Walrus move functions from rust.

--- a/crates/walrus-sui/src/client/retry_client.rs
+++ b/crates/walrus-sui/src/client/retry_client.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Infrastructure for retrying RPC calls with backoff, in case there are network errors.

--- a/crates/walrus-sui/src/client/rpc_config.rs
+++ b/crates/walrus-sui/src/client/rpc_config.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Configuration for the RPC client.

--- a/crates/walrus-sui/src/client/transaction_builder.rs
+++ b/crates/walrus-sui/src/client/transaction_builder.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! A transaction builder for programmable transactions containing Walrus-related calls.

--- a/crates/walrus-sui/src/config.rs
+++ b/crates/walrus-sui/src/config.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Wallet configuration utilities.

--- a/crates/walrus-sui/src/contracts.rs
+++ b/crates/walrus-sui/src/contracts.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Walrus contract bindings. Provides an interface for looking up contract function,

--- a/crates/walrus-sui/src/lib.rs
+++ b/crates/walrus-sui/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Bindings to call the Walrus contracts from Rust.

--- a/crates/walrus-sui/src/system_setup.rs
+++ b/crates/walrus-sui/src/system_setup.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Utilities to publish the walrus contracts and deploy a system object for testing.

--- a/crates/walrus-sui/src/test_utils.rs
+++ b/crates/walrus-sui/src/test_utils.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Test utilities for `walrus-sui`.

--- a/crates/walrus-sui/src/test_utils/system_setup.rs
+++ b/crates/walrus-sui/src/test_utils/system_setup.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Utilities to publish the walrus contracts and deploy a system object for testing.

--- a/crates/walrus-sui/src/types.rs
+++ b/crates/walrus-sui/src/types.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Walrus Move type bindings. Replicates the Move types in Rust and provides some convenient

--- a/crates/walrus-sui/src/types/events.rs
+++ b/crates/walrus-sui/src/types/events.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Walrus event type bindings. Replicates the move event types in Rust.

--- a/crates/walrus-sui/src/types/move_errors.rs
+++ b/crates/walrus-sui/src/types/move_errors.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Walrus move error bindings. Converts Move execution errors from a string into matchable errors.

--- a/crates/walrus-sui/src/types/move_structs.rs
+++ b/crates/walrus-sui/src/types/move_structs.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Walrus move type bindings. Replicates the move types in Rust.

--- a/crates/walrus-sui/src/utils.rs
+++ b/crates/walrus-sui/src/utils.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Helper functions for the crate.

--- a/crates/walrus-sui/tests/test_walrus_sui.rs
+++ b/crates/walrus-sui/tests/test_walrus_sui.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Contains integration tests for the Sui bindings.

--- a/crates/walrus-test-utils/src/lib.rs
+++ b/crates/walrus-test-utils/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 //! Test utilities shared between various crates.

--- a/crates/walrus-utils/src/backoff.rs
+++ b/crates/walrus-utils/src/backoff.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{future::Future, num::Saturating, time::Duration};

--- a/crates/walrus-utils/src/config.rs
+++ b/crates/walrus-utils/src/config.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::path::{Path, PathBuf};

--- a/crates/walrus-utils/src/http.rs
+++ b/crates/walrus-utils/src/http.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{

--- a/crates/walrus-utils/src/lib.rs
+++ b/crates/walrus-utils/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(feature = "backoff")]

--- a/crates/walrus-utils/src/metrics.rs
+++ b/crates/walrus-utils/src/metrics.rs
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 use prometheus::IntGauge;

--- a/docker/local-testbed/build-local-image.sh
+++ b/docker/local-testbed/build-local-image.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) Mysten Labs, Inc.
+# Copyright (c) Walrus Foundation
 # SPDX-License-Identifier: Apache-2.0
 
 PLATFORM=linux/arm64

--- a/docker/local-testbed/docker-compose.yaml
+++ b/docker/local-testbed/docker-compose.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) Mysten Labs, Inc.
+# Copyright (c) Walrus Foundation
 # SPDX-License-Identifier: Apache-2.0
 
 version: "3"

--- a/docker/local-testbed/files/deploy-walrus.sh
+++ b/docker/local-testbed/files/deploy-walrus.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) Mysten Labs, Inc.
+# Copyright (c) Walrus Foundation
 # SPDX-License-Identifier: Apache-2.0
 
 # use EPOCH_DURATION to set the epoch duration, default is 2 minutes

--- a/docker/local-testbed/files/run-walrus.sh
+++ b/docker/local-testbed/files/run-walrus.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) Mysten Labs, Inc.
+# Copyright (c) Walrus Foundation
 # SPDX-License-Identifier: Apache-2.0
 
 ## -----------------------------------------------------------------------------

--- a/docker/walrus-antithesis/build-test-config-image/docker-compose.yaml
+++ b/docker/walrus-antithesis/build-test-config-image/docker-compose.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) Mysten Labs, Inc.
+# Copyright (c) Walrus Foundation
 # SPDX-License-Identifier: Apache-2.0
 
 # This docker-compose file sets up a test environment for Walrus with:

--- a/docker/walrus-antithesis/build-test-config-image/files/complete-setup.sh
+++ b/docker/walrus-antithesis/build-test-config-image/files/complete-setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) Mysten Labs, Inc.
+# Copyright (c) Walrus Foundation
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/docker/walrus-antithesis/build-test-config-image/files/deploy-walrus.sh
+++ b/docker/walrus-antithesis/build-test-config-image/files/deploy-walrus.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) Mysten Labs, Inc.
+# Copyright (c) Walrus Foundation
 # SPDX-License-Identifier: Apache-2.0
 
 # use EPOCH_DURATION to set the epoch duration, default is 10 minutes in antithesis test.

--- a/docker/walrus-antithesis/build-test-config-image/files/run-stress.sh
+++ b/docker/walrus-antithesis/build-test-config-image/files/run-stress.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) Mysten Labs, Inc.
+# Copyright (c) Walrus Foundation
 # SPDX-License-Identifier: Apache-2.0
 
 ## -----------------------------------------------------------------------------

--- a/docker/walrus-antithesis/build-test-config-image/files/run-walrus.sh
+++ b/docker/walrus-antithesis/build-test-config-image/files/run-walrus.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) Mysten Labs, Inc.
+# Copyright (c) Walrus Foundation
 # SPDX-License-Identifier: Apache-2.0
 
 ## -----------------------------------------------------------------------------

--- a/docker/walrus-antithesis/build-walrus-image-for-antithesis/update_move_toml.sh
+++ b/docker/walrus-antithesis/build-walrus-image-for-antithesis/update_move_toml.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) Mysten Labs, Inc.
+# Copyright (c) Walrus Foundation
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/docker/walrus-orchestrator/build.sh
+++ b/docker/walrus-orchestrator/build.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright (c) Mysten Labs, Inc.
+# Copyright (c) Walrus Foundation
 # SPDX-License-Identifier: Apache-2.0
 
 # fast fail.

--- a/docker/walrus-service/build.sh
+++ b/docker/walrus-service/build.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright (c) Mysten Labs, Inc.
+# Copyright (c) Walrus Foundation
 # SPDX-License-Identifier: Apache-2.0
 
 # fast fail.

--- a/docker/walrus-stress/build.sh
+++ b/docker/walrus-stress/build.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright (c) Mysten Labs, Inc.
+# Copyright (c) Walrus Foundation
 # SPDX-License-Identifier: Apache-2.0
 
 # fast fail.

--- a/docs/examples/javascript/blob_upload_download_webapi.html
+++ b/docs/examples/javascript/blob_upload_download_webapi.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) Mysten Labs, Inc.
+  Copyright (c) Walrus Foundation
   SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/docs/examples/move/walrus_dep/sources/tests/walrus_dep_tests.move
+++ b/docs/examples/move/walrus_dep/sources/tests/walrus_dep_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[test_only]

--- a/docs/examples/move/walrus_dep/sources/wrapped_blob.move
+++ b/docs/examples/move/walrus_dep/sources/wrapped_blob.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus_dep::wrapped_blob {

--- a/docs/examples/python/hello_walrus_jsonapi.py
+++ b/docs/examples/python/hello_walrus_jsonapi.py
@@ -1,4 +1,4 @@
-# Copyright (c) Mysten Labs, Inc.
+# Copyright (c) Walrus Foundation
 # SPDX-License-Identifier: Apache-2.0
 
 # Example of uploading and downloading a file to / from the Walrus service

--- a/docs/examples/python/hello_walrus_webapi.py
+++ b/docs/examples/python/hello_walrus_webapi.py
@@ -1,4 +1,4 @@
-# Copyright (c) Mysten Labs, Inc.
+# Copyright (c) Walrus Foundation
 # SPDX-License-Identifier: Apache-2.0
 
 # Example of uploading and downloading a file to / from the Walrus service

--- a/docs/examples/python/track_walrus_events.py
+++ b/docs/examples/python/track_walrus_events.py
@@ -1,4 +1,4 @@
-# Copyright (c) Mysten Labs, Inc.
+# Copyright (c) Walrus Foundation
 # SPDX-License-Identifier: Apache-2.0
 
 # Track Walrus storage related events on the Sui blockchain

--- a/docs/examples/python/utils.py
+++ b/docs/examples/python/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) Mysten Labs, Inc.
+# Copyright (c) Walrus Foundation
 # SPDX-License-Identifier: Apache-2.0
 
 import base64

--- a/scripts/crash_recovery.sh
+++ b/scripts/crash_recovery.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) Mysten Labs, Inc.
+# Copyright (c) Walrus Foundation
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail

--- a/scripts/local-testbed.sh
+++ b/scripts/local-testbed.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) Mysten Labs, Inc.
+# Copyright (c) Walrus Foundation
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail

--- a/scripts/move_coverage.sh
+++ b/scripts/move_coverage.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) Mysten Labs, Inc.
+# Copyright (c) Walrus Foundation
 # SPDX-License-Identifier: Apache-2.0
 
 shopt -s nullglob

--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -1,4 +1,4 @@
-# Copyright (c) Mysten Labs, Inc.
+# Copyright (c) Walrus Foundation
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/scripts/simtest/cargo-simtest
+++ b/scripts/simtest/cargo-simtest
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) Mysten Labs, Inc.
+# Copyright (c) Walrus Foundation
 # SPDX-License-Identifier: Apache-2.0
 
 if [ "$1" != "simtest" ]; then

--- a/scripts/simtest/install.sh
+++ b/scripts/simtest/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) Mysten Labs, Inc.
+# Copyright (c) Walrus Foundation
 # SPDX-License-Identifier: Apache-2.0
 
 cd "$(dirname "${BASH_SOURCE[0]}")"

--- a/scripts/simtest/simtest-run.sh
+++ b/scripts/simtest/simtest-run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) Mysten Labs, Inc.
+# Copyright (c) Walrus Foundation
 # SPDX-License-Identifier: Apache-2.0
 
 echo "Running Walrus simtests at commit $(git rev-parse HEAD)"

--- a/scripts/walrus-install.sh
+++ b/scripts/walrus-install.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright (c) Mysten Labs, Inc.
+# Copyright (c) Walrus Foundation
 # SPDX-License-Identifier: Apache-2.0
 
 msg() {

--- a/testnet-contracts/subsidies/sources/subsidies.move
+++ b/testnet-contracts/subsidies/sources/subsidies.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// Module: `subsidies`

--- a/testnet-contracts/subsidies/tests/subsidies_tests.move
+++ b/testnet-contracts/subsidies/tests/subsidies_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[test_only]

--- a/testnet-contracts/wal/sources/wal.move
+++ b/testnet-contracts/wal/sources/wal.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// Module: wal

--- a/testnet-contracts/wal_exchange/sources/wal_exchange.move
+++ b/testnet-contracts/wal_exchange/sources/wal_exchange.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// Module: wal_exchange

--- a/testnet-contracts/walrus/docs/msg_formats.txt
+++ b/testnet-contracts/walrus/docs/msg_formats.txt
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 

--- a/testnet-contracts/walrus/sources/init.move
+++ b/testnet-contracts/walrus/sources/init.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::init;

--- a/testnet-contracts/walrus/sources/staking.move
+++ b/testnet-contracts/walrus/sources/staking.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[allow(unused_variable, unused_function, unused_field, unused_mut_parameter)]

--- a/testnet-contracts/walrus/sources/staking/active_set.move
+++ b/testnet-contracts/walrus/sources/staking/active_set.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// Contains an active set of storage nodes. The active set is a smart collection

--- a/testnet-contracts/walrus/sources/staking/apportionment_queue.move
+++ b/testnet-contracts/walrus/sources/staking/apportionment_queue.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// A custom priority queue implementation for use in the apportionment algorithm.

--- a/testnet-contracts/walrus/sources/staking/auth.move
+++ b/testnet-contracts/walrus/sources/staking/auth.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::auth;

--- a/testnet-contracts/walrus/sources/staking/committee.move
+++ b/testnet-contracts/walrus/sources/staking/committee.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// This module defines the `Committee` struct which stores the current

--- a/testnet-contracts/walrus/sources/staking/exchange_rate.move
+++ b/testnet-contracts/walrus/sources/staking/exchange_rate.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// A utility module which implements an `ExchangeRate` struct and its methods.

--- a/testnet-contracts/walrus/sources/staking/node_metadata.move
+++ b/testnet-contracts/walrus/sources/staking/node_metadata.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// Metadata that describes a Storage Node. Attached to the `StakingPool`

--- a/testnet-contracts/walrus/sources/staking/pending_values.move
+++ b/testnet-contracts/walrus/sources/staking/pending_values.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::pending_values;

--- a/testnet-contracts/walrus/sources/staking/staked_wal.move
+++ b/testnet-contracts/walrus/sources/staking/staked_wal.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// Module: `staked_wal`

--- a/testnet-contracts/walrus/sources/staking/staking_inner.move
+++ b/testnet-contracts/walrus/sources/staking/staking_inner.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::staking_inner;

--- a/testnet-contracts/walrus/sources/staking/staking_pool.move
+++ b/testnet-contracts/walrus/sources/staking/staking_pool.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// Module: staking_pool

--- a/testnet-contracts/walrus/sources/staking/storage_node.move
+++ b/testnet-contracts/walrus/sources/staking/storage_node.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[allow(unused_field, unused_function, unused_variable, unused_use)]

--- a/testnet-contracts/walrus/sources/staking/walrus_context.move
+++ b/testnet-contracts/walrus/sources/staking/walrus_context.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// Module: `walrus_context`

--- a/testnet-contracts/walrus/sources/system.move
+++ b/testnet-contracts/walrus/sources/system.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[allow(unused_variable, unused_function, unused_field, unused_mut_parameter)]

--- a/testnet-contracts/walrus/sources/system/blob.move
+++ b/testnet-contracts/walrus/sources/system/blob.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::blob;

--- a/testnet-contracts/walrus/sources/system/bls_aggregate.move
+++ b/testnet-contracts/walrus/sources/system/bls_aggregate.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::bls_aggregate;

--- a/testnet-contracts/walrus/sources/system/encoding.move
+++ b/testnet-contracts/walrus/sources/system/encoding.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::encoding;

--- a/testnet-contracts/walrus/sources/system/epoch_parameters.move
+++ b/testnet-contracts/walrus/sources/system/epoch_parameters.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::epoch_parameters;

--- a/testnet-contracts/walrus/sources/system/event_blob.move
+++ b/testnet-contracts/walrus/sources/system/event_blob.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// Module to certify event blobs.

--- a/testnet-contracts/walrus/sources/system/events.move
+++ b/testnet-contracts/walrus/sources/system/events.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// Module to emit events. Used to allow filtering all events in the

--- a/testnet-contracts/walrus/sources/system/messages.move
+++ b/testnet-contracts/walrus/sources/system/messages.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::messages;

--- a/testnet-contracts/walrus/sources/system/metadata.move
+++ b/testnet-contracts/walrus/sources/system/metadata.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// Contains the metadata for Blobs on Walrus.

--- a/testnet-contracts/walrus/sources/system/redstuff.move
+++ b/testnet-contracts/walrus/sources/system/redstuff.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::redstuff;

--- a/testnet-contracts/walrus/sources/system/shared_blob.move
+++ b/testnet-contracts/walrus/sources/system/shared_blob.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::shared_blob;

--- a/testnet-contracts/walrus/sources/system/storage_accounting.move
+++ b/testnet-contracts/walrus/sources/system/storage_accounting.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::storage_accounting;

--- a/testnet-contracts/walrus/sources/system/storage_resource.move
+++ b/testnet-contracts/walrus/sources/system/storage_resource.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::storage_resource;

--- a/testnet-contracts/walrus/sources/system/system_state_inner.move
+++ b/testnet-contracts/walrus/sources/system/system_state_inner.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[allow(unused_variable, unused_mut_parameter, unused_field)]

--- a/testnet-contracts/walrus/sources/upgrade.move
+++ b/testnet-contracts/walrus/sources/upgrade.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// Module to manage Walrus contract upgrades.

--- a/testnet-contracts/walrus/sources/utils/extended_field.move
+++ b/testnet-contracts/walrus/sources/utils/extended_field.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// Module: extended_field

--- a/testnet-contracts/walrus/sources/utils/sort.move
+++ b/testnet-contracts/walrus/sources/utils/sort.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// Implements sorting macros for commonly used data structures.

--- a/testnet-contracts/walrus/tests/e2e_runner.move
+++ b/testnet-contracts/walrus/tests/e2e_runner.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::e2e_runner;

--- a/testnet-contracts/walrus/tests/e2e_tests.move
+++ b/testnet-contracts/walrus/tests/e2e_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[allow(unused_mut_ref)]

--- a/testnet-contracts/walrus/tests/staking/active_set_tests.move
+++ b/testnet-contracts/walrus/tests/staking/active_set_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 /// Contains an active set of storage nodes. The active set is a smart collection

--- a/testnet-contracts/walrus/tests/staking/committee_tests.move
+++ b/testnet-contracts/walrus/tests/staking/committee_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::committee_tests;

--- a/testnet-contracts/walrus/tests/staking/staked_wal_tests.move
+++ b/testnet-contracts/walrus/tests/staking/staked_wal_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::staked_wal_tests;

--- a/testnet-contracts/walrus/tests/staking/staking_inner_compute_tests.move
+++ b/testnet-contracts/walrus/tests/staking/staking_inner_compute_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::staking_inner_compute_tests;

--- a/testnet-contracts/walrus/tests/staking/staking_inner_tests.move
+++ b/testnet-contracts/walrus/tests/staking/staking_inner_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::staking_inner_tests;

--- a/testnet-contracts/walrus/tests/staking/staking_pool/pool_commission_tests.move
+++ b/testnet-contracts/walrus/tests/staking/staking_pool/pool_commission_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::pool_commission_tests;

--- a/testnet-contracts/walrus/tests/staking/staking_pool/pool_direct_withdraw_tests.move
+++ b/testnet-contracts/walrus/tests/staking/staking_pool/pool_direct_withdraw_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[allow(unused_use, unused_const)]

--- a/testnet-contracts/walrus/tests/staking/staking_pool/pool_early_withdraw_tests.move
+++ b/testnet-contracts/walrus/tests/staking/staking_pool/pool_early_withdraw_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 // Early withdrawal mechanics (for E0, E0', E1, E1', E2, E2'):

--- a/testnet-contracts/walrus/tests/staking/staking_pool/pool_rounding_tests.move
+++ b/testnet-contracts/walrus/tests/staking/staking_pool/pool_rounding_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::pool_rounding_tests;

--- a/testnet-contracts/walrus/tests/staking/staking_pool/staking_pool_tests.move
+++ b/testnet-contracts/walrus/tests/staking/staking_pool/staking_pool_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::staking_pool_tests;

--- a/testnet-contracts/walrus/tests/staking/walrus_context_tests.move
+++ b/testnet-contracts/walrus/tests/staking/walrus_context_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::walrus_context_tests;

--- a/testnet-contracts/walrus/tests/system/blob_tests.move
+++ b/testnet-contracts/walrus/tests/system/blob_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[test_only]

--- a/testnet-contracts/walrus/tests/system/bls_tests.move
+++ b/testnet-contracts/walrus/tests/system/bls_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[test_only]

--- a/testnet-contracts/walrus/tests/system/deny_list_tests.move
+++ b/testnet-contracts/walrus/tests/system/deny_list_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[test_only]

--- a/testnet-contracts/walrus/tests/system/event_blob_tests.move
+++ b/testnet-contracts/walrus/tests/system/event_blob_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[test_only]

--- a/testnet-contracts/walrus/tests/system/invalid_tests.move
+++ b/testnet-contracts/walrus/tests/system/invalid_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[test_only]

--- a/testnet-contracts/walrus/tests/system/metadata_tests.move
+++ b/testnet-contracts/walrus/tests/system/metadata_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[test_only]

--- a/testnet-contracts/walrus/tests/system/ringbuffer_tests.move
+++ b/testnet-contracts/walrus/tests/system/ringbuffer_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[test_only]

--- a/testnet-contracts/walrus/tests/system/storage_resource_tests.move
+++ b/testnet-contracts/walrus/tests/system/storage_resource_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[test_only]

--- a/testnet-contracts/walrus/tests/system/system_state_inner_tests.move
+++ b/testnet-contracts/walrus/tests/system/system_state_inner_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 #[test_only]

--- a/testnet-contracts/walrus/tests/test_node.move
+++ b/testnet-contracts/walrus/tests/test_node.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 module walrus::test_node;

--- a/testnet-contracts/walrus/tests/test_utils.move
+++ b/testnet-contracts/walrus/tests/test_utils.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 // editorconfig-checker-disable-file
 

--- a/testnet-contracts/walrus/tests/upgrade_tests.move
+++ b/testnet-contracts/walrus/tests/upgrade_tests.move
@@ -1,4 +1,4 @@
-// Copyright (c) Mysten Labs, Inc.
+// Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
 // SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
## Description

Copyright was transferred to the Walrus foundation.

## Test plan

Not needed.