### PR TITLE
fix: epoch shard assignment should always use node `event_epoch` rather than the epoch from the event

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -1783,7 +1783,6 @@ impl StorageNodeInner {
         }
 
         tracing::error!("unknown epoch {} when checking shard assignment", epoch);
-
         anyhow::bail!("unknown epoch {} when checking shard assignment", epoch);
     }
 
@@ -6009,6 +6008,7 @@ mod tests {
         Ok(())
     }
 
+    // Tests that blob extension is correctly handled after multiple epochs.
     #[tokio::test]
     async fn extend_blob_after_multiple_epochs() -> TestResult {
         let _ = tracing_subscriber::fmt::try_init();
@@ -6017,7 +6017,8 @@ mod tests {
             cluster_with_initial_epoch_and_certified_blob(&[&[0, 1, 2, 3]], &[], 1, None).await?;
 
         let blob_details = EncodedBlob::new(BLOB, cluster.encoding_config());
-        println!("blob_details: {:?}", blob_details.blob_id());
+
+        println!("blob to be extended: {:?}", blob_details.blob_id());
         let object_id = ObjectID::random();
         events.send(
             BlobRegistered {
@@ -6037,6 +6038,7 @@ mod tests {
             .into(),
         )?;
 
+        // Advance to multiple epochs before extending the blob.
         advance_cluster_to_epoch(&cluster, &[&events], 4).await?;
 
         events.send(

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -1790,7 +1790,6 @@ impl StorageNodeInner {
                 .to_vec());
         }
 
-        tracing::error!("unknown epoch {} when checking shard assignment", epoch);
         anyhow::bail!("unknown epoch {} when checking shard assignment", epoch);
     }
 
@@ -6026,7 +6025,7 @@ mod tests {
 
         let blob_details = EncodedBlob::new(BLOB, cluster.encoding_config());
 
-        println!("blob to be extended: {:?}", blob_details.blob_id());
+        tracing::info!("blob to be extended: {:?}", blob_details.blob_id());
         let object_id = ObjectID::random();
         events.send(
             BlobRegistered {

--- a/crates/walrus-simtest/src/test_utils.rs
+++ b/crates/walrus-simtest/src/test_utils.rs
@@ -6,13 +6,13 @@
 /// and consistency verification.
 pub mod simtest_utils {
     use std::{
-        collections::HashMap,
+        collections::{HashMap, HashSet},
         sync::{atomic::AtomicBool, Arc, Mutex},
         time::Duration,
     };
 
     use anyhow::Context;
-    use rand::Rng;
+    use rand::{seq::IteratorRandom, Rng};
     use sui_types::base_types::ObjectID;
     use tokio::task::JoinHandle;
     use walrus_core::{
@@ -49,6 +49,7 @@ pub mod simtest_utils {
         client: &WithTempDir<Client<SuiContractClient>>,
         data_length: usize,
         write_only: bool,
+        blobs_written: &mut HashSet<ObjectID>,
     ) -> anyhow::Result<()> {
         // Get a random epoch length for the blob to be stored.
         let epoch_ahead = rand::thread_rng().gen_range(1..=5);
@@ -96,9 +97,26 @@ pub mod simtest_utils {
             blob_confirmation.blob_id
         );
 
+        blobs_written.insert(blob_confirmation.id);
+
         if write_only {
             tracing::info!("write-only mode, skipping read verification");
             return Ok(());
+        }
+
+        // Probabilstically extend one of the blobs from blobs_written.
+        if rand::thread_rng().gen_bool(0.1) {
+            let blob_obj_id = blobs_written
+                .iter()
+                .choose(&mut rand::thread_rng())
+                .unwrap();
+            let result = client
+                .as_ref()
+                .sui_client()
+                .extend_blob(*blob_obj_id, 5)
+                .await;
+            // TODO(zhewu): account for already expired blobs.
+            tracing::info!("extend blob {:?} result: {:?}", blob_obj_id, result);
         }
 
         tracing::info!("attempting to read blob using primary slivers");
@@ -167,13 +185,19 @@ pub mod simtest_utils {
     ) -> JoinHandle<()> {
         tokio::spawn(async move {
             let mut data_length = 64;
+            let mut blobs_written = HashSet::new();
             loop {
                 tracing::info!("writing data with size {data_length}");
 
                 // TODO(#995): use stress client for better coverage of the workload.
-                write_read_and_check_random_blob(client_clone.as_ref(), data_length, write_only)
-                    .await
-                    .expect("workload should not fail");
+                write_read_and_check_random_blob(
+                    client_clone.as_ref(),
+                    data_length,
+                    write_only,
+                    &mut blobs_written,
+                )
+                .await
+                .expect("workload should not fail");
 
                 tracing::info!("finished writing data with size {data_length}");
 

--- a/crates/walrus-simtest/src/test_utils.rs
+++ b/crates/walrus-simtest/src/test_utils.rs
@@ -163,12 +163,12 @@ pub mod simtest_utils {
         Ok(())
     }
 
-    /// Probabilstically extend one of the blobs from blobs_written.
+    /// Probabilistically extend one of the blobs from blobs_written.
     async fn maybe_extend_blob(
         client: &WithTempDir<Client<SuiContractClient>>,
         blobs_written: &HashSet<ObjectID>,
     ) {
-        // Probabilstically extend one of the blobs from blobs_written.
+        // Probabilistically extend one of the blobs from blobs_written.
         if rand::thread_rng().gen_bool(0.1) {
             let blob_obj_id = blobs_written
                 .iter()

--- a/crates/walrus-simtest/tests/simtest.rs
+++ b/crates/walrus-simtest/tests/simtest.rs
@@ -7,6 +7,7 @@
 #[cfg(msim)]
 mod tests {
     use std::{
+        collections::HashSet,
         sync::{atomic::AtomicBool, Arc},
         time::Duration,
     };
@@ -73,7 +74,8 @@ mod tests {
             .await
             .unwrap();
 
-        simtest_utils::write_read_and_check_random_blob(&client, 31415, false)
+        let mut blobs_written = HashSet::new();
+        simtest_utils::write_read_and_check_random_blob(&client, 31415, false, &mut blobs_written)
             .await
             .expect("workload should not fail");
 
@@ -214,7 +216,6 @@ mod tests {
         sui_simulator::task::kill_current_node(Some(crash_duration));
     }
 
-    #[ignore = "ignore integration simtests by default"]
     #[walrus_simtest]
     async fn test_new_node_joining_cluster() {
         register_fail_point("fail_point_direct_shard_sync_recovery", move || {

--- a/crates/walrus-simtest/tests/simtest.rs
+++ b/crates/walrus-simtest/tests/simtest.rs
@@ -216,6 +216,7 @@ mod tests {
         sui_simulator::task::kill_current_node(Some(crash_duration));
     }
 
+    #[ignore = "ignore integration simtests by default"]
     #[walrus_simtest]
     async fn test_new_node_joining_cluster() {
         register_fail_point("fail_point_direct_shard_sync_recovery", move || {

--- a/crates/walrus-simtest/tests/simtest_failure.rs
+++ b/crates/walrus-simtest/tests/simtest_failure.rs
@@ -78,11 +78,17 @@ mod tests {
 
         // Run workload and wait until a crash is triggered.
         let mut data_length = 31415;
+        let mut blobs_written = HashSet::new();
         loop {
             // TODO(#995): use stress client for better coverage of the workload.
-            simtest_utils::write_read_and_check_random_blob(&client, data_length, false)
-                .await
-                .expect("workload should not fail");
+            simtest_utils::write_read_and_check_random_blob(
+                &client,
+                data_length,
+                false,
+                &mut blobs_written,
+            )
+            .await
+            .expect("workload should not fail");
 
             data_length += 1024;
             if fail_triggered.load(std::sync::atomic::Ordering::SeqCst) {
@@ -92,11 +98,17 @@ mod tests {
 
         // Continue running the workload for another 60 seconds.
         let _ = tokio::time::timeout(Duration::from_secs(60), async {
+            let mut blobs_written = HashSet::new();
             loop {
                 // TODO(#995): use stress client for better coverage of the workload.
-                simtest_utils::write_read_and_check_random_blob(&client, data_length, false)
-                    .await
-                    .expect("workload should not fail");
+                simtest_utils::write_read_and_check_random_blob(
+                    &client,
+                    data_length,
+                    false,
+                    &mut blobs_written,
+                )
+                .await
+                .expect("workload should not fail");
 
                 data_length += 1024;
             }
@@ -383,6 +395,7 @@ mod tests {
         // stopped the workload once started crashing the node.
         let mut data_length = 64;
         let workload_start_time = Instant::now();
+        let mut blobs_written = HashSet::new();
         loop {
             if workload_start_time.elapsed() > Duration::from_secs(20) {
                 tracing::info!("generated 60s of data; stopping workload");
@@ -395,6 +408,7 @@ mod tests {
                 client_clone.as_ref(),
                 data_length,
                 true,
+                &mut blobs_written,
             )
             .await
             .expect("workload should not fail");

--- a/crates/walrus-sui/src/types/events.rs
+++ b/crates/walrus-sui/src/types/events.rs
@@ -350,6 +350,14 @@ impl BlobEvent {
             BlobEvent::DenyListBlobDeleted(_) => "DenyListBlobDeleted",
         }
     }
+
+    /// Returns true if the event is a blob extension.
+    pub fn is_blob_extension(&self) -> bool {
+        match self {
+            BlobEvent::Certified(event) => event.is_extension,
+            _ => false,
+        }
+    }
 }
 
 impl TryFrom<SuiEvent> for BlobEvent {
@@ -843,6 +851,16 @@ impl ContractEvent {
             ContractEvent::EpochChangeEvent(event) => event.event_epoch(),
             ContractEvent::PackageEvent(event) => event.event_epoch(),
             ContractEvent::DenyListEvent(event) => event.event_epoch(),
+        }
+    }
+
+    /// Returns true if the event is a blob extension.
+    pub fn is_blob_extension(&self) -> bool {
+        match self {
+            ContractEvent::BlobEvent(event) => event.is_blob_extension(),
+            ContractEvent::EpochChangeEvent(_) => false,
+            ContractEvent::PackageEvent(_) => false,
+            ContractEvent::DenyListEvent(_) => false,
         }
     }
 }


### PR DESCRIPTION
## Description

Certified blob's event epoch is the epoch that the blob is originally certified, not the epoch of the event generated.
This epoch can be very old if certified blob event is generated from a blob extension.

## Test plan

Unittest, integration test, local testbed.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
