### PR TITLE
fix: add longer watchdog timeout in nightly simtest

### DIFF
--- a/scripts/simtest/simtest-run.sh
+++ b/scripts/simtest/simtest-run.sh
@@ -43,6 +43,12 @@ WALRUS_TMP_DIR=~/walrus_simtest_tmp
 RUST_LIB_PATHS=$(find ~/.rustup/toolchains -type d -path "*/lib/rustlib/x86_64-unknown-linux-gnu/lib" 2>/dev/null)
 export LD_LIBRARY_PATH=$(echo "$RUST_LIB_PATHS" | tr '\n' ':')${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 
+# Use increased watch dog timeout in simtest.
+# Walrus simtest using default setup creates a sui cluster in a single thread, and when initializing
+# the cluster 5 seconds wall time of idle activity is common especially when initializing the
+# database. This often causes the simtest to be killed by the watchdog.
+WATCHDOG_TIMEOUT_MS=30000
+
 # By default run 1 iteration for each test, if not specified.
 : ${TEST_NUM:=1}
 
@@ -59,6 +65,7 @@ date
 TMPDIR="$WALRUS_TMP_DIR" \
 MSIM_TEST_SEED="$SEED" \
 MSIM_TEST_NUM=${TEST_NUM} \
+MSIM_WATCHDOG_TIMEOUT_MS="$WATCHDOG_TIMEOUT_MS" \
 scripts/simtest/cargo-simtest simtest simtest \
   --color never \
   --test-threads "$NUM_CPUS" \


### PR DESCRIPTION
## Description

In the past few days, the simtest nightly constantly encounter watchdog timeout in simtest using the
`default_setup()`. After debugging, it is primarily due to that in those tests, we create a sui cluster in a simgle
thread and the initializatine of the the sui cluster often taking more than 5 seconds (the default watch dog timeout).

We should increase the watcdog timeout in general to account for this case.

After this PR, the nightly [is successful](https://github.com/MystenLabs/sui-operations/actions/runs/14163659039).

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
