### PR TITLE
fix: save and reuse metrics instead of adding a unique ID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12208,6 +12208,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tempfile",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-metrics",
  "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crates/checkpoint-downloader/src/downloader.rs
+++ b/crates/checkpoint-downloader/src/downloader.rs
@@ -9,7 +9,6 @@ use std::{
 };
 
 use anyhow::{anyhow, Result};
-use prometheus::Registry;
 use rand::{rngs::StdRng, SeedableRng};
 use sui_rpc_api::client::ResponseExt;
 use sui_types::messages_checkpoint::{CheckpointSequenceNumber, TrustedCheckpoint};
@@ -22,6 +21,7 @@ use typed_store::{rocks::DBMap, Map};
 use walrus_sui::client::retry_client::{RetriableClientError, RetriableRpcClient};
 #[cfg(not(test))]
 use walrus_utils::backoff::ExponentialBackoff;
+use walrus_utils::metrics::Registry;
 
 use crate::{
     config::{AdaptiveDownloaderConfig, PoolMonitorConfig},

--- a/crates/checkpoint-downloader/src/metrics.rs
+++ b/crates/checkpoint-downloader/src/metrics.rs
@@ -3,7 +3,8 @@
 
 //! Metrics for the checkpoint downloader.
 
-use prometheus::{register_int_gauge_with_registry, IntGauge, Registry};
+use prometheus::{register_int_gauge_with_registry, IntGauge};
+use walrus_utils::metrics::Registry;
 
 #[derive(Clone, Debug)]
 pub(crate) struct AdaptiveDownloaderMetrics {

--- a/crates/walrus-sdk/src/client/builder.rs
+++ b/crates/walrus-sdk/src/client/builder.rs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::{net::SocketAddr, sync::Arc, time::Duration};
 
-use prometheus::Registry;
 use reqwest::{ClientBuilder as ReqwestClientBuilder, Url};
 use rustls::pki_types::CertificateDer;
 use rustls_native_certs::CertificateResult;
 use walrus_core::NetworkPublicKey;
+use walrus_utils::metrics::Registry;
 
 use super::{HttpClientMetrics, HttpMiddleware};
 use crate::{
@@ -186,14 +186,12 @@ impl ClientBuilder {
             .build()
             .map_err(ClientBuildError::reqwest)?;
 
-        let registry = self
-            .registry
-            .as_ref()
-            .unwrap_or_else(|| prometheus::default_registry());
-
         Ok(Client {
             client_clone: inner.clone(),
-            inner: HttpMiddleware::new(inner, HttpClientMetrics::new(registry)),
+            inner: HttpMiddleware::new(
+                inner,
+                HttpClientMetrics::new(&self.registry.unwrap_or_default()),
+            ),
             endpoints,
         })
     }

--- a/crates/walrus-service/bin/node.rs
+++ b/crates/walrus-service/bin/node.rs
@@ -459,7 +459,6 @@ mod commands {
         NodeRegistrationParamsForThirdPartyRegistration,
         ServiceRole,
     };
-    use prometheus::Registry;
     use sui_sdk::SuiClientBuilder;
     #[cfg(not(msim))]
     use tokio::task::JoinSet;
@@ -487,7 +486,7 @@ mod commands {
         config::{load_wallet_context_from_path, WalletConfig},
         types::move_structs::NodeMetadata,
     };
-    use walrus_utils::backoff::ExponentialBackoffConfig;
+    use walrus_utils::{backoff::ExponentialBackoffConfig, metrics::Registry};
 
     use super::*;
 

--- a/crates/walrus-service/src/backup/service.rs
+++ b/crates/walrus-service/src/backup/service.rs
@@ -20,10 +20,7 @@ use diesel_async::{
 use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
 use futures::{stream, StreamExt};
 use object_store::{gcp::GoogleCloudStorageBuilder, local::LocalFileSystem, ObjectStore};
-use prometheus::{
-    core::{AtomicU64, GenericCounter},
-    Registry,
-};
+use prometheus::core::{AtomicU64, GenericCounter};
 use sha2::Digest;
 use sui_types::event::EventID;
 use tokio_util::sync::CancellationToken;
@@ -32,6 +29,7 @@ use walrus_sui::{
     client::{retry_client::RetriableSuiClient, SuiReadClient},
     types::{BlobEvent, ContractEvent, EpochChangeEvent, EpochChangeStart},
 };
+use walrus_utils::metrics::Registry;
 
 use super::{
     config::{BackupConfig, BackupDbConfig},

--- a/crates/walrus-service/src/client.rs
+++ b/crates/walrus-service/src/client.rs
@@ -10,7 +10,6 @@ use cli::{styled_progress_bar, styled_spinner};
 use communication::NodeCommunicationFactory;
 use futures::{Future, FutureExt};
 use indicatif::{HumanDuration, MultiProgress};
-use prometheus::Registry;
 use rand::{rngs::ThreadRng, RngCore as _};
 use rayon::{
     iter::{IndexedParallelIterator, IntoParallelRefIterator},
@@ -55,7 +54,7 @@ use walrus_sui::{
     },
     types::{move_structs::BlobWithAttribute, Blob, BlobEvent, StakedWal},
 };
-use walrus_utils::backoff::BackoffStrategy;
+use walrus_utils::{backoff::BackoffStrategy, metrics::Registry};
 
 use self::{
     communication::NodeResult,

--- a/crates/walrus-service/src/client/cli/runner.rs
+++ b/crates/walrus-service/src/client/cli/runner.rs
@@ -16,7 +16,6 @@ use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use indicatif::MultiProgress;
 use itertools::Itertools as _;
-use prometheus::Registry;
 use rand::seq::SliceRandom;
 use sui_config::{sui_config_dir, SUI_CLIENT_CONFIG};
 use sui_sdk::wallet_context::WalletContext;
@@ -49,6 +48,7 @@ use walrus_sui::{
     types::move_structs::{Authorized, BlobAttribute, EpochState},
     utils::SuiNetwork,
 };
+use walrus_utils::metrics::Registry;
 
 use super::args::{
     AggregatorArgs,

--- a/crates/walrus-service/src/client/communication/factory.rs
+++ b/crates/walrus-service/src/client/communication/factory.rs
@@ -9,7 +9,6 @@ use std::{
 };
 
 use anyhow::anyhow;
-use prometheus::Registry;
 use rand::{seq::SliceRandom, thread_rng};
 use reqwest::Client as ReqwestClient;
 use rustls::pki_types::CertificateDer;
@@ -21,6 +20,7 @@ use walrus_sdk::{
     error::ClientBuildError,
 };
 use walrus_sui::types::{Committee, NetworkAddress, StorageNode};
+use walrus_utils::metrics::Registry;
 
 use super::{NodeCommunication, NodeReadCommunication, NodeWriteCommunication};
 use crate::{

--- a/crates/walrus-service/src/client/daemon.rs
+++ b/crates/walrus-service/src/client/daemon.rs
@@ -20,7 +20,6 @@ use axum_extra::{
     TypedHeader,
 };
 use openapi::{AggregatorApiDoc, DaemonApiDoc, PublisherApiDoc};
-use prometheus::Registry;
 use reqwest::StatusCode;
 pub use routes::PublisherQuery;
 use routes::{BLOB_GET_ENDPOINT, BLOB_OBJECT_GET_ENDPOINT, BLOB_PUT_ENDPOINT, STATUS_ENDPOINT};
@@ -39,6 +38,7 @@ use walrus_sui::{
     client::{BlobPersistence, PostStoreAction, ReadClient, SuiContractClient},
     types::move_structs::BlobWithAttribute,
 };
+use walrus_utils::metrics::Registry;
 
 use super::{responses::BlobStoreResult, Client, ClientResult, StoreWhen};
 use crate::{

--- a/crates/walrus-service/src/client/metrics.rs
+++ b/crates/walrus-service/src/client/metrics.rs
@@ -12,8 +12,8 @@ use prometheus::{
     CounterVec,
     HistogramVec,
     IntCounter,
-    Registry,
 };
+use walrus_utils::metrics::Registry;
 
 const LATENCY_SEC_BUCKETS: &[f64] = &[
     1., 1.5, 2., 2.5, 3., 4., 5., 6., 7., 8., 9., 10., 20., 40., 80., 160.,

--- a/crates/walrus-service/src/client/multiplexer.rs
+++ b/crates/walrus-service/src/client/multiplexer.rs
@@ -11,7 +11,6 @@ use std::{
     },
 };
 
-use prometheus::Registry;
 use sui_sdk::{
     sui_client_config::SuiEnv,
     types::base_types::SuiAddress,
@@ -31,6 +30,7 @@ use walrus_sui::{
     types::move_structs::BlobWithAttribute,
     utils::create_wallet,
 };
+use walrus_utils::metrics::Registry;
 
 use super::{
     cli::PublisherArgs,

--- a/crates/walrus-service/src/common/telemetry.rs
+++ b/crates/walrus-service/src/common/telemetry.rs
@@ -36,7 +36,6 @@ use prometheus::{
     IntGauge,
     IntGaugeVec,
     Opts,
-    Registry,
 };
 use reqwest::Method;
 use tokio::time::Instant;
@@ -47,7 +46,7 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 use walrus_core::Epoch;
 use walrus_utils::{
     http::{http_body::Frame, BodyVisitor, VisitBody},
-    metrics::TaskMonitorFamily,
+    metrics::{Registry, TaskMonitorFamily},
 };
 
 use super::active_committees::ActiveCommittees;

--- a/crates/walrus-service/src/common/utils.rs
+++ b/crates/walrus-service/src/common/utils.rs
@@ -26,7 +26,7 @@ use fastcrypto::{
 };
 use futures::future::FusedFuture;
 use pin_project::pin_project;
-use prometheus::{Encoder, HistogramVec, Registry};
+use prometheus::{Encoder, HistogramVec};
 use serde::{
     de::{DeserializeOwned, Error},
     Deserialize,
@@ -58,6 +58,7 @@ use walrus_sui::{
     client::{retry_client::RetriableSuiClient, SuiReadClient},
     utils::SuiNetwork,
 };
+use walrus_utils::metrics::Registry;
 
 use super::active_committees::ActiveCommittees;
 use crate::node::{config::MetricsPushConfig, events::event_processor::EventProcessorMetrics};
@@ -289,7 +290,7 @@ impl MetricsAndLoggingRuntime {
 
         Ok(Self {
             runtime,
-            registry: walrus_registry,
+            registry: Registry::new(walrus_registry),
             _telemetry_guards: telemetry_guards,
             _tracing_handle: tracing_handle,
         })

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -29,7 +29,6 @@ use futures::{
 };
 use itertools::Either;
 use node_recovery::NodeRecoveryHandler;
-use prometheus::Registry;
 use rand::{rngs::StdRng, thread_rng, Rng, SeedableRng};
 use recovery_symbol_service::{RecoverySymbolRequest, RecoverySymbolService};
 use serde::Serialize;
@@ -113,7 +112,7 @@ use walrus_sui::{
         GENESIS_EPOCH,
     },
 };
-use walrus_utils::metrics::TaskMonitorFamily;
+use walrus_utils::metrics::{Registry, TaskMonitorFamily};
 
 use self::{
     blob_sync::BlobSyncHandler,

--- a/crates/walrus-service/src/node/committee/committee_service.rs
+++ b/crates/walrus-service/src/node/committee/committee_service.rs
@@ -11,7 +11,6 @@ use std::{
 };
 
 use futures::TryFutureExt;
-use prometheus::Registry;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use tokio::sync::{watch, Mutex as TokioMutex};
 use tower::ServiceExt as _;
@@ -32,6 +31,7 @@ use walrus_core::{
     SliverType,
 };
 use walrus_sui::types::Committee;
+use walrus_utils::metrics::Registry;
 
 use super::{
     node_service::{NodeService, NodeServiceError, RemoteStorageNode, Request, Response},

--- a/crates/walrus-service/src/node/committee/node_service.rs
+++ b/crates/walrus-service/src/node/committee/node_service.rs
@@ -24,7 +24,6 @@ use std::{
 };
 
 use futures::{future::BoxFuture, FutureExt};
-use prometheus::Registry;
 use tower::Service;
 use walrus_core::{
     encoding::{EncodingConfig, GeneralRecoverySymbol, Primary, Secondary},
@@ -46,6 +45,7 @@ use walrus_sdk::{
     error::{ClientBuildError, NodeError},
 };
 use walrus_sui::types::StorageNode as SuiStorageNode;
+use walrus_utils::metrics::Registry;
 
 use super::{DefaultRecoverySymbol, NodeServiceFactory};
 

--- a/crates/walrus-service/src/node/contract_service.rs
+++ b/crates/walrus-service/src/node/contract_service.rs
@@ -11,10 +11,7 @@ use std::{
 
 use anyhow::Context as _;
 use async_trait::async_trait;
-use prometheus::{
-    core::{AtomicU64, GenericGaugeVec},
-    Registry,
-};
+use prometheus::core::{AtomicU64, GenericGaugeVec};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use sui_types::base_types::ObjectID;
 use tokio::{sync::Mutex as TokioMutex, task::JoinSet, time::MissedTickBehavior};
@@ -37,7 +34,10 @@ use walrus_sui::{
         UpdatePublicKeyParams,
     },
 };
-use walrus_utils::backoff::{self, ExponentialBackoff};
+use walrus_utils::{
+    backoff::{self, ExponentialBackoff},
+    metrics::Registry,
+};
 
 use super::{
     committee::CommitteeService,
@@ -225,9 +225,7 @@ impl SuiSystemContractServiceBuilder {
         service.start_balance_monitor(
             self.balance_check_frequency,
             self.balance_check_warning_threshold,
-            self.metrics_registry
-                .as_ref()
-                .unwrap_or_else(|| prometheus::default_registry()),
+            &self.metrics_registry.clone().unwrap_or_default(),
         );
 
         service

--- a/crates/walrus-service/src/node/events/event_blob_writer.rs
+++ b/crates/walrus-service/src/node/events/event_blob_writer.rs
@@ -14,7 +14,7 @@ use std::{
 use anyhow::{Context, Result};
 use byteorder::{BigEndian, WriteBytesExt};
 use futures_util::future::try_join_all;
-use prometheus::{register_int_gauge_with_registry, IntGauge, Registry};
+use prometheus::{register_int_gauge_with_registry, IntGauge};
 use rand::{thread_rng, Rng};
 use rocksdb::Options;
 use serde::{Deserialize, Serialize};
@@ -43,6 +43,7 @@ use walrus_sui::{
         EpochChangeEvent,
     },
 };
+use walrus_utils::metrics::Registry;
 
 use crate::node::{
     errors::StoreSliverError,
@@ -1615,7 +1616,6 @@ mod tests {
     };
 
     use anyhow::Result;
-    use prometheus::Registry;
     use sui_types::{digests::TransactionDigest, event::EventID};
     use typed_store::Map;
     use walrus_core::{BlobId, ShardIndex};
@@ -1623,6 +1623,7 @@ mod tests {
         test_utils::EventForTesting,
         types::{BlobCertified, ContractEvent, EpochChangeEvent, EpochChangeStart},
     };
+    use walrus_utils::metrics::Registry;
 
     use crate::{
         node::events::{
@@ -1640,7 +1641,7 @@ mod tests {
         const NUM_EVENTS_PER_CHECKPOINT: u64 = 2;
 
         let dir: PathBuf = tempfile::tempdir()?.into_path();
-        let registry = Registry::new();
+        let registry = Registry::default();
         let node = create_test_node().await?;
         let blob_writer_factory = EventBlobWriterFactory::new(
             &dir,
@@ -1692,7 +1693,7 @@ mod tests {
 
         let dir: PathBuf = tempfile::tempdir()?.into_path();
         let node = create_test_node().await?;
-        let registry = Registry::new();
+        let registry = Registry::default();
 
         let blob_writer_factory = EventBlobWriterFactory::new(
             &dir,
@@ -1775,7 +1776,7 @@ mod tests {
 
         let dir: PathBuf = tempfile::tempdir()?.into_path();
         let node = create_test_node().await?;
-        let registry = Registry::new();
+        let registry = Registry::default();
         let blob_writer_factory = EventBlobWriterFactory::new(
             &dir,
             node.storage_node.inner().clone(),

--- a/crates/walrus-service/src/node/events/event_processor.rs
+++ b/crates/walrus-service/src/node/events/event_processor.rs
@@ -24,7 +24,7 @@ use move_core_types::{
     account_address::AccountAddress,
     annotated_value::{MoveDatatypeLayout, MoveTypeLayout},
 };
-use prometheus::{IntCounter, IntCounterVec, IntGauge, Registry};
+use prometheus::{IntCounter, IntCounterVec, IntGauge};
 use rocksdb::Options;
 use sui_package_resolver::{
     error::Error as PackageResolverError,
@@ -69,7 +69,7 @@ use walrus_sui::{
     },
     types::ContractEvent,
 };
-use walrus_utils::backoff::ExponentialBackoffConfig;
+use walrus_utils::{backoff::ExponentialBackoffConfig, metrics::Registry};
 
 use crate::{
     node::events::{

--- a/crates/walrus-service/src/node/events/event_processor_runtime.rs
+++ b/crates/walrus-service/src/node/events/event_processor_runtime.rs
@@ -6,12 +6,12 @@
 use std::{path::Path, sync::Arc};
 
 use anyhow::Context;
-use prometheus::Registry;
 use tokio::{
     runtime::{self, Runtime},
     task::JoinHandle,
 };
 use tokio_util::sync::CancellationToken;
+use walrus_utils::metrics::Registry;
 
 use crate::{
     common::config::SuiReaderConfig,

--- a/crates/walrus-service/src/node/recovery_symbol_service.rs
+++ b/crates/walrus-service/src/node/recovery_symbol_service.rs
@@ -9,7 +9,7 @@ use std::{
 use fastcrypto::hash::Blake2b256;
 use futures::{future::BoxFuture, FutureExt as _, TryFutureExt};
 use moka::future::Cache;
-use prometheus::{IntCounter, Registry};
+use prometheus::IntCounter;
 use tower::Service;
 use walrus_core::{
     by_axis::{self, ByAxis},
@@ -22,6 +22,7 @@ use walrus_core::{
     SliverPairIndex,
     SliverType,
 };
+use walrus_utils::metrics::Registry;
 
 use super::thread_pool::{self, BoundedThreadPool};
 use crate::utils;

--- a/crates/walrus-service/src/node/server.rs
+++ b/crates/walrus-service/src/node/server.rs
@@ -17,7 +17,6 @@ use fastcrypto::{secp256r1::Secp256r1PrivateKey, traits::ToFromBytes};
 use futures::{future::Either, FutureExt};
 use openapi::RestApiDoc;
 use p256::{elliptic_curve::pkcs8::EncodePrivateKey as _, SecretKey};
-use prometheus::Registry;
 use rcgen::{CertificateParams, CertifiedKey, DnType, KeyPair as RcGenKeyPair};
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
@@ -27,6 +26,7 @@ use tracing::Instrument as _;
 use utoipa::OpenApi as _;
 use utoipa_redoc::{Redoc, Servable as _};
 use walrus_core::{encoding, keys::NetworkKeyPair};
+use walrus_utils::metrics::Registry;
 
 use self::telemetry::MetricsMiddlewareState;
 use super::config::{defaults, Http2Config, PathOrInPlace, StorageNodeConfig, TlsConfig};
@@ -702,7 +702,7 @@ mod tests {
             Arc::new(MockServiceState),
             CancellationToken::new(),
             rest_api_config,
-            &Registry::new(),
+            &Registry::default(),
         );
         let server = Arc::new(server);
         let server_copy = server.clone();
@@ -1039,7 +1039,7 @@ mod tests {
             Arc::new(MockServiceState),
             cancel_token.clone(),
             config.as_ref().into(),
-            &Registry::new(),
+            &Registry::default(),
         );
         let handle = tokio::spawn(async move { server.run().await });
 

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -15,7 +15,6 @@ use blob_info::{BlobInfoIterator, PerObjectBlobInfo, PerObjectBlobInfoIterator};
 use event_cursor_table::EventIdWithProgress;
 use itertools::Itertools;
 use metrics::{CommonDatabaseMetrics, Labels, OperationType};
-use prometheus::Registry;
 use rocksdb::Options;
 use serde::{Deserialize, Serialize};
 use sui_sdk::types::event::EventID;
@@ -34,6 +33,7 @@ use walrus_core::{
     ShardIndex,
 };
 use walrus_sui::types::BlobEvent;
+use walrus_utils::metrics::Registry;
 
 use self::{
     blob_info::{BlobInfo, BlobInfoApi, BlobInfoTable},
@@ -764,7 +764,6 @@ pub(crate) mod tests {
         shard_status_column_family_name,
         shard_sync_progress_column_family_name,
     };
-    use prometheus::Registry;
     use tempfile::TempDir;
     use tokio::runtime::Runtime;
     use walrus_core::{
@@ -797,7 +796,7 @@ pub(crate) mod tests {
 
     /// Returns an empty storage, with the column families for [`SHARD_INDEX`] already created.
     pub(crate) async fn empty_storage() -> WithTempDir<Storage> {
-        typed_store::metrics::DBMetrics::init(&Registry::new());
+        typed_store::metrics::DBMetrics::init(&prometheus::Registry::default());
         empty_storage_with_shards(&[SHARD_INDEX]).await
     }
 

--- a/crates/walrus-service/src/node/storage/shard.rs
+++ b/crates/walrus-service/src/node/storage/shard.rs
@@ -14,7 +14,6 @@ use std::{
 
 use fastcrypto::traits::KeyPair;
 use futures::{stream::FuturesUnordered, StreamExt};
-use prometheus::Registry;
 use regex::Regex;
 use rocksdb::{Options, DB};
 use serde::{Deserialize, Serialize};
@@ -40,6 +39,7 @@ use walrus_core::{
     Sliver,
     SliverType,
 };
+use walrus_utils::metrics::Registry;
 
 use super::{
     blob_info::{BlobInfo, BlobInfoIterator},

--- a/crates/walrus-service/src/node/thread_pool.rs
+++ b/crates/walrus-service/src/node/thread_pool.rs
@@ -13,7 +13,7 @@ use std::{
 };
 
 use futures::FutureExt;
-use prometheus::{HistogramVec, IntGauge, Registry};
+use prometheus::{HistogramVec, IntGauge};
 use rayon::ThreadPoolBuilder as RayonThreadPoolBuilder;
 use tokio::{
     sync::oneshot::{self, Receiver as OneshotReceiver},
@@ -21,7 +21,7 @@ use tokio::{
 };
 use tower::{limit::ConcurrencyLimit, Service};
 use tracing::span::Span;
-use walrus_utils::metrics::OwnedGaugeGuard;
+use walrus_utils::metrics::{OwnedGaugeGuard, Registry};
 
 use self::metrics::{STATUS_IN_PROGRESS, STATUS_QUEUED};
 use super::metrics;
@@ -115,11 +115,7 @@ impl ThreadPoolBuilder {
             }
         });
 
-        let registry = self
-            .metrics_registry
-            .as_ref()
-            .unwrap_or_else(|| prometheus::default_registry());
-        let metrics = ThreadPoolMetrics::new(registry);
+        let metrics = ThreadPoolMetrics::new(&self.metrics_registry.clone().unwrap_or_default());
 
         BlockingThreadPool { inner, metrics }
     }

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -21,7 +21,6 @@ use anyhow::Context;
 use async_trait::async_trait;
 use chrono::Utc;
 use futures::{future, stream::FuturesUnordered, StreamExt};
-use prometheus::Registry;
 use sui_macros::nondeterministic;
 use sui_types::base_types::ObjectID;
 use tempfile::TempDir;
@@ -69,7 +68,7 @@ use walrus_sui::{
     },
 };
 use walrus_test_utils::WithTempDir;
-use walrus_utils::backoff::ExponentialBackoffConfig;
+use walrus_utils::{backoff::ExponentialBackoffConfig, metrics::Registry};
 
 #[cfg(msim)]
 use crate::common::config::SuiConfig;

--- a/crates/walrus-stress/src/main.rs
+++ b/crates/walrus-stress/src/main.rs
@@ -128,7 +128,9 @@ async fn main() -> anyhow::Result<()> {
     let metrics_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), args.metrics_port);
     let registry_service = mysten_metrics::start_prometheus_server(metrics_address);
     let prometheus_registry = registry_service.default_registry();
-    let metrics = Arc::new(ClientMetrics::new(&prometheus_registry));
+    let metrics = Arc::new(ClientMetrics::new(&walrus_utils::metrics::Registry::new(
+        prometheus_registry,
+    )));
     tracing::info!("starting metrics server on {metrics_address}");
 
     if let Some(wallet_path) = &args.wallet_path {

--- a/crates/walrus-utils/Cargo.toml
+++ b/crates/walrus-utils/Cargo.toml
@@ -10,7 +10,7 @@ backoff = ["dep:anyhow", "dep:rand", "dep:serde", "dep:serde_with", "dep:tracing
 config = ["dep:anyhow", "dep:home", "dep:serde", "dep:tracing"]
 default = []
 http = ["dep:bytes", "dep:http-body", "dep:pin-project"]
-metrics = ["dep:prometheus"]
+metrics = ["dep:prometheus", "dep:thiserror"]
 test-utils = ["dep:tempfile", "tokio/sync"]
 tokio-metrics = ["dep:tokio-metrics"]
 
@@ -26,6 +26,7 @@ serde = { workspace = true, features = ["derive"], optional = true }
 serde_json = { workspace = true, optional = true }
 serde_with = { workspace = true, optional = true }
 tempfile = { workspace = true, optional = true }
+thiserror = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"], optional = true }
 tokio-metrics = { version = "0.4.0", optional = true, default-features = false }
 tokio-util = { workspace = true, optional = true }

--- a/crates/walrus-utils/src/metrics/tokio.rs
+++ b/crates/walrus-utils/src/metrics/tokio.rs
@@ -11,9 +11,10 @@ use std::{
 use prometheus::{
     core::{Collector, Desc},
     proto::{Counter, LabelPair, Metric, MetricFamily, MetricType},
-    Registry,
 };
 use tokio_metrics::TaskMonitor;
+
+use super::Registry;
 
 /// Default duration at which polls cross the threshold into being categorized as 'slow' is 1ms.
 ///


### PR DESCRIPTION
## Description

The unique `metric_set_instance_id` led to high cardinality resulting in many series. Remove it, and instead store declared metrics and provide an API to get them during registration.


## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
