### PR TITLE
fix(client): prevent panic in genesis epoch

### DIFF
--- a/crates/walrus-sdk/src/client/communication/factory.rs
+++ b/crates/walrus-sdk/src/client/communication/factory.rs
@@ -300,6 +300,10 @@ fn node_communications<'a, W>(
     committee: &Committee,
     constructor: impl Fn(usize) -> Result<Option<NodeCommunication<'a, W>>, ClientBuildError>,
 ) -> ClientResult<Vec<NodeCommunication<'a, W>>> {
+    if committee.n_members() == 0 {
+        return Err(ClientError::from(ClientErrorKind::EmptyCommittee));
+    }
+
     let mut comms: Vec<_> = (0..committee.n_members())
         .map(|i| (i, constructor(i)))
         .collect();

--- a/crates/walrus-sdk/src/error.rs
+++ b/crates/walrus-sdk/src/error.rs
@@ -185,6 +185,9 @@ pub enum ClientErrorKind {
     /// The client was notified that the committee has changed.
     #[error("the client was notified that the committee has changed")]
     CommitteeChangeNotified,
+    /// The committee has no members.
+    #[error("the committee has no members; most likely, the system is in the genesis epoch")]
+    EmptyCommittee,
     /// The amount of stake is below the threshold for staking.
     #[error(
         "the stake amount {0} FROST is below the minimum threshold of {MIN_STAKING_THRESHOLD} \

--- a/crates/walrus-service/src/node/metrics.rs
+++ b/crates/walrus-service/src/node/metrics.rs
@@ -269,6 +269,7 @@ impl TelemetryLabel for ClientErrorKind {
             ClientErrorKind::BehindCurrentEpoch { .. } => "behind-current-epoch",
             ClientErrorKind::UnsupportedEncodingType(_) => "unsupported-encoding-type",
             ClientErrorKind::CommitteeChangeNotified => "committee-change-notified",
+            ClientErrorKind::EmptyCommittee => "empty-committee",
             ClientErrorKind::StakeBelowThreshold(_) => "stake-below-threshold",
             ClientErrorKind::FailedToLoadCerts(_) => "failed-to-load-certs",
             ClientErrorKind::Other(_) => "unknown",


### PR DESCRIPTION
## Description

Without this change, the panic a few lines below can be triggered in the genesis epoch (which results in a cryptic error output):

```
thread 'main' panicked at crates/walrus-service/src/client/communication/factory.rs:302:13:
internal error: entered unreachable code: `all()` guarantees at least 1 result and all results are errors
```

## Test plan

None.
