### PR TITLE
docs(walrus-sites): curl request and s-b publish number of epochs

### DIFF
--- a/docs/book/SUMMARY.md
+++ b/docs/book/SUMMARY.md
@@ -49,7 +49,7 @@
 - [Advanced functionality](./walrus-sites/advanced.md)
   - [Site builder commands](./walrus-sites/commands.md)
   - [Advanced site-builder configuration](./walrus-sites/builder-config.md)
-  - [Specifying headers and routing](./walrus-sites/routing.md)
+  - [Specifying headers, routing, and metadata](./walrus-sites/routing.md)
   - [Linking from and to Walrus Sites](./walrus-sites/linking.md)
   - [Redirecting objects to Walrus Sites](./walrus-sites/redirects.md)
 - [Technical overview](./walrus-sites/overview.md)

--- a/docs/book/walrus-sites/routing.md
+++ b/docs/book/walrus-sites/routing.md
@@ -1,8 +1,4 @@
-# Specifying headers and routing
-
-``` admonish tip title="New with Walrus Sites Testnet version"
-The following features have been released with the Walrus Sites Testnet version.
-```
+# Specifying headers, routing, and metadata
 
 In its base configuration, Walrus Sites serves static assets through a portal. However, many modern
 web applications require more advanced features, such as custom headers and client-side routing.

--- a/docs/book/walrus-sites/tutorial-install.md
+++ b/docs/book/walrus-sites/tutorial-install.md
@@ -144,7 +144,7 @@ Download the `sites-config.yaml` file from the repository, and place it in one o
 default locations. To illustrate, we will use the `~/.config/walrus` directory, like so:
 
 ```sh
-curl https://raw.githubusercontent.com/MystenLabs/walrus-sites/refs/heads/testnet/sites-config.yaml -o ~/.config/walrus/sites-config.yaml
+curl https://raw.githubusercontent.com/MystenLabs/walrus-sites/refs/heads/mainnet/sites-config.yaml -o ~/.config/walrus/sites-config.yaml
 ```
 
 You are now ready to start working on your Walrus Sites! 🎉

--- a/docs/book/walrus-sites/tutorial-publish.md
+++ b/docs/book/walrus-sites/tutorial-publish.md
@@ -113,6 +113,8 @@ The wallet you are using must be the *owner* of the Walrus Site object to be abl
 
 ```admonish danger title="Extending the expiration date of an existing site"
 To extend the expiration date of a previously-stored site, use the `update` command with the
-`--force` flag, and specify the number of additional epochs (from the current epoch) with the
-`--epochs` flag.
+`--check-extend` flag. With this flag, the site-builder will force a check of the status of
+all the Walrus blobs composing the site, and will extend the ones that expire before `--epochs`
+epochs. This is useful to ensure all the resources in the site are available for the same amount
+of epochs.
 ```

--- a/docs/book/walrus-sites/tutorial-publish.md
+++ b/docs/book/walrus-sites/tutorial-publish.md
@@ -26,7 +26,7 @@ Since we have placed the `walrus` and `site-builder` binaries and configuration 
 locations, publishing the `./walrus-snake` site is as simple as calling the publishing command:
 
 ``` sh
-site-builder publish ./walrus-snake --epochs 100
+site-builder publish ./walrus-snake --epochs 1 
 ```
 
 ``` admonish tip
@@ -81,7 +81,7 @@ where to find the updated files (still `./walrus-snake`) and the object ID of th
 (`0x407a3081...`):
 
 ``` sh
-site-builder update --epochs 100 ./walrus-snake 0xe674c14...
+site-builder update --epochs 1 ./walrus-snake 0xe674c14...
 ```
 
 The output this time should be:


### PR DESCRIPTION
## Description

- Update curl request to use the mainnet branch in the site-builder tutorial-install.
- Reduce epoch count in publish and update commands from 100 to 1 in the publishing tutorial. Apart from 100 epochs not being supported in mainnet, it's also unecessary to publish a test site for so long.
- Include metadata in the ws-resources section.
- Remove an old admonish info page about Testnet features.

## Test plan

Proof read.

---
