### PR TITLE
feat: allow single-node local testbeds

### DIFF
--- a/crates/walrus-service/bin/deploy.rs
+++ b/crates/walrus-service/bin/deploy.rs
@@ -108,7 +108,7 @@ struct DeploySystemContractArgs {
     #[clap(flatten)]
     epoch_zero_config: EpochZeroConfig,
     /// The list of host names or public IP addresses of the storage nodes.
-    #[clap(long, value_name = "ADDR", value_delimiter = ' ', num_args(4..))]
+    #[clap(long, value_name = "ADDR", value_delimiter = ' ', num_args(1..))]
     host_addresses: Vec<String>,
     /// The port on which the REST API of the storage nodes will listen.
     #[clap(long, default_value_t = REST_API_PORT)]

--- a/scripts/local-testbed.sh
+++ b/scripts/local-testbed.sh
@@ -41,6 +41,7 @@ usage() {
   echo "  -n <network>          Sui network to generate configs for (default: devnet)"
   echo "  -s <n_shards>         Number of shards (default: 10)"
   echo "  -t                    Use testnet contracts"
+  echo "  -a <ip_address>       Specify the IP address that is used for all nodes (default: 127.0.0.1)"
 }
 
 run_node() {
@@ -59,8 +60,9 @@ shards=10 # Default value of 4 if no argument is provided
 tail_logs=false
 use_existing_config=false
 contract_dir="./contracts"
+host_address="127.0.0.1"
 
-while getopts "b:c:d:efhn:s:t" arg; do
+while getopts "b:c:d:efhn:s:ta:" arg; do
   case "${arg}" in
     f)
       tail_logs=true
@@ -85,6 +87,9 @@ while getopts "b:c:d:efhn:s:t" arg; do
       ;;
     t)
       contract_dir="./testnet-contracts"
+      ;;
+    a)
+      host_address=${OPTARG}
       ;;
     h)
       usage
@@ -151,7 +156,7 @@ working_dir="./working_dir"
 # Derive the ip addresses for the storage nodes
 ips=( )
 for node_count in $(seq 1 "$committee_size"); do
-  ips+=( 127.0.0.1 )
+  ips+=( "${host_address}" )
 done
 
 # Initialize cleanup to be empty

--- a/scripts/local-testbed.sh
+++ b/scripts/local-testbed.sh
@@ -19,7 +19,7 @@ join_by() {
 }
 
 kill_tmux_sessions() {
-  { tmux ls || true; } | { grep -o "dryrun-node-\d*" || true; } | xargs -n1 tmux kill-session -t
+  { tmux ls || true; } | { grep -o "dryrun-node-\d*" || true; } | xargs -rn1 tmux kill-session -t
 }
 
 ctrl_c() {


### PR DESCRIPTION
## Description

This enable running ./local-testbed.sh with a single node, and also allows providing an IP address different from 127.0.0.1.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
