### PR TITLE
feat: per object blob info consistency check

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -145,7 +145,11 @@ use self::{
     },
     metrics::{NodeMetricSet, TelemetryLabel as _, STATUS_PENDING, STATUS_PERSISTED},
     shard_sync::ShardSyncHandler,
-    storage::{blob_info::BlobInfoApi as _, ShardStatus, ShardStorage},
+    storage::{
+        blob_info::{BlobInfoApi, CertifiedBlobInfoApi},
+        ShardStatus,
+        ShardStorage,
+    },
     system_events::{EventManager, SuiSystemEventProvider},
 };
 use crate::{

--- a/crates/walrus-service/src/node/consistency_check.rs
+++ b/crates/walrus-service/src/node/consistency_check.rs
@@ -115,19 +115,19 @@ fn compose_certified_blob_list_digest(
         "EpochChange::background_certified_blob_info_consistency_check",
     );
     let epoch_bucket = get_epoch_bucket(epoch);
-    let result = compose_blob_list_digest(
+
+    let value = match compose_blob_list_digest(
         blob_info_iter,
         epoch,
         &node.metrics.blob_info_consistency_check_certified_scanned,
-    );
-
-    if let Err(error) = result {
-        tracing::warn!(?error, "error when processing blob info");
-        node.metrics.blob_info_consistency_check_error.inc();
-        return;
-    }
-
-    let value = result.expect("just checked for error");
+    ) {
+        Ok(value) => value,
+        Err(error) => {
+            tracing::warn!(?error, "error when processing blob info");
+            node.metrics.blob_info_consistency_check_error.inc();
+            return;
+        }
+    };
 
     tracing::info!(?epoch, certified_blob_hash = ?value,
             "background blob info consistency check finished");
@@ -157,23 +157,23 @@ fn compose_certified_object_blob_list_digest(
         "EpochChange::background_certified_blob_object_info_consistency_check",
     );
     let epoch_bucket = get_epoch_bucket(epoch);
-    let result = compose_blob_list_digest(
+
+    let value = match compose_blob_list_digest(
         per_object_blob_info_iter,
         epoch,
         &node
             .metrics
             .per_object_blob_info_consistency_check_certified_scanned,
-    );
-
-    if let Err(error) = result {
-        tracing::warn!(?error, "error when processing per object blob info");
-        node.metrics
-            .per_object_blob_info_consistency_check_error
-            .inc();
-        return;
-    }
-
-    let value = result.expect("just checked for error");
+    ) {
+        Ok(value) => value,
+        Err(error) => {
+            tracing::warn!(?error, "error when processing per object blob info");
+            node.metrics
+                .per_object_blob_info_consistency_check_error
+                .inc();
+            return;
+        }
+    };
 
     tracing::info!(?epoch, certified_blob_hash = ?value,
             "background per-object blob info consistency check finished");

--- a/crates/walrus-service/src/node/consistency_check.rs
+++ b/crates/walrus-service/src/node/consistency_check.rs
@@ -8,12 +8,22 @@ use std::{collections::HashMap, sync::Mutex};
 use std::{hash::Hasher, sync::Arc};
 
 use anyhow::{Context, Result};
+use prometheus::IntCounterVec;
 #[cfg(msim)]
 use sui_types::base_types::ObjectID;
 use tokio::sync::oneshot;
+use typed_store::TypedStoreError;
 use walrus_core::Epoch;
 
-use super::{storage::blob_info::BlobInfoIterator, StorageNodeInner};
+use super::{
+    storage::blob_info::{
+        BlobInfoIter,
+        BlobInfoIterator,
+        CertifiedBlobInfoApi,
+        PerObjectBlobInfoIterator,
+    },
+    StorageNodeInner,
+};
 
 /// Schedule a background task to compute the hash of the list of certified blobs at the
 /// beginning of the epoch. This is used to detect inconsistencies in the blob info table
@@ -32,9 +42,17 @@ pub(super) async fn schedule_background_consistency_check(
 
         // Create a blob info iterator that takes the current blob info table as the snapshot.
         let blob_info_iterator = node.storage.certified_blob_info_iter_before_epoch(epoch);
+        let per_object_blob_info_iterator = node
+            .storage
+            .certified_per_object_blob_info_iter_before_epoch(epoch);
         let _ = tx.send(());
 
         compose_certified_blob_list_digest(node.clone(), blob_info_iterator, epoch);
+        compose_certified_object_blob_list_digest(
+            node.clone(),
+            per_object_blob_info_iterator,
+            epoch,
+        )
     });
 
     // We need to make sure that the function returns only after the blob info iterator is
@@ -45,37 +63,66 @@ pub(super) async fn schedule_background_consistency_check(
     Ok(())
 }
 
-/// Compose the digest of the certified blob list.
-fn compose_certified_blob_list_digest(
+/// Compose the digest of the blob list returned by the iterator.
+fn compose_blob_list_digest<B: AsRef<[u8]>, T: CertifiedBlobInfoApi>(
+    epoch_bucket: &str,
     node: Arc<StorageNodeInner>,
-    blob_info_iter: BlobInfoIterator,
+    blob_info_iter: BlobInfoIter<
+        B,
+        T,
+        impl Iterator<Item = Result<(B, T), TypedStoreError>> + Send + ?Sized,
+    >,
     epoch: Epoch,
-) {
+    scan_counter: &IntCounterVec,
+) -> Result<u64, TypedStoreError> {
     // xxhash is not a cryptographic hash function, but it is fast, has good collision
     // resistance, and is consistent across all platforms.
     let mut hasher = twox_hash::XxHash64::with_seed(epoch as u64);
-    let epoch_bucket = (epoch % 100).to_string();
     for item in blob_info_iter {
         match item {
             Ok(blob_info) => {
                 hasher.write(blob_info.0.as_ref());
-                walrus_utils::with_label!(
-                    node.metrics.blob_info_consistency_check_certified_scanned,
-                    epoch_bucket
-                )
-                .inc();
+                walrus_utils::with_label!(scan_counter, epoch_bucket).inc();
             }
             Err(error) => {
                 // Upon error, we can terminate the task and return immediately since
                 // we no longer can get a consistent view of the blob info table.
                 tracing::warn!(?error, "error when processing blob info");
                 node.metrics.blob_info_consistency_check_error.inc();
-                return;
+                return Err(error);
             }
         }
     }
 
     let value = hasher.finish();
+    Ok(value)
+}
+
+/// Compose the digest of the certified blob list.
+fn compose_certified_blob_list_digest(
+    node: Arc<StorageNodeInner>,
+    blob_info_iter: BlobInfoIterator,
+    epoch: Epoch,
+) {
+    let _scope = mysten_metrics::monitored_scope(
+        "EpochChange::background_certified_blob_info_consistency_check",
+    );
+    let epoch_bucket = (epoch % 100).to_string();
+    let result = compose_blob_list_digest(
+        &epoch_bucket,
+        node.clone(),
+        blob_info_iter,
+        epoch,
+        &node.metrics.blob_info_consistency_check_certified_scanned,
+    );
+
+    if let Err(error) = result {
+        tracing::warn!(?error, "error when processing blob info");
+        node.metrics.blob_info_consistency_check_error.inc();
+        return;
+    }
+
+    let value = result.expect("just checked for error");
 
     tracing::info!(?epoch, certified_blob_hash = ?value,
             "background blob info consistency check finished");
@@ -92,4 +139,55 @@ fn compose_certified_blob_list_digest(
             .or_insert_with(|| HashMap::new())
             .insert(node.node_capability, value);
     });
+}
+
+/// Compose the digest of the certified object blob list.
+fn compose_certified_object_blob_list_digest(
+    node: Arc<StorageNodeInner>,
+    per_object_blob_info_iter: PerObjectBlobInfoIterator,
+    epoch: Epoch,
+) {
+    let _scope = mysten_metrics::monitored_scope(
+        "EpochChange::background_certified_blob_object_info_consistency_check",
+    );
+    let epoch_bucket = (epoch % 100).to_string();
+    let result = compose_blob_list_digest(
+        &epoch_bucket,
+        node.clone(),
+        per_object_blob_info_iter,
+        epoch,
+        &node
+            .metrics
+            .per_object_blob_info_consistency_check_certified_scanned,
+    );
+
+    if let Err(error) = result {
+        tracing::warn!(?error, "error when processing per object blob info");
+        node.metrics
+            .per_object_blob_info_consistency_check_error
+            .inc();
+        return;
+    }
+
+    let value = result.expect("just checked for error");
+
+    tracing::info!(?epoch, certified_blob_hash = ?value,
+            "background per-object blob info consistency check finished");
+    walrus_utils::with_label!(
+        node.metrics.per_object_blob_info_consistency_check,
+        epoch_bucket
+    )
+    .set(value as i64);
+
+    sui_macros::fail_point_arg!(
+        "storage_node_certified_blob_object_digest",
+        |digest_map: Arc<Mutex<HashMap<Epoch, HashMap<ObjectID, u64>>>>| {
+            digest_map
+                .lock()
+                .expect("failed to lock the digest map")
+                .entry(epoch)
+                .or_insert_with(|| HashMap::new())
+                .insert(node.node_capability, value);
+        }
+    );
 }

--- a/crates/walrus-service/src/node/dbtool.rs
+++ b/crates/walrus-service/src/node/dbtool.rs
@@ -40,7 +40,7 @@ use crate::node::{
             blob_info_cf_options,
             per_object_blob_info_cf_options,
             BlobInfo,
-            BlobInfoApi,
+            CertifiedBlobInfoApi,
             PerObjectBlobInfo,
         },
         constants::{

--- a/crates/walrus-service/src/node/metrics.rs
+++ b/crates/walrus-service/src/node/metrics.rs
@@ -143,8 +143,8 @@ walrus_utils::metrics::define_metric_set! {
         #[help = "The number of certified blobs scanned during the blob info consistency check."]
         blob_info_consistency_check_certified_scanned: IntCounterVec["epoch"],
 
-        #[help = "The number of errors occurred when checking the consistency of the per-object \
-        blob info table."]
+        #[help = "The hash of the list of certified per-object blobs at the beginning of the \
+        epoch. Note that the label is the last two digits of the epoch number."]
         per_object_blob_info_consistency_check: IntGaugeVec["epoch"],
 
         #[help = "The number of errors occurred when checking the consistency of the per-object \

--- a/crates/walrus-service/src/node/metrics.rs
+++ b/crates/walrus-service/src/node/metrics.rs
@@ -143,6 +143,18 @@ walrus_utils::metrics::define_metric_set! {
         #[help = "The number of certified blobs scanned during the blob info consistency check."]
         blob_info_consistency_check_certified_scanned: IntCounterVec["epoch"],
 
+        #[help = "The number of errors occurred when checking the consistency of the per-object \
+        blob info table."]
+        per_object_blob_info_consistency_check: IntGaugeVec["epoch"],
+
+        #[help = "The number of errors occurred when checking the consistency of the per-object \
+        blob info table."]
+        per_object_blob_info_consistency_check_error: IntCounter[],
+
+        #[help = "The number of certified per-object blobs scanned during the per-object blob info \
+        consistency check."]
+        per_object_blob_info_consistency_check_certified_scanned: IntCounterVec["epoch"],
+
         #[help = "Status metric indicating the node's ID"]
         node_id: IntGaugeVec["walrus_node_id"],
     }

--- a/crates/walrus-service/src/node/node_recovery.rs
+++ b/crates/walrus-service/src/node/node_recovery.rs
@@ -9,7 +9,7 @@ use typed_store::TypedStoreError;
 use walrus_core::Epoch;
 
 use super::{blob_sync::BlobSyncHandler, StorageNodeInner};
-use crate::node::{storage::blob_info::BlobInfoApi, NodeStatus};
+use crate::node::{storage::blob_info::CertifiedBlobInfoApi, NodeStatus};
 
 #[derive(Debug, Clone)]
 pub struct NodeRecoveryHandler {

--- a/crates/walrus-service/src/node/shard_sync.rs
+++ b/crates/walrus-service/src/node/shard_sync.rs
@@ -25,7 +25,7 @@ use super::{
     NodeStatus,
     StorageNodeInner,
 };
-use crate::node::{errors::ShardNotAssigned, storage::blob_info::BlobInfoApi};
+use crate::node::{errors::ShardNotAssigned, storage::blob_info::CertifiedBlobInfoApi};
 
 /// The result of syncing a shard.
 enum SyncShardResult {

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -11,7 +11,7 @@ use std::{
     time::Instant,
 };
 
-use blob_info::{BlobInfoIterator, PerObjectBlobInfo};
+use blob_info::{BlobInfoIterator, PerObjectBlobInfo, PerObjectBlobInfoIterator};
 use event_cursor_table::EventIdWithProgress;
 use itertools::Itertools;
 use metrics::{CommonDatabaseMetrics, Labels, OperationType};
@@ -703,6 +703,15 @@ impl Storage {
             .certified_blob_info_iter_before_epoch(epoch, std::ops::Bound::Unbounded)
     }
 
+    /// Returns an iterator over the certified per-object blob info before the specified epoch.
+    pub(crate) fn certified_per_object_blob_info_iter_before_epoch(
+        &self,
+        epoch: Epoch,
+    ) -> PerObjectBlobInfoIterator {
+        self.blob_info
+            .certified_per_object_blob_info_iter_before_epoch(epoch, std::ops::Bound::Unbounded)
+    }
+
     /// Returns the current event cursor.
     pub(crate) fn get_event_cursor_progress(&self) -> Result<EventProgress, TypedStoreError> {
         self.event_cursor.get_event_cursor_progress()
@@ -763,6 +772,7 @@ pub(crate) mod tests {
         Sliver,
         SliverIndex,
         SliverType,
+        SuiObjectId,
     };
     use walrus_sui::{
         test_utils::{event_id_for_testing, EventForTesting},
@@ -1566,6 +1576,35 @@ pub(crate) mod tests {
         )
     }
 
+    fn registered_per_object_blob_info(blob_id: BlobId, epoch: Epoch) -> PerObjectBlobInfo {
+        PerObjectBlobInfo::new_for_testing(
+            blob_id,
+            epoch,
+            None,
+            100,
+            true,
+            event_id_for_testing(),
+            false,
+        )
+    }
+
+    fn certified_per_object_blob_info(
+        blob_id: BlobId,
+        certified_epoch: Epoch,
+        end_epoch: Epoch,
+        deleted: bool,
+    ) -> PerObjectBlobInfo {
+        PerObjectBlobInfo::new_for_testing(
+            blob_id,
+            1,
+            Some(certified_epoch),
+            end_epoch,
+            true,
+            event_id_for_testing(),
+            deleted,
+        )
+    }
+
     fn all_certified_blob_ids(
         storage: &WithTempDir<Storage>,
         after_blob: Option<BlobId>,
@@ -1578,6 +1617,18 @@ pub(crate) mod tests {
                 new_epoch,
                 after_blob.map_or(Unbounded, Excluded),
             )
+            .map(|result| result.map(|(id, _info)| id))
+            .collect::<Result<Vec<_>, _>>()
+    }
+
+    fn all_certified_blob_object_ids(
+        storage: &WithTempDir<Storage>,
+        new_epoch: Epoch,
+    ) -> Result<Vec<ObjectID>, TypedStoreError> {
+        storage
+            .inner
+            .blob_info
+            .certified_per_object_blob_info_iter_before_epoch(new_epoch, Unbounded)
             .map(|result| result.map(|(id, _info)| id))
             .collect::<Result<Vec<_>, _>>()
     }
@@ -1630,6 +1681,69 @@ pub(crate) mod tests {
         for blob_id in blob_ids.iter().take(6).skip(5) {
             assert!(all_certified_blob_ids(&storage, Some(*blob_id), new_epoch)?.is_empty());
         }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_certified_per_object_blob_info_iter_before_epoch() -> TestResult {
+        let storage = empty_storage().await;
+        let blob_info = storage.inner.blob_info.clone();
+
+        let blob_ids = [BlobId([0; 32]), BlobId([1; 32])];
+
+        let object_ids = [
+            SuiObjectId([0; 32]), // blob 0, not certified
+            SuiObjectId([1; 32]), // blob 0, certified within epoch 2
+            SuiObjectId([2; 32]), // blob 0, certified after epoch 2
+            SuiObjectId([3; 32]), // blob 0, certified within epoch 2
+            SuiObjectId([4; 32]), // blob 0, deleted
+            SuiObjectId([5; 32]), // blob 1, certified within epoch 2
+        ]
+        .into_iter()
+        .map(ObjectID::from)
+        .collect::<Vec<_>>();
+
+        let blob_info_map = HashMap::from([
+            (
+                object_ids[0],
+                registered_per_object_blob_info(blob_ids[0], 1),
+            ),
+            (
+                object_ids[1],
+                certified_per_object_blob_info(blob_ids[0], 2, 100, false),
+            ),
+            (
+                object_ids[2],
+                certified_per_object_blob_info(blob_ids[0], 3, 100, false),
+            ),
+            (
+                object_ids[3],
+                certified_per_object_blob_info(blob_ids[0], 2, 4, false),
+            ),
+            (
+                object_ids[4],
+                certified_per_object_blob_info(blob_ids[0], 2, 100, true),
+            ),
+            (
+                object_ids[5],
+                certified_per_object_blob_info(blob_ids[1], 2, 4, false),
+            ),
+        ]);
+
+        let mut batch = blob_info.batch();
+        blob_info.insert_per_object_batch(&mut batch, blob_info_map.iter())?;
+        batch.write()?;
+
+        assert_eq!(
+            all_certified_blob_object_ids(&storage, 3)?,
+            vec![object_ids[1], object_ids[3], object_ids[5]]
+        );
+
+        assert_eq!(
+            all_certified_blob_object_ids(&storage, 4)?,
+            vec![object_ids[1], object_ids[2]]
+        );
 
         Ok(())
     }

--- a/crates/walrus-service/src/node/storage/blob_info.rs
+++ b/crates/walrus-service/src/node/storage/blob_info.rs
@@ -28,6 +28,18 @@ use self::per_object_blob_info::PerObjectBlobInfoMergeOperand;
 pub(crate) use self::per_object_blob_info::{PerObjectBlobInfo, PerObjectBlobInfoApi};
 use super::{constants::*, database_config::DatabaseTableOptions, DatabaseConfig};
 
+pub type BlobInfoIterator<'a> = BlobInfoIter<
+    BlobId,
+    BlobInfo,
+    dyn Iterator<Item = Result<(BlobId, BlobInfo), TypedStoreError>> + Send + 'a,
+>;
+
+pub type PerObjectBlobInfoIterator<'a> = BlobInfoIter<
+    ObjectID,
+    PerObjectBlobInfo,
+    dyn Iterator<Item = Result<(ObjectID, PerObjectBlobInfo), TypedStoreError>> + Send + 'a,
+>;
+
 #[derive(Debug, Clone)]
 pub(super) struct BlobInfoTable {
     aggregate_blob_info: DBMap<BlobId, BlobInfo>,
@@ -174,6 +186,23 @@ impl BlobInfoTable {
         )
     }
 
+    /// Returns an iterator over all blobs that were certified before the specified epoch in the
+    /// per-object blob info table starting with the `starting_object_id` bound.
+    #[tracing::instrument(skip_all)]
+    pub fn certified_per_object_blob_info_iter_before_epoch(
+        &self,
+        before_epoch: Epoch,
+        starting_object_id_bound: Bound<ObjectID>,
+    ) -> PerObjectBlobInfoIterator {
+        BlobInfoIter::new(
+            Box::new(
+                self.per_object_blob_info
+                    .safe_range_iter((starting_object_id_bound, Unbounded)),
+            ),
+            before_epoch,
+        )
+    }
+
     /// Returns the blob info for `blob_id`.
     pub fn get(&self, blob_id: &BlobId) -> Result<Option<BlobInfo>, TypedStoreError> {
         self.aggregate_blob_info.get(blob_id)
@@ -228,29 +257,38 @@ impl BlobInfoTable {
         batch.insert_batch(&self.aggregate_blob_info, new_vals)?;
         Ok(())
     }
+
+    pub fn insert_per_object_batch<'a>(
+        &self,
+        batch: &mut DBBatch,
+        new_vals: impl IntoIterator<Item = (&'a ObjectID, &'a PerObjectBlobInfo)>,
+    ) -> Result<(), TypedStoreError> {
+        batch.insert_batch(&self.per_object_blob_info, new_vals)?;
+        Ok(())
+    }
 }
 
 /// An iterator over the blob info table.
-pub(crate) struct BlobInfoIter<I: ?Sized>
+pub(crate) struct BlobInfoIter<B, T: CertifiedBlobInfoApi, I: ?Sized>
 where
-    I: Iterator<Item = Result<(BlobId, BlobInfo), TypedStoreError>> + Send,
+    I: Iterator<Item = Result<(B, T), TypedStoreError>> + Send,
 {
     iter: Box<I>,
     before_epoch: Epoch,
 }
 
-impl<I: ?Sized> BlobInfoIter<I>
+impl<B, T: CertifiedBlobInfoApi, I: ?Sized> BlobInfoIter<B, T, I>
 where
-    I: Iterator<Item = Result<(BlobId, BlobInfo), TypedStoreError>> + Send,
+    I: Iterator<Item = Result<(B, T), TypedStoreError>> + Send,
 {
     pub fn new(iter: Box<I>, before_epoch: Epoch) -> Self {
         Self { iter, before_epoch }
     }
 }
 
-impl<I: ?Sized> Debug for BlobInfoIter<I>
+impl<B, T: CertifiedBlobInfoApi, I: ?Sized> Debug for BlobInfoIter<B, T, I>
 where
-    I: Iterator<Item = Result<(BlobId, BlobInfo), TypedStoreError>> + Send,
+    I: Iterator<Item = Result<(B, T), TypedStoreError>> + Send,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("BlobInfoIter")
@@ -259,11 +297,11 @@ where
     }
 }
 
-impl<I: ?Sized> Iterator for BlobInfoIter<I>
+impl<B, T: CertifiedBlobInfoApi, I: ?Sized> Iterator for BlobInfoIter<B, T, I>
 where
-    I: Iterator<Item = Result<(BlobId, BlobInfo), TypedStoreError>> + Send,
+    I: Iterator<Item = Result<(B, T), TypedStoreError>> + Send,
 {
-    type Item = Result<(BlobId, BlobInfo), TypedStoreError>;
+    type Item = Result<(B, T), TypedStoreError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         for item in self.iter.by_ref() {
@@ -287,9 +325,6 @@ where
         None
     }
 }
-
-pub type BlobInfoIterator<'a> =
-    BlobInfoIter<dyn Iterator<Item = Result<(BlobId, BlobInfo), TypedStoreError>> + Send + 'a>;
 
 pub(super) trait ToBytes: Serialize + Sized {
     /// Converts the value to a `Vec<u8>`.
@@ -327,15 +362,8 @@ pub(super) trait Mergeable: ToBytes + Debug + DeserializeOwned + Serialize + Siz
     }
 }
 
-/// Trait defining methods for retrieving information about a blob.
-// NB: Before adding functions to this trait, think twice if you really need it as it needs to be
-// implementable by future internal representations of the blob status as well.
 #[enum_dispatch]
-pub(crate) trait BlobInfoApi {
-    /// Returns a boolean indicating whether the metadata of the blob is stored.
-    fn is_metadata_stored(&self) -> bool;
-    /// Returns true iff there exists at least one non-expired deletable or permanent `Blob` object.
-    fn is_registered(&self, current_epoch: Epoch) -> bool;
+pub(crate) trait CertifiedBlobInfoApi {
     /// Returns true iff there exists at least one non-expired and certified deletable or permanent
     /// `Blob` object.
     fn is_certified(&self, current_epoch: Epoch) -> bool;
@@ -344,6 +372,18 @@ pub(crate) trait BlobInfoApi {
     ///
     /// Returns `None` if it isn't certified.
     fn initial_certified_epoch(&self) -> Option<Epoch>;
+}
+
+/// Trait defining methods for retrieving information about a blob.
+// NB: Before adding functions to this trait, think twice if you really need it as it needs to be
+// implementable by future internal representations of the blob status as well.
+#[enum_dispatch]
+pub(crate) trait BlobInfoApi: CertifiedBlobInfoApi {
+    /// Returns a boolean indicating whether the metadata of the blob is stored.
+    fn is_metadata_stored(&self) -> bool;
+    /// Returns true iff there exists at least one non-expired deletable or permanent `Blob` object.
+    fn is_registered(&self, current_epoch: Epoch) -> bool;
+
     /// Returns the event through which this blob was marked invalid.
     ///
     /// Returns `None` if it isn't invalid.
@@ -960,6 +1000,28 @@ impl PermanentBlobInfoV1 {
     }
 }
 
+impl CertifiedBlobInfoApi for BlobInfoV1 {
+    fn is_certified(&self, current_epoch: Epoch) -> bool {
+        if let Self::Valid(valid_blob_info) = self {
+            valid_blob_info.is_certified(current_epoch)
+        } else {
+            false
+        }
+    }
+
+    fn initial_certified_epoch(&self) -> Option<Epoch> {
+        if let Self::Valid(ValidBlobInfoV1 {
+            initial_certified_epoch,
+            ..
+        }) = self
+        {
+            *initial_certified_epoch
+        } else {
+            None
+        }
+    }
+}
+
 impl BlobInfoApi for BlobInfoV1 {
     fn is_metadata_stored(&self) -> bool {
         matches!(
@@ -992,26 +1054,6 @@ impl BlobInfoApi for BlobInfoV1 {
             && latest_seen_deletable_registered_epoch.is_some_and(|l| l > current_epoch);
 
         exists_registered_permanent_blob || maybe_exists_registered_deletable_blob
-    }
-
-    fn is_certified(&self, current_epoch: Epoch) -> bool {
-        if let Self::Valid(valid_blob_info) = self {
-            valid_blob_info.is_certified(current_epoch)
-        } else {
-            false
-        }
-    }
-
-    fn initial_certified_epoch(&self) -> Option<Epoch> {
-        if let Self::Valid(ValidBlobInfoV1 {
-            initial_certified_epoch,
-            ..
-        }) = self
-        {
-            *initial_certified_epoch
-        } else {
-            None
-        }
     }
 
     fn invalidation_event(&self) -> Option<EventID> {
@@ -1146,6 +1188,7 @@ impl Ord for BlobCertificationStatus {
 
 /// Internal representation of the aggregate blob information for use in the database etc. Use
 /// [`walrus_sdk::api::BlobStatus`] for anything public facing (e.g., communication to the client).
+#[enum_dispatch(CertifiedBlobInfoApi)]
 #[enum_dispatch(BlobInfoApi)]
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone)]
 pub(crate) enum BlobInfo {
@@ -1240,7 +1283,7 @@ mod per_object_blob_info {
     // be implementable by future internal representations of the per-object blob status as well.
     #[enum_dispatch]
     #[allow(dead_code)]
-    pub(crate) trait PerObjectBlobInfoApi {
+    pub(crate) trait PerObjectBlobInfoApi: CertifiedBlobInfoApi {
         /// Returns the blob ID associated with this object.
         fn blob_id(&self) -> BlobId;
         /// Returns true iff the object is deletable.
@@ -1248,19 +1291,36 @@ mod per_object_blob_info {
 
         /// Returns true iff the object is not expired and not deleted.
         fn is_registered(&self, current_epoch: Epoch) -> bool;
-        /// Returns true iff the object is certified and not expired and not deleted.
-        fn is_certified(&self, current_epoch: Epoch) -> bool;
-
-        /// Returns the epoch at which this blob was first certified.
-        ///
-        /// Returns `None` if it was never certified.
-        fn certified_epoch(&self) -> Option<Epoch>;
     }
 
-    #[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone)]
+    #[enum_dispatch(CertifiedBlobInfoApi)]
     #[enum_dispatch(PerObjectBlobInfoApi)]
+    #[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone)]
     pub(crate) enum PerObjectBlobInfo {
         V1(PerObjectBlobInfoV1),
+    }
+
+    impl PerObjectBlobInfo {
+        #[cfg(test)]
+        pub(crate) fn new_for_testing(
+            blob_id: BlobId,
+            registered_epoch: Epoch,
+            certified_epoch: Option<Epoch>,
+            end_epoch: Epoch,
+            deletable: bool,
+            event: EventID,
+            deleted: bool,
+        ) -> Self {
+            Self::V1(PerObjectBlobInfoV1 {
+                blob_id,
+                registered_epoch,
+                certified_epoch,
+                end_epoch,
+                deletable,
+                event,
+                deleted,
+            })
+        }
     }
 
     impl ToBytes for PerObjectBlobInfo {}
@@ -1297,6 +1357,16 @@ mod per_object_blob_info {
         pub deleted: bool,
     }
 
+    impl CertifiedBlobInfoApi for PerObjectBlobInfoV1 {
+        fn is_certified(&self, current_epoch: Epoch) -> bool {
+            self.is_registered(current_epoch) && self.certified_epoch.is_some()
+        }
+
+        fn initial_certified_epoch(&self) -> Option<Epoch> {
+            self.certified_epoch
+        }
+    }
+
     impl PerObjectBlobInfoApi for PerObjectBlobInfoV1 {
         fn blob_id(&self) -> BlobId {
             self.blob_id
@@ -1308,14 +1378,6 @@ mod per_object_blob_info {
 
         fn is_registered(&self, current_epoch: Epoch) -> bool {
             self.end_epoch > current_epoch && !self.deleted
-        }
-
-        fn is_certified(&self, current_epoch: Epoch) -> bool {
-            self.is_registered(current_epoch) && self.certified_epoch.is_some()
-        }
-
-        fn certified_epoch(&self) -> Option<Epoch> {
-            self.certified_epoch
         }
     }
 

--- a/crates/walrus-service/src/node/storage/blob_info.rs
+++ b/crates/walrus-service/src/node/storage/blob_info.rs
@@ -186,8 +186,8 @@ impl BlobInfoTable {
         )
     }
 
-    /// Returns an iterator over all blobs that were certified before the specified epoch in the
-    /// per-object blob info table starting with the `starting_object_id` bound.
+    /// Returns an iterator over all blob objects that were certified before the specified epoch in
+    /// the per-object blob info table starting with the `starting_object_id` bound.
     #[tracing::instrument(skip_all)]
     pub fn certified_per_object_blob_info_iter_before_epoch(
         &self,
@@ -362,6 +362,7 @@ pub(super) trait Mergeable: ToBytes + Debug + DeserializeOwned + Serialize + Siz
     }
 }
 
+/// Trait defining methods for retrieving information about a certified blob.
 #[enum_dispatch]
 pub(crate) trait CertifiedBlobInfoApi {
     /// Returns true iff there exists at least one non-expired and certified deletable or permanent

--- a/crates/walrus-simtest/src/test_utils.rs
+++ b/crates/walrus-simtest/src/test_utils.rs
@@ -184,6 +184,7 @@ pub mod simtest_utils {
     #[derive(Debug)]
     pub struct BlobInfoConsistencyCheck {
         certified_blob_digest_map: Arc<Mutex<HashMap<Epoch, HashMap<ObjectID, u64>>>>,
+        per_object_blob_digest_map: Arc<Mutex<HashMap<Epoch, HashMap<ObjectID, u64>>>>,
         checked: Arc<AtomicBool>,
     }
 
@@ -192,6 +193,8 @@ pub mod simtest_utils {
         pub fn new() -> Self {
             let certified_blob_digest_map = Arc::new(Mutex::new(HashMap::new()));
             let certified_blob_digest_map_clone = certified_blob_digest_map.clone();
+            let per_object_blob_digest_map = Arc::new(Mutex::new(HashMap::new()));
+            let per_object_blob_digest_map_clone = per_object_blob_digest_map.clone();
 
             sui_macros::register_fail_point_arg(
                 "storage_node_certified_blob_digest",
@@ -200,8 +203,15 @@ pub mod simtest_utils {
                 },
             );
 
+            sui_macros::register_fail_point_arg(
+                "storage_node_certified_blob_object_digest",
+                move || -> Option<Arc<Mutex<HashMap<Epoch, HashMap<ObjectID, u64>>>>> {
+                    Some(per_object_blob_digest_map_clone.clone())
+                },
+            );
             Self {
                 certified_blob_digest_map,
+                per_object_blob_digest_map,
                 checked: Arc::new(AtomicBool::new(false)),
             }
         }
@@ -228,6 +238,24 @@ pub mod simtest_utils {
                     }
                 }
             }
+
+            // Ensure that for all epochs, all nodes have the same per object blob digest
+            let digest_map = self.per_object_blob_digest_map.lock().unwrap();
+            for (epoch, node_digest_map) in digest_map.iter() {
+                // Ensure that for the same epoch, all nodes have the same per object blob digest
+                let mut epoch_digest = None;
+                for (node_id, digest) in node_digest_map.iter() {
+                    tracing::info!(
+                        "blob info consistency check: node {node_id} has digest \
+                        {digest} in epoch {epoch}",
+                    );
+                    if epoch_digest.is_none() {
+                        epoch_digest = Some(digest);
+                    } else {
+                        assert_eq!(epoch_digest, Some(digest));
+                    }
+                }
+            }
         }
     }
 
@@ -235,6 +263,7 @@ pub mod simtest_utils {
         fn drop(&mut self) {
             assert!(self.checked.load(std::sync::atomic::Ordering::SeqCst));
             sui_macros::clear_fail_point("storage_node_certified_blob_digest");
+            sui_macros::clear_fail_point("storage_node_certified_blob_object_digest");
         }
     }
 

--- a/crates/walrus-simtest/src/test_utils.rs
+++ b/crates/walrus-simtest/src/test_utils.rs
@@ -221,10 +221,10 @@ pub mod simtest_utils {
             self.checked
                 .store(true, std::sync::atomic::Ordering::SeqCst);
 
-            // Ensure that for all epochs, all nodes have the same certified blob digest
+            // Ensure that for all epochs, all nodes have the same certified blob digest.
             let digest_map = self.certified_blob_digest_map.lock().unwrap();
             for (epoch, node_digest_map) in digest_map.iter() {
-                // Ensure that for the same epoch, all nodes have the same certified blob digest
+                // Ensure that for the same epoch, all nodes have the same certified blob digest.
                 let mut epoch_digest = None;
                 for (node_id, digest) in node_digest_map.iter() {
                     tracing::info!(
@@ -239,10 +239,10 @@ pub mod simtest_utils {
                 }
             }
 
-            // Ensure that for all epochs, all nodes have the same per object blob digest
+            // Ensure that for all epochs, all nodes have the same per object blob digest.
             let digest_map = self.per_object_blob_digest_map.lock().unwrap();
             for (epoch, node_digest_map) in digest_map.iter() {
-                // Ensure that for the same epoch, all nodes have the same per object blob digest
+                // Ensure that for the same epoch, all nodes have the same per object blob digest.
                 let mut epoch_digest = None;
                 for (node_id, digest) in node_digest_map.iter() {
                     tracing::info!(


### PR DESCRIPTION
## Description

Similar to #1790 , this PR implements consistency check for per object blob info table. The bulk of the implementation
is to implement an iterator over the per object blob info table.

Also turned on per object blob info consistency check in all simtest.

Contributes to WAL-701

## Test plan

Unit test, simtest

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
