### PR TITLE
chore: stress client wallets setup in antithesis

### DIFF
--- a/crates/walrus-sui/src/utils.rs
+++ b/crates/walrus-sui/src/utils.rs
@@ -417,9 +417,11 @@ pub async fn get_sui_from_wallet_or_faucet(
         .get_balance(sender, None)
         .await?;
     tracing::debug!(
-        "funding {address} with {sui_amount} SUI, balance: {balance:?}, min_balance: {min_balance:?}",
-        balance = balance.total_balance,
-        min_balance = min_balance
+        address = %address,
+        sui_amount = %sui_amount,
+        balance = %balance.total_balance,
+        min_balance = %min_balance,
+        "funding address with SUI"
     );
     if balance.total_balance >= u128::from(min_balance) {
         let mut ptb = ProgrammableTransactionBuilder::new();

--- a/crates/walrus-sui/src/utils.rs
+++ b/crates/walrus-sui/src/utils.rs
@@ -422,7 +422,6 @@ pub async fn get_sui_from_wallet_or_faucet(
         min_balance = min_balance
     );
     if balance.total_balance >= u128::from(min_balance) {
-        tracing::debug!("funding from admin wallet");
         let mut ptb = ProgrammableTransactionBuilder::new();
         ptb.transfer_sui(address, Some(sui_amount));
         let ptb = ptb.finish();
@@ -449,7 +448,6 @@ pub async fn get_sui_from_wallet_or_faucet(
             .await?;
         Ok(())
     } else {
-        tracing::debug!("funding from faucet");
         request_sui_from_faucet(address, network, &wallet.get_client().await?).await?;
         Ok(())
     }

--- a/crates/walrus-sui/src/utils.rs
+++ b/crates/walrus-sui/src/utils.rs
@@ -416,7 +416,13 @@ pub async fn get_sui_from_wallet_or_faucet(
         .coin_read_api()
         .get_balance(sender, None)
         .await?;
+    tracing::debug!(
+        "funding {address} with {sui_amount} SUI, balance: {balance:?}, min_balance: {min_balance:?}",
+        balance = balance.total_balance,
+        min_balance = min_balance
+    );
     if balance.total_balance >= u128::from(min_balance) {
+        tracing::debug!("funding from admin wallet");
         let mut ptb = ProgrammableTransactionBuilder::new();
         ptb.transfer_sui(address, Some(sui_amount));
         let ptb = ptb.finish();
@@ -443,6 +449,7 @@ pub async fn get_sui_from_wallet_or_faucet(
             .await?;
         Ok(())
     } else {
+        tracing::debug!("funding from faucet");
         request_sui_from_faucet(address, network, &wallet.get_client().await?).await?;
         Ok(())
     }

--- a/docker/walrus-antithesis/build-test-config-image/files/deploy-walrus.sh
+++ b/docker/walrus-antithesis/build-test-config-image/files/deploy-walrus.sh
@@ -34,4 +34,6 @@ echo "Generating dry run configs"
 /opt/walrus/bin/walrus-deploy generate-dry-run-configs \
   --working-dir /opt/walrus/outputs \
   --extra-client-wallets stress,staking \
+  --admin-wallet-path /opt/walrus/outputs/sui_admin.yaml \
+  --sui-amount 1000000000000 \
   || die "Failed to generate dry-run configs"


### PR DESCRIPTION
## Description

We need to fund enough tokens to stress client wallets. Current setup encounters not enough gas coin errors.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
