### PR TITLE
feat: Allow updating logging verbosity dynamically at runtime

### DIFF
--- a/crates/walrus-service/src/common.rs
+++ b/crates/walrus-service/src/common.rs
@@ -5,7 +5,7 @@
 
 pub(crate) mod api;
 pub mod config;
-pub(crate) mod telemetry;
+pub mod telemetry;
 pub mod utils;
 
 #[cfg(feature = "client")]

--- a/crates/walrus-service/src/common/telemetry.rs
+++ b/crates/walrus-service/src/common/telemetry.rs
@@ -37,6 +37,7 @@ use prometheus::{
     core::{AtomicU64, Collector, GenericGauge},
 };
 use reqwest::Method;
+use telemetry_subscribers::TracingHandle;
 use tokio::time::Instant;
 use tokio_metrics::TaskMonitor;
 use tower_http::trace::{MakeSpan, OnResponse};
@@ -607,5 +608,28 @@ impl Default for CurrentEpochStateMetric {
 impl From<CurrentEpochStateMetric> for Box<dyn Collector> {
     fn from(value: CurrentEpochStateMetric) -> Self {
         Box::new(value.0)
+    }
+}
+
+/// A handle to the tracing system.
+#[derive(Clone)]
+pub struct WalrusTracingHandle(pub Arc<TracingHandle>);
+
+impl std::ops::Deref for WalrusTracingHandle {
+    type Target = Arc<TracingHandle>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<WalrusTracingHandle> for Arc<TracingHandle> {
+    fn from(value: WalrusTracingHandle) -> Self {
+        value.0
+    }
+}
+
+impl std::fmt::Debug for WalrusTracingHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "WalrusTracingHandle")
     }
 }

--- a/crates/walrus-service/src/common/utils.rs
+++ b/crates/walrus-service/src/common/utils.rs
@@ -219,7 +219,8 @@ pub struct MetricsAndLoggingRuntime {
     /// The Prometheus registry.
     pub registry: Registry,
     _telemetry_guards: TelemetryGuards,
-    _tracing_handle: TracingHandle,
+    /// The tracing handle.
+    pub tracing_handle: Arc<TracingHandle>,
     /// The runtime for metrics and logging.
     // INV: Runtime must be dropped last.
     pub runtime: Option<Runtime>,
@@ -260,7 +261,7 @@ impl MetricsAndLoggingRuntime {
             runtime,
             registry: Registry::new(walrus_registry),
             _telemetry_guards: telemetry_guards,
-            _tracing_handle: tracing_handle,
+            tracing_handle: Arc::new(tracing_handle),
         })
     }
 }

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -161,8 +161,9 @@ use crate::{
     common::{
         config::SuiConfig,
         event_blob_downloader::{EventBlobDownloader, LastCertifiedEventBlob},
+        utils::should_reposition_cursor,
     },
-    utils::{ShardDiffCalculator, should_reposition_cursor},
+    utils::ShardDiffCalculator,
 };
 
 pub(crate) mod db_checkpoint;


### PR DESCRIPTION
## Description

This PR adds code for updating log directives to control logging verbosity dynamically at runtime through unix socket endpoint.

## Test plan

sudo /opt/walrus/bin/walrus-node local-admin --socket-path /opt/walrus/admin.socket log-level --level "info"
Log level updated successfully to: info

---