### PR TITLE
fix: changing shard status query from non-blocking to wait for status is retrieved

### DIFF
--- a/crates/walrus-service/src/node/server.rs
+++ b/crates/walrus-service/src/node/server.rs
@@ -671,7 +671,7 @@ mod tests {
             walrus_core::test_utils::encoding_config().n_shards()
         }
 
-        fn health_info(&self, _detailed: bool) -> ServiceHealthInfo {
+        async fn health_info(&self, _detailed: bool) -> ServiceHealthInfo {
             ServiceHealthInfo {
                 uptime: Duration::from_secs(0),
                 epoch: 0,

--- a/crates/walrus-service/src/node/server/routes.rs
+++ b/crates/walrus-service/src/node/server/routes.rs
@@ -662,7 +662,7 @@ pub async fn health_info<S: SyncServiceState>(
     Query(query): Query<HealthInfoQuery>,
     State(state): State<Arc<S>>,
 ) -> ApiSuccess<ServiceHealthInfo> {
-    ApiSuccess::ok(state.health_info(query.detailed))
+    ApiSuccess::ok(state.health_info(query.detailed).await)
 }
 
 #[tracing::instrument(skip_all)]


### PR DESCRIPTION
## Description

It was not an issue before when using std::sync::lock because there won't be any interleaving of locks. By switching to
tokio locks, now it's possible that code can yield when holding the lock.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
