### PR TITLE
fix: reduce blocking on tokio core threads

### DIFF
--- a/crates/walrus-service/bin/deploy.rs
+++ b/crates/walrus-service/bin/deploy.rs
@@ -108,7 +108,7 @@ struct DeploySystemContractArgs {
     #[clap(flatten)]
     epoch_zero_config: EpochZeroConfig,
     /// The list of host names or public IP addresses of the storage nodes.
-    #[clap(long, value_name = "ADDR", value_delimiter = ' ', num_args(4..))]
+    #[clap(long, value_name = "ADDR", value_delimiter = ' ', num_args(1..))]
     host_addresses: Vec<String>,
     /// The port on which the REST API of the storage nodes will listen.
     #[clap(long, default_value_t = REST_API_PORT)]

--- a/crates/walrus-service/bin/node.rs
+++ b/crates/walrus-service/bin/node.rs
@@ -1143,6 +1143,7 @@ impl StorageNodeRuntime {
         let runtime = runtime::Builder::new_multi_thread()
             .thread_name("walrus-node-runtime")
             .enable_all()
+            .max_blocking_threads(node_config.thread_pool.max_blocking_io_threads)
             .build()
             .expect("walrus-node runtime creation must succeed");
         let _guard = runtime.enter();

--- a/crates/walrus-service/node_config_example.yaml
+++ b/crates/walrus-service/node_config_example.yaml
@@ -130,3 +130,4 @@ balance_check:
   warning_threshold_mist: 5000000000
 thread_pool:
   max_concurrent_tasks: null
+  max_blocking_io_threads: 1024

--- a/crates/walrus-service/src/common/utils.rs
+++ b/crates/walrus-service/src/common/utils.rs
@@ -39,7 +39,7 @@ use telemetry_subscribers::{TelemetryGuards, TracingHandle};
 use tokio::{
     runtime::{self, Runtime},
     sync::{oneshot, Semaphore},
-    task::JoinHandle,
+    task::{JoinError, JoinHandle},
     time::Instant,
 };
 use tokio_util::sync::CancellationToken;
@@ -867,6 +867,15 @@ where
 {
     let unready_clone = svc.clone();
     mem::replace(svc, unready_clone)
+}
+
+/// Unwraps the return value from a call to [`tokio::task::spawn_blocking`],
+/// or resumes a panic if the function had panicked.
+pub(crate) fn unwrap_or_resume_unwind<T>(result: Result<T, JoinError>) -> T {
+    match result {
+        Ok(value) => value,
+        Err(error) => std::panic::resume_unwind(error.into_panic()),
+    }
 }
 
 #[cfg(test)]

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -1753,7 +1753,7 @@ impl StorageNodeInner {
             .get_and_verify_metadata(*blob_id, certified_epoch)
             .await;
 
-        self.storage.put_verified_metadata(&metadata)?;
+        self.storage.put_verified_metadata(&metadata).await?;
         tracing::debug!(%blob_id, "metadata successfully synced");
         Ok(metadata)
     }
@@ -2218,6 +2218,7 @@ impl ServiceState for StorageNodeInner {
 
         self.storage
             .put_verified_metadata(&verified_metadata_with_id)
+            .await
             .context("unable to store metadata")?;
 
         self.metrics

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -1900,13 +1900,15 @@ impl StorageNodeInner {
             })
             .await;
         let (metadata, sliver) = thread_pool::unwrap_or_resume_panic(result)?;
+        let sliver_type = sliver.r#type();
 
         // Finally store the sliver in the appropriate shard storage.
         shard_storage
-            .put_sliver(metadata.blob_id(), &sliver)
+            .put_sliver(*metadata.blob_id(), sliver)
+            .await
             .context("unable to store sliver")?;
 
-        walrus_utils::with_label!(self.metrics.slivers_stored_total, sliver.r#type()).inc();
+        walrus_utils::with_label!(self.metrics.slivers_stored_total, sliver_type).inc();
 
         Ok(true)
     }

--- a/crates/walrus-service/src/node/blob_sync.rs
+++ b/crates/walrus-service/src/node/blob_sync.rs
@@ -631,7 +631,7 @@ impl BlobSynchronizer {
 
             match sliver_or_proof {
                 Ok(sliver) => {
-                    shard_storage.put_sliver(&self.blob_id, &sliver)?;
+                    shard_storage.put_sliver(self.blob_id, sliver).await?;
                     tracing::debug!("sliver successfully synced");
                     Ok(true)
                 }

--- a/crates/walrus-service/src/node/blob_sync.rs
+++ b/crates/walrus-service/src/node/blob_sync.rs
@@ -589,7 +589,7 @@ impl BlobSynchronizer {
             .get_and_verify_metadata(self.blob_id, self.certified_epoch)
             .await;
 
-        self.storage().put_verified_metadata(&metadata)?;
+        self.storage().put_verified_metadata(&metadata).await?;
 
         tracing::debug!("metadata successfully synced");
         Ok((true, metadata))

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -1002,7 +1002,7 @@ impl Default for BalanceCheckConfig {
 }
 
 /// Configuration for the blocking thread pool.
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ThreadPoolConfig {
     /// Specify the maximum number of concurrent tasks that will be pending on the thread pool.
@@ -1010,6 +1010,17 @@ pub struct ThreadPoolConfig {
     /// Defaults to an amount calculated from the number of cores.
     #[serde(skip_serializing_if = "defaults::is_none")]
     pub max_concurrent_tasks: Option<usize>,
+    /// Specify the maximum number of blocking threads to use for I/O.
+    pub max_blocking_io_threads: usize,
+}
+
+impl Default for ThreadPoolConfig {
+    fn default() -> Self {
+        Self {
+            max_concurrent_tasks: None,
+            max_blocking_io_threads: 1024,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/walrus-service/src/node/events/event_blob_writer.rs
+++ b/crates/walrus-service/src/node/events/event_blob_writer.rs
@@ -980,12 +980,14 @@ impl EventBlobWriter {
         // TODO: Once shard assignment per storage node will be read from walrus
         // system object at the beginning of the walrus epoch, we can only store the blob for
         // shards that are locally assigned to this node. (#682)
+        let blob_metadata_clone = blob_metadata.clone();
+
         try_join_all(sliver_pairs.iter().map(|sliver_pair| async {
             self.node
                 .store_sliver_unchecked(
-                    &blob_metadata,
+                    blob_metadata_clone.clone(),
                     sliver_pair.index(),
-                    &Sliver::Primary(sliver_pair.primary.clone()),
+                    Sliver::Primary(sliver_pair.primary.clone()),
                 )
                 .await
                 .map_or_else(
@@ -1001,12 +1003,15 @@ impl EventBlobWriter {
         }))
         .await
         .map(|_| ())?;
+
+        let blob_metadata_clone = blob_metadata.clone();
+
         try_join_all(sliver_pairs.iter().map(|sliver_pair| async {
             self.node
                 .store_sliver_unchecked(
-                    &blob_metadata,
+                    blob_metadata_clone.clone(),
                     sliver_pair.index(),
-                    &Sliver::Secondary(sliver_pair.secondary.clone()),
+                    Sliver::Secondary(sliver_pair.secondary.clone()),
                 )
                 .await
                 .map_or_else(

--- a/crates/walrus-service/src/node/server.rs
+++ b/crates/walrus-service/src/node/server.rs
@@ -510,7 +510,7 @@ mod tests {
             }
         }
 
-        fn store_metadata(
+        async fn store_metadata(
             &self,
             _metadata: UnverifiedBlobMetadataWithId,
         ) -> Result<bool, StoreMetadataError> {

--- a/crates/walrus-service/src/node/server.rs
+++ b/crates/walrus-service/src/node/server.rs
@@ -588,9 +588,9 @@ mod tests {
         /// Successful only for the pair index 0, otherwise, returns an internal error.
         async fn store_sliver(
             &self,
-            _blob_id: &BlobId,
+            _blob_id: BlobId,
             sliver_pair_index: SliverPairIndex,
-            _sliver: &Sliver,
+            _sliver: Sliver,
         ) -> Result<bool, StoreSliverError> {
             if sliver_pair_index.as_usize() == 0 {
                 Ok(true)

--- a/crates/walrus-service/src/node/server/routes.rs
+++ b/crates/walrus-service/src/node/server/routes.rs
@@ -165,12 +165,14 @@ pub async fn put_metadata<S: SyncServiceState>(
     Path(BlobIdString(blob_id)): Path<BlobIdString>,
     Bcs(metadata): Bcs<BlobMetadata>,
 ) -> Result<ApiSuccess<&'static str>, StoreMetadataError> {
-    let (code, message) =
-        if state.store_metadata(UnverifiedBlobMetadataWithId::new(blob_id, metadata))? {
-            (StatusCode::CREATED, "metadata successfully stored")
-        } else {
-            (StatusCode::OK, "metadata already stored")
-        };
+    let (code, message) = if state
+        .store_metadata(UnverifiedBlobMetadataWithId::new(blob_id, metadata))
+        .await?
+    {
+        (StatusCode::CREATED, "metadata successfully stored")
+    } else {
+        (StatusCode::OK, "metadata already stored")
+    };
 
     Ok(ApiSuccess::new(code, message))
 }

--- a/crates/walrus-service/src/node/server/routes.rs
+++ b/crates/walrus-service/src/node/server/routes.rs
@@ -258,7 +258,7 @@ pub async fn put_sliver<S: SyncServiceState>(
     };
 
     state
-        .store_sliver(&blob_id, sliver_pair_index, &sliver)
+        .store_sliver(blob_id, sliver_pair_index, sliver)
         .await?;
 
     // TODO(WAL-253): Change to CREATED.

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -842,11 +842,15 @@ pub(crate) mod tests {
 
             for (blob_id, which) in sliver_list.iter() {
                 if matches!(*which, WhichSlivers::Primary | WhichSlivers::Both) {
-                    shard_storage.put_sliver(blob_id, &get_sliver(SliverType::Primary, seed))?;
+                    shard_storage
+                        .put_sliver(*blob_id, get_sliver(SliverType::Primary, seed))
+                        .await?;
                     seed += 1;
                 }
                 if matches!(*which, WhichSlivers::Secondary | WhichSlivers::Both) {
-                    shard_storage.put_sliver(blob_id, &get_sliver(SliverType::Secondary, seed))?;
+                    shard_storage
+                        .put_sliver(*blob_id, get_sliver(SliverType::Secondary, seed))
+                        .await?;
                     seed += 1;
                 }
             }
@@ -1464,7 +1468,7 @@ pub(crate) mod tests {
                     // are not stored, handle_sync_shard_request should continue getting following
                     // slivers until the count is reached.
                     if !(5..=6).contains(&index) {
-                        shard_storage.put_sliver(blob_id, &sliver_data)?;
+                        shard_storage.put_sliver(*blob_id, sliver_data).await?;
                     }
                 }
             }

--- a/crates/walrus-service/src/node/storage/shard.rs
+++ b/crates/walrus-service/src/node/storage/shard.rs
@@ -47,11 +47,14 @@ use super::{
     metrics::{CommonDatabaseMetrics, Labels, OperationType},
     DatabaseConfig,
 };
-use crate::node::{
-    blob_retirement_notifier::ExecutionResultWithRetirementCheck,
-    config::ShardSyncConfig,
-    errors::SyncShardClientError,
-    StorageNodeInner,
+use crate::{
+    node::{
+        blob_retirement_notifier::ExecutionResultWithRetirementCheck,
+        config::ShardSyncConfig,
+        errors::SyncShardClientError,
+        StorageNodeInner,
+    },
+    utils,
 };
 
 type ShardMetrics = CommonDatabaseMetrics;
@@ -344,10 +347,10 @@ impl ShardStorage {
 
     /// Stores the provided primary or secondary sliver for the given blob ID.
     #[tracing::instrument(skip_all, fields(walrus.shard_index = %self.id), err)]
-    pub(crate) fn put_sliver(
+    pub(crate) async fn put_sliver(
         &self,
-        blob_id: &BlobId,
-        sliver: &Sliver,
+        blob_id: BlobId,
+        sliver: Sliver,
     ) -> Result<(), TypedStoreError> {
         let start = Instant::now();
         let labels = Labels {
@@ -358,13 +361,24 @@ impl ShardStorage {
         };
 
         let response = match sliver {
-            Sliver::Primary(primary) => self
-                .primary_slivers
-                .insert(blob_id, &PrimarySliverData::from(primary.clone())),
-            Sliver::Secondary(secondary) => self
-                .secondary_slivers
-                .insert(blob_id, &SecondarySliverData::from(secondary.clone())),
+            Sliver::Primary(primary) => {
+                let table = self.primary_slivers.clone();
+
+                tokio::task::spawn_blocking(move || {
+                    table.insert(&blob_id, &PrimarySliverData::from(primary))
+                })
+                .await
+            }
+            Sliver::Secondary(secondary) => {
+                let table = self.secondary_slivers.clone();
+
+                tokio::task::spawn_blocking(move || {
+                    table.insert(&blob_id, &SecondarySliverData::from(secondary))
+                })
+                .await
+            }
         };
+        let response = utils::unwrap_or_resume_unwind(response);
 
         self.metrics
             .observe_operation_duration(labels.with_response(response.as_ref()), start.elapsed());
@@ -1143,7 +1157,8 @@ impl ShardStorage {
             ExecutionResultWithRetirementCheck::Executed(result) => {
                 match result {
                     Ok(sliver) => {
-                        self.handle_successful_recovery(&node, sliver_type, blob_id, sliver)?;
+                        self.handle_successful_recovery(&node, sliver_type, blob_id, sliver)
+                            .await?;
                     }
                     Err(inconsistency_proof) => {
                         self.handle_inconsistency(&node, sliver_type, blob_id, inconsistency_proof)
@@ -1162,7 +1177,7 @@ impl ShardStorage {
     }
 
     /// Handles the successful recovery of a blob.
-    fn handle_successful_recovery(
+    async fn handle_successful_recovery(
         &self,
         node: &StorageNodeInner,
         sliver_type: SliverType,
@@ -1175,7 +1190,7 @@ impl ShardStorage {
             &sliver_type.to_string()
         )
         .inc();
-        self.put_sliver(&blob_id, &sliver)
+        self.put_sliver(blob_id, sliver).await
     }
 
     /// Handles the inconsistency of a blob.
@@ -1388,7 +1403,7 @@ mod tests {
             .expect("shard should exist");
         let sliver = get_sliver(sliver_type, 1);
 
-        shard.put_sliver(&BLOB_ID, &sliver)?;
+        shard.put_sliver(BLOB_ID, sliver.clone()).await?;
         let retrieved = shard.get_sliver(&BLOB_ID, sliver_type)?;
 
         assert_eq!(retrieved, Some(sliver));
@@ -1408,8 +1423,8 @@ mod tests {
         let primary = get_sliver(SliverType::Primary, 1);
         let secondary = get_sliver(SliverType::Secondary, 2);
 
-        shard.put_sliver(&BLOB_ID, &primary)?;
-        shard.put_sliver(&BLOB_ID, &secondary)?;
+        shard.put_sliver(BLOB_ID, primary.clone()).await?;
+        shard.put_sliver(BLOB_ID, secondary.clone()).await?;
 
         let retrieved_primary = shard.get_sliver(&BLOB_ID, SliverType::Primary)?;
         let retrieved_secondary = shard.get_sliver(&BLOB_ID, SliverType::Secondary)?;
@@ -1436,8 +1451,8 @@ mod tests {
         let primary = get_sliver(SliverType::Primary, 1);
         let secondary = get_sliver(SliverType::Secondary, 2);
 
-        shard.put_sliver(&BLOB_ID, &primary)?;
-        shard.put_sliver(&BLOB_ID, &secondary)?;
+        shard.put_sliver(BLOB_ID, primary.clone()).await?;
+        shard.put_sliver(BLOB_ID, secondary.clone()).await?;
 
         assert!(shard.is_sliver_pair_stored(&BLOB_ID)?);
 
@@ -1498,8 +1513,12 @@ mod tests {
             .expect("shard should exist");
         let second_sliver = get_sliver(type_second, 2);
 
-        first_shard.put_sliver(&BLOB_ID, &first_sliver)?;
-        second_shard.put_sliver(&BLOB_ID, &second_sliver)?;
+        first_shard
+            .put_sliver(BLOB_ID, first_sliver.clone())
+            .await?;
+        second_shard
+            .put_sliver(BLOB_ID, second_sliver.clone())
+            .await?;
 
         let first_retrieved = first_shard.get_sliver(&BLOB_ID, type_first)?;
         let second_retrieved = second_shard.get_sliver(&BLOB_ID, type_second)?;
@@ -1540,10 +1559,14 @@ mod tests {
             .expect("shard should exist");
 
         if store_primary {
-            shard.put_sliver(&BLOB_ID, &get_sliver(SliverType::Primary, 3))?;
+            shard
+                .put_sliver(BLOB_ID, get_sliver(SliverType::Primary, 3))
+                .await?;
         }
         if store_secondary {
-            shard.put_sliver(&BLOB_ID, &get_sliver(SliverType::Secondary, 4))?;
+            shard
+                .put_sliver(BLOB_ID, get_sliver(SliverType::Secondary, 4))
+                .await?;
         }
 
         assert_eq!(shard.is_sliver_pair_stored(&BLOB_ID)?, is_pair_stored);
@@ -1621,7 +1644,7 @@ mod tests {
         // Populates the shard with the generated data.
         for blob_data in data.iter() {
             for (_sliver_type, sliver) in blob_data.1.iter() {
-                shard.put_sliver(blob_data.0, sliver)?;
+                shard.put_sliver(*blob_data.0, sliver.clone()).await?;
             }
         }
 

--- a/scripts/local-testbed.sh
+++ b/scripts/local-testbed.sh
@@ -41,6 +41,7 @@ usage() {
   echo "  -n <network>          Sui network to generate configs for (default: devnet)"
   echo "  -s <n_shards>         Number of shards (default: 10)"
   echo "  -t                    Use testnet contracts"
+  echo "  -a <ip_address>       Specify the IP address that is used for all nodes (default: 127.0.0.1)"
 }
 
 run_node() {
@@ -59,8 +60,9 @@ shards=10 # Default value of 4 if no argument is provided
 tail_logs=false
 use_existing_config=false
 contract_dir="./contracts"
+host_address="127.0.0.1"
 
-while getopts "b:c:d:efhn:s:t" arg; do
+while getopts "b:c:d:efhn:s:ta:" arg; do
   case "${arg}" in
     f)
       tail_logs=true
@@ -85,6 +87,9 @@ while getopts "b:c:d:efhn:s:t" arg; do
       ;;
     t)
       contract_dir="./testnet-contracts"
+      ;;
+    a)
+      host_address=${OPTARG}
       ;;
     h)
       usage
@@ -151,7 +156,7 @@ working_dir="./working_dir"
 # Derive the ip addresses for the storage nodes
 ips=( )
 for node_count in $(seq 1 "$committee_size"); do
-  ips+=( 127.0.0.1 )
+  ips+=( "${host_address}" )
 done
 
 # Initialize cleanup to be empty

--- a/scripts/local-testbed.sh
+++ b/scripts/local-testbed.sh
@@ -19,7 +19,7 @@ join_by() {
 }
 
 kill_tmux_sessions() {
-  { tmux ls || true; } | { grep -o "dryrun-node-\d*" || true; } | xargs -n1 tmux kill-session -t
+  { tmux ls || true; } | { grep -o "dryrun-node-\d*" || true; } | xargs -rn1 tmux kill-session -t
 }
 
 ctrl_c() {


### PR DESCRIPTION
## Description

This moves two verifications to run on background threads and changes the methods that store slivers such that they use `tokio::task::spawn_blocking`.

Depends on #1893 

## Test plan

Refactoring, existing tests apply.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
