### PR TITLE
fix: simplify wording for gas errors

### DIFF
--- a/crates/walrus-service/src/client/error.rs
+++ b/crates/walrus-service/src/client/error.rs
@@ -141,7 +141,7 @@ pub enum ClientErrorKind {
     #[error("the blob ID {0} is blocked")]
     BlobIdBlocked(BlobId),
     /// No matching payment coin found for the transaction.
-    #[error("no compatible payment coin found")]
+    #[error("could not find WAL coins with sufficient balance")]
     NoCompatiblePaymentCoin,
     /// No gas coins with sufficient balance found for the transaction.
     #[error("could not find SUI coins with sufficient balance [requested_amount={0:?}]")]

--- a/crates/walrus-service/src/client/error.rs
+++ b/crates/walrus-service/src/client/error.rs
@@ -144,9 +144,7 @@ pub enum ClientErrorKind {
     #[error("no compatible payment coin found")]
     NoCompatiblePaymentCoin,
     /// No gas coins with sufficient balance found for the transaction.
-    #[error(
-        "no compatible gas coins with sufficient total balance found [requested_amount={0:?}]"
-    )]
+    #[error("could not find SUI coins with sufficient balance [requested_amount={0:?}]")]
     NoCompatibleGasCoins(Option<u128>),
     /// The client was unable to open connections to any storage node.
     #[error("connecting to all storage nodes failed: {0}")]

--- a/crates/walrus-sui/src/client.rs
+++ b/crates/walrus-sui/src/client.rs
@@ -127,7 +127,7 @@ pub enum SuiClientError {
     #[error("could not find WAL coins with sufficient balance")]
     NoCompatibleWalCoins,
     /// No matching gas coin found for the transaction.
-    #[error("could not find gas coins with sufficient balance [requested_amount={0:?}]")]
+    #[error("could not find SUI coins with sufficient balance [requested_amount={0:?}]")]
     NoCompatibleGasCoins(Option<u128>),
     /// The Walrus system object does not exist.
     #[error(


### PR DESCRIPTION
## Description

Clarify the insufficient Sui error messages to say SUI, instead of "gas."

## Test plan

CI Pipeline.