### PR TITLE
fix(client): fixed generation of a new wallet at default path

### DIFF
--- a/crates/walrus-service/src/client/cli/args.rs
+++ b/crates/walrus-service/src/client/cli/args.rs
@@ -411,7 +411,7 @@ pub enum CliCommands {
         path: Option<PathBuf>,
         /// Sui network for which the wallet is generated.
         ///
-        /// Available options are `devnet`, `testnet`, and `localnet`.
+        /// Available options are `devnet`, `testnet`, `mainnet`, and `localnet`.
         #[arg(long, default_value_t = default::sui_network())]
         #[serde(default = "default::sui_network")]
         sui_network: SuiNetwork,

--- a/crates/walrus-service/src/client/cli/runner.rs
+++ b/crates/walrus-service/src/client/cli/runner.rs
@@ -252,21 +252,17 @@ impl ClientCommandRunner {
                 let wallet_path = if let Some(path) = path {
                     path
                 } else {
-                    // Check if the Sui configuration directory exists.
+                    // This automatically creates the Sui configuration directory if it doesn't
+                    // exist.
                     let config_dir = sui_config_dir()?;
-                    if config_dir.exists() {
-                        anyhow::bail!(
-                            "Sui configuration directory already exists; please specify a \
-                            different path using `--path` or manage the wallet using the Sui CLI."
-                        );
-                    } else {
-                        tracing::debug!(
-                            config_dir = ?config_dir.display(),
-                            "creating the Sui configuration directory"
-                        );
-                        std::fs::create_dir_all(&config_dir)?;
-                        config_dir.join(SUI_CLIENT_CONFIG)
-                    }
+                    anyhow::ensure!(
+                        config_dir.read_dir()?.next().is_none(),
+                        "The Sui configuration directory {} is not empty; please specify a \
+                        different wallet path using `--path` or manage the wallet using the Sui \
+                        CLI.",
+                        config_dir.display()
+                    );
+                    config_dir.join(SUI_CLIENT_CONFIG)
                 };
 
                 self.generate_sui_wallet(&wallet_path, sui_network, use_faucet, faucet_timeout)

--- a/docs/book/usage/networks.md
+++ b/docs/book/usage/networks.md
@@ -9,7 +9,8 @@ Mainnet. Finally, developers can operate local Walrus and Sui networks for testi
 Some important fixed system parameters for Mainnet and Testnet are summarized in the following table:
 
 | Parameter                                                | Mainnet | Testnet |
-| -------------------------------------------------------- | ------- | ------- |
+|----------------------------------------------------------|---------|---------|
+| Sui network                                              | Mainnet | Testnet |
 | Number of shards                                         | 1000    | 1000    |
 | Epoch duration                                           | 2 weeks | 1 day   |
 | Maximum number of epochs for which storage can be bought | 53      | 53      |
@@ -68,7 +69,8 @@ available.
 Interacting with Walrus requires a valid Sui Testnet wallet with some amount of SUI tokens. The
 normal way to set this up is via the Sui CLI; see the [installation
 instructions](https://docs.sui.io/guides/developer/getting-started/sui-install) in the Sui
-documentation.
+documentation. If you do not want to install the Sui CLI, you can also generate a new Sui wallet for
+Testnet using `walrus generate-sui-wallet --network testnet`.
 
 After installing the Sui CLI, you need to set up a Testnet wallet by running `sui client`, which
 prompts you to set up a new configuration. Make sure to point it to Sui Testnet, you can use the

--- a/docs/book/usage/setup.md
+++ b/docs/book/usage/setup.md
@@ -16,14 +16,12 @@ for an overview over all Walrus networks.
 ## Prerequisites: Sui wallet, SUI and WAL {#prerequisites}
 
 ```admonish tip title="Quick wallet setup"
-If you just want to set up a new Sui wallet for Walrus, you can skip this section and use the
-`walrus generate-sui-wallet` command after [installing Walrus](#installation). In that case, make
-sure to set the `wallet_config` parameter in the [Walrus
-configuration](#advanced-configuration-optional) to the newly generated wallet. Also, make sure to
-obtain some SUI and WAL tokens.
+If you just want to set up a new Sui wallet for Walrus, you can generate one using the
+`walrus generate-sui-wallet --network mainnet` command after [installing Walrus](#installation).
+You still need to obtain some SUI and WAL tokens, but you do not have to install the Sui CLI.
 ```
 
-Interacting with Walrus requires a valid Sui wallet with some amount of SUI tokens. The
+Interacting with Walrus requires a valid Sui wallet with some amount of SUI and WAL tokens. The
 normal way to set this up is via the Sui CLI; see the [installation
 instructions](https://docs.sui.io/guides/developer/getting-started/sui-install) in the Sui
 documentation.


### PR DESCRIPTION
## Description

There was a bug in our code where we check for the existence of the default Sui configuration directory, which we implicitly created immediately before.

This PR also updates some related documentation.

Closes #1941. 

## Test plan

Manual testing:

```terminal
$ walrus generate-sui-wallet
2025-04-10T10:06:13.998079Z DEBUG walrus_service::common::utils: initialized scoped tracing subscriber
2025-04-10T10:06:14.003090Z  INFO walrus: client version: 1.21.0-1566f8114f84-dirty
2025-04-10T10:06:14.008298Z  INFO walrus_service::client::cli: using Walrus configuration from '~/.config/walrus/client_config.yaml' with 'mainnet' context
2025-04-10T10:06:14.008499Z  INFO walrus_sui::config: using Sui wallet configuration from '~/.sui/sui_config/client.yaml'
2025-04-10T10:06:14.010574Z  INFO walrus_service::common::utils: generating Sui wallet for testnet at '~/.sui/sui_config/client.yaml'
2025-04-10T10:06:14.037703Z  INFO walrus_sui::config: using Sui wallet configuration from '~/.sui/sui_config/client.yaml'
2025-04-10T10:06:14.038669Z  INFO walrus_service::common::utils: generated a new Sui wallet; address: 0x1004a389a42afac3bd747afd6c9498fd52b8cfb1775be6e93dd2ad08cf6f8716
Success: Generated a new Sui wallet with address 0x1004a389a42afac3bd747afd6c9498fd52b8cfb1775be6e93dd2ad08cf6f8716

$ walrus generate-sui-wallet
2025-04-10T10:07:13.337810Z  INFO walrus: client version: 1.21.0-1566f8114f84-dirty
2025-04-10T10:07:13.339012Z  INFO walrus_service::client::cli: using Walrus configuration from '~/.config/walrus/client_config.yaml' with 'mainnet' context
2025-04-10T10:07:13.339062Z  INFO walrus_sui::config: using Sui wallet configuration from '~/.sui/sui_config/client.yaml'
Error: The Sui configuration directory ~/.sui/sui_config is not empty; please specify a different wallet path using `--path` or manage the wallet using the Sui CLI.
```

---

## Release notes

- [x] CLI: Fix a bug that prevented the creation of a Sui wallet at the default location through `walrus generate-sui-wallet`.
