### PR TITLE
feat: config sui client request timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12169,6 +12169,7 @@ dependencies = [
  "anyhow",
  "clap",
  "futures",
+ "humantime",
  "indicatif",
  "mysten-metrics",
  "prometheus",

--- a/crates/walrus-sdk/client_config_example.yaml
+++ b/crates/walrus-sdk/client_config_example.yaml
@@ -34,6 +34,7 @@ communication_config:
     min_backoff_millis: 1000
     max_backoff_millis: 5000
     max_retries: 5
+  sui_client_request_timeout_millis: null
 refresh_config:
   refresh_grace_period_secs: 10
   max_auto_refresh_interval_secs: 30

--- a/crates/walrus-sdk/src/config.rs
+++ b/crates/walrus-sdk/src/config.rs
@@ -167,7 +167,7 @@ impl ClientConfig {
         &self,
         gas_budget: Option<u64>,
     ) -> anyhow::Result<SuiContractClient> {
-        let wallet = WalletConfig::load_wallet_context_with_request_timeout(
+        let wallet = WalletConfig::load_wallet_context(
             self.wallet_config.as_ref(),
             self.communication_config.sui_client_request_timeout,
         )

--- a/crates/walrus-sdk/src/config.rs
+++ b/crates/walrus-sdk/src/config.rs
@@ -167,8 +167,11 @@ impl ClientConfig {
         &self,
         gas_budget: Option<u64>,
     ) -> anyhow::Result<SuiContractClient> {
-        let wallet = WalletConfig::load_wallet_context(self.wallet_config.as_ref())
-            .context("new_contract_client_with_wallet_in_config")?;
+        let wallet = WalletConfig::load_wallet_context_with_request_timeout(
+            self.wallet_config.as_ref(),
+            self.communication_config.sui_client_request_timeout,
+        )
+        .context("new_contract_client_with_wallet_in_config")?;
         Ok(self.new_contract_client(wallet, gas_budget).await?)
     }
 

--- a/crates/walrus-sdk/src/config/communication_config.rs
+++ b/crates/walrus-sdk/src/config/communication_config.rs
@@ -57,7 +57,8 @@ pub struct ClientCommunicationConfig {
     pub max_total_blob_size: usize,
     /// The configuration for the backoff after committee change is detected.
     pub committee_change_backoff: ExponentialBackoffConfig,
-    /// The request timeout for the Sui client.
+    /// The request timeout for the SuiClient communicating with Sui network.
+    /// If not set, the default timeout in SuiClient will be used.
     #[serde(rename = "sui_client_request_timeout_millis")]
     #[serde_as(as = "Option<DurationMilliSeconds>")]
     pub sui_client_request_timeout: Option<Duration>,

--- a/crates/walrus-sdk/src/config/communication_config.rs
+++ b/crates/walrus-sdk/src/config/communication_config.rs
@@ -57,6 +57,10 @@ pub struct ClientCommunicationConfig {
     pub max_total_blob_size: usize,
     /// The configuration for the backoff after committee change is detected.
     pub committee_change_backoff: ExponentialBackoffConfig,
+    /// The request timeout for the Sui client.
+    #[serde(rename = "sui_client_request_timeout_millis")]
+    #[serde_as(as = "Option<DurationMilliSeconds>")]
+    pub sui_client_request_timeout: Option<Duration>,
 }
 
 impl Default for ClientCommunicationConfig {
@@ -80,6 +84,7 @@ impl Default for ClientCommunicationConfig {
                 Duration::from_secs(5),
                 Some(5),
             ),
+            sui_client_request_timeout: None,
         }
     }
 }

--- a/crates/walrus-service/bin/deploy.rs
+++ b/crates/walrus-service/bin/deploy.rs
@@ -226,6 +226,9 @@ struct GenerateDryRunConfigsArgs {
     /// Any extra client wallets to generate. Each will get 1 Million WAL and some Sui.
     #[arg(long)]
     extra_client_wallets: Option<String>,
+    /// The request timeout for the client config.
+    #[arg(long, value_parser = humantime::parse_duration)]
+    client_config_request_timeout: Option<Duration>,
 }
 
 #[derive(Debug, Clone, clap::Args)]
@@ -444,6 +447,7 @@ mod commands {
             admin_wallet_path,
             sui_amount,
             extra_client_wallets,
+            client_config_request_timeout,
         }: GenerateDryRunConfigsArgs,
     ) -> anyhow::Result<()> {
         utils::init_tracing_subscriber()?;
@@ -483,6 +487,7 @@ mod commands {
             &mut admin_contract_client,
             sui_amount,
             extra_client_wallets,
+            client_config_request_timeout,
         )
         .await?;
 
@@ -575,6 +580,7 @@ mod commands {
         admin_contract_client: &mut SuiContractClient,
         sui_amount: u64,
         extra_client_wallets: Option<String>,
+        client_config_request_timeout: Option<Duration>,
     ) -> anyhow::Result<()> {
         // The "sui_client" wallet is always created, and we add on any extra client wallets as
         // requested.
@@ -607,6 +613,7 @@ mod commands {
                 testbed_config.exchange_object.into_iter().collect(),
                 sui_amount,
                 &sui_wallet_name,
+                client_config_request_timeout,
             )
             .await?;
             let serialized_client_config = serde_yaml::to_string(&client_config)

--- a/crates/walrus-service/bin/node.rs
+++ b/crates/walrus-service/bin/node.rs
@@ -904,6 +904,7 @@ mod commands {
                     .clone()
                     .and_then(|args| args.to_config()),
                 additional_rpc_endpoints,
+                request_timeout: None,
             }),
             tls: TlsConfig {
                 certificate_path,

--- a/crates/walrus-service/bin/node.rs
+++ b/crates/walrus-service/bin/node.rs
@@ -547,9 +547,12 @@ mod commands {
                 &metrics_runtime.registry,
                 &config.contract_config.system_object,
                 &config.contract_config.staking_object,
-                WalletConfig::load_wallet_context(Some(&config.wallet_config))
-                    .and_then(|mut wallet| wallet.active_address())
-                    .ok(),
+                WalletConfig::load_wallet_context(
+                    Some(&config.wallet_config),
+                    config.request_timeout,
+                )
+                .and_then(|mut wallet| wallet.active_address())
+                .ok(),
             );
         }
 
@@ -843,7 +846,7 @@ mod commands {
                 "getting Sui RPC URL from wallet at '{}'",
                 wallet_config.display()
             );
-            let wallet_context = load_wallet_context_from_path(Some(&wallet_config))
+            let wallet_context = load_wallet_context_from_path(Some(&wallet_config), None)
                 .context("Reading Sui wallet failed")?;
             wallet_context
                 .config

--- a/crates/walrus-service/node_config_example.yaml
+++ b/crates/walrus-service/node_config_example.yaml
@@ -80,6 +80,7 @@ sui:
     max_retries: 5
   gas_budget: null
   rpc_fallback_config: null
+  request_timeout: null
 blob_recovery:
   max_concurrent_blob_syncs: 100
   max_concurrent_sliver_syncs: 2000

--- a/crates/walrus-service/src/backup/service.rs
+++ b/crates/walrus-service/src/backup/service.rs
@@ -589,6 +589,7 @@ async fn backup_fetcher(
         RetriableSuiClient::new_for_rpc(
             &backup_config.sui.rpc,
             backup_config.sui.backoff_config.clone(),
+            None,
         )
         .await
         .context("[backup_fetcher] cannot create RetriableSuiClient")?,

--- a/crates/walrus-service/src/client/cli.rs
+++ b/crates/walrus-service/src/client/cli.rs
@@ -123,9 +123,13 @@ pub async fn get_sui_read_client_from_rpc_node_or_wallet(
     let sui_client = match rpc_url {
         Some(url) => {
             tracing::info!("using explicitly set RPC URL {url}");
-            RetriableSuiClient::new_for_rpc(&url, backoff_config)
-                .await
-                .context(format!("cannot connect to Sui RPC node at {url}"))
+            RetriableSuiClient::new_for_rpc(
+                &url,
+                backoff_config,
+                config.communication_config.sui_client_request_timeout,
+            )
+            .await
+            .context(format!("cannot connect to Sui RPC node at {url}"))
         }
         None => match wallet {
             Ok(wallet) => {
@@ -137,11 +141,15 @@ pub async fn get_sui_read_client_from_rpc_node_or_wallet(
             Err(e) => {
                 if allow_fallback_to_default {
                     tracing::info!("using default RPC URL '{DEFAULT_RPC_URL}'");
-                    RetriableSuiClient::new_for_rpc(DEFAULT_RPC_URL, backoff_config)
-                        .await
-                        .context(format!(
-                            "cannot connect to Sui RPC node at {DEFAULT_RPC_URL}"
-                        ))
+                    RetriableSuiClient::new_for_rpc(
+                        DEFAULT_RPC_URL,
+                        backoff_config,
+                        config.communication_config.sui_client_request_timeout,
+                    )
+                    .await
+                    .context(format!(
+                        "cannot connect to Sui RPC node at {DEFAULT_RPC_URL}"
+                    ))
                 } else {
                     Err(e)
                 }

--- a/crates/walrus-service/src/client/cli/runner.rs
+++ b/crates/walrus-service/src/client/cli/runner.rs
@@ -152,7 +152,7 @@ impl ClientCommandRunner {
                 .as_ref()
                 .ok()
                 .and_then(|config: &ClientConfig| config.wallet_config.clone()));
-        let wallet = WalletConfig::load_wallet_context_with_request_timeout(
+        let wallet = WalletConfig::load_wallet_context(
             wallet_config.as_ref(),
             config.as_ref().map_or(None, |config| {
                 config.communication_config.sui_client_request_timeout

--- a/crates/walrus-service/src/client/cli/runner.rs
+++ b/crates/walrus-service/src/client/cli/runner.rs
@@ -154,9 +154,10 @@ impl ClientCommandRunner {
                 .and_then(|config: &ClientConfig| config.wallet_config.clone()));
         let wallet = WalletConfig::load_wallet_context(
             wallet_config.as_ref(),
-            config.as_ref().map_or(None, |config| {
-                config.communication_config.sui_client_request_timeout
-            }),
+            config
+                .as_ref()
+                .ok()
+                .and_then(|config| config.communication_config.sui_client_request_timeout),
         );
 
         Self {

--- a/crates/walrus-service/src/client/cli/runner.rs
+++ b/crates/walrus-service/src/client/cli/runner.rs
@@ -152,7 +152,12 @@ impl ClientCommandRunner {
                 .as_ref()
                 .ok()
                 .and_then(|config: &ClientConfig| config.wallet_config.clone()));
-        let wallet = WalletConfig::load_wallet_context(wallet_config.as_ref());
+        let wallet = WalletConfig::load_wallet_context_with_request_timeout(
+            wallet_config.as_ref(),
+            config.as_ref().map_or(None, |config| {
+                config.communication_config.sui_client_request_timeout
+            }),
+        );
 
         Self {
             wallet,

--- a/crates/walrus-service/src/client/multiplexer.rs
+++ b/crates/walrus-service/src/client/multiplexer.rs
@@ -365,7 +365,10 @@ impl<'a> SubClientLoader<'a> {
 
         if wallet_config_path.exists() {
             tracing::debug!(?wallet_config_path, "loading sub-wallet from file");
-            load_wallet_context_from_path(Some(&wallet_config_path))
+            load_wallet_context_from_path(
+                Some(&wallet_config_path),
+                self.config.communication_config.sui_client_request_timeout,
+            )
         } else {
             tracing::debug!(?wallet_config_path, "creating new sub-wallet");
             create_wallet(

--- a/crates/walrus-service/src/client/multiplexer.rs
+++ b/crates/walrus-service/src/client/multiplexer.rs
@@ -372,6 +372,7 @@ impl<'a> SubClientLoader<'a> {
                 &wallet_config_path,
                 self.sui_env.clone(),
                 Some(&keystore_filename),
+                self.config.communication_config.sui_client_request_timeout,
             )
         }
     }

--- a/crates/walrus-service/src/common/config.rs
+++ b/crates/walrus-service/src/common/config.rs
@@ -52,7 +52,7 @@ pub struct SuiConfig {
     /// Additional RPC endpoints to use for the event processor.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub additional_rpc_endpoints: Vec<String>,
-    /// The request timeout for the client config.
+    /// The request timeout for communicating with Sui network.
     #[serde(default, skip_serializing_if = "defaults::is_none")]
     pub request_timeout: Option<Duration>,
 }
@@ -75,7 +75,7 @@ impl SuiConfig {
     ) -> Result<SuiContractClient, SuiClientError> {
         if let Some(metrics) = metrics {
             SuiContractClient::new_from_wallet_with_metrics(
-                WalletConfig::load_wallet_context(Some(&self.wallet_config))?,
+                WalletConfig::load_wallet_context(Some(&self.wallet_config), self.request_timeout)?,
                 &self.contract_config,
                 self.backoff_config.clone(),
                 self.gas_budget,
@@ -84,7 +84,7 @@ impl SuiConfig {
             .await
         } else {
             SuiContractClient::new(
-                WalletConfig::load_wallet_context(Some(&self.wallet_config))?,
+                WalletConfig::load_wallet_context(Some(&self.wallet_config), self.request_timeout)?,
                 &self.contract_config,
                 self.backoff_config.clone(),
                 self.gas_budget,
@@ -135,7 +135,7 @@ pub struct SuiReaderConfig {
     /// Additional RPC endpoints to use for the event processor.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub additional_rpc_endpoints: Vec<String>,
-    /// The request timeout for the client config.
+    /// The request timeout for communicating with Sui network.
     #[serde(default, skip_serializing_if = "defaults::is_none")]
     pub request_timeout: Option<Duration>,
 }

--- a/crates/walrus-service/src/common/config.rs
+++ b/crates/walrus-service/src/common/config.rs
@@ -52,6 +52,9 @@ pub struct SuiConfig {
     /// Additional RPC endpoints to use for the event processor.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub additional_rpc_endpoints: Vec<String>,
+    /// The request timeout for the client config.
+    #[serde(default, skip_serializing_if = "defaults::is_none")]
+    pub request_timeout: Option<Duration>,
 }
 
 impl SuiConfig {
@@ -100,6 +103,7 @@ impl From<&SuiConfig> for SuiReaderConfig {
             backoff_config: config.backoff_config.clone(),
             rpc_fallback_config: config.rpc_fallback_config.clone(),
             additional_rpc_endpoints: config.additional_rpc_endpoints.clone(),
+            request_timeout: config.request_timeout,
         }
     }
 }
@@ -131,6 +135,9 @@ pub struct SuiReaderConfig {
     /// Additional RPC endpoints to use for the event processor.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub additional_rpc_endpoints: Vec<String>,
+    /// The request timeout for the client config.
+    #[serde(default, skip_serializing_if = "defaults::is_none")]
+    pub request_timeout: Option<Duration>,
 }
 
 impl SuiReaderConfig {

--- a/crates/walrus-service/src/common/utils.rs
+++ b/crates/walrus-service/src/common/utils.rs
@@ -525,7 +525,8 @@ pub async fn generate_sui_wallet(
         "generating Sui wallet for {sui_network} at '{}'",
         path.display()
     );
-    let mut wallet = walrus_sui::utils::create_wallet(path, sui_network.env(), None)?;
+    let mut wallet =
+        walrus_sui::utils::create_wallet(path, sui_network.env(), None, Some(faucet_timeout))?;
     let wallet_address = wallet.active_address()?;
     tracing::info!("generated a new Sui wallet; address: {wallet_address}");
 

--- a/crates/walrus-service/src/common/utils.rs
+++ b/crates/walrus-service/src/common/utils.rs
@@ -525,8 +525,7 @@ pub async fn generate_sui_wallet(
         "generating Sui wallet for {sui_network} at '{}'",
         path.display()
     );
-    let mut wallet =
-        walrus_sui::utils::create_wallet(path, sui_network.env(), None, Some(faucet_timeout))?;
+    let mut wallet = walrus_sui::utils::create_wallet(path, sui_network.env(), None, None)?;
     let wallet_address = wallet.active_address()?;
     tracing::info!("generated a new Sui wallet; address: {wallet_address}");
 

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -1070,6 +1070,7 @@ mod tests {
                 gas_budget: None,
                 rpc_fallback_config: None,
                 additional_rpc_endpoints: Default::default(),
+                request_timeout: None,
             }),
             config_synchronizer: ConfigSynchronizerConfig {
                 interval: Duration::from_secs(defaults::CONFIG_SYNCHRONIZER_INTERVAL_SECS),

--- a/crates/walrus-service/src/node/events/event_processor.rs
+++ b/crates/walrus-service/src/node/events/event_processor.rs
@@ -663,6 +663,7 @@ impl EventProcessor {
 
         let url = runtime_config.rpc_addresses[0].clone();
         let sui_client = SuiClientBuilder::default()
+            .request_timeout(Duration::from_secs(120))
             .build(&url)
             .await
             .context(format!("cannot connect to Sui RPC node at {url}"))?;

--- a/crates/walrus-service/src/node/events/event_processor.rs
+++ b/crates/walrus-service/src/node/events/event_processor.rs
@@ -663,7 +663,7 @@ impl EventProcessor {
 
         let url = runtime_config.rpc_addresses[0].clone();
         let sui_client = SuiClientBuilder::default()
-            .request_timeout(Duration::from_secs(120))
+            .request_timeout(config.checkpoint_request_timeout)
             .build(&url)
             .await
             .context(format!("cannot connect to Sui RPC node at {url}"))?;

--- a/crates/walrus-service/src/node/storage/shard.rs
+++ b/crates/walrus-service/src/node/storage/shard.rs
@@ -679,7 +679,8 @@ impl ShardStorage {
 
         let shard_status = self.status()?;
         assert!(
-            shard_status == ShardStatus::ActiveSync || shard_status == ShardStatus::ActiveRecover
+            shard_status == ShardStatus::ActiveSync || shard_status == ShardStatus::ActiveRecover,
+            "unexpected shard status at the beginning of a shard sync: {shard_status}"
         );
 
         match self.get_last_sync_status(&shard_status)? {

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -1044,6 +1044,7 @@ impl StorageNodeHandleBuilder {
                     .skip(1)
                     .map(|url| url.clone())
                     .collect::<Vec<String>>(),
+                request_timeout: None,
             }),
             config_synchronizer: ConfigSynchronizerConfig {
                 interval: Duration::from_secs(5),

--- a/crates/walrus-service/src/testbed.rs
+++ b/crates/walrus-service/src/testbed.rs
@@ -25,6 +25,7 @@ use walrus_core::{
     EpochCount,
     ShardIndex,
 };
+use walrus_sdk::config::ClientCommunicationConfig;
 use walrus_sui::{
     client::{rpc_config::RpcFallbackConfig, SuiContractClient},
     config::{load_wallet_context_from_path, WalletConfig},
@@ -371,6 +372,7 @@ pub async fn deploy_walrus_contract(
             &working_dir.join(format!("{ADMIN_CONFIG_PREFIX}.yaml")),
             sui_network.env(),
             Some(&format!("{ADMIN_CONFIG_PREFIX}.keystore")),
+            None,
         )?;
 
         // Print the wallet address.
@@ -513,6 +515,7 @@ pub async fn create_client_config(
     exchange_objects: Vec<ObjectID>,
     sui_amount: u64,
     wallet_name: &str,
+    client_config_request_timeout: Option<Duration>,
 ) -> anyhow::Result<client::ClientConfig> {
     // Create the working directory if it does not exist
     fs::create_dir_all(working_dir).expect("Failed to create working directory");
@@ -523,6 +526,7 @@ pub async fn create_client_config(
         &sui_client_wallet_path,
         sui_network.env(),
         Some(&format!("{}.keystore", wallet_name)),
+        client_config_request_timeout,
     )?;
 
     let client_address = sui_client_wallet_context.active_address()?;
@@ -562,7 +566,10 @@ pub async fn create_client_config(
         contract_config,
         exchange_objects,
         wallet_config: Some(WalletConfig::from_path(wallet_path)),
-        communication_config: Default::default(),
+        communication_config: ClientCommunicationConfig {
+            sui_client_request_timeout: client_config_request_timeout,
+            ..Default::default()
+        },
         refresh_config: Default::default(),
     };
 
@@ -586,6 +593,7 @@ pub async fn create_backup_config(
             event_polling_interval: defaults::polling_interval(),
             rpc_fallback_config,
             additional_rpc_endpoints: vec![],
+            request_timeout: None,
         },
         database_url.to_string(),
     ))
@@ -713,6 +721,7 @@ pub async fn create_storage_node_configs(
             gas_budget: None,
             rpc_fallback_config: rpc_fallback_config.clone(),
             additional_rpc_endpoints: vec![],
+            request_timeout: None,
         });
 
         let storage_path = set_db_path
@@ -856,6 +865,7 @@ async fn create_storage_node_wallets(
                 &wallet_path,
                 sui_network.env(),
                 Some(&format!("{}.keystore", name)),
+                None,
             )
         })
         .collect::<Result<Vec<_>, _>>()?;

--- a/crates/walrus-service/src/testbed.rs
+++ b/crates/walrus-service/src/testbed.rs
@@ -365,7 +365,7 @@ pub async fn deploy_walrus_contract(
             "Loading existing admin wallet from path: {}",
             admin_wallet_path.display()
         );
-        load_wallet_context_from_path(Some(&admin_wallet_path))?
+        load_wallet_context_from_path(Some(&admin_wallet_path), None)?
     } else {
         tracing::debug!("Creating new admin wallet in working directory");
         let mut admin_wallet = create_wallet(
@@ -515,7 +515,7 @@ pub async fn create_client_config(
     exchange_objects: Vec<ObjectID>,
     sui_amount: u64,
     wallet_name: &str,
-    client_config_request_timeout: Option<Duration>,
+    sui_client_request_timeout: Option<Duration>,
 ) -> anyhow::Result<client::ClientConfig> {
     // Create the working directory if it does not exist
     fs::create_dir_all(working_dir).expect("Failed to create working directory");
@@ -526,7 +526,7 @@ pub async fn create_client_config(
         &sui_client_wallet_path,
         sui_network.env(),
         Some(&format!("{}.keystore", wallet_name)),
-        client_config_request_timeout,
+        sui_client_request_timeout,
     )?;
 
     let client_address = sui_client_wallet_context.active_address()?;
@@ -567,7 +567,7 @@ pub async fn create_client_config(
         exchange_objects,
         wallet_config: Some(WalletConfig::from_path(wallet_path)),
         communication_config: ClientCommunicationConfig {
-            sui_client_request_timeout: client_config_request_timeout,
+            sui_client_request_timeout,
             ..Default::default()
         },
         refresh_config: Default::default(),
@@ -615,6 +615,7 @@ pub async fn create_storage_node_configs(
     use_legacy_event_provider: bool,
     disable_event_blob_writer: bool,
     sui_amount: u64,
+    sui_client_request_timeout: Option<Duration>,
 ) -> anyhow::Result<Vec<StorageNodeConfig>> {
     tracing::debug!(
         ?working_dir,
@@ -721,7 +722,7 @@ pub async fn create_storage_node_configs(
             gas_budget: None,
             rpc_fallback_config: rpc_fallback_config.clone(),
             additional_rpc_endpoints: vec![],
-            request_timeout: None,
+            request_timeout: sui_client_request_timeout,
         });
 
         let storage_path = set_db_path

--- a/crates/walrus-stress/Cargo.toml
+++ b/crates/walrus-stress/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 anyhow.workspace = true
 clap.workspace = true
 futures.workspace = true
+humantime.workspace = true
 indicatif.workspace = true
 mysten-metrics.workspace = true
 prometheus.workspace = true

--- a/crates/walrus-stress/src/generator.rs
+++ b/crates/walrus-stress/src/generator.rs
@@ -71,6 +71,9 @@ impl LoadGenerator {
         let sui_client = RetriableSuiClient::new_for_rpc(
             network.env().rpc.clone(),
             ExponentialBackoffConfig::default(),
+            client_config
+                .communication_config
+                .sui_client_request_timeout,
         )
         .await?;
 

--- a/crates/walrus-stress/src/generator/write_client.rs
+++ b/crates/walrus-stress/src/generator/write_client.rs
@@ -244,7 +244,7 @@ async fn new_client(
     refiller: Refiller,
 ) -> anyhow::Result<WithTempDir<Client<SuiContractClient>>> {
     // Create the client with a separate wallet
-    let wallet = wallet_for_testing_from_refill(network, refiller).await?;
+    let wallet = wallet_for_testing_from_refill(config, network, refiller).await?;
     let sui_client =
         RetriableSuiClient::new_from_wallet(wallet.as_ref(), Default::default()).await?;
     let sui_read_client = config.new_read_client(sui_client).await?;
@@ -262,10 +262,14 @@ async fn new_client(
 
 /// Creates a new wallet for testing and fills it with gas and WAL tokens
 pub async fn wallet_for_testing_from_refill(
+    config: &ClientConfig,
     network: &SuiNetwork,
     refiller: Refiller,
 ) -> anyhow::Result<WithTempDir<WalletContext>> {
-    let mut wallet = temp_dir_wallet(network.env())?;
+    let mut wallet = temp_dir_wallet(
+        config.communication_config.sui_client_request_timeout,
+        network.env(),
+    )?;
     let address = wallet.as_mut().active_address()?;
     refiller.send_gas_request(address).await?;
     refiller.send_wal_request(address).await?;

--- a/crates/walrus-stress/src/main.rs
+++ b/crates/walrus-stress/src/main.rs
@@ -159,7 +159,7 @@ async fn run_stress(
 
     // Start the write transaction generator.
     let gas_refill_period = Duration::from_millis(args.gas_refill_period_millis.get());
-    let wallet = WalletConfig::load_wallet_context_with_request_timeout(
+    let wallet = WalletConfig::load_wallet_context(
         client_config.wallet_config.as_ref(),
         client_config
             .communication_config
@@ -212,7 +212,7 @@ async fn run_staking(config: ClientConfig, _metrics: Arc<ClientMetrics>) -> anyh
     tracing::info!("Starting the staking stress runner.");
     // Start the re-staking machine.
     let restaking_period = Duration::from_secs(15);
-    let wallet = WalletConfig::load_wallet_context_with_request_timeout(
+    let wallet = WalletConfig::load_wallet_context(
         config.wallet_config.as_ref(),
         config.communication_config.sui_client_request_timeout,
     )

--- a/crates/walrus-stress/src/main.rs
+++ b/crates/walrus-stress/src/main.rs
@@ -121,7 +121,7 @@ struct StressArgs {
 async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     let _ = tracing_subscriber::fmt::try_init();
-    let mut config: ClientConfig =
+    let mut client_config: ClientConfig =
         load_from_yaml(args.config_path).context("Failed to load client config")?;
 
     // Start the metrics server.
@@ -138,19 +138,19 @@ async fn main() -> anyhow::Result<()> {
             "overriding wallet configuration from '{}'",
             wallet_path.display()
         );
-        config.wallet_config = Some(WalletConfig::from_path(wallet_path));
+        client_config.wallet_config = Some(WalletConfig::from_path(wallet_path));
     }
 
     match args.command {
         Commands::Stress(stress_args) => {
-            run_stress(config, metrics, args.sui_network, stress_args).await
+            run_stress(client_config, metrics, args.sui_network, stress_args).await
         }
-        Commands::Staking => run_staking(config, metrics).await,
+        Commands::Staking => run_staking(client_config, metrics).await,
     }
 }
 
 async fn run_stress(
-    config: ClientConfig,
+    client_config: ClientConfig,
     metrics: Arc<ClientMetrics>,
     sui_network: SuiNetwork,
     args: StressArgs,
@@ -159,9 +159,14 @@ async fn run_stress(
 
     // Start the write transaction generator.
     let gas_refill_period = Duration::from_millis(args.gas_refill_period_millis.get());
-    let wallet = WalletConfig::load_wallet_context(config.wallet_config.as_ref())
-        .context("Failed to load wallet context")?;
-    let contract_client = config.new_contract_client(wallet, None).await?;
+    let wallet = WalletConfig::load_wallet_context_with_request_timeout(
+        client_config.wallet_config.as_ref(),
+        client_config
+            .communication_config
+            .sui_client_request_timeout,
+    )
+    .context("Failed to load wallet context")?;
+    let contract_client = client_config.new_contract_client(wallet, None).await?;
 
     let wal_balance = contract_client.balance(CoinType::Wal).await?;
     let sui_balance = contract_client.balance(CoinType::Sui).await?;
@@ -182,7 +187,7 @@ async fn run_stress(
     let mut load_generator = LoadGenerator::new(
         n_clients,
         blob_config,
-        config,
+        client_config,
         sui_network,
         gas_refill_period,
         metrics,
@@ -207,8 +212,11 @@ async fn run_staking(config: ClientConfig, _metrics: Arc<ClientMetrics>) -> anyh
     tracing::info!("Starting the staking stress runner.");
     // Start the re-staking machine.
     let restaking_period = Duration::from_secs(15);
-    let wallet = WalletConfig::load_wallet_context(config.wallet_config.as_ref())
-        .context("Failed to load wallet context")?;
+    let wallet = WalletConfig::load_wallet_context_with_request_timeout(
+        config.wallet_config.as_ref(),
+        config.communication_config.sui_client_request_timeout,
+    )
+    .context("Failed to load wallet context")?;
     let contract_client: SuiContractClient = config.new_contract_client(wallet, None).await?;
 
     // The Staked Wal at any given time.

--- a/crates/walrus-sui/src/client/read_client.rs
+++ b/crates/walrus-sui/src/client/read_client.rs
@@ -346,7 +346,7 @@ impl SuiReadClient {
         contract_config: &ContractConfig,
         backoff_config: ExponentialBackoffConfig,
     ) -> SuiClientResult<Self> {
-        let client = RetriableSuiClient::new_for_rpc(rpc_address, backoff_config).await?;
+        let client = RetriableSuiClient::new_for_rpc(rpc_address, backoff_config, None).await?;
         Self::new(client, contract_config).await
     }
 

--- a/crates/walrus-sui/src/config.rs
+++ b/crates/walrus-sui/src/config.rs
@@ -5,6 +5,7 @@
 use std::{
     fmt::Debug,
     path::{Path, PathBuf},
+    time::Duration,
 };
 
 use anyhow::{anyhow, Result};
@@ -40,6 +41,18 @@ pub enum WalletConfig {
         #[serde(default)]
         active_address: Option<SuiAddress>,
     },
+}
+
+/// Helper function to load the wallet context from the given optional wallet path with a custom
+/// request timeout.
+pub fn load_wallet_context_from_path_with_request_timeout(
+    wallet_path: Option<impl AsRef<Path>>,
+    request_timeout: Option<Duration>,
+) -> Result<WalletContext> {
+    WalletConfig::load_wallet_context_with_request_timeout(
+        wallet_path.map(WalletConfig::from_path).as_ref(),
+        request_timeout,
+    )
 }
 
 /// Helper function to load the wallet context from the given optional wallet path.
@@ -81,12 +94,22 @@ impl WalletConfig {
 
     /// Loads the wallet context from the given optional wallet config (optional path and optional
     /// Sui env).
+    pub fn load_wallet_context(wallet_config: Option<&WalletConfig>) -> Result<WalletContext> {
+        Self::load_wallet_context_with_request_timeout(wallet_config, None)
+    }
+
+    /// Loads the wallet context from the given optional wallet config (optional path and optional
+    /// Sui env), with an optional request timeout. If the request timeout is not provided, the
+    /// default timeout (60 seconds) will be used.
     ///
     /// If no path is provided, tries to load the configuration first from the local folder, and
     /// then from the standard Sui configuration directory.
     // NB: When making changes to the logic, make sure to update the argument docs in
     // `crates/walrus-service/bin/client.rs`.
-    pub fn load_wallet_context(wallet_config: Option<&WalletConfig>) -> Result<WalletContext> {
+    pub fn load_wallet_context_with_request_timeout(
+        wallet_config: Option<&WalletConfig>,
+        request_timeout: Option<Duration>,
+    ) -> Result<WalletContext> {
         let mut default_paths = vec!["./sui_config.yaml".into()];
         if let Some(home_dir) = home::home_dir() {
             default_paths.push(home_dir.join(".sui").join("sui_config").join("client.yaml"))
@@ -95,7 +118,7 @@ impl WalletConfig {
         let path = path_or_defaults_if_exist(wallet_config.map(|c| c.path()), &default_paths)
             .ok_or(anyhow!("could not find a valid wallet config file"))?;
         tracing::info!("using Sui wallet configuration from '{}'", path.display());
-        let mut wallet_context: WalletContext = WalletContext::new(&path, None, None)?;
+        let mut wallet_context: WalletContext = WalletContext::new(&path, request_timeout, None)?;
         if let Some(active_env) = wallet_config.and_then(|wallet_config| wallet_config.active_env())
         {
             if !wallet_context

--- a/crates/walrus-sui/src/config.rs
+++ b/crates/walrus-sui/src/config.rs
@@ -45,21 +45,17 @@ pub enum WalletConfig {
 
 /// Helper function to load the wallet context from the given optional wallet path with a custom
 /// request timeout.
-pub fn load_wallet_context_from_path_with_request_timeout(
+///
+/// Request timeout is in effect when interacting with Sui via the WalletContext, or the SuiClient
+/// created from the wallet.
+pub fn load_wallet_context_from_path(
     wallet_path: Option<impl AsRef<Path>>,
     request_timeout: Option<Duration>,
 ) -> Result<WalletContext> {
-    WalletConfig::load_wallet_context_with_request_timeout(
+    WalletConfig::load_wallet_context(
         wallet_path.map(WalletConfig::from_path).as_ref(),
         request_timeout,
     )
-}
-
-/// Helper function to load the wallet context from the given optional wallet path.
-pub fn load_wallet_context_from_path(
-    wallet_path: Option<impl AsRef<Path>>,
-) -> Result<WalletContext> {
-    WalletConfig::load_wallet_context(wallet_path.map(WalletConfig::from_path).as_ref())
 }
 
 impl WalletConfig {
@@ -93,12 +89,6 @@ impl WalletConfig {
     }
 
     /// Loads the wallet context from the given optional wallet config (optional path and optional
-    /// Sui env).
-    pub fn load_wallet_context(wallet_config: Option<&WalletConfig>) -> Result<WalletContext> {
-        Self::load_wallet_context_with_request_timeout(wallet_config, None)
-    }
-
-    /// Loads the wallet context from the given optional wallet config (optional path and optional
     /// Sui env), with an optional request timeout. If the request timeout is not provided, the
     /// default timeout (60 seconds) will be used.
     ///
@@ -106,7 +96,7 @@ impl WalletConfig {
     /// then from the standard Sui configuration directory.
     // NB: When making changes to the logic, make sure to update the argument docs in
     // `crates/walrus-service/bin/client.rs`.
-    pub fn load_wallet_context_with_request_timeout(
+    pub fn load_wallet_context(
         wallet_config: Option<&WalletConfig>,
         request_timeout: Option<Duration>,
     ) -> Result<WalletContext> {

--- a/crates/walrus-sui/src/test_utils.rs
+++ b/crates/walrus-sui/src/test_utils.rs
@@ -408,7 +408,7 @@ pub async fn create_and_fund_wallets_on_cluster(
     // Load the cluster's wallet from file instead of using the wallet stored in the cluster.
     // This prevents tasks from being spawned in the current runtime that are expected by
     // the wallet to continue running.
-    let mut cluster_wallet = load_wallet_context_from_path(Some(path_guard.as_path()))?;
+    let mut cluster_wallet = load_wallet_context_from_path(Some(path_guard.as_path()), None)?;
 
     let mut wallets = vec![];
     let mut addresses = vec![];
@@ -438,7 +438,7 @@ pub async fn new_wallet_on_sui_test_cluster(
     // Load the cluster's wallet from file instead of using the wallet stored in the cluster.
     // This prevents tasks from being spawned in the current runtime that are expected by
     // the wallet to continue running.
-    let mut cluster_wallet = load_wallet_context_from_path(Some(path_guard.as_path()))?;
+    let mut cluster_wallet = load_wallet_context_from_path(Some(path_guard.as_path()), None)?;
     let wallet = wallet_for_testing(&mut cluster_wallet, true).await?;
     drop(path_guard);
     Ok(wallet)

--- a/crates/walrus-sui/src/utils.rs
+++ b/crates/walrus-sui/src/utils.rs
@@ -42,7 +42,7 @@ use walrus_core::{
 
 use crate::{
     client::{SuiClientResult, SuiContractClient},
-    config::load_wallet_context_from_path,
+    config::load_wallet_context_from_path_with_request_timeout,
     contracts::AssociatedContractStruct,
 };
 
@@ -307,6 +307,7 @@ pub fn create_wallet(
     config_path: &Path,
     sui_env: SuiEnv,
     keystore_filename: Option<&str>,
+    request_timeout: Option<Duration>,
 ) -> Result<WalletContext> {
     let keystore_path = config_path
         .parent()
@@ -328,7 +329,7 @@ pub fn create_wallet(
     }
     .persisted(config_path)
     .save()?;
-    load_wallet_context_from_path(Some(config_path))
+    load_wallet_context_from_path_with_request_timeout(Some(config_path), request_timeout)
 }
 
 /// Sends a request to the faucet to request coins for `address`.

--- a/crates/walrus-sui/src/utils.rs
+++ b/crates/walrus-sui/src/utils.rs
@@ -42,7 +42,7 @@ use walrus_core::{
 
 use crate::{
     client::{SuiClientResult, SuiContractClient},
-    config::load_wallet_context_from_path_with_request_timeout,
+    config::load_wallet_context_from_path,
     contracts::AssociatedContractStruct,
 };
 
@@ -303,6 +303,9 @@ impl std::fmt::Display for SuiNetwork {
 ///
 /// The keystore will be stored in the same directory as the wallet config and named
 /// `keystore_filename` (if provided) and `sui.keystore` otherwise.  Returns the created Wallet.
+///
+/// `request_time` is a configuration that is set in the wallet, and automatically populated to
+/// the SuiClient created from the wallet.
 pub fn create_wallet(
     config_path: &Path,
     sui_env: SuiEnv,
@@ -329,7 +332,7 @@ pub fn create_wallet(
     }
     .persisted(config_path)
     .save()?;
-    load_wallet_context_from_path_with_request_timeout(Some(config_path), request_timeout)
+    load_wallet_context_from_path(Some(config_path), request_timeout)
 }
 
 /// Sends a request to the faucet to request coins for `address`.

--- a/docker/walrus-antithesis/build-test-config-image/files/deploy-walrus.sh
+++ b/docker/walrus-antithesis/build-test-config-image/files/deploy-walrus.sh
@@ -36,5 +36,5 @@ echo "Generating dry run configs"
   --extra-client-wallets stress,staking \
   --admin-wallet-path /opt/walrus/outputs/sui_admin.yaml \
   --sui-amount 1000000000000 \
-  --client-config-request-timeout 120s \
+  --sui-client-request-timeout 90s \
   || die "Failed to generate dry-run configs"

--- a/docker/walrus-antithesis/build-test-config-image/files/deploy-walrus.sh
+++ b/docker/walrus-antithesis/build-test-config-image/files/deploy-walrus.sh
@@ -36,4 +36,5 @@ echo "Generating dry run configs"
   --extra-client-wallets stress,staking \
   --admin-wallet-path /opt/walrus/outputs/sui_admin.yaml \
   --sui-amount 1000000000000 \
+  --client-config-request-timeout 120s \
   || die "Failed to generate dry-run configs"


### PR DESCRIPTION
## Description

Add a request timeout config option in ClientConfig (client side) and SuiConfig (server side) to config
the WalletContext and SuiClient request timeout communicating with Sui.

By default we are not setting it, which is the same behavior as today.

This is needed mostly for antithesis test at the moment.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
