### PR TITLE
docs: correctly link to MD files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,7 +156,7 @@ Note that it is currently not possible to use an external cluster with `cargo ne
 
 We would like to cover as much code as possible with tests. Ideally you would add unit tests for all
 code you contribute. To analyze test coverage, we use
-[Tarpaulin](https://crates.io/crates/tarpaulin). You can install and run the tool as follows:
+[Tarpaulin](https://crates.io/crates/cargo-tarpaulin). You can install and run the tool as follows:
 
 ```sh
 cargo install cargo-tarpaulin

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,7 +156,7 @@ Note that it is currently not possible to use an external cluster with `cargo ne
 
 We would like to cover as much code as possible with tests. Ideally you would add unit tests for all
 code you contribute. To analyze test coverage, we use
-[Tarpaulin](https://crates.io/crates/cargo-tarpaulin). You can install and run the tool as follows:
+[Tarpaulin](https://crates.io/crates/tarpaulin). You can install and run the tool as follows:
 
 ```sh
 cargo install cargo-tarpaulin

--- a/docs/book/walrus-sites/builder-config.md
+++ b/docs/book/walrus-sites/builder-config.md
@@ -11,10 +11,10 @@ here the details for all the configuration options.
 ## Minimal configuration
 
 The config file is expected to be in one of the [default
-locations](../usage/setup.html#config-custom-path), and it is possible to point elsewhere with the
+locations](../usage/setup.md#config-custom-path), and it is possible to point elsewhere with the
 `--config` flag. For your first run, it should be sufficient to call the `site-builder` without
 specifying the config explicitly, which is already configured if you followed thoroughly the
-[installation steps](./tutorial-install.html#configuration).
+[installation steps](./tutorial-install.md#configuration).
 
 If, for any reason, you didn't add `walrus` to `$PATH`, make sure to configure a pointer to the
 binary, see below.

--- a/docs/book/walrus-sites/tutorial-install.md
+++ b/docs/book/walrus-sites/tutorial-install.md
@@ -138,7 +138,7 @@ site-builder --config /path/to/sites-config.yaml publish <build-directory-of-a-s
 ```
 
 However, if are not a fan of repeating the same flags over and over, it's always easier to have the
-configuration file in one of the [default locations](./tutorial-install.html#admonition-note).
+configuration file in one of the [default locations](./tutorial-install.md#admonition-note).
 
 Download the `sites-config.yaml` file from the repository, and place it in one of the aforementioned
 default locations. To illustrate, we will use the `~/.config/walrus` directory, like so:

--- a/docs/book/walrus-sites/tutorial-publish.md
+++ b/docs/book/walrus-sites/tutorial-publish.md
@@ -62,7 +62,7 @@ have a look in the explorer and use it to set the SuiNS name) and, finally, the 
 browse the site.
 
 Note here that we are implicitly using the default `sites-config.yaml` as the config for the site
-builder that we set up previously on the [installation section](./tutorial-install.html). The
+builder that we set up previously on the [installation section](./tutorial-install.md). The
 configuration file is necessary to ensure that the `site-builder` knows the correct Sui package for
 the Walrus Sites logic.
 


### PR DESCRIPTION
## Description

This PR fixes multiple broken or outdated internal and external links identified via automated link checking. The following types of updates were made:

- ✅ Updated internal `.html` references to `.md` (e.g., `tutorial-install.html` → `tutorial-install.md`)


Error

![Pasted Graphic 11](https://github.com/user-attachments/assets/d7511c43-7ebf-412c-8889-35280379120a)

