### PR TITLE
feat: add detailed metrics for recovering slivers

### DIFF
--- a/crates/walrus-service/src/node/committee/request_futures.rs
+++ b/crates/walrus-service/src/node/committee/request_futures.rs
@@ -49,12 +49,13 @@ use walrus_core::{
 use walrus_rest_client::client::RecoverySymbolsFilter;
 use walrus_sdk::active_committees::CommitteeTracker;
 use walrus_sui::types::Committee;
-use walrus_utils::backoff::ExponentialBackoffState;
+use walrus_utils::{backoff::ExponentialBackoffState, metrics::OwnedGaugeGuard};
 
 use super::{
     committee_service::NodeCommitteeServiceInner,
     node_service::{NodeService, NodeServiceError, Request, Response},
 };
+use crate::node::metrics::CommitteeServiceMetricSet;
 
 pub(super) struct GetAndVerifyMetadata<'a, T> {
     blob_id: BlobId,
@@ -175,6 +176,70 @@ where
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RecoveryStateLabel {
+    Init,
+    CollectingSymbols,
+    Backoff,
+    TailRequest,
+    BuildingSliver,
+}
+
+impl AsRef<str> for RecoveryStateLabel {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::Init => "init",
+            Self::CollectingSymbols => "collecting-symbols",
+            Self::Backoff => "backoff",
+            Self::TailRequest => "tail-request",
+            Self::BuildingSliver => "building-sliver",
+        }
+    }
+}
+
+/// Tracks aggregated statistics and the state of a RecoverSliver future.
+struct RecoverSliverStats {
+    /// The total number of backoffs performed during the recovery.
+    total_backoffs: usize,
+    /// The total number of failed requests observed during the recovery.
+    total_failed_requests: usize,
+    /// The current "recovery state" of the request, as identified by the `RecoveryStateLabel`.
+    current_state: (RecoveryStateLabel, OwnedGaugeGuard),
+
+    metrics: Arc<CommitteeServiceMetricSet>,
+}
+
+impl RecoverSliverStats {
+    fn new(metrics: Arc<CommitteeServiceMetricSet>) -> Self {
+        let current_state = (
+            RecoveryStateLabel::Init,
+            OwnedGaugeGuard::acquire(walrus_utils::with_label!(
+                metrics.recovery_future_state,
+                RecoveryStateLabel::Init
+            )),
+        );
+
+        Self {
+            total_backoffs: 0,
+            total_failed_requests: 0,
+            current_state,
+            metrics,
+        }
+    }
+
+    fn record_state(&mut self, state: RecoveryStateLabel) {
+        if self.current_state.0 == state {
+            return;
+        }
+
+        let guard = OwnedGaugeGuard::acquire(walrus_utils::with_label!(
+            self.metrics.recovery_future_state,
+            state
+        ));
+        self.current_state = (state, guard);
+    }
+}
+
 pub(super) struct RecoverSliver<'a, T> {
     metadata: Arc<VerifiedBlobMetadataWithId>,
     target_index: SliverIndex,
@@ -182,6 +247,7 @@ pub(super) struct RecoverSliver<'a, T> {
     epoch_certified: Epoch,
     backoff: ExponentialBackoffState,
     shared: &'a NodeCommitteeServiceInner<T>,
+    stats: RecoverSliverStats,
 }
 
 impl<'a, T> RecoverSliver<'a, T>
@@ -210,6 +276,7 @@ where
             ),
             shared,
             metadata,
+            stats: RecoverSliverStats::new(shared.metrics.clone()),
         }
     }
 
@@ -280,6 +347,7 @@ where
                 &mut symbol_tracker,
                 weak_committee.clone(),
                 self.shared,
+                &mut self.stats,
             );
 
             tokio::select! {
@@ -290,6 +358,12 @@ where
                                 %n_symbols,
                                 "successfully collected the desired number of recovery symbols"
                             );
+                            self.stats.metrics.recovery_future_backoffs
+                                .observe(self.stats.total_backoffs as f64);
+                            self.stats.metrics.recovery_future_failed_requests
+                                .observe(self.stats.total_failed_requests as f64);
+                            self.stats.record_state(RecoveryStateLabel::BuildingSliver);
+
                             return self.decode_sliver(symbol_tracker).await;
                         },
                         Err(n_symbols_remaining) => {
@@ -297,6 +371,10 @@ where
                                 %n_symbols_remaining,
                                 "failed to collect sufficient recovery symbols"
                             );
+                            self.stats.record_state(RecoveryStateLabel::Backoff);
+                            self.stats.metrics.recovery_future_backoff_total.inc();
+                            self.stats.total_backoffs += 1;
+
                             wait_before_next_attempts(&mut self.backoff, &self.shared.rng).await;
                         }
                     }
@@ -406,6 +484,7 @@ struct CollectRecoverySymbols<'a, T> {
     shared: &'a NodeCommitteeServiceInner<T>,
     upcoming_nodes: RemainingShards,
     pending_requests: FuturesUnordered<BoxFuture<'a, (usize, Option<Vec<GeneralRecoverySymbol>>)>>,
+    stats: &'a mut RecoverSliverStats,
 }
 
 impl<'a, T: NodeService> CollectRecoverySymbols<'a, T> {
@@ -414,6 +493,7 @@ impl<'a, T: NodeService> CollectRecoverySymbols<'a, T> {
         tracker: &'a mut SymbolTracker,
         committee: Weak<Committee>,
         shared: &'a NodeCommitteeServiceInner<T>,
+        stats: &'a mut RecoverSliverStats,
     ) -> Self {
         // Clear counts of in-progress collections.
         tracker.clear_in_progress();
@@ -434,6 +514,7 @@ impl<'a, T: NodeService> CollectRecoverySymbols<'a, T> {
             shared,
             tracker,
             upcoming_nodes,
+            stats,
         }
     }
 
@@ -445,6 +526,9 @@ impl<'a, T: NodeService> CollectRecoverySymbols<'a, T> {
 
             if let Some(symbols) = maybe_symbols {
                 self.tracker.extend_collected(symbols);
+            } else {
+                // No symbols, which indicates a request failure.
+                self.stats.total_failed_requests += 1;
             }
 
             // If we have collected enough symbols to decode the sliver, we can stop.
@@ -545,6 +629,14 @@ impl<'a, T: NodeService> CollectRecoverySymbols<'a, T> {
             new_request_count,
             "completed refilling pending requests with additional futures"
         );
+
+        match self.pending_requests.len() {
+            0 => (),
+            1 => self.stats.record_state(RecoveryStateLabel::TailRequest),
+            _ => self
+                .stats
+                .record_state(RecoveryStateLabel::CollectingSymbols),
+        }
     }
 
     fn symbol_id_at_shard(&self, shard_id: ShardIndex) -> SymbolId {

--- a/crates/walrus-service/src/node/metrics.rs
+++ b/crates/walrus-service/src/node/metrics.rs
@@ -191,7 +191,7 @@ walrus_utils::metrics::define_metric_set! {
         },
 
         #[help = "The number of recovery futures in a given recovery state."]
-        recovery_future_state: IntGaugeVec["recovery_state"],
+        recovery_future_state: IntGaugeVec["recovery_state", "tail_count"],
     }
 }
 

--- a/crates/walrus-service/src/node/metrics.rs
+++ b/crates/walrus-service/src/node/metrics.rs
@@ -175,6 +175,23 @@ walrus_utils::metrics::define_metric_set! {
 
         #[help = "The number shards currently owned by this node"]
         shards_owned: U64Gauge[],
+
+        #[help = "The total number of times recovery futures entered exponential backoff."]
+        recovery_future_backoff_total: IntCounter[],
+
+        #[help = "The number of times a recovery futures entered exponential backoff before
+        completing."]
+        recovery_future_backoffs: Histogram {
+            buckets: [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+        },
+
+        #[help = "The number of failed recovery symbol requests before completion"]
+        recovery_future_failed_requests: Histogram {
+            buckets: prometheus::exponential_buckets(1.0, 2.0, 11).expect("valid static buckets")
+        },
+
+        #[help = "The number of recovery futures in a given recovery state."]
+        recovery_future_state: IntGaugeVec["recovery_state"],
     }
 }
 


### PR DESCRIPTION
## Description

This adds the following metrics to the recover sliver flow:
- `walrus_recovery_future_backoff_total` - a simple counter of the total number of times that recoveries enter exponential backoff,
- `walrus_recovery_future_backoffs` -  a single histogram recording the number of backoffs that each sliver recovery entered before collecting enough symbols,
- `walrus_recovery_future_failed_requests` - a single histogram recording the number of request failures that each sliver recovery encountered before collecting enough symbols, and
- `walrus_recovery_future_state` - a vector of gauges, one for each of 5 states, that gives insight to the state that each future is in when the metrics are being scraped.

Depends on #1976 

## Test plan

Observed metrics being exported in the local testbed.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
