### PR TITLE
fix: explicitly cast dyn EventManager to EventProcessor ref

### DIFF
--- a/crates/walrus-service/src/node/storage/shard.rs
+++ b/crates/walrus-service/src/node/storage/shard.rs
@@ -749,6 +749,7 @@ impl ShardStorage {
             );
 
         let mut next_blob_info = blob_info_iter.next().transpose()?;
+
         // For transitioning from GENESIS epoch to epoch 1, since GENESIS epoch does not have
         // any committees and should not receive any user blobs, there shouldn't be any certified
         // blobs. In case, the shard sync should finish immediately and transition to Active state.


### PR DESCRIPTION
## Description

Previously, we use .as_any().downcast_ref<EventProcessor>, but the dyn EventManager can also be a Arc<EventProcessor>, depending on where the event processor is initialized. Since all the downcast was to 
convert to EventProcessor, implement as_event_processor() so that all the types implementing EventManager
can do explicit type conversion.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
