### PR TITLE
feat: Pass db config settings to event processor and blob writer dbs

### DIFF
--- a/crates/walrus-service/bin/node.rs
+++ b/crates/walrus-service/bin/node.rs
@@ -473,6 +473,7 @@ mod commands {
                 event_processor::{EventProcessor, EventProcessorRuntimeConfig, SystemConfig},
                 EventProcessorConfig,
             },
+            DatabaseConfig,
         },
         utils,
     };
@@ -585,6 +586,7 @@ mod commands {
             &config.storage_path,
             &metrics_runtime.registry,
             cancel_token.child_token(),
+            &config.db_config,
         )?;
 
         let node_runtime = StorageNodeRuntime::start(
@@ -950,6 +952,7 @@ mod commands {
             event_polling_interval: Duration::from_secs(1),
             db_path: db_path.clone(),
             rpc_fallback_config: rpc_fallback_config_args.and_then(|args| args.to_config()),
+            db_config: DatabaseConfig::default(),
         };
 
         // Create SuiClientSet

--- a/crates/walrus-service/node_config_example.yaml
+++ b/crates/walrus-service/node_config_example.yaml
@@ -43,6 +43,15 @@ db_config:
   shard_status: null
   shard_sync_progress: null
   pending_recover_slivers: null
+  certified: null
+  pending: null
+  attested: null
+  failed_to_attest: null
+  checkpoint_store: null
+  walrus_package_store: null
+  committee_store: null
+  event_store: null
+  init_state: null
 protocol_key_pair:
   path: /opt/walrus/config/protocol.key
 next_protocol_key_pair: null

--- a/crates/walrus-service/src/backup/service.rs
+++ b/crates/walrus-service/src/backup/service.rs
@@ -51,6 +51,7 @@ use crate::{
         },
         metrics::TelemetryLabel as _,
         system_events::SystemEventProvider as _,
+        DatabaseConfig,
     },
 };
 
@@ -328,6 +329,7 @@ pub async fn start_backup_orchestrator(
         &config.backup_storage_path,
         &metrics_runtime.registry,
         cancel_token.child_token(),
+        &DatabaseConfig::default(),
     )
     .await?;
 

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -406,6 +406,7 @@ impl StorageNodeBuilder {
                     event_polling_interval: sui_config.event_polling_interval,
                     db_path: config.storage_path.join("events"),
                     rpc_fallback_config: sui_config.rpc_fallback_config.clone(),
+                    db_config: config.db_config.clone(),
                 };
                 let system_config = SystemConfig {
                     system_pkg_id: read_client.get_system_package_id(),
@@ -658,6 +659,7 @@ impl StorageNode {
         let event_blob_writer_factory = if !config.disable_event_blob_writer {
             Some(EventBlobWriterFactory::new(
                 &config.storage_path,
+                &config.db_config,
                 inner.clone(),
                 registry,
                 node_params.num_checkpoints_per_blob,

--- a/crates/walrus-service/src/node/events/event_blob_writer.rs
+++ b/crates/walrus-service/src/node/events/event_blob_writer.rs
@@ -55,6 +55,7 @@ use crate::node::{
         InitState,
         PositionedStreamEvent,
     },
+    DatabaseConfig,
     StorageNodeInner,
 };
 
@@ -343,6 +344,7 @@ impl EventBlobWriterFactory {
     /// Create a new event blob writer factory.
     pub fn new(
         root_dir_path: &Path,
+        db_config: &DatabaseConfig,
         node: Arc<StorageNodeInner>,
         registry: &Registry,
         num_checkpoints_per_blob: Option<u32>,
@@ -352,8 +354,8 @@ impl EventBlobWriterFactory {
         let db_path = Self::db_path(root_dir_path);
         fs::create_dir_all(db_path.as_path())?;
 
-        let mut db_opts = Options::default();
-        let metric_conf = MetricConf::default();
+        let mut db_opts = Options::from(&db_config.global());
+        let metric_conf = MetricConf::new("event_blob_writer");
         db_opts.create_missing_column_families(true);
         db_opts.create_if_missing(true);
         let database = rocks::open_cf_opts(
@@ -361,30 +363,30 @@ impl EventBlobWriterFactory {
             Some(db_opts),
             metric_conf,
             &[
-                (PENDING, Options::default()),
-                (ATTESTED, Options::default()),
-                (CERTIFIED, Options::default()),
-                (FAILED_TO_ATTEST, Options::default()),
+                (PENDING, db_config.pending().to_options()),
+                (ATTESTED, db_config.attested().to_options()),
+                (CERTIFIED, db_config.certified().to_options()),
+                (FAILED_TO_ATTEST, db_config.failed_to_attest().to_options()),
             ],
         )?;
         if database.cf_handle(CERTIFIED).is_none() {
             database
-                .create_cf(CERTIFIED, &Options::default())
+                .create_cf(CERTIFIED, &db_config.certified().to_options())
                 .map_err(typed_store_err_from_rocks_err)?;
         }
         if database.cf_handle(ATTESTED).is_none() {
             database
-                .create_cf(ATTESTED, &Options::default())
+                .create_cf(ATTESTED, &db_config.attested().to_options())
                 .map_err(typed_store_err_from_rocks_err)?;
         }
         if database.cf_handle(PENDING).is_none() {
             database
-                .create_cf(PENDING, &Options::default())
+                .create_cf(PENDING, &db_config.pending().to_options())
                 .map_err(typed_store_err_from_rocks_err)?;
         }
         if database.cf_handle(FAILED_TO_ATTEST).is_none() {
             database
-                .create_cf(FAILED_TO_ATTEST, &Options::default())
+                .create_cf(FAILED_TO_ATTEST, &db_config.failed_to_attest().to_options())
                 .map_err(typed_store_err_from_rocks_err)?;
         }
         let certified: DBMap<(), CertifiedEventBlobMetadata> = DBMap::reopen(
@@ -1631,11 +1633,14 @@ mod tests {
     use walrus_utils::metrics::Registry;
 
     use crate::{
-        node::events::{
-            event_blob::EventBlob,
-            event_blob_writer::{EventBlobWriter, EventBlobWriterFactory},
-            CheckpointEventPosition,
-            PositionedStreamEvent,
+        node::{
+            events::{
+                event_blob::EventBlob,
+                event_blob_writer::{EventBlobWriter, EventBlobWriterFactory},
+                CheckpointEventPosition,
+                PositionedStreamEvent,
+            },
+            DatabaseConfig,
         },
         test_utils::StorageNodeHandle,
     };
@@ -1650,6 +1655,7 @@ mod tests {
         let node = create_test_node().await?;
         let blob_writer_factory = EventBlobWriterFactory::new(
             &dir,
+            &DatabaseConfig::default(),
             node.storage_node.inner().clone(),
             &registry,
             Some(10),
@@ -1702,6 +1708,7 @@ mod tests {
 
         let blob_writer_factory = EventBlobWriterFactory::new(
             &dir,
+            &DatabaseConfig::default(),
             node.storage_node.inner().clone(),
             &registry,
             Some(10),
@@ -1784,6 +1791,7 @@ mod tests {
         let registry = Registry::default();
         let blob_writer_factory = EventBlobWriterFactory::new(
             &dir,
+            &DatabaseConfig::default(),
             node.storage_node.inner().clone(),
             &registry,
             Some(10),

--- a/crates/walrus-service/src/node/events/event_processor.rs
+++ b/crates/walrus-service/src/node/events/event_processor.rs
@@ -72,15 +72,18 @@ use walrus_sui::{
 use walrus_utils::{backoff::ExponentialBackoffConfig, metrics::Registry};
 
 use crate::{
-    node::events::{
-        ensure_experimental_rest_endpoint_exists,
-        event_blob::EventBlob,
-        CheckpointEventPosition,
-        EventProcessorConfig,
-        IndexedStreamEvent,
-        InitState,
-        PositionedStreamEvent,
-        StreamEventWithInitState,
+    node::{
+        events::{
+            ensure_experimental_rest_endpoint_exists,
+            event_blob::EventBlob,
+            CheckpointEventPosition,
+            EventProcessorConfig,
+            IndexedStreamEvent,
+            InitState,
+            PositionedStreamEvent,
+            StreamEventWithInitState,
+        },
+        DatabaseConfig,
     },
     utils::collect_event_blobs_for_catchup,
 };
@@ -231,6 +234,8 @@ pub struct EventProcessorRuntimeConfig {
     pub db_path: PathBuf,
     /// The path to the rpc fallback config.
     pub rpc_fallback_config: Option<RpcFallbackConfig>,
+    /// The database config.
+    pub db_config: DatabaseConfig,
 }
 
 /// Struct to group client-related parameters.
@@ -746,8 +751,8 @@ impl EventProcessor {
     pub fn initialize_database(
         processor_config: &EventProcessorRuntimeConfig,
     ) -> Result<Arc<RocksDB>> {
-        let metric_conf = MetricConf::default();
-        let mut db_opts = Options::default();
+        let metric_conf = MetricConf::new("event_processor");
+        let mut db_opts = Options::from(&processor_config.db_config.global());
         db_opts.create_missing_column_families(true);
         db_opts.create_if_missing(true);
         let database = rocks::open_cf_opts(
@@ -755,37 +760,73 @@ impl EventProcessor {
             Some(db_opts),
             metric_conf,
             &[
-                (CHECKPOINT_STORE, Options::default()),
-                (WALRUS_PACKAGE_STORE, Options::default()),
-                (COMMITTEE_STORE, Options::default()),
-                (EVENT_STORE, Options::default()),
-                (INIT_STATE, Options::default()),
+                (
+                    CHECKPOINT_STORE,
+                    processor_config.db_config.checkpoint_store().to_options(),
+                ),
+                (
+                    WALRUS_PACKAGE_STORE,
+                    processor_config
+                        .db_config
+                        .walrus_package_store()
+                        .to_options(),
+                ),
+                (
+                    COMMITTEE_STORE,
+                    processor_config.db_config.committee_store().to_options(),
+                ),
+                (
+                    EVENT_STORE,
+                    processor_config.db_config.event_store().to_options(),
+                ),
+                (
+                    INIT_STATE,
+                    processor_config.db_config.init_state().to_options(),
+                ),
             ],
         )?;
 
         if database.cf_handle(CHECKPOINT_STORE).is_none() {
             database
-                .create_cf(CHECKPOINT_STORE, &Options::default())
+                .create_cf(
+                    CHECKPOINT_STORE,
+                    &processor_config.db_config.checkpoint_store().to_options(),
+                )
                 .map_err(typed_store_err_from_rocks_err)?;
         }
         if database.cf_handle(WALRUS_PACKAGE_STORE).is_none() {
             database
-                .create_cf(WALRUS_PACKAGE_STORE, &Options::default())
+                .create_cf(
+                    WALRUS_PACKAGE_STORE,
+                    &processor_config
+                        .db_config
+                        .walrus_package_store()
+                        .to_options(),
+                )
                 .map_err(typed_store_err_from_rocks_err)?;
         }
         if database.cf_handle(COMMITTEE_STORE).is_none() {
             database
-                .create_cf(COMMITTEE_STORE, &Options::default())
+                .create_cf(
+                    COMMITTEE_STORE,
+                    &processor_config.db_config.committee_store().to_options(),
+                )
                 .map_err(typed_store_err_from_rocks_err)?;
         }
         if database.cf_handle(EVENT_STORE).is_none() {
             database
-                .create_cf(EVENT_STORE, &Options::default())
+                .create_cf(
+                    EVENT_STORE,
+                    &processor_config.db_config.event_store().to_options(),
+                )
                 .map_err(typed_store_err_from_rocks_err)?;
         }
         if database.cf_handle(INIT_STATE).is_none() {
             database
-                .create_cf(INIT_STATE, &Options::default())
+                .create_cf(
+                    INIT_STATE,
+                    &processor_config.db_config.init_state().to_options(),
+                )
                 .map_err(typed_store_err_from_rocks_err)?;
         }
         Ok(database)

--- a/crates/walrus-service/src/node/storage/database_config.rs
+++ b/crates/walrus-service/src/node/storage/database_config.rs
@@ -273,9 +273,32 @@ pub struct DatabaseConfig {
     pub(super) shard_sync_progress: Option<DatabaseTableOptions>,
     /// Pending recover slivers database options.
     pub(super) pending_recover_slivers: Option<DatabaseTableOptions>,
+    /// Event blob writer certified options.
+    pub(super) certified: Option<DatabaseTableOptions>,
+    /// Event blob writer pending options.
+    pub(super) pending: Option<DatabaseTableOptions>,
+    /// Event blob writer attested options.
+    pub(super) attested: Option<DatabaseTableOptions>,
+    /// Event blob writer failed to attest options.
+    pub(super) failed_to_attest: Option<DatabaseTableOptions>,
+    /// Checkpoint store database options.
+    pub(super) checkpoint_store: Option<DatabaseTableOptions>,
+    /// Walrus package store database options.
+    pub(super) walrus_package_store: Option<DatabaseTableOptions>,
+    /// Committee store database options.
+    pub(super) committee_store: Option<DatabaseTableOptions>,
+    /// Event store database options.
+    pub(super) event_store: Option<DatabaseTableOptions>,
+    /// Init state store database options.
+    pub(super) init_state: Option<DatabaseTableOptions>,
 }
 
 impl DatabaseConfig {
+    /// Returns the global database options.
+    pub fn global(&self) -> GlobalDatabaseOptions {
+        self.global.clone()
+    }
+
     /// Returns the node status database option.
     pub fn node_status(&self) -> DatabaseTableOptions {
         self.node_status
@@ -347,6 +370,69 @@ impl DatabaseConfig {
             .map(|options| options.inherit_from(self.standard.clone()))
             .unwrap_or_else(|| self.standard.clone())
     }
+
+    /// Returns the event blob writer certified database option.
+    pub fn certified(&self) -> DatabaseTableOptions {
+        self.certified
+            .clone()
+            .unwrap_or_else(|| self.standard.clone())
+    }
+
+    /// Returns the event blob writer pending database option.
+    pub fn pending(&self) -> DatabaseTableOptions {
+        self.pending
+            .clone()
+            .unwrap_or_else(|| self.standard.clone())
+    }
+
+    /// Returns the event blob writer attested database option.
+    pub fn attested(&self) -> DatabaseTableOptions {
+        self.attested
+            .clone()
+            .unwrap_or_else(|| self.standard.clone())
+    }
+
+    /// Returns the event blob writer failed to attest database option.
+    pub fn failed_to_attest(&self) -> DatabaseTableOptions {
+        self.failed_to_attest
+            .clone()
+            .unwrap_or_else(|| self.standard.clone())
+    }
+
+    /// Returns the checkpoint store database option.
+    pub fn checkpoint_store(&self) -> DatabaseTableOptions {
+        self.checkpoint_store
+            .clone()
+            .unwrap_or_else(|| self.standard.clone())
+    }
+
+    /// Returns the walrus package store database option.
+    pub fn walrus_package_store(&self) -> DatabaseTableOptions {
+        self.walrus_package_store
+            .clone()
+            .unwrap_or_else(|| self.standard.clone())
+    }
+
+    /// Returns the committee store database option.
+    pub fn committee_store(&self) -> DatabaseTableOptions {
+        self.committee_store
+            .clone()
+            .unwrap_or_else(|| self.standard.clone())
+    }
+
+    /// Returns the event store database option.
+    pub fn event_store(&self) -> DatabaseTableOptions {
+        self.event_store
+            .clone()
+            .unwrap_or_else(|| self.standard.clone())
+    }
+
+    /// Returns the init state store database option.
+    pub fn init_state(&self) -> DatabaseTableOptions {
+        self.init_state
+            .clone()
+            .unwrap_or_else(|| self.standard.clone())
+    }
 }
 
 impl Default for DatabaseConfig {
@@ -364,6 +450,15 @@ impl Default for DatabaseConfig {
             shard_status: None,
             shard_sync_progress: None,
             pending_recover_slivers: None,
+            certified: None,
+            pending: None,
+            attested: None,
+            failed_to_attest: None,
+            checkpoint_store: None,
+            walrus_package_store: None,
+            committee_store: None,
+            event_store: None,
+            init_state: None,
         }
     }
 }

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -499,6 +499,7 @@ impl SimStorageNodeHandle {
                         .path()
                         .to_path_buf()),
                     rpc_fallback_config: None,
+                    db_config: DatabaseConfig::default(),
                 };
             let system_config = crate::node::events::event_processor::SystemConfig {
                 system_object_id: sui_config.contract_config.system_object,
@@ -2585,6 +2586,7 @@ pub mod test_cluster {
                     .path()
                     .to_path_buf()),
                 rpc_fallback_config: None,
+                db_config: DatabaseConfig::default(),
             };
             let system_config = SystemConfig {
                 system_pkg_id: sui_read_client.get_system_package_id(),


### PR DESCRIPTION
## Description

Some rocksdb instances are not configurable from db config settings. This PR allows event processor db and event blob writer dbs to be configured by user defined settings.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
