### PR TITLE
feat: add an option to request additional symbols from the beginning during sliver recovery

### DIFF
--- a/crates/walrus-service/node_config_example.yaml
+++ b/crates/walrus-service/node_config_example.yaml
@@ -91,6 +91,7 @@ blob_recovery:
   sliver_request_timeout_secs: 300
   invalidity_sync_timeout_secs: 300
   node_connect_timeout_secs: 1
+  experimental_sliver_recovery_additional_symbols: 0
 tls:
   disable_tls: false
   certificate_path: null

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -580,6 +580,9 @@ pub struct CommitteeServiceConfig {
     #[serde_as(as = "DurationSeconds<u64>")]
     #[serde(rename = "node_connect_timeout_secs")]
     pub node_connect_timeout: Duration,
+    /// The number of additional symbols to request from the remote storage node for sliver
+    /// recovery.
+    pub experimental_sliver_recovery_additional_symbols: usize,
 }
 
 impl Default for CommitteeServiceConfig {
@@ -592,6 +595,7 @@ impl Default for CommitteeServiceConfig {
             invalidity_sync_timeout: Duration::from_secs(300),
             max_concurrent_metadata_requests: NonZeroUsize::new(1).unwrap(),
             node_connect_timeout: Duration::from_secs(1),
+            experimental_sliver_recovery_additional_symbols: 0,
         }
     }
 }


### PR DESCRIPTION
## Description

As we have seen, sliver recovery is currently bottlenecked by storage nodes that are overwhelmed by recovery symbols
requests, and may take long time to return 503. This currently is suspected to be the main bottleneck of blob recovery
after all the blob recovery improvements implemented by @jpcsmith. By allowing requesting additional symbols initially,
sliver recovery saves on latency to wait for a 503 to return and create another requests.

## Test plan

All simtest integration tests are randomly chosen a value to request additional symbols.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
