### PR TITLE
docs: extend SDKs page

### DIFF
--- a/docs/book/usage/sdks.md
+++ b/docs/book/usage/sdks.md
@@ -1,5 +1,7 @@
 # Software development kits (SDKs) and other tools
 
+## SDKs maintained by Mysten Labs
+
 Mysten Labs has built and published a [Walrus TypeScript SDK](https://sdk.mystenlabs.com/walrus),
 which supports a wide variety of operations. See also the related
 [examples](https://github.com/MystenLabs/ts-sdks/tree/main/packages/walrus/examples).
@@ -7,16 +9,34 @@ which supports a wide variety of operations. See also the related
 The Walrus core team is also actively working on a Rust SDK for Walrus, which will be made available
 some time after the Mainnet launch.
 
+For data security, use the [TypeScript SDK](https://www.npmjs.com/package/@mysten/seal) for Seal.
+It provides threshold encryption and onchain access control for decentralized data protection.
+Also, refer to [Data security](../dev-guide/data-security.md) for details.
+
+## Community-maintained SDKs
+
 Besides these official SDKs, there also exist a few unofficial third-party SDKs for interacting
 with the [HTTP API](./web-api.md#http-api-usage) exposed by Walrus aggregators and publishers:
 
 - [Walrus Go SDK](https://github.com/namihq/walrus-go) (maintained by the *Nami Cloud* team)
 - [Walrus PHP SDK](https://github.com/suicore/walrus-sdk-php) (maintained by the *Suicore* team)
-
-For data security, use the [TypeScript SDK](https://www.npmjs.com/package/@mysten/seal) for Seal.
-It provides threshold encryption and onchain access control for decentralized data protection.
-Also, refer to [Data security](../dev-guide/data-security.md) for details.
+- [Walrus Python SDK](https://github.com/standard-crypto/walrus-python) (maintained by the *Standard
+  Crypto* team)
 
 Finally, there is [Tusky](https://docs.tusky.io/about/about-tusky), a complete data storage platform
 built on Walrus, including encryption, HTTP APIs, sharing capabilities, and more.
 Tusky maintains its own [TypeScript SDK](https://github.com/tusky-io/ts-sdk).
+
+## Explorers
+
+There is currently the [Walruscan](https://walruscan.com/) blob explorer built and maintained by the
+*Staketab* team, which supports exploring blobs, blob events, operators, etc. It also supports
+staking operations.
+
+See the [*Awesome Walrus* repository](https://github.com/MystenLabs/awesome-walrus?tab=readme-ov-file#visualization)
+for more visualization tools.
+
+## Other tools
+
+There are many other tools built by the community for visualization, monitoring, etc. For a full
+list, see the [*Awesome Walrus* repository](https://github.com/MystenLabs/awesome-walrus).


### PR DESCRIPTION
## Description

Adds a Python SDK to the list of community SDKs and adds info on Walruscan and the Awesome Walrus repo.

## Test plan

Look at preview. 👀 