### PR TITLE
fix: make mainnet-contracts/*/Move.* correspond to deployed version

### DIFF
--- a/mainnet-contracts/subsidies/Move.lock
+++ b/mainnet-contracts/subsidies/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "EED1338DA187CE13DE19336996CBB716BAC5DB75A89666E9F95AD9F4E4863797"
+manifest_digest = "9A2082DC6F53FA70312454FB0E4E66F3442B2529705FE6BCB044AC8E71B81E04"
 deps_digest = "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -12,11 +12,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.46.0", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.44.3", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.46.0", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.44.3", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -40,7 +40,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.46.0"
+compiler-version = "1.44.3"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/mainnet-contracts/subsidies/Move.toml
+++ b/mainnet-contracts/subsidies/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.46.0" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.44.3" }
 WAL = { local = "../wal" }
 Walrus = { local = "../walrus" }
 

--- a/mainnet-contracts/wal/Move.lock
+++ b/mainnet-contracts/wal/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "1FDE1C0F15EE122E4CEFF9F67F6599F1C541ABF7091349F1A1325400AD78C81D"
+manifest_digest = "498CF889960139A5523E778325E052F14A68529E0BA1DAEF212FAD88D50CAEC9"
 deps_digest = "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -10,18 +10,18 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.46.0", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.43.0", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.46.0", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.43.0", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
 ]
 
 [move.toolchain-version]
-compiler-version = "1.46.0"
+compiler-version = "1.43.0"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/mainnet-contracts/wal/Move.toml
+++ b/mainnet-contracts/wal/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.46.0" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.44.3" }
 
 [addresses]
 wal = "0x0"

--- a/mainnet-contracts/walrus/Move.lock
+++ b/mainnet-contracts/walrus/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "E3144F143AE44219A54275B9D0EB14EF73570CC3C7FFE2DD6D9EDC8E95D206B6"
+manifest_digest = "4BC589454DF8DC51D8FEC230BFFDCA8B2013DD09197792A169A73B22DDF64907"
 deps_digest = "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -11,11 +11,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.46.0", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.44.3", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.46.0", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.44.3", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -30,7 +30,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.46.0"
+compiler-version = "1.44.3"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/mainnet-contracts/walrus/Move.toml
+++ b/mainnet-contracts/walrus/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.46.0" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.44.3" }
 WAL = { local = "../wal" }
 
 [addresses]

--- a/mainnet-contracts/walrus/sources/staking/staking_inner.move
+++ b/mainnet-contracts/walrus/sources/staking/staking_inner.move
@@ -34,7 +34,6 @@ use walrus::{
 const MIN_STAKE: u64 = 0;
 
 // TODO: Remove once solutions are in place to prevent hitting move execution limits (#935).
-//
 /// Temporary upper limit for the number of storage nodes.
 const TEMP_ACTIVE_SET_SIZE_LIMIT: u16 = 111;
 


### PR DESCRIPTION
## Description

This PR makes sure that the compiler `Move.toml` and `Move.lock` files in `mainnet-contracts` reflect the state at the actual time of deployment. For the `wal` contract, this was commit 16606e7e52e3f7573cd917665a71e7caf49b0807, and for the `walrus` and `subsidies` contracts, this was commit 10217c558c110b2f9dc7bbc35b8947628b65e5e3.

In particular, the goal is to make the used compiler version clear to ensure that running `sui client verify-source` succeeds if the sui version corresponding to the compiler version in the `Move.lock` files is used. Small changes from after the deployment to e.g. comments or formatting in the source code that do not affect this have been kept intact.

There are some caveats, namely, we cannot accurately reflect the dependency versions for `wal`, since the compilation of `walrus` and `subsidies` requires that the dependency versions are the same. However, this does not matter for source verification, so it does not affect the main goal.

## Test plan

- Verified the source of `walrus` and `subsidies` locally against the on-chain versions using sui version `mainnet-v1.44.3`

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
