### PR TITLE
docs: Replace dead links of walrus.site with wal.app

### DIFF
--- a/docs/book/blog/01_announcing_walrus.md
+++ b/docs/book/blog/01_announcing_walrus.md
@@ -81,9 +81,9 @@ Stay tuned for more updates on how Walrus will revolutionize data storage in the
 ## What can developers build?
 
 As part of this developer preview, we provide a binary client (currently macOS, ubuntu) that can be
-operated from the [command line interface](https://docs.walrus.site/usage/client-cli.html), a [JSON
-API](https://docs.walrus.site/usage/json-api.html), and an [HTTP
-API](https://docs.walrus.site/usage/web-api.html). We also offer the community an aggregator and
+operated from the [command line interface](https://docs.wal.app/usage/client-cli.html), a [JSON
+API](https://docs.wal.app/usage/json-api.html), and an [HTTP
+API](https://docs.wal.app/usage/web-api.html). We also offer the community an aggregator and
 publisher service and a Devnet deployment of 10 storage nodes operated by Mysten Labs.
 
 We hope developers will experiment with building applications that leverage the Walrus Decentralized
@@ -122,7 +122,7 @@ We are excited to see what else the web3 developer community can imagine!
 ## Getting Started
 
 For this developer preview the public Walrus Devnet is openly available to all developers. Developer
-documentation is available at <https://docs.walrus.site>.
+documentation is available at <https://docs.wal.app>.
 
 SUI Testnet token is the main currency for interacting with Walrus. Developers pay for Walrus Devnet
 storage using SUI Testnet tokens which can be acquired at the [Sui Testnet Discord
@@ -130,6 +130,6 @@ faucet](https://discord.com/channels/916379725201563759/1037811694564560966).
 
 ## One more thing …
 
-The [Walrus Sites website](https://walrus.site), the [Walrus docs](https://docs.walrus.site), and
-[this very blog](https://blog.walrus.site) are hosted on Walrus. To learn more about Walrus Sites
-and how you can deploy your own, [click here](https://docs.walrus.site/walrus-sites/intro.html).
+The [Walrus Sites website](https://wal.app), the [Walrus docs](https://docs.wal.app), and
+[this very blog](https://blog.wal.app) are hosted on Walrus. To learn more about Walrus Sites
+and how you can deploy your own, [click here](https://docs.wal.app/walrus-sites/intro.html).

--- a/docs/book/blog/03_whitepaper.md
+++ b/docs/book/blog/03_whitepaper.md
@@ -8,7 +8,7 @@ and broken links.
 ```
 
 In June, Mysten Labs announced Walrus, a new decentralized secure blob store design, and introduced
-a developer preview that currently stores over [12TiB](https://capacity.walrus.site/) of data.
+a developer preview that currently stores over [12TiB](https://capacity.wal.app/) of data.
 [Breaking the Ice](https://info.breakingtheice.sui.io/) gathered over 200 developers to build apps
 leveraging decentralized storage.
 

--- a/docs/book/blog/04_testnet_update.md
+++ b/docs/book/blog/04_testnet_update.md
@@ -88,7 +88,7 @@ storage node committee changes: better shard allocation mechanisms upon changes 
 stake; efficient ways to sync state between storage nodes; as well as better ways for storage nodes
 to follow Sui event streams.
 
-- Explore the [Walrus staking dApp](https://stake.walrus.site).
+- Explore the [Walrus staking dApp](https://stake-wal.wal.app/).
 - Look at recent activity on the [Walrus Explorer](https://walruscan.com/testnet/home).
 
 ## New Move contracts & documentation


### PR DESCRIPTION
## Description

Replaced some links in docs that were still directing to the old walrus.site 

## Test plan
-
