### PR TITLE
fix: Use event id for checkpoint events when repositioning event cursor

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -39,7 +39,7 @@ pub use storage::{DatabaseConfig, NodeStatus, Storage};
 use sui_macros::fail_point_if;
 use sui_macros::{fail_point_arg, fail_point_async};
 use sui_types::{base_types::ObjectID, event::EventID};
-use system_events::{CompletableHandle, EventHandle};
+use system_events::{CompletableHandle, EventHandle, EVENT_ID_FOR_CHECKPOINT_EVENTS};
 use thread_pool::{BoundedThreadPool, ThreadPoolBuilder};
 use tokio::{select, sync::watch, time::Instant};
 use tokio_metrics::TaskMonitor;
@@ -789,7 +789,10 @@ impl StorageNode {
                 actual_event_index
             );
             self.inner.reposition_event_cursor(
-                init_state.event_cursor.event_id.expect("EventID expected"),
+                init_state
+                    .event_cursor
+                    .event_id
+                    .unwrap_or(EVENT_ID_FOR_CHECKPOINT_EVENTS),
                 actual_event_index,
             )?;
             storage_node_cursor_repositioned = true;

--- a/crates/walrus-service/src/node/system_events.rs
+++ b/crates/walrus-service/src/node/system_events.rs
@@ -34,6 +34,12 @@ use crate::{
 /// The capacity of the event channel.
 pub const EVENT_CHANNEL_CAPACITY: usize = 1024;
 
+/// The event ID for checkpoint events.
+pub const EVENT_ID_FOR_CHECKPOINT_EVENTS: EventID = EventID {
+    tx_digest: TransactionDigest::ZERO,
+    event_seq: 0,
+};
+
 /// Represents a Walrus event and the obligation to completely process that event.
 ///
 /// A function that obtains an `EventHandle` must do one of the following:
@@ -59,15 +65,10 @@ pub(super) struct EventHandle {
 }
 
 impl EventHandle {
-    const EVENT_ID_FOR_CHECKPOINT_EVENTS: EventID = EventID {
-        tx_digest: TransactionDigest::ZERO,
-        event_seq: 0,
-    };
-
     pub fn new(index: u64, event_id: Option<EventID>, node: Arc<StorageNodeInner>) -> Self {
         Self {
             index,
-            event_id: event_id.unwrap_or(Self::EVENT_ID_FOR_CHECKPOINT_EVENTS),
+            event_id: event_id.unwrap_or(EVENT_ID_FOR_CHECKPOINT_EVENTS),
             node,
             can_be_dropped: false,
         }


### PR DESCRIPTION
## Description

This PR fixes the issue that when repositioning event cursor for a node which recovered using event blobs, we expect `EventID` to always exist. But `EventID` is only used in legacy event processor and since when creating the blobs, we do not use `EventID` it is captured as `None` in event blobs and hence it doesn't exist in event blobs. The fix is to do the same thing that we do in normal functioning of event cursor table i.e. to use a special event id when updating cursor.

## Test plan

Deployed it to the ptn node which was breaking, and the node is able to get past the error (but now fails because of a different but expected error):
```
Apr 09 19:47:01 mia-ptn-sto-00 walrus-node[1350683]: {"timestamp":"2025-04-09T19:47:01.030127Z","level":"INFO","fields":{"message":"open storage for existing shards IDs: "},"target":"walrus_service::node::storage","filename":"crates/walrus-service/src/node/storage.rs","line_number":182}
Apr 09 19:47:01 mia-ptn-sto-00 walrus-node[1350683]: {"timestamp":"2025-04-09T19:47:01.389300Z","level":"INFO","fields":{"message":"successfully opened the node database"},"target":"walrus_service::node","filename":"crates/walrus-service/src/node.rs","line_number":589}
Apr 09 19:47:02 mia-ptn-sto-00 walrus-node[1350683]: {"timestamp":"2025-04-09T19:47:02.048777Z","level":"INFO","fields":{"message":"Skipping reset: uncertified blobs (0/0) below threshold 3. Last certified at checkpoint 182042016"},"target":"walrus_service::node::events::event_blob_writer","filename":"crates/walrus-service/src/node/events/event_blob_writer.rs","line_number":631}
Apr 09 19:47:02 mia-ptn-sto-00 walrus-node[1350683]: {"timestamp":"2025-04-09T19:47:02.048981Z","level":"INFO","fields":{"message":"started REST API on 144.202.38.156:9185"},"target":"walrus_node","filename":"crates/walrus-service/bin/node.rs","line_number":1204}
Apr 09 19:47:02 mia-ptn-sto-00 walrus-node[1350683]: {"timestamp":"2025-04-09T19:47:02.359240Z","level":"INFO","fields":{"message":"Repositioning storage node cursor from 0 to 11263445"},"target":"walrus_service::node","filename":"crates/walrus-service/src/node.rs","line_number":786}
Apr 09 19:47:02 mia-ptn-sto-00 walrus-node[1350683]: {"timestamp":"2025-04-09T19:47:02.359350Z","level":"INFO","fields":{"message":"Repositioning event blob writer cursor from 0 to 11263445"},"target":"walrus_service::node","filename":"crates/walrus-service/src/node.rs","line_number":805}
Apr 09 19:47:02 mia-ptn-sto-00 walrus-node[1350683]: {"timestamp":"2025-04-09T19:47:02.360901Z","level":"WARN","fields":{"message":"the current epoch (428) is far ahead of the event epoch (321); node entering recovery mode"},"target":"walrus_service::node","filename":"crates/walrus-service/src/node.rs","line_number":927}
Apr 09 19:47:02 mia-ptn-sto-00 walrus-node[1350683]: {"timestamp":"2025-04-09T19:47:02.361606Z","level":"ERROR","fields":{"message":"encountered an update other than 'register' for an untracked blob ID","operand":"ChangeStatus { change_type: Certify, change_info: BlobStatusChangeInfo { blob_id: BlobId(i3ZXyJxqtWOvyg1Z-I9mbLcQkkgnYb6A3CtcyIKSnWg), deletable: false, epoch: 321, end_epoch: 331, status_event: EventID { tx_digest: TransactionDigest(Dn6q8rzTTsHPagwhhG5oH2tCBC5GVymVVRYCK7zxPXZP), event_seq: 0 } } }"},"target":"walrus_service::node::storage::blob_info","filename":"crates/walrus-service/src/node/storage/blob_info.rs","line_number":1127,"span":{"name":"get_blob_info"},"spans":[{"messaging.client.id":"pQRK21fFaU07UmLXYo2x/qGoI4TD12W8bg7Wdom3Cka7n0783TNZFD8qPPkfsT3H","messaging.destination.name":"blob_store","messaging.operation.type":"receive","messaging.system":"sui","otel.kind":"CONSUMER","walrus.blob_id":"Some(BlobId(i3ZXyJxqtWOvyg1Z-I9mbLcQkkgnYb6A3CtcyIKSnWg))","walrus.event.checkpoint_seq":"179486020","walrus.event.index":11263449,"walrus.event.kind":"certified","walrus.event.tx_digest":"Some(TransactionDigest(Dn6q8rzTTsHPagwhhG5oH2tCBC5GVymVVRYCK7zxPXZP))","walrus.node_status":"RecoveryCatchUp","name":"blob_store receive"},{"name":"process_event"},{"name":"process_blob_event"},{"name":"process_blob_certified_event"},{"name":"get_blob_info"}]}
Apr 09 19:47:02 mia-ptn-sto-00 walrus-node[1350683]: {"timestamp":"2025-04-09T19:47:02.361668Z","level":"ERROR","fields":{"error":"rocksdb error: Corruption: Merge operator failed"},"target":"typed_store::rocks","filename":"/home/runner/.cargo/git/checkouts/sui-e0a047c8ed89192d/e011e77/crates/typed-store/src/rocks/mod.rs","line_number":1358,"span":{"name":"get_blob_info"},"spans":[{"messaging.client.id":"pQRK21fFaU07UmLXYo2x/qGoI4TD12W8bg7Wdom3Cka7n0783TNZFD8qPPkfsT3H","messaging.destination.name":"blob_store","messaging.operation.type":"receive","messaging.system":"sui","otel.kind":"CONSUMER","walrus.blob_id":"Some(BlobId(i3ZXyJxqtWOvyg1Z-I9mbLcQkkgnYb6A3CtcyIKSnWg))","walrus.event.checkpoint_seq":"179486020","walrus.event.index":11263449,"walrus.event.kind":"certified","walrus.event.tx_digest":"Some(TransactionDigest(Dn6q8rzTTsHPagwhhG5oH2tCBC5GVymVVRYCK7zxPXZP))","walrus.node_status":"RecoveryCatchUp","name":"blob_store receive"},{"name":"process_event"},{"name":"process_blob_event"},{"name":"process_blob_certified_event"},{"name":"get_blob_info"}]}
Apr 09 19:47:02 mia-ptn-sto-00 walrus-node[1350683]: {"timestamp":"2025-04-09T19:47:02.361729Z","level":"ERROR","fields":{"message":"event handle dropped before being marked as complete"},"target":"walrus_service::node::system_events","filename":"crates/walrus-service/src/node/system_events.rs","line_number":125,"span":{"self":"EventHandle { index: 11263449, event_id: EventID { tx_digest: TransactionDigest(Dn6q8rzTTsHPagwhhG5oH2tCBC5GVymVVRYCK7zxPXZP), event_seq: 0 }, can_be_dropped: false }","name":"drop"},"spans":[{"messaging.client.id":"pQRK21fFaU07UmLXYo2x/qGoI4TD12W8bg7Wdom3Cka7n0783TNZFD8qPPkfsT3H","messaging.destination.name":"blob_store","messaging.operation.type":"receive","messaging.system":"sui","otel.kind":"CONSUMER","walrus.blob_id":"Some(BlobId(i3ZXyJxqtWOvyg1Z-I9mbLcQkkgnYb6A3CtcyIKSnWg))","walrus.event.checkpoint_seq":"179486020","walrus.event.index":11263449,"walrus.event.kind":"certified","walrus.event.tx_digest":"Some(TransactionDigest(Dn6q8rzTTsHPagwhhG5oH2tCBC5GVymVVRYCK7zxPXZP))","walrus.node_status":"RecoveryCatchUp","name":"blob_store receive"},{"name":"process_event"},{"name":"process_blob_event"},{"name":"process_blob_certified_event"},{"self":"EventHandle { index: 11263449, event_id: EventID { tx_digest: TransactionDigest(Dn6q8rzTTsHPagwhhG5oH2tCBC5GVymVVRYCK7zxPXZP), event_seq: 0 }, can_be_dropped: false }","name":"drop"}]}
Apr 09 19:47:02 mia-ptn-sto-00 walrus-node[1350683]: {"timestamp":"2025-04-09T19:47:02.361934Z","level":"INFO","fields":{"message":"exit notification received"},"target":"walrus_service::common::utils","filename":"crates/walrus-service/src/common/utils.rs","line_number":846,"span":{"name":"wait_until_terminated"},"spans":[{"name":"wait_until_terminated"}]}

```
