### PR TITLE
docs(walrus-sites): remove non-working md tabs temporarily

### DIFF
--- a/docs/book/walrus-sites/portal.md
+++ b/docs/book/walrus-sites/portal.md
@@ -59,43 +59,32 @@ The environment variables are set in the `.env.local` file at the root of each p
 To just run a simple instance of a portal, you can use the environment variables specified
 in the `.env.<network>.example` file:
 
-{{#tabs }}
-
-{{#tab name="Mainnet" }}
+##### Mainnet Server Portal Environment Variables
 
 ```sh
 cp ./portal/server/.env.mainnet.example ./portal/server/.env.local
 ```
 
-{{#endtab }}
-{{#tab name="Testnet" }}
+##### Testnet Server Portal Environment Variables
 
 ```sh
 cp ./portal/server/.env.testnet.example ./portal/server/.env.local
 ```
 
-{{#endtab }}
-{{#endtabs }}
-
 Likewise, if you want to run the service-worker portal, you can copy the `.env.<network>.example`
 file to `.env.local` in the `portal/worker` directory.
 
-{{#tabs}}
-{{#tab name="Mainnet" }}
+##### Mainnet Service Worker Portal Environment Variables
 
 ```sh
 cp ./portal/worker/.env.mainnet.example ./portal/worker/.env.local
 ```
 
-{{#endtab }}
-{{#tab name="Testnet" }}
+##### Testnet Service Worker Portal Environment Variables
 
 ```sh
 cp ./portal/worker/.env.testnet.example ./portal/worker/.env.local
 ```
-
-{{#endtab }}
-{{#endtabs }}
 
 For a more detailed configuration, you can modify the `.env.local` files to suit your needs.
 As a reference, here are the definitions of the environment variables:

--- a/docs/book/walrus-sites/tutorial-install.md
+++ b/docs/book/walrus-sites/tutorial-install.md
@@ -17,8 +17,7 @@ Then, follow these additional setup steps.
 Similar to the `walrus` client CLI tool, we currently provide the `site-builder` client binary for
 macOS (Intel and Apple CPUs), Ubuntu, and Windows:
 
-{{#tabs}}
-{{#tab name="Mainnet" }}
+### Mainnet Binaries
 
 | OS      | CPU                   | Architecture |
 |---------|-----------------------|-----------------------------------------------------------------------------------------------------------------------------------|
@@ -27,8 +26,7 @@ macOS (Intel and Apple CPUs), Ubuntu, and Windows:
 | MacOS   | Intel 64bit           | [`site-builder-mainnet-latest-macos-x86_64`](https://storage.googleapis.com/mysten-walrus-binaries/site-builder-mainnet-latest-macos-x86_64)                  |
 | Windows | Intel 64bit           | [`site-builder-mainnet-latest-windows-x86_64.exe`](https://storage.googleapis.com/mysten-walrus-binaries/site-builder-mainnet-latest-windows-x86_64.exe)      |
 
-{{#endtab }}
-{{#tab name="Testnet" }}
+### Testnet Binaries
 
 | OS      | CPU                   | Architecture |
 |---------|-----------------------|-----------------------------------------------------------------------------------------------------------------------------------|
@@ -36,9 +34,6 @@ macOS (Intel and Apple CPUs), Ubuntu, and Windows:
 | MacOS   | Apple Silicon         | [`site-builder-testnet-latest-macos-arm64`](https://storage.googleapis.com/mysten-walrus-binaries/site-builder-testnet-latest-macos-arm64)                    |
 | MacOS   | Intel 64bit           | [`site-builder-testnet-latest-macos-x86_64`](https://storage.googleapis.com/mysten-walrus-binaries/site-builder-testnet-latest-macos-x86_64)                  |
 | Windows | Intel 64bit           | [`site-builder-testnet-latest-windows-x86_64.exe`](https://storage.googleapis.com/mysten-walrus-binaries/site-builder-testnet-latest-windows-x86_64.exe)      |
-
-{{#endtab }}
-{{#endtabs }}
 
 ```admonish title="Windows"
 We now offer a pre-built binary also for Windows. However, most of the remaining instructions assume
@@ -49,8 +44,7 @@ adapt most of those.
 You can download the latest build from our Google Cloud Storage (GCS) bucket (correctly setting the
 `$SYSTEM` variable):
 
-{{#tabs}}
-{{#tab name="Mainnet" }}
+### Mainnet curl request
 
 ``` sh
 SYSTEM= # set this to your system: ubuntu-x86_64, ubuntu-x86_64-generic, macos-x86_64, macos-arm64, windows-x86_64.exe
@@ -58,17 +52,13 @@ curl https://storage.googleapis.com/mysten-walrus-binaries/site-builder-mainnet-
 chmod +x site-builder
 ```
 
-{{#endtab }}
-{{#tab name="Testnet" }}
+### Testnet curl request
 
 ``` sh
 SYSTEM= # set this to your system: ubuntu-x86_64, ubuntu-x86_64-generic, macos-x86_64, macos-arm64, windows-x86_64.exe
 curl https://storage.googleapis.com/mysten-walrus-binaries/site-builder-testnet-latest-$SYSTEM -o site-builder
 chmod +x site-builder
 ```
-
-{{#endtab }}
-{{#endtabs }}
 
 To be able to run it simply as `site-builder`, move the binary to any directory included in your
 `$PATH` environment variable. Standard locations are `/usr/local/bin/`, `$HOME/bin/`, or


### PR DESCRIPTION
The markdown tabs are not working. I am removing them until we fix this. 

![image](https://github.com/user-attachments/assets/e9607817-6c44-4d44-9fb9-37104698e4ff)
