### PR TITLE
fix(service): fix invalid docstring diagram in EventBlobWriter

### DIFF
--- a/crates/walrus-service/src/node/events/event_blob_writer.rs
+++ b/crates/walrus-service/src/node/events/event_blob_writer.rs
@@ -680,34 +680,33 @@ impl EventBlobWriterFactory {
 }
 
 /// EventBlobWriter manages the creation, storage, and certification of event blobs.
-/// ```
-///  +-------------------+
-///  |  EventBlobWriter  |
-///  +-------------------+
-///           |
-///           v
-///   +------------+    +-------------+    +-------------+    +---------------+
-///   |Current Blob|--->| Pending Blob|--->|Attested Blob|--->|System Contract|
-///   +------------+    +-------------+    +-------------+    +---------------+
-///         |                 |                  ^                   |
-///         |                 |                  |                   |
-///         |                 v                  |                   |
-///   +-----------------+    +------------------+                    |
-///   |Filesystem (tmp) |    | Failed to Attest |                    |
-///   +-----------------+    +------------------+                    |
-///                                                                  v
-///                  +------------------+                     +--------------+
-///                  | Database Storage |<------------------- |Certified Blob|
-///                  +------------------+                     +--------------+
-///                  (Blob removed from
-///                   filesystem after
-///                   certification)
 ///
-/// ```
-/// Flow: Current -> Pending -> Attested -> Certified
-///                     |
-///                     +-> Failed to Attest -> Attested -> Certified
 /// ```text
+/// +-------------------+
+/// |  EventBlobWriter  |
+/// +-------------------+
+///         |
+///         v
+/// +------------+    +-------------+    +-------------+    +---------------+
+/// |Current Blob|--->| Pending Blob|--->|Attested Blob|--->|System Contract|
+/// +------------+    +-------------+    +-------------+    +---------------+
+///       |                 |                  ^                   |
+///       |                 |                  |                   |
+///       |                 v                  |                   |
+/// +-----------------+    +------------------+                    |
+/// |Filesystem (tmp) |    | Failed to Attest |                    |
+/// +-----------------+    +------------------+                    |
+///                                                              v
+///              +------------------+                     +--------------+
+///              | Database Storage |<------------------- |Certified Blob|
+///              +------------------+                     +--------------+
+///              (Blob removed from
+///               filesystem after
+///               certification)
+/// ```
+/// Flow: Current -> Pending -> Attested -> Certified  
+///            |  
+///            +-> Failed to Attest -> Attested -> Certified
 ///
 /// Blob Lifecycle:
 ///


### PR DESCRIPTION
## Description

This PR fixes a docstring issue in `EventBlobWriter` (crates/walrus-service/src/node/events/event_blob_writer.rs) where an invalid ASCII diagram format caused the doctest to fail.

- The block diagram is now wrapped correctly inside a ```text code block.
- Removed leading `+` characters that triggered parsing errors.
- Verified with `cargo test -p walrus-service --doc`, all doc tests now pass.

No functional or logic changes were made.

Before Fix:

cargo test
![Pasted Graphic 2](https://github.com/user-attachments/assets/84e1ba9a-1f35-4757-b141-b00c3dd36d67)

## Test plan

After Fix : 

![Pasted Graphic 3](https://github.com/user-attachments/assets/ac4f4970-9b3f-49c7-a662-0ad08ebb0113)

