### PR TITLE
feat: add an option that when resuming shard sync upon node restart always try shard transfer first

### DIFF
--- a/crates/walrus-service/node_config_example.yaml
+++ b/crates/walrus-service/node_config_example.yaml
@@ -89,6 +89,7 @@ shard_sync_config:
   max_concurrent_metadata_fetch: 10
   shard_sync_concurrency: 10
   shard_sync_retry_switch_to_recovery_interval_secs: 7200
+  restart_shard_sync_always_retry_transfer_first: true
 event_processor_config:
   pruning_interval_secs: 3600
   checkpoint_request_timeout_secs: 60

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -4704,6 +4704,93 @@ mod tests {
             Ok(())
         }
 
+        // Tests that restarting shard sync will retry shard transfer first, even though last sync
+        // entered recovery mode.
+        simtest_param_test! {
+            sync_shard_restart_recover_retry_transfer -> TestResult: [
+                primary5: (5, SliverType::Primary),
+                primary15: (15, SliverType::Primary),
+                secondary5: (5, SliverType::Secondary),
+                secondary15: (15, SliverType::Secondary),
+            ]
+        }
+        async fn sync_shard_restart_recover_retry_transfer(
+            break_index: u64,
+            sliver_type: SliverType,
+        ) -> TestResult {
+            let (cluster, blob_details, storage_dst, shard_storage_set) =
+                setup_cluster_for_shard_sync_tests(None, None).await?;
+
+            assert_eq!(shard_storage_set.shard_storage.len(), 1);
+            let shard_storage_dst = shard_storage_set.shard_storage[0].clone();
+
+            // Register two fail points here. `fail_point_fetch_sliver` will cause shard transfer
+            // to fail in the middle, which makes node entering recover mode, and
+            // `fail_point_after_start_recovery` will cause the shard recovery to fail, which
+            // terminates the shard sync process. Upon restart, we should see that shards retry
+            // shard transfer first.
+            register_fail_point_arg(
+                "fail_point_fetch_sliver",
+                move || -> Option<(SliverType, u64)> { Some((sliver_type, break_index)) },
+            );
+            register_fail_point_if("fail_point_after_start_recovery", || true);
+
+            // Starts the shard syncing process in the new shard, which will fail at the specified
+            // break index.
+            cluster.nodes[1]
+                .storage_node
+                .shard_sync_handler
+                .start_sync_shards(vec![ShardIndex(0)], false)
+                .await?;
+
+            // Waits for the shard sync process to stop.
+            wait_until_no_sync_tasks(&cluster.nodes[1].storage_node.shard_sync_handler).await?;
+
+            // Check that shard sync process is not finished.
+            let shard_storage_src = cluster.nodes[0]
+                .storage_node
+                .inner
+                .storage
+                .shard_storage(ShardIndex(0))
+                .await
+                .expect("shard storage should exist");
+            assert!(
+                shard_storage_dst.sliver_count(SliverType::Primary)
+                    < shard_storage_src.sliver_count(SliverType::Primary)
+                    || shard_storage_dst.sliver_count(SliverType::Secondary)
+                        < shard_storage_src.sliver_count(SliverType::Secondary)
+            );
+
+            // Register a fail point to check that the node will not enter recovery mode from this
+            // point after restart.
+            register_fail_point("fail_point_shard_sync_recovery", move || {
+                panic!("shard sync should not enter recovery mode in this test");
+            });
+            clear_fail_point("fail_point_fetch_sliver");
+
+            // restart the shard syncing process, to simulate a reboot.
+            cluster.nodes[1]
+                .storage_node
+                .shard_sync_handler
+                .clear_shard_sync_tasks()
+                .await;
+            cluster.nodes[1]
+                .storage_node
+                .shard_sync_handler
+                .restart_syncs()
+                .await?;
+
+            // Waits for the shard to be synced.
+            wait_until_no_sync_tasks(&cluster.nodes[1].storage_node.shard_sync_handler).await?;
+
+            // Checks that the shard is completely migrated.
+            check_all_blobs_are_synced(&blob_details, &storage_dst, &shard_storage_dst, &[])?;
+
+            clear_fail_point("fail_point_shard_sync_recovery");
+            clear_fail_point("fail_point_after_start_recovery");
+            Ok(())
+        }
+
         simtest_param_test! {
             sync_shard_src_abnormal_return -> TestResult: [
                 // Tests that there is a discrepancy between the source and destination shards in

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -4763,7 +4763,7 @@ mod tests {
 
             // Register a fail point to check that the node will not enter recovery mode from this
             // point after restart.
-            register_fail_point("fail_point_shard_sync_recovery", move || {
+            register_fail_point("fail_point_shard_sync_recover_blob", move || {
                 panic!("shard sync should not enter recovery mode in this test");
             });
             clear_fail_point("fail_point_fetch_sliver");
@@ -4786,7 +4786,7 @@ mod tests {
             // Checks that the shard is completely migrated.
             check_all_blobs_are_synced(&blob_details, &storage_dst, &shard_storage_dst, &[])?;
 
-            clear_fail_point("fail_point_shard_sync_recovery");
+            clear_fail_point("fail_point_shard_sync_recover_blob");
             clear_fail_point("fail_point_after_start_recovery");
             Ok(())
         }

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -606,60 +606,48 @@ impl Default for CommitteeServiceConfig {
 #[serde(default)]
 pub struct ShardSyncConfig {
     /// The number of slivers to fetch in a single sync shard request.
-    #[serde(default = "defaults::sliver_count_per_sync_request")]
     pub sliver_count_per_sync_request: u64,
     /// The minimum backoff time for shard sync retries.
     #[serde_as(as = "DurationSeconds<u64>")]
     #[serde(rename = "shard_sync_retry_min_backoff_secs")]
-    #[serde(default = "defaults::shard_sync_retry_min_backoff")]
     pub shard_sync_retry_min_backoff: Duration,
     /// The maximum backoff time for shard sync retries.
     #[serde_as(as = "DurationSeconds<u64>")]
     #[serde(rename = "shard_sync_retry_max_backoff_secs")]
-    #[serde(default = "defaults::shard_sync_retry_max_backoff")]
     pub shard_sync_retry_max_backoff: Duration,
     /// The maximum number of concurrent blob recoveries during shard recovery.
-    #[serde(default = "defaults::max_concurrent_blob_recovery_during_shard_recovery")]
     pub max_concurrent_blob_recovery_during_shard_recovery: usize,
     /// The interval to check if the blob is still certified during recovery.
     #[serde_as(as = "DurationSeconds<u64>")]
     #[serde(rename = "blob_certified_check_interval_secs")]
-    #[serde(default = "defaults::blob_certified_check_interval")]
     pub blob_certified_check_interval: Duration,
     /// The number of metadata to fetch in parallel.
-    #[serde(default = "defaults::max_concurrent_metadata_fetch")]
     pub max_concurrent_metadata_fetch: usize,
     /// Maximum number of concurrent shard syncs allowed per node.
-    #[serde(default = "defaults::shard_sync_concurrency")]
     pub shard_sync_concurrency: usize,
     /// The interval to switch to recovery mode if the shard sync retries continue to fail.
     #[serde_as(as = "DurationSeconds<u64>")]
     #[serde(rename = "shard_sync_retry_switch_to_recovery_interval_secs")]
-    #[serde(default = "defaults::shard_sync_retry_switch_to_recovery_interval")]
     pub shard_sync_retry_switch_to_recovery_interval: Duration,
     /// Whether to restart shard sync always retry shard transfer first. This is a fallback
     /// mechanism in case a shard recovery is initiated, restarting the node can resume shard
     /// transfer. This is the preferred option since it's always cheaper to scan the blob info
     /// table without transferring the shards.
-    #[serde(default = "defaults::restart_shard_sync_always_retry_transfer_first")]
     pub restart_shard_sync_always_retry_transfer_first: bool,
 }
 
 impl Default for ShardSyncConfig {
     fn default() -> Self {
         Self {
-            sliver_count_per_sync_request: defaults::sliver_count_per_sync_request(),
-            shard_sync_retry_min_backoff: defaults::shard_sync_retry_min_backoff(),
-            shard_sync_retry_max_backoff: defaults::shard_sync_retry_max_backoff(),
-            max_concurrent_blob_recovery_during_shard_recovery:
-                defaults::max_concurrent_blob_recovery_during_shard_recovery(),
-            blob_certified_check_interval: defaults::blob_certified_check_interval(),
-            max_concurrent_metadata_fetch: defaults::max_concurrent_metadata_fetch(),
-            shard_sync_concurrency: defaults::shard_sync_concurrency(),
-            shard_sync_retry_switch_to_recovery_interval:
-                defaults::shard_sync_retry_switch_to_recovery_interval(),
-            restart_shard_sync_always_retry_transfer_first:
-                defaults::restart_shard_sync_always_retry_transfer_first(),
+            sliver_count_per_sync_request: 10,
+            shard_sync_retry_min_backoff: Duration::from_secs(60),
+            shard_sync_retry_max_backoff: Duration::from_secs(600),
+            max_concurrent_blob_recovery_during_shard_recovery: 5,
+            blob_certified_check_interval: Duration::from_secs(60),
+            max_concurrent_metadata_fetch: 10,
+            shard_sync_concurrency: 10,
+            shard_sync_retry_switch_to_recovery_interval: Duration::from_secs(2 * 60 * 60), // 2hr
+            restart_shard_sync_always_retry_transfer_first: true,
         }
     }
 }
@@ -748,51 +736,6 @@ pub mod defaults {
     /// Returns false in test mode.
     pub fn config_synchronizer_enabled() -> bool {
         !cfg!(test)
-    }
-
-    /// The default number of slivers to fetch in a single sync shard request.
-    pub fn sliver_count_per_sync_request() -> u64 {
-        10
-    }
-
-    /// The default minimum backoff time for shard sync retries.
-    pub fn shard_sync_retry_min_backoff() -> Duration {
-        Duration::from_secs(60)
-    }
-
-    /// The default maximum backoff time for shard sync retries.
-    pub fn shard_sync_retry_max_backoff() -> Duration {
-        Duration::from_secs(600)
-    }
-
-    /// The default maximum number of concurrent blob recoveries during shard recovery.
-    pub fn max_concurrent_blob_recovery_during_shard_recovery() -> usize {
-        5
-    }
-
-    /// The default interval to check if the blob is still certified during recovery.
-    pub fn blob_certified_check_interval() -> Duration {
-        Duration::from_secs(60)
-    }
-
-    /// The default number of metadata to fetch in parallel.
-    pub fn max_concurrent_metadata_fetch() -> usize {
-        10
-    }
-
-    /// The default maximum number of concurrent shard syncs allowed per node.
-    pub fn shard_sync_concurrency() -> usize {
-        10
-    }
-
-    /// The default interval to switch to recovery mode if the shard sync retries continue to fail.
-    pub fn shard_sync_retry_switch_to_recovery_interval() -> Duration {
-        Duration::from_secs(2 * 60 * 60) // 2hr
-    }
-
-    /// The default value for whether to restart shard sync always retry transfer first.
-    pub fn restart_shard_sync_always_retry_transfer_first() -> bool {
-        true
     }
 }
 

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -606,42 +606,60 @@ impl Default for CommitteeServiceConfig {
 #[serde(default)]
 pub struct ShardSyncConfig {
     /// The number of slivers to fetch in a single sync shard request.
+    #[serde(default = "defaults::sliver_count_per_sync_request")]
     pub sliver_count_per_sync_request: u64,
     /// The minimum backoff time for shard sync retries.
     #[serde_as(as = "DurationSeconds<u64>")]
     #[serde(rename = "shard_sync_retry_min_backoff_secs")]
+    #[serde(default = "defaults::shard_sync_retry_min_backoff")]
     pub shard_sync_retry_min_backoff: Duration,
     /// The maximum backoff time for shard sync retries.
     #[serde_as(as = "DurationSeconds<u64>")]
     #[serde(rename = "shard_sync_retry_max_backoff_secs")]
+    #[serde(default = "defaults::shard_sync_retry_max_backoff")]
     pub shard_sync_retry_max_backoff: Duration,
     /// The maximum number of concurrent blob recoveries during shard recovery.
+    #[serde(default = "defaults::max_concurrent_blob_recovery_during_shard_recovery")]
     pub max_concurrent_blob_recovery_during_shard_recovery: usize,
     /// The interval to check if the blob is still certified during recovery.
     #[serde_as(as = "DurationSeconds<u64>")]
     #[serde(rename = "blob_certified_check_interval_secs")]
+    #[serde(default = "defaults::blob_certified_check_interval")]
     pub blob_certified_check_interval: Duration,
     /// The number of metadata to fetch in parallel.
+    #[serde(default = "defaults::max_concurrent_metadata_fetch")]
     pub max_concurrent_metadata_fetch: usize,
     /// Maximum number of concurrent shard syncs allowed per node.
+    #[serde(default = "defaults::shard_sync_concurrency")]
     pub shard_sync_concurrency: usize,
     /// The interval to switch to recovery mode if the shard sync retries continue to fail.
     #[serde_as(as = "DurationSeconds<u64>")]
     #[serde(rename = "shard_sync_retry_switch_to_recovery_interval_secs")]
+    #[serde(default = "defaults::shard_sync_retry_switch_to_recovery_interval")]
     pub shard_sync_retry_switch_to_recovery_interval: Duration,
+    /// Whether to restart shard sync always retry shard transfer first. This is a fallback
+    /// mechanism in case a shard recovery is initiated, restarting the node can resume shard
+    /// transfer. This is the preferred option since it's always cheaper to scan the blob info
+    /// table without transferring the shards.
+    #[serde(default = "defaults::restart_shard_sync_always_retry_transfer_first")]
+    pub restart_shard_sync_always_retry_transfer_first: bool,
 }
 
 impl Default for ShardSyncConfig {
     fn default() -> Self {
         Self {
-            sliver_count_per_sync_request: 10,
-            shard_sync_retry_min_backoff: Duration::from_secs(60),
-            shard_sync_retry_max_backoff: Duration::from_secs(600),
-            max_concurrent_blob_recovery_during_shard_recovery: 5,
-            blob_certified_check_interval: Duration::from_secs(60),
-            max_concurrent_metadata_fetch: 10,
-            shard_sync_concurrency: 10,
-            shard_sync_retry_switch_to_recovery_interval: Duration::from_secs(2 * 60 * 60), // 2hr
+            sliver_count_per_sync_request: defaults::sliver_count_per_sync_request(),
+            shard_sync_retry_min_backoff: defaults::shard_sync_retry_min_backoff(),
+            shard_sync_retry_max_backoff: defaults::shard_sync_retry_max_backoff(),
+            max_concurrent_blob_recovery_during_shard_recovery:
+                defaults::max_concurrent_blob_recovery_during_shard_recovery(),
+            blob_certified_check_interval: defaults::blob_certified_check_interval(),
+            max_concurrent_metadata_fetch: defaults::max_concurrent_metadata_fetch(),
+            shard_sync_concurrency: defaults::shard_sync_concurrency(),
+            shard_sync_retry_switch_to_recovery_interval:
+                defaults::shard_sync_retry_switch_to_recovery_interval(),
+            restart_shard_sync_always_retry_transfer_first:
+                defaults::restart_shard_sync_always_retry_transfer_first(),
         }
     }
 }
@@ -730,6 +748,51 @@ pub mod defaults {
     /// Returns false in test mode.
     pub fn config_synchronizer_enabled() -> bool {
         !cfg!(test)
+    }
+
+    /// The default number of slivers to fetch in a single sync shard request.
+    pub fn sliver_count_per_sync_request() -> u64 {
+        10
+    }
+
+    /// The default minimum backoff time for shard sync retries.
+    pub fn shard_sync_retry_min_backoff() -> Duration {
+        Duration::from_secs(60)
+    }
+
+    /// The default maximum backoff time for shard sync retries.
+    pub fn shard_sync_retry_max_backoff() -> Duration {
+        Duration::from_secs(600)
+    }
+
+    /// The default maximum number of concurrent blob recoveries during shard recovery.
+    pub fn max_concurrent_blob_recovery_during_shard_recovery() -> usize {
+        5
+    }
+
+    /// The default interval to check if the blob is still certified during recovery.
+    pub fn blob_certified_check_interval() -> Duration {
+        Duration::from_secs(60)
+    }
+
+    /// The default number of metadata to fetch in parallel.
+    pub fn max_concurrent_metadata_fetch() -> usize {
+        10
+    }
+
+    /// The default maximum number of concurrent shard syncs allowed per node.
+    pub fn shard_sync_concurrency() -> usize {
+        10
+    }
+
+    /// The default interval to switch to recovery mode if the shard sync retries continue to fail.
+    pub fn shard_sync_retry_switch_to_recovery_interval() -> Duration {
+        Duration::from_secs(2 * 60 * 60) // 2hr
+    }
+
+    /// The default value for whether to restart shard sync always retry transfer first.
+    pub fn restart_shard_sync_always_retry_transfer_first() -> bool {
+        true
     }
 }
 

--- a/crates/walrus-service/src/node/metrics.rs
+++ b/crates/walrus-service/src/node/metrics.rs
@@ -75,10 +75,7 @@ walrus_utils::metrics::define_metric_set! {
         sync_shard_recover_sliver_error_total: IntCounterVec["shard", "sliver_type"],
 
         #[help = "Total number of slivers skipped during shard sync"]
-        sync_shard_recover_sliver_skip_total: IntCounterVec["shard", "sliver_type"],
-
-        #[help = "Total number of cancelled sliver recoveries during shard sync"]
-        sync_shard_recover_sliver_cancellation_total: IntCounterVec["shard", "sliver_type"],
+        sync_shard_recover_sliver_skip_total: IntCounterVec["shard", "sliver_type", "reason"],
 
         #[help = "The total number of slivers stored"]
         slivers_stored_total: IntCounterVec["sliver_type"],

--- a/crates/walrus-stress/src/generator/blob.rs
+++ b/crates/walrus-stress/src/generator/blob.rs
@@ -57,7 +57,7 @@ impl BlobData {
                 .collect()
         })
         .await
-        .expect("should be able to join spawned task");
+        .expect("should be able to join spawned task testing PR");
 
         Self {
             bytes,

--- a/crates/walrus-stress/src/generator/blob.rs
+++ b/crates/walrus-stress/src/generator/blob.rs
@@ -57,7 +57,7 @@ impl BlobData {
                 .collect()
         })
         .await
-        .expect("should be able to join spawned task testing PR");
+        .expect("should be able to join spawned task");
 
         Self {
             bytes,


### PR DESCRIPTION
## Description

Since at the current stage, shard transfer is significantly faster than shard recovery.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
