### PR TITLE
fix: add CORS headers to server endponints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ tokio-stream = "0.1.17"
 tokio-util = "0.7.13"
 tonic = { version = "0.12.3", default-features = false }
 tower = "0.5"
-tower-http = { version = "0.5.2", features = ["timeout", "trace"] }
+tower-http = { version = "0.5.2", features = ["cors", "timeout", "trace"] }
 tracing = "0.1.41"
 tracing-opentelemetry = { version = "=0.28.0", default-features = false }
 tracing-subscriber = { version = "0.3.19", default-features = false, features = ["fmt"] }

--- a/crates/walrus-service/src/client/daemon/routes.rs
+++ b/crates/walrus-service/src/client/daemon/routes.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashSet, str::FromStr, sync::Arc};
+use std::{collections::HashSet, str::FromStr, sync::Arc, time::Duration};
 
 use anyhow::anyhow;
 use axum::{
@@ -16,18 +16,13 @@ use axum_extra::{
     TypedHeader,
 };
 use jsonwebtoken::{DecodingKey, Validation};
-use reqwest::header::{
-    ACCESS_CONTROL_ALLOW_HEADERS,
-    ACCESS_CONTROL_ALLOW_METHODS,
-    ACCESS_CONTROL_ALLOW_ORIGIN,
-    ACCESS_CONTROL_MAX_AGE,
-    CACHE_CONTROL,
-    CONTENT_TYPE,
-    ETAG,
-    X_CONTENT_TYPE_OPTIONS,
+use reqwest::{
+    header::{CACHE_CONTROL, CONTENT_TYPE, ETAG, X_CONTENT_TYPE_OPTIONS},
+    Method,
 };
 use serde::Deserialize;
 use sui_types::base_types::{ObjectID, SuiAddress};
+use tower_http::cors::{Any, CorsLayer};
 use tracing::Level;
 use utoipa::IntoParams;
 use walrus_core::{BlobId, EncodingType, EpochCount};
@@ -89,8 +84,6 @@ pub(super) async fn get_blob<T: WalrusReadClient>(
             tracing::debug!("successfully retrieved blob");
             let mut response = (StatusCode::OK, blob).into_response();
             let headers = response.headers_mut();
-            // Allow requests from any origin, s.t. content can be loaded in browsers.
-            headers.insert(ACCESS_CONTROL_ALLOW_ORIGIN, HeaderValue::from_static("*"));
             // Prevent the browser from trying to guess the MIME type to avoid dangerous inferences.
             headers.insert(X_CONTENT_TYPE_OPTIONS, HeaderValue::from_static("nosniff"));
             // Insert headers that help caches distribute Walrus blobs.
@@ -290,7 +283,7 @@ pub(super) async fn put_blob<T: WalrusWriteClient>(
     };
     tracing::debug!(?post_store_action, "starting to store received blob");
 
-    let mut response = match client
+    match client
         .write_blob(
             &blob[..],
             encoding_type,
@@ -315,12 +308,7 @@ pub(super) async fn put_blob<T: WalrusWriteClient>(
             tracing::error!(?error, "error storing blob");
             StoreBlobError::from(error).into_response()
         }
-    };
-
-    response
-        .headers_mut()
-        .insert(ACCESS_CONTROL_ALLOW_ORIGIN, HeaderValue::from_static("*"));
-    response
+    }
 }
 
 /// Checks if the JWT claim has a maximum size and if the blob exceeds it.
@@ -391,14 +379,13 @@ impl From<ClientError> for StoreBlobError {
     }
 }
 
-#[tracing::instrument(level = Level::ERROR, skip_all)]
-pub(super) async fn store_blob_options() -> impl IntoResponse {
-    [
-        (ACCESS_CONTROL_ALLOW_ORIGIN, "*"),
-        (ACCESS_CONTROL_ALLOW_METHODS, "PUT, OPTIONS"),
-        (ACCESS_CONTROL_MAX_AGE, "86400"),
-        (ACCESS_CONTROL_ALLOW_HEADERS, "*"),
-    ]
+/// Returns a `CorsLayer` for the blob store endpoint.
+pub(super) fn store_blob_cors_layer() -> CorsLayer {
+    CorsLayer::new()
+        .allow_origin(Any)
+        .allow_methods([Method::GET, Method::PUT])
+        .max_age(Duration::from_secs(86400))
+        .allow_headers(Any)
 }
 
 #[tracing::instrument(level = Level::ERROR, skip_all)]

--- a/crates/walrus-service/src/client/daemon/routes.rs
+++ b/crates/walrus-service/src/client/daemon/routes.rs
@@ -16,10 +16,7 @@ use axum_extra::{
     TypedHeader,
 };
 use jsonwebtoken::{DecodingKey, Validation};
-use reqwest::{
-    header::{CACHE_CONTROL, CONTENT_TYPE, ETAG, X_CONTENT_TYPE_OPTIONS},
-    Method,
-};
+use reqwest::header::{CACHE_CONTROL, CONTENT_TYPE, ETAG, X_CONTENT_TYPE_OPTIONS};
 use serde::Deserialize;
 use sui_types::base_types::{ObjectID, SuiAddress};
 use tower_http::cors::{Any, CorsLayer};
@@ -380,10 +377,10 @@ impl From<ClientError> for StoreBlobError {
 }
 
 /// Returns a `CorsLayer` for the blob store endpoint.
-pub(super) fn store_blob_cors_layer() -> CorsLayer {
+pub(super) fn daemon_cors_layer() -> CorsLayer {
     CorsLayer::new()
         .allow_origin(Any)
-        .allow_methods([Method::GET, Method::PUT])
+        .allow_methods(Any)
         .max_age(Duration::from_secs(86400))
         .allow_headers(Any)
 }

--- a/deny.toml
+++ b/deny.toml
@@ -20,6 +20,8 @@ ignore = [
   "RUSTSEC-2025-0012",
   # Crash due to uncontrolled recursion in `protobuf` crate.
   "RUSTSEC-2024-0437",
+  # Potential double-free in crossbeam.
+  "RUSTSEC-2025-0024",
 ]
 
 


### PR DESCRIPTION
## Description

Adds CORS headers to the node endpoints, and improves the CORS header on the daemon endpoints.
Depends on #1929 , because it resolves a RUSTSEC advisory in tokio that would have otherwise been added to the `deny.toml` exceptions.

Closes WAL-748

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
