### PR TITLE
fix(cli): replace deprecated `clap` attributes with `command` or `arg`

### DIFF
--- a/crates/walrus-orchestrator/src/main.rs
+++ b/crates/walrus-orchestrator/src/main.rs
@@ -38,12 +38,17 @@ type ClientParameters = ProtocolClientParameters;
 
 /// The orchestrator command line options.
 #[derive(Parser, Debug)]
-#[command(author, version, about = "Testbed orchestrator", long_about = None)]
-#[clap(rename_all = "kebab-case")]
+#[command(
+    author,
+    version,
+    about = "Testbed orchestrator",
+    long_about = None,
+    rename_all = "kebab-case"
+)]
 pub struct Opts {
     /// The path to the settings file. This file contains basic information to deploy testbeds
     /// and run benchmarks such as the url of the git repo, the commit to deploy, etc.
-    #[clap(
+    #[arg(
         long,
         value_name = "FILE",
         default_value = "crates/walrus-orchestrator/assets/settings.yaml",
@@ -52,49 +57,49 @@ pub struct Opts {
     settings_path: String,
 
     /// The type of operation to run.
-    #[clap(subcommand)]
+    #[command(subcommand)]
     operation: Operation,
 }
 
 /// The type of operation to run.
 #[derive(Parser, Debug)]
-#[clap(rename_all = "kebab-case")]
+#[command(rename_all = "kebab-case")]
 pub enum Operation {
     /// Read or modify the status of the testbed.
     Testbed {
         /// The action to perform on the testbed.
-        #[clap(subcommand)]
+        #[command(subcommand)]
         action: TestbedAction,
     },
     /// Deploy clients and run a benchmark using the specified testbed.
     Benchmark {
         /// The number of clients to deploy.
-        #[clap(long, value_name = "INT", default_value_t = 4, global = true)]
+        #[arg(long, value_name = "INT", default_value_t = 4, global = true)]
         clients: usize,
 
         /// Whether to skip testbed updates before running benchmarks. This is a dangerous
         /// operation as it may lead to running benchmarks on outdated nodes. It is however
         /// useful when debugging in some specific scenarios.
-        #[clap(long, action, default_value_t = false, global = true)]
+        #[arg(long, global = true)]
         skip_testbed_update: bool,
 
         /// Whether to skip testbed configuration before running benchmarks. This is a dangerous
         /// operation as it may lead to running benchmarks on misconfigured nodes. It is however
         /// useful when debugging in some specific scenarios.
-        #[clap(long, action, default_value_t = false, global = true)]
+        #[arg(long, global = true)]
         skip_testbed_configuration: bool,
     },
     /// Print a summary of the specified measurements collection.
     Summarize {
         /// The path to the settings file.
-        #[clap(long, value_name = "FILE")]
+        #[arg(long, value_name = "FILE")]
         path: PathBuf,
     },
 }
 
 /// The action to perform on the testbed.
 #[derive(Parser, Debug)]
-#[clap(rename_all = "kebab-case")]
+#[command(rename_all = "kebab-case")]
 pub enum TestbedAction {
     /// Display the testbed status.
     Status,
@@ -102,20 +107,20 @@ pub enum TestbedAction {
     /// Deploy the specified number of instances in all regions specified by in the setting file.
     Deploy {
         /// Number of instances to deploy.
-        #[clap(long)]
+        #[arg(long)]
         instances: usize,
 
         /// The region where to deploy the instances. If this parameter is not specified, the
         /// command deploys the specified number of instances in all regions listed in the
         /// setting file.
-        #[clap(long)]
+        #[arg(long)]
         region: Option<String>,
     },
 
     /// Start at most the specified number of instances per region on an existing testbed.
     Start {
         /// Number of instances to deploy.
-        #[clap(long, default_value_t = 10)]
+        #[arg(long, default_value_t = 10)]
         instances: usize,
     },
 

--- a/crates/walrus-proxy/src/main.rs
+++ b/crates/walrus-proxy/src/main.rs
@@ -32,11 +32,13 @@ static APP_USER_AGENT: &str = const_str::concat!(
 );
 
 #[derive(Parser, Debug)]
-#[clap(rename_all = "kebab-case")]
-#[clap(name = env!("CARGO_BIN_NAME"))]
-#[clap(version = VERSION)]
+#[command(
+    name = env!("CARGO_BIN_NAME"),
+    version = VERSION,
+    rename_all = "kebab-case"
+)]
 struct Args {
-    #[clap(
+    #[arg(
         long,
         short,
         default_value = "./walrus-proxy.yaml",

--- a/crates/walrus-service/bin/backup.rs
+++ b/crates/walrus-service/bin/backup.rs
@@ -21,14 +21,16 @@ use walrus_service::{
 
 /// Manage and run Walrus backup nodes
 #[derive(Parser)]
-#[clap(rename_all = "kebab-case")]
-#[clap(name = env!("CARGO_BIN_NAME"))]
-#[clap(version = VERSION)]
+#[command(
+    name = env!("CARGO_BIN_NAME"),
+    version = VERSION,
+    rename_all = "kebab-case",
+)]
 #[derive(Debug)]
 struct Args {
-    #[clap(long, short, help = "Specify the config file path to use")]
+    #[arg(long, short, help = "Specify the config file path to use")]
     config: PathBuf,
-    #[clap(
+    #[arg(
         long,
         short,
         help = "Override the metrics address to use (ie: 127.0.0.1:9184)"
@@ -39,7 +41,7 @@ struct Args {
 }
 
 #[derive(Subcommand, Debug, Clone)]
-#[clap(rename_all = "kebab-case")]
+#[command(rename_all = "kebab-case")]
 enum BackupCommands {
     /// Run a backup orchestrator with the provided configuration.
     Orchestrator,

--- a/crates/walrus-service/bin/client.rs
+++ b/crates/walrus-service/bin/client.rs
@@ -19,13 +19,17 @@ pub const VERSION: &str = walrus_service::utils::version!();
 
 /// The command-line arguments for the Walrus client.
 #[derive(Parser, Debug, Clone, Deserialize)]
-#[command(author, version, about = "Walrus client", long_about = None)]
-#[clap(name = env!("CARGO_BIN_NAME"))]
-#[clap(version = VERSION)]
-#[clap(rename_all = "kebab-case")]
+#[command(
+    author,
+    about = "Walrus client",
+    long_about = None,
+    name = env!("CARGO_BIN_NAME"),
+    version = VERSION,
+    rename_all = "kebab-case"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct ClientArgs {
-    #[clap(flatten)]
+    #[command(flatten)]
     inner: App,
 }
 

--- a/crates/walrus-service/bin/node.rs
+++ b/crates/walrus-service/bin/node.rs
@@ -64,14 +64,14 @@ const VERSION: &str = version!();
 
 /// Manage and run a Walrus storage node.
 #[derive(Debug, Parser)]
-#[clap(rename_all = "kebab-case", name = env!("CARGO_BIN_NAME"), version = VERSION)]
+#[command(rename_all = "kebab-case", name = env!("CARGO_BIN_NAME"), version = VERSION)]
 struct Args {
     #[command(subcommand)]
     command: Commands,
 }
 
 #[derive(Subcommand, Debug, Clone)]
-#[clap(rename_all = "kebab-case")]
+#[command(rename_all = "kebab-case")]
 enum Commands {
     /// Generate Sui wallet, keys, and configuration for a Walrus node and optionally generates a
     /// YAML file that can be used to register the node by a third party.
@@ -83,24 +83,24 @@ enum Commands {
     /// Register a new node with the Walrus storage network.
     Register {
         /// The path to the node's configuration file.
-        #[clap(long)]
+        #[arg(long)]
         config_path: PathBuf,
         /// Overwrite existing storage node capability object if the input config already has one.
-        #[clap(long)]
+        #[arg(long)]
         force: bool,
     },
 
     /// Run a storage node with the provided configuration.
     Run {
         /// Path to the Walrus node configuration file.
-        #[clap(long)]
+        #[arg(long)]
         config_path: PathBuf,
         /// Whether to cleanup the storage directory before starting the node.
-        #[clap(long, action, default_value_t = false)]
+        #[arg(long, default_value_t = false)]
         cleanup_storage: bool,
         /// Whether to ignore the failures from node parameter synchronization with on-chain values.
         #[deprecated(note = "This flag is being removed and will have no effect")]
-        #[clap(long, action, default_value_t = false)]
+        #[arg(long, default_value_t = false)]
         ignore_sync_failures: bool,
     },
 
@@ -110,39 +110,39 @@ enum Commands {
         ///
         /// If the file already exists, it is not overwritten and the operation will fail unless
         /// the `--force` option is provided.
-        #[clap(long)]
+        #[arg(long)]
         out: Option<PathBuf>,
         /// Which type of key to generate.
-        #[clap(long, value_enum)]
+        #[arg(long, value_enum)]
         key_type: KeyType,
         /// Output the key in the specified format.
-        #[clap(long, value_enum, default_value_t = KeyFormat::Tagged)]
+        #[arg(long, value_enum, default_value_t = KeyFormat::Tagged)]
         format: KeyFormat,
         /// Overwrite existing files.
-        #[clap(long)]
+        #[arg(long)]
         force: bool,
         /// Convert an existing key instead of generating a new key.
         ///
         /// Provide a path to an existing key in a supported format. The key is converted to the
         /// format specified by `--format` before being written.
-        #[clap(long, value_name = "INPUT_KEY_PATH")]
+        #[arg(long, value_name = "INPUT_KEY_PATH")]
         convert: Option<PathBuf>,
     },
 
     /// Generate a new node configuration.
     GenerateConfig {
-        #[clap(flatten)]
+        #[command(flatten)]
         path_args: PathArgs,
-        #[clap(flatten)]
+        #[command(flatten)]
         config_args: ConfigArgs,
         /// Overwrite existing files.
-        #[clap(long)]
+        #[arg(long)]
         force: bool,
     },
 
     /// Database inspection and maintenance tools.
     /// Hidden command for emergency use only.
-    #[clap(hide = true)]
+    #[command(hide = true)]
     DbTool {
         #[command(subcommand)]
         command: DbToolCommands,
@@ -150,7 +150,7 @@ enum Commands {
 
     /// Catchup events using event blobs.
     /// Hidden command for emergency use only.
-    #[clap(hide = true)]
+    #[command(hide = true)]
     Catchup(CatchupArgs),
 }
 
@@ -201,23 +201,23 @@ impl Display for KeyFormat {
 #[derive(Debug, Clone, clap::Args)]
 struct SetupArgs {
     /// The path to the directory in which to set up wallet and node configuration.
-    #[clap(long)]
+    #[arg(long)]
     config_directory: PathBuf,
     /// The path where the Walrus database will be stored.
-    #[clap(long)]
+    #[arg(long)]
     storage_path: PathBuf,
     /// Sui network for which the config is generated.
     ///
     /// Available options are `devnet`, `testnet`, `mainnet`, and `localnet`, or a custom Sui
     /// network. To specify a custom Sui network, pass a string of the format
     /// `<RPC_URL>(;<FAUCET_URL>)?`.
-    #[clap(long, default_value = "testnet")]
+    #[arg(long, default_value = "testnet")]
     sui_network: SuiNetwork,
     /// Whether to attempt to get SUI tokens from the faucet.
-    #[clap(long, action)]
+    #[arg(long)]
     use_faucet: bool,
     /// Timeout for the faucet call.
-    #[clap(
+    #[arg(
         long,
         value_parser = humantime::parse_duration,
         default_value = "1min",
@@ -225,22 +225,22 @@ struct SetupArgs {
     )]
     faucet_timeout: Duration,
     /// Additional arguments for the generated configuration.
-    #[clap(flatten)]
+    #[command(flatten)]
     config_args: ConfigArgs,
     /// Path to an existing network key. If not specified, a new key will be generated.
-    #[clap(long)]
+    #[arg(long)]
     network_key_path: Option<PathBuf>,
     /// Overwrite existing files.
-    #[clap(long)]
+    #[arg(long)]
     force: bool,
     /// The wallet address of the third party that will register the node.
     ///
     /// If this is set, a YAML file is generated that can be used to register the node by a
     /// third party.
-    #[clap(long)]
+    #[arg(long)]
     registering_third_party: Option<SuiAddress>,
     /// The epoch at which the node will be registered.
-    #[clap(long, requires = "registering_third_party", default_value_t = 0)]
+    #[arg(long, requires = "registering_third_party", default_value_t = 0)]
     registration_epoch: Epoch,
 }
 
@@ -248,24 +248,24 @@ struct SetupArgs {
 struct ConfigArgs {
     /// Object ID of the Walrus system object. If not provided, a dummy value is used and the
     /// system object needs to be manually added to the configuration file at a later time.
-    #[clap(long)]
+    #[arg(long)]
     system_object: Option<ObjectID>,
     /// Object ID of the Walrus staking object. If not provided, a dummy value is used and the
     /// staking object needs to be manually added to the configuration file at a later time.
-    #[clap(long)]
+    #[arg(long)]
     staking_object: Option<ObjectID>,
     /// Initial storage capacity of this node in bytes.
     ///
     /// The value can either by unitless; have suffixes for powers of 1000, such as (B),
     /// kilobytes (K), etc.; or have suffixes for the IEC units such as kibibytes (Ki),
     /// mebibytes (Mi), etc.
-    #[clap(long)]
+    #[arg(long)]
     node_capacity: ByteCount,
     /// The host name or public IP address of the node.
-    #[clap(long)]
+    #[arg(long)]
     public_host: String,
     /// The name of the storage node used in the registration.
-    #[clap(long)]
+    #[arg(long)]
     name: String,
 
     // ***************************
@@ -275,52 +275,52 @@ struct ConfigArgs {
     /// processing.
     ///
     /// If not provided, the RPC node from the wallet's active environment will be used.
-    #[clap(long)]
+    #[arg(long)]
     sui_rpc: Option<String>,
     /// The port on which the storage node will serve requests.
-    #[clap(long, default_value_t = REST_API_PORT)]
+    #[arg(long, default_value_t = REST_API_PORT)]
     public_port: u16,
     /// Socket address on which the REST API listens.
-    #[clap(long, default_value_t = config::defaults::rest_api_address())]
+    #[arg(long, default_value_t = config::defaults::rest_api_address())]
     rest_api_address: SocketAddr,
     /// Socket address on which the Prometheus server should export its metrics.
-    #[clap(long, default_value_t = config::defaults::metrics_address())]
+    #[arg(long, default_value_t = config::defaults::metrics_address())]
     metrics_address: SocketAddr,
     /// URL of the Walrus proxy to push metrics to.
-    #[clap(long)]
+    #[arg(long)]
     metrics_push_url: Option<String>,
     /// Path to an existing TLS certificate. If not specified, the node will automatically generate
     /// self-signed certificates.
-    #[clap(long)]
+    #[arg(long)]
     certificate_path: Option<PathBuf>,
     /// Gas budget for transactions.
     ///
     /// If not specified, the gas budget is estimated automatically.
-    #[clap(long)]
+    #[arg(long)]
     gas_budget: Option<u64>,
     /// Initial vote for the storage price in FROST per MiB per epoch.
-    #[clap(long, default_value_t = config::defaults::storage_price())]
+    #[arg(long, default_value_t = config::defaults::storage_price())]
     storage_price: u64,
     /// Initial vote for the write price in FROST per MiB.
-    #[clap(long, default_value_t = config::defaults::write_price())]
+    #[arg(long, default_value_t = config::defaults::write_price())]
     write_price: u64,
     /// The commission rate of the storage node, in basis points (1% = 100 basis points).
-    #[clap(long, default_value_t = config::defaults::commission_rate())]
+    #[arg(long, default_value_t = config::defaults::commission_rate())]
     commission_rate: u16,
     /// The image URL of the storage node.
-    #[clap(long, default_value = "")]
+    #[arg(long, default_value = "")]
     image_url: String,
     /// The project URL of the storage node.
-    #[clap(long, default_value = "")]
+    #[arg(long, default_value = "")]
     project_url: String,
     /// The description of the storage node.
-    #[clap(long, default_value = "")]
+    #[arg(long, default_value = "")]
     description: String,
     /// The config for rpc fallback.
-    #[clap(flatten)]
+    #[command(flatten)]
     rpc_fallback_config_args: Option<RpcFallbackConfigArgs>,
     /// Additional Sui full-node RPC endpoints.
-    #[clap(long, default_values_t = Vec::<String>::new())]
+    #[arg(long, default_values_t = Vec::<String>::new())]
     additional_rpc_endpoints: Vec<String>,
 }
 
@@ -328,46 +328,46 @@ struct ConfigArgs {
 struct PathArgs {
     /// The output path for the generated configuration file. If the file already exists, it is
     /// not overwritten and the operation will fail unless the `--force` option is provided.
-    #[clap(long)]
+    #[arg(long)]
     config_path: PathBuf,
     /// The path where the Walrus database will be stored.
-    #[clap(long)]
+    #[arg(long)]
     storage_path: PathBuf,
     /// The path to the key pair used in Walrus protocol messages.
-    #[clap(long)]
+    #[arg(long)]
     protocol_key_path: PathBuf,
     /// The path to the key pair used to authenticate nodes in network communication.
-    #[clap(long)]
+    #[arg(long)]
     network_key_path: PathBuf,
     /// Location of the node's wallet config.
-    #[clap(long)]
+    #[arg(long)]
     wallet_config: PathBuf,
 }
 
 #[derive(Debug, Clone, clap::Args)]
 struct CatchupArgs {
-    #[clap(long)]
+    #[arg(long)]
     /// Path to the RocksDB database directory.
     db_path: PathBuf,
-    #[clap(long)]
+    #[arg(long)]
     /// Object ID of the Walrus system object.
     system_object_id: ObjectID,
-    #[clap(long)]
+    #[arg(long)]
     /// Object ID of the Walrus staking object.
     staking_object_id: ObjectID,
-    #[clap(long, default_value = "http://localhost:9000")]
+    #[arg(long, default_value = "http://localhost:9000")]
     /// The Sui RPC URL to use for catchup.
     sui_rpc_url: String,
-    #[clap(long, value_parser = humantime::parse_duration, default_value = "10s")]
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
     /// The timeout for each request to the Sui RPC node.
     checkpoint_request_timeout: Duration,
-    #[clap(long, value_parser = humantime::parse_duration, default_value = "1min")]
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "1min")]
     /// The duration to run the event processor for.
     runtime_duration: Duration,
-    #[clap(long)]
+    #[arg(long)]
     /// The minimum checkpoint lag to use for event stream catchup.
     event_stream_catchup_min_checkpoint_lag: u64,
-    #[clap(flatten)]
+    #[command(flatten)]
     /// The config for RPC fallback.
     rpc_fallback_config_args: Option<RpcFallbackConfigArgs>,
 }

--- a/crates/walrus-service/src/client/daemon/cache.rs
+++ b/crates/walrus-service/src/client/daemon/cache.rs
@@ -35,15 +35,15 @@ pub(crate) const DEFAULT_CACHE_CHANNEL_SIZE: usize = 100;
 #[serde_as]
 #[derive(Debug, Clone, clap::Parser, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(default)]
-#[clap(rename_all = "kebab-case")]
+#[command(rename_all = "kebab-case")]
 #[serde(rename_all = "camelCase")]
 pub struct CacheConfig {
     /// The maximum number of elements the cache can hold.
-    #[clap(long = "jwt-cache-size", default_value_t = default::max_size())]
+    #[arg(long = "jwt-cache-size", default_value_t = default::max_size())]
     max_size: usize,
     /// The interval at which the cache should check for expired elements.
     #[serde(rename = "refresh_interval_secs")]
-    #[clap(
+    #[arg(
         long = "jwt-cache-refresh-interval",
         value_parser = humantime::parse_duration,
         default_value = "5s"

--- a/crates/walrus-service/src/node/dbtool.rs
+++ b/crates/walrus-service/src/node/dbtool.rs
@@ -62,70 +62,70 @@ use crate::node::{
 /// Database inspection and maintenance tools.
 #[derive(Subcommand, Debug, Clone, Serialize, Deserialize)]
 #[serde_as]
-#[clap(rename_all = "kebab-case")]
+#[command(rename_all = "kebab-case")]
 pub enum DbToolCommands {
     /// Repair a corrupted RocksDB database due to non-clean shutdowns.
     RepairDb {
         /// Path to the RocksDB database directory.
-        #[clap(long)]
+        #[arg(long)]
         db_path: PathBuf,
     },
 
     /// Scan events from the event_store table in RocksDB.
     ScanEvents {
         /// Path to the RocksDB database directory.
-        #[clap(long)]
+        #[arg(long)]
         db_path: PathBuf,
         /// Start index of the events to scan.
-        #[clap(long)]
+        #[arg(long)]
         start_event_index: u64,
         /// Number of events to scan.
-        #[clap(long, default_value = "1")]
+        #[arg(long, default_value = "1")]
         count: u64,
     },
 
     /// Read blob info from the RocksDB database.
     ReadBlobInfo {
         /// Path to the RocksDB database directory.
-        #[clap(long)]
+        #[arg(long)]
         db_path: PathBuf,
         /// Start blob ID in URL-safe base64 format (no padding).
-        #[clap(long)]
+        #[arg(long)]
         #[serde_as(as = "Option<DisplayFromStr>")]
         start_blob_id: Option<BlobId>,
         /// Number of entries to scan.
-        #[clap(long, default_value = "1")]
+        #[arg(long, default_value = "1")]
         count: u64,
     },
 
     /// Read object blob info from the RocksDB database.
     ReadObjectBlobInfo {
         /// Path to the RocksDB database directory.
-        #[clap(long)]
+        #[arg(long)]
         db_path: PathBuf,
         /// Start object ID to read.
-        #[clap(long)]
+        #[arg(long)]
         #[serde_as(as = "Option<DisplayFromStr>")]
         start_object_id: Option<ObjectID>,
         /// Count of objects to read.
-        #[clap(long, default_value = "1")]
+        #[arg(long, default_value = "1")]
         count: u64,
     },
 
     /// Count the number of certified blobs in the RocksDB database.
     CountCertifiedBlobs {
         /// Path to the RocksDB database directory.
-        #[clap(long)]
+        #[arg(long)]
         db_path: PathBuf,
         /// Epoch the blobs are in certified status.
-        #[clap(long)]
+        #[arg(long)]
         epoch: Epoch,
     },
 
     /// Drop a column family from the RocksDB database.
     DropColumnFamily {
         /// Path to the RocksDB database directory.
-        #[clap(long)]
+        #[arg(long)]
         db_path: PathBuf,
         /// Column family to drop.
         column_family_name: String,
@@ -134,65 +134,65 @@ pub enum DbToolCommands {
     /// List all column families in the RocksDB database.
     ListColumnFamilies {
         /// Path to the RocksDB database directory.
-        #[clap(long)]
+        #[arg(long)]
         db_path: PathBuf,
     },
 
     /// Scan blob metadata from the RocksDB database.
     ReadBlobMetadata {
         /// Path to the RocksDB database directory.
-        #[clap(long)]
+        #[arg(long)]
         db_path: PathBuf,
         /// Start blob ID in URL-safe base64 format (no padding).
-        #[clap(long)]
+        #[arg(long)]
         #[serde_as(as = "Option<DisplayFromStr>")]
         start_blob_id: Option<BlobId>,
         /// Number of entries to scan.
-        #[clap(long, default_value = "1")]
+        #[arg(long, default_value = "1")]
         count: u64,
         /// Output size only.
-        #[clap(long, default_value = "false")]
+        #[arg(long, default_value = "false")]
         output_size_only: bool,
     },
 
     /// Read primary slivers from the RocksDB database.
     ReadPrimarySlivers {
         /// Path to the RocksDB database directory.
-        #[clap(long)]
+        #[arg(long)]
         db_path: PathBuf,
         /// Start blob ID in URL-safe base64 format (no padding).
-        #[clap(long)]
+        #[arg(long)]
         #[serde_as(as = "Option<DisplayFromStr>")]
         start_blob_id: Option<BlobId>,
         /// Number of entries to scan.
-        #[clap(long, default_value = "1")]
+        #[arg(long, default_value = "1")]
         count: u64,
         /// Shard index to read from.
-        #[clap(long)]
+        #[arg(long)]
         shard_index: u16,
     },
 
     /// Read secondary slivers from the RocksDB database.
     ReadSecondarySlivers {
         /// Path to the RocksDB database directory.
-        #[clap(long)]
+        #[arg(long)]
         db_path: PathBuf,
         /// Start blob ID in URL-safe base64 format (no padding).
-        #[clap(long)]
+        #[arg(long)]
         #[serde_as(as = "Option<DisplayFromStr>")]
         start_blob_id: Option<BlobId>,
         /// Number of entries to scan.
-        #[clap(long, default_value = "1")]
+        #[arg(long, default_value = "1")]
         count: u64,
         /// Shard index to read from.
-        #[clap(long)]
+        #[arg(long)]
         shard_index: u16,
     },
 
     /// Read event blob writer metadata from the RocksDB database.
     EventBlobWriter {
         /// Path to the RocksDB database directory.
-        #[clap(long)]
+        #[arg(long)]
         db_path: PathBuf,
         /// Commands to read event blob writer metadata.
         #[command(subcommand)]
@@ -203,7 +203,7 @@ pub enum DbToolCommands {
 /// Commands for reading event blob writer metadata.
 #[derive(Subcommand, Debug, Clone, Serialize, Deserialize)]
 #[serde_as]
-#[clap(rename_all = "kebab-case")]
+#[command(rename_all = "kebab-case")]
 pub enum EventBlobWriterCommands {
     /// Read certified event blob metadata.
     ReadCertified,
@@ -214,10 +214,10 @@ pub enum EventBlobWriterCommands {
     /// Read pending event blob metadata.
     ReadPending {
         /// Start sequence number.
-        #[clap(long)]
+        #[arg(long)]
         start_seq: Option<u64>,
         /// Number of entries to scan.
-        #[clap(long, default_value = "1")]
+        #[arg(long, default_value = "1")]
         count: u64,
     },
 

--- a/crates/walrus-stress/src/main.rs
+++ b/crates/walrus-stress/src/main.rs
@@ -38,27 +38,26 @@ const COIN_REFILL_AMOUNT: u64 = 500_000_000;
 const MIN_BALANCE: u64 = 1_000_000_000;
 
 #[derive(Parser)]
-#[clap(rename_all = "kebab-case")]
-#[clap(name = env!("CARGO_BIN_NAME"))]
+#[command(name = env!("CARGO_BIN_NAME"), rename_all = "kebab-case")]
 #[derive(Debug)]
 struct Args {
     /// The path to the client configuration file containing the system object address.
-    #[clap(long, default_value = "./working_dir/client_config.yaml")]
+    #[arg(long, default_value = "./working_dir/client_config.yaml")]
     config_path: PathBuf,
 
     /// Sui network for which the config is generated.
-    #[clap(long, default_value = "testnet")]
+    #[arg(long, default_value = "testnet")]
     sui_network: SuiNetwork,
 
     /// The port on which metrics are exposed.
-    #[clap(long, default_value = "9584")]
+    #[arg(long, default_value = "9584")]
     metrics_port: u16,
 
     /// The path to the Sui Wallet to be used for funding the gas.
     ///
     /// If specified, the funds to run the stress client will be taken from this wallet. Otherwise,
     /// the stress client will try to use the faucet.
-    #[clap(long)]
+    #[arg(long)]
     wallet_path: Option<PathBuf>,
 
     #[command(subcommand)]
@@ -66,7 +65,7 @@ struct Args {
 }
 
 #[derive(Subcommand, Debug, Clone)]
-#[clap(rename_all = "kebab-case")]
+#[command(rename_all = "kebab-case")]
 enum Commands {
     /// Register nodes based on parameters exported by the `walrus-node setup` command, send the
     /// storage-node capability to the respective node's wallet, and optionally stake with them.
@@ -76,44 +75,44 @@ enum Commands {
 }
 
 #[derive(Parser, Debug, Clone)]
-#[clap(rename_all = "kebab-case")]
+#[command(rename_all = "kebab-case")]
 #[command(author, version, about = "Walrus stress load generator", long_about = None)]
 struct StressArgs {
     /// The target write load to submit to the system (writes/minute).
     /// The actual load may be limited by the number of clients.
     /// If the write load is 0, a single write will be performed to enable reads.
-    #[clap(long, default_value_t = 60)]
+    #[arg(long, default_value_t = 60)]
     write_load: u64,
     /// The minimum duration of epoch (inclusive) to store the blob for.
-    #[clap(long, default_value_t = 1)]
+    #[arg(long, default_value_t = 1)]
     min_epochs_to_store: u32,
     /// The maximum duration of epoch (inclusive) to store the blob for.
-    #[clap(long, default_value_t = 10)]
+    #[arg(long, default_value_t = 10)]
     max_epochs_to_store: u32,
     /// The target read load to submit to the system (reads/minute).
     /// The actual load may be limited by the number of clients.
-    #[clap(long, default_value_t = 60)]
+    #[arg(long, default_value_t = 60)]
     read_load: u64,
     /// The number of clients to use for the load generation for reads and writes.
-    #[clap(long, default_value = "10")]
+    #[arg(long, default_value = "10")]
     n_clients: NonZeroUsize,
     /// The binary logarithm of the minimum blob size to use for the load generation.
     ///
     /// Blobs sizes are uniformly distributed across the powers of two between
     /// this and the maximum blob size.
-    #[clap(long, default_value = "10")]
+    #[arg(long, default_value = "10")]
     min_size_log2: u8,
     /// The binary logarithm of the maximum blob size to use for the load generation.
-    #[clap(long, default_value = "20")]
+    #[arg(long, default_value = "20")]
     max_size_log2: u8,
     /// The period in milliseconds to check if gas needs to be refilled.
     ///
     /// This is useful for continuous load testing where the gas budget need to be refilled
     /// periodically.
-    #[clap(long, default_value = "1000")]
+    #[arg(long, default_value = "1000")]
     gas_refill_period_millis: NonZeroU64,
     /// The fraction of writes that write inconsistent blobs.
-    #[clap(long, default_value_t = 0.0)]
+    #[arg(long, default_value_t = 0.0)]
     inconsistent_blob_rate: f64,
 }
 

--- a/crates/walrus-sui/src/client/rpc_config.rs
+++ b/crates/walrus-sui/src/client/rpc_config.rs
@@ -35,25 +35,25 @@ impl RpcFallbackConfig {
 #[derive(Debug, Clone, clap::Args)]
 pub struct RpcFallbackConfigArgs {
     /// The fallback checkpoint bucket URL.
-    #[clap(long)]
+    #[arg(long)]
     pub checkpoint_bucket: Option<reqwest::Url>,
 
     /// The minimum backoff interval in milliseconds
     /// to retry the fullnode RPC before falling back
     /// to the checkpoint bucket when available.
-    #[clap(long)]
+    #[arg(long)]
     pub min_backoff: Option<u64>,
 
     /// The maximum backoff interval in milliseconds
     /// to retry the fullnode RPC before falling back
     /// to the checkpoint bucket when available.
-    #[clap(long)]
+    #[arg(long)]
     pub max_backoff: Option<u64>,
 
     /// The maximum number of retries
     /// to retry the fullnode RPC before falling back
     /// to the checkpoint bucket when available.
-    #[clap(long)]
+    #[arg(long)]
     pub max_retries: Option<u32>,
 }
 


### PR DESCRIPTION
## Description
Fixes #1944 

This PR updates deprecated #[clap(...)] attributes to their modern equivalents in clap 4.x.
The current codebase still uses outdated syntax that has been deprecated since version 4.0.
By making this update, we ensure compatibility with future versions and maintain code quality.

I ran cargo check --features clap/deprecated after making the changes, and the previous clap deprecation warnings are no longer present.

## Test plan
cargo check --features clap/deprecated

![Pasted Graphic 6](https://github.com/user-attachments/assets/55c332db-e46d-4e52-80ef-79064ee1634c)

