### PR TITLE
fix: Recreate rpc client on extended failure and fallback to archive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,6 +616,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ce4f10ea3abcd6617873bae9f91d1c5332b4a778bd9ce34d0cd517474c1de82"
 
 [[package]]
+name = "atomic-time"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9622f5c6fb50377516c70f65159e70b25465409760c6bd6d4e581318bf704e83"
+dependencies = [
+ "once_cell",
+ "portable-atomic",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12182,6 +12192,7 @@ version = "1.22.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "atomic-time",
  "bcs",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ version = "1.22.0"
 anyhow = "1.0.97"
 async-channel = "2.3.1"
 async-trait = "0.1.88"
+atomic-time = "0.1.5"
 axum = { version = "0.8", default-features = false, features = ["http2", "tokio"] }
 axum-extra = { version = "0.10" }
 axum-server = { version = "0.7.2", default-features = false }

--- a/crates/checkpoint-downloader/src/downloader.rs
+++ b/crates/checkpoint-downloader/src/downloader.rs
@@ -502,7 +502,6 @@ mod tests {
     use std::time::Duration;
 
     use rocksdb::Options;
-    use sui_rpc_api::Client;
     use typed_store::{
         rocks,
         rocks::{errors::typed_store_err_from_rocks_err, MetricConf, ReadWriteOptions},
@@ -516,7 +515,6 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn test_parallel_fetcher() -> Result<()> {
         let rest_url = "http://localhost:9000";
-        let client = Client::new(rest_url)?;
         let fallible = FallibleRpcClient::new(rest_url.to_string())?;
         let retriable_client = RetriableRpcClient::new(
             vec![(fallible, rest_url.to_string())],

--- a/crates/checkpoint-downloader/src/downloader.rs
+++ b/crates/checkpoint-downloader/src/downloader.rs
@@ -507,6 +507,7 @@ mod tests {
         rocks,
         rocks::{errors::typed_store_err_from_rocks_err, MetricConf, ReadWriteOptions},
     };
+    use walrus_sui::client::retry_client::FallibleRpcClient;
     use walrus_utils::{backoff::ExponentialBackoffConfig, tests::global_test_lock};
 
     use super::*;
@@ -516,8 +517,9 @@ mod tests {
     async fn test_parallel_fetcher() -> Result<()> {
         let rest_url = "http://localhost:9000";
         let client = Client::new(rest_url)?;
+        let fallible = FallibleRpcClient::new(rest_url.to_string())?;
         let retriable_client = RetriableRpcClient::new(
-            vec![(client, rest_url.to_string())],
+            vec![(fallible, rest_url.to_string())],
             Duration::from_secs(5),
             ExponentialBackoffConfig::default(),
             None,

--- a/crates/walrus-service/src/node/events.rs
+++ b/crates/walrus-service/src/node/events.rs
@@ -8,6 +8,7 @@ use std::{
     fmt::Debug,
     fs::File,
     io::{BufReader, BufWriter},
+    sync::Arc,
     time::Duration,
 };
 
@@ -301,7 +302,7 @@ impl Ord for EventStreamCursor {
 }
 
 /// Checks if the full node provides the required REST endpoint for event processing.
-async fn check_experimental_rest_endpoint_exists(client: Client) -> anyhow::Result<bool> {
+async fn check_experimental_rest_endpoint_exists(client: Arc<Client>) -> anyhow::Result<bool> {
     // TODO: https://github.com/MystenLabs/walrus/issues/1049
     // TODO: Use utils::retry once it is outside walrus-service such that it doesn't trigger
     // cyclic dependency errors
@@ -327,7 +328,7 @@ async fn check_experimental_rest_endpoint_exists(client: Client) -> anyhow::Resu
 }
 
 /// Ensures that the full node provides the required REST endpoint for event processing.
-async fn ensure_experimental_rest_endpoint_exists(client: Client) -> anyhow::Result<()> {
+async fn ensure_experimental_rest_endpoint_exists(client: Arc<Client>) -> anyhow::Result<()> {
     if !check_experimental_rest_endpoint_exists(client.clone()).await? {
         bail!(
             "the configured full node *does not* provide the required REST endpoint for event \

--- a/crates/walrus-service/src/node/events/event_processor.rs
+++ b/crates/walrus-service/src/node/events/event_processor.rs
@@ -64,7 +64,7 @@ use typed_store::{
 use walrus_core::{ensure, BlobId};
 use walrus_sui::{
     client::{
-        retry_client::{RetriableRpcClient, RetriableSuiClient},
+        retry_client::{FallibleRpcClient, RetriableRpcClient, RetriableSuiClient},
         rpc_config::RpcFallbackConfig,
     },
     types::ContractEvent,
@@ -721,9 +721,9 @@ impl EventProcessor {
         let clients = rest_urls
             .iter()
             .map(
-                |rest_url| -> Result<(sui_rpc_api::Client, String), anyhow::Error> {
-                    let client = sui_rpc_api::Client::new(rest_url)?;
-                    Ok((client, rest_url.clone()))
+                |rest_url| -> Result<(FallibleRpcClient, String), anyhow::Error> {
+                    let fallible = FallibleRpcClient::new(rest_url.clone())?;
+                    Ok((fallible, rest_url.clone()))
                 },
             )
             .collect::<Result<Vec<_>, _>>()?;
@@ -731,7 +731,7 @@ impl EventProcessor {
         // Validate each client and filter out invalid ones.
         let mut valid_clients = Vec::new();
         for (client, rest_url) in clients {
-            match ensure_experimental_rest_endpoint_exists(client.clone()).await {
+            match ensure_experimental_rest_endpoint_exists(client.inner().await).await {
                 Ok(()) => valid_clients.push((client, rest_url)),
                 Err(e) => {
                     tracing::warn!("Client validation failed for {:?}: {:?}", rest_url, e);
@@ -1331,8 +1331,9 @@ mod tests {
         )?;
         let rest_url = "http://localhost:8080";
         let client = sui_rpc_api::Client::new(rest_url)?;
+        let fallible = FallibleRpcClient::new(rest_url.to_string())?;
         let retry_client = RetriableRpcClient::new(
-            vec![(client, rest_url.to_string())],
+            vec![(fallible, rest_url.to_string())],
             Duration::from_secs(5),
             ExponentialBackoffConfig::default(),
             None,

--- a/crates/walrus-service/src/node/events/event_processor.rs
+++ b/crates/walrus-service/src/node/events/event_processor.rs
@@ -1330,7 +1330,6 @@ mod tests {
             false,
         )?;
         let rest_url = "http://localhost:8080";
-        let client = sui_rpc_api::Client::new(rest_url)?;
         let fallible = FallibleRpcClient::new(rest_url.to_string())?;
         let retry_client = RetriableRpcClient::new(
             vec![(fallible, rest_url.to_string())],

--- a/crates/walrus-sui/Cargo.toml
+++ b/crates/walrus-sui/Cargo.toml
@@ -21,6 +21,7 @@ utoipa = [
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
+atomic-time.workspace = true
 bcs.workspace = true
 chrono.workspace = true
 clap.workspace = true


### PR DESCRIPTION
## Description

This PR does two fixes:
1. Recreate the rpc client on 10 minutes worth of continuous failure. Recreating the client is similar to restarting the node
2. Allows rpc to fallback to archive using a exponentially growing window size. This allows rpc to fallback to archive after 1 minute of no success  from any endpoint

## Test plan
Existing tests