### PR TITLE
feat: allow looking up shared blobs by their object ID

### DIFF
--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -1460,6 +1460,12 @@ async fn test_share_blobs() -> TestResult {
         .await?;
     assert_eq!(shared_blob.blob.storage.end_epoch, end_epoch + 100);
     assert_eq!(shared_blob.funds, 999999500);
+
+    // Read the blob object with attributes from the shared blob object id
+    let _blob_with_attribute = client
+        .as_ref()
+        .get_blob_by_object_id(&shared_blob_object_id)
+        .await?;
     Ok(())
 }
 

--- a/crates/walrus-sui/src/client/read_client.rs
+++ b/crates/walrus-sui/src/client/read_client.rs
@@ -58,6 +58,7 @@ use crate::{
             EpochState,
             EventBlob,
             NodeMetadata,
+            SharedBlob,
             StakingInnerV1,
             StakingObjectForDeserialization,
             StakingPool,
@@ -1002,13 +1003,28 @@ impl ReadClient for SuiReadClient {
         &self,
         blob_object_id: &ObjectID,
     ) -> SuiClientResult<BlobWithAttribute> {
-        Ok(BlobWithAttribute {
-            blob: self
-                .sui_client
-                .get_sui_object::<Blob>(*blob_object_id)
-                .await?,
-            attribute: self.get_blob_attribute(blob_object_id).await?,
-        })
+        let blob_object_response = self
+            .sui_client
+            .get_object_with_options(
+                *blob_object_id,
+                SuiObjectDataOptions::new().with_bcs().with_type(),
+            )
+            .await?;
+        let blob = if let Ok(blob) =
+            get_sui_object_from_object_response::<Blob>(&blob_object_response)
+        {
+            blob
+        } else {
+            let shared_blob = get_sui_object_from_object_response::<SharedBlob>(
+                &blob_object_response,
+            )
+            .map_err(|_| {
+                anyhow!("could not retrieve blob or shared blob from object id {blob_object_id}")
+            })?;
+            shared_blob.blob
+        };
+        let attribute = self.get_blob_attribute(&blob.id).await?;
+        Ok(BlobWithAttribute { blob, attribute })
     }
 
     async fn epoch_state(&self) -> SuiClientResult<EpochState> {


### PR DESCRIPTION
## Description

Allows reading a shared blob by object ID.

## Test plan

extended existing test

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
