### PR TITLE
fix(client): change `NodeResult` to normal struct from tuple struct

### DIFF
--- a/crates/walrus-sdk/src/client.rs
+++ b/crates/walrus-sdk/src/client.rs
@@ -1213,7 +1213,7 @@ impl<T> Client<T> {
                 let value = progress_bar.clone();
                 move |result| {
                     if result.is_ok() && !value.is_finished() {
-                        value.inc(result.1.try_into().expect("the weight fits a usize"))
+                        value.inc(result.weight.try_into().expect("the weight fits a usize"))
                     }
                 }
             })
@@ -1339,7 +1339,13 @@ impl<T> Client<T> {
         let mut signers = Vec::with_capacity(confirmations.len());
         let mut signed_messages = Vec::with_capacity(confirmations.len());
 
-        for NodeResult(_, weight, node, result) in confirmations {
+        for NodeResult {
+            weight,
+            node,
+            result,
+            ..
+        } in confirmations
+        {
             match result {
                 Ok(confirmation) => {
                     aggregate_weight += weight;
@@ -1456,7 +1462,7 @@ impl<T> Client<T> {
         let slivers = requests
             .take_results()
             .into_iter()
-            .filter_map(|NodeResult(_, _, node, result)| {
+            .filter_map(|NodeResult { node, result, .. }| {
                 result
                     .map_err(|error| {
                         tracing::debug!(%node, %error, "retrieving sliver failed");
@@ -1517,7 +1523,7 @@ impl<T> Client<T> {
         I: Iterator<Item = Fut>,
         Fut: Future<Output = NodeResult<SliverData<U>, NodeError>>,
     {
-        while let Some(NodeResult(_, _, node, result)) = requests
+        while let Some(NodeResult { node, result, .. }) = requests
             .next(
                 self.communication_limits
                     .max_concurrent_sliver_reads_for_blob_size(
@@ -1616,7 +1622,13 @@ impl<T> Client<T> {
 
         let mut n_not_found = 0;
         let mut n_forbidden = 0;
-        for NodeResult(_, weight, node, result) in requests.into_results() {
+        for NodeResult {
+            weight,
+            node,
+            result,
+            ..
+        } in requests.into_results()
+        {
             match result {
                 Ok(metadata) => {
                     tracing::debug!(?node, "metadata received");

--- a/crates/walrus-sdk/src/client/communication/node.rs
+++ b/crates/walrus-sdk/src/client/communication/node.rs
@@ -51,25 +51,43 @@ pub type NodeIndex = usize;
 ///
 /// Contains the epoch, the "weight" of the interaction (e.g., the number of shards for which an
 /// operation was performed), the storage node that issued it, and the result of the operation.
+
 #[derive(Debug, Clone)]
-pub struct NodeResult<T, E>(
-    #[allow(dead_code)] pub Epoch,
-    pub usize,
-    pub NodeIndex,
-    pub Result<T, E>,
-);
+pub struct NodeResult<T, E> {
+    #[allow(dead_code)]
+    pub committee_epoch: Epoch,
+    pub weight: usize,
+    pub node: NodeIndex,
+    pub result: Result<T, E>,
+}
+
+impl<T, E> NodeResult<T, E> {
+    pub fn new(
+        committee_epoch: Epoch,
+        weight: usize,
+        node: NodeIndex,
+        result: Result<T, E>,
+    ) -> Self {
+        Self {
+            committee_epoch,
+            weight,
+            node,
+            result,
+        }
+    }
+}
 
 impl<T, E> WeightedResult for NodeResult<T, E> {
     type Inner = T;
     type Error = E;
     fn weight(&self) -> usize {
-        self.1
+        self.weight
     }
     fn inner_result(&self) -> &Result<Self::Inner, Self::Error> {
-        &self.3
+        &self.result
     }
     fn take_inner_result(self) -> Result<Self::Inner, Self::Error> {
-        self.3
+        self.result
     }
 }
 
@@ -177,7 +195,7 @@ impl<W> NodeCommunication<'_, W> {
     }
 
     fn to_node_result<T, E>(&self, weight: usize, result: Result<T, E>) -> NodeResult<T, E> {
-        NodeResult(self.committee_epoch, weight, self.node_index, result)
+        NodeResult::new(self.committee_epoch, weight, self.node_index, result)
     }
 
     fn to_node_result_with_n_shards<T, E>(&self, result: Result<T, E>) -> NodeResult<T, E> {


### PR DESCRIPTION
## Description
Converted  `NodeResult` to normal struct from tuple struct

Closes: #1224 
