### PR TITLE
chore: add doctests to CI and pre-commit

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -44,8 +44,7 @@ jobs:
       isDenyConfig: ${{ steps.diff.outputs.isDenyConfig }}
       isTestConfig: ${{ steps.diff.outputs.isTestConfig }}
       isOpenapi: ${{ steps.diff.outputs.isOpenapi }}
-      isRelevantForRustTests:
-        ${{ steps.diff.outputs.isRust == 'true' || steps.diff.outputs.isMove == 'true' || steps.diff.outputs.isTestConfig
+      isRelevantForRustTests: ${{ steps.diff.outputs.isRust == 'true' || steps.diff.outputs.isMove == 'true' || steps.diff.outputs.isTestConfig
         == 'true' }}
       isTestnetContracts: ${{ steps.diff.outputs.isTestnetContracts }}
       isExampleConfig: ${{ steps.diff.outputs.isExampleConfig }}
@@ -135,6 +134,8 @@ jobs:
           sudo apt-get install -y libssl-dev pkg-config zlib1g-dev libpq-dev build-essential cmake
       - name: Run tests
         run: cargo nextest run --workspace --features "walrus-service/backup" --profile ci --run-ignored all
+      - name: Run doctests
+        run: cargo test --doc
 
   test-coverage:
     name: Run all Rust tests and report coverage
@@ -207,7 +208,8 @@ jobs:
         if: steps.cache-sui-restore.outputs.cache-hit != 'true'
       - name: Install sui
         if: steps.cache-sui-restore.outputs.cache-hit != 'true'
-        run: cargo install --locked --git https://github.com/MystenLabs/sui.git --tag $SUI_TAG --debug --features tracing sui
+        run: cargo install --locked --git https://github.com/MystenLabs/sui.git --tag $SUI_TAG --debug --features tracing
+          sui
       - name: Run Move tests and check coverage
         run: bash ./scripts/move_coverage.sh
       - name: Cache sui binary

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,6 +75,12 @@ repos:
         language: rust
         files: (^crates/|Cargo\.(toml|lock)$|nextest\.toml$)
         pass_filenames: false
+      - id: cargo-doctests
+        name: cargo-doctests
+        entry: cargo test --doc
+        language: rust
+        files: (^crates/|Cargo\.(toml|lock)$)
+        pass_filenames: false
       - id: clippy-with-tests
         name: clippy-with-tests
         entry: cargo clippy

--- a/crates/walrus-service/src/node/events/event_blob_writer.rs
+++ b/crates/walrus-service/src/node/events/event_blob_writer.rs
@@ -681,7 +681,8 @@ impl EventBlobWriterFactory {
 }
 
 /// EventBlobWriter manages the creation, storage, and certification of event blobs.
-/// ```
+///
+/// ```text
 ///  +-------------------+
 ///  |  EventBlobWriter  |
 ///  +-------------------+
@@ -705,10 +706,6 @@ impl EventBlobWriterFactory {
 ///                   certification)
 ///
 /// ```
-/// Flow: Current -> Pending -> Attested -> Certified
-///                     |
-///                     +-> Failed to Attest -> Attested -> Certified
-/// ```text
 ///
 /// Blob Lifecycle:
 ///


### PR DESCRIPTION
## Description

Because we use [nextest](https://nexte.st/) to run our tests, which [doesn't support doctests](https://github.com/nextest-rs/nextest/issues/16), we didn't actually notice this. This adds doctests to CI and pre-commit (and fixes one issue that causes doctests to fail).

## Test plan

CI.
