### PR TITLE
chore: leverage RetriableSuiClient for reference gas price

### DIFF
--- a/crates/walrus-sui/src/client.rs
+++ b/crates/walrus-sui/src/client.rs
@@ -2236,7 +2236,7 @@ impl SuiContractClientInner {
         method: &str,
     ) -> SuiClientResult<SuiTransactionBlockResponse> {
         // Get the current gas price from the network
-        let gas_price = self.wallet.get_reference_gas_price().await?;
+        let gas_price = self.read_client.get_reference_gas_price().await?;
         let wallet_address = self.wallet.active_address()?;
 
         tracing::debug!(?programmable_transaction, "sending PTB");

--- a/crates/walrus-sui/src/client/read_client.rs
+++ b/crates/walrus-sui/src/client/read_client.rs
@@ -579,6 +579,11 @@ impl SuiReadClient {
             })
     }
 
+    /// Get the reference gas price for the current epoch.
+    pub async fn get_reference_gas_price(&self) -> SuiClientResult<u64> {
+        Ok(self.sui_client.get_reference_gas_price().await?)
+    }
+
     /// Get the [`StorageNodeCap`] object associated with the address.
     ///
     /// Returns an error if there is more than one [`StorageNodeCap`] object associated with the


### PR DESCRIPTION
## Description

Reduce the usage of the WalletContext for access to Sui RPC nodes, since it lacks failover semantics. Note that RetriableSuiClient also lacks failover semantics, but we can add them in the future.

## Test plan

CI pipeline.