### PR TITLE
fix: cherry pick epoch shard assignment should always use node `event_epoch` rather than the epoch from the event

### DIFF
--- a/crates/walrus-simtest/tests/simtest.rs
+++ b/crates/walrus-simtest/tests/simtest.rs
@@ -7,6 +7,7 @@
 #[cfg(msim)]
 mod tests {
     use std::{
+        collections::HashSet,
         sync::{atomic::AtomicBool, Arc},
         time::Duration,
     };
@@ -79,7 +80,8 @@ mod tests {
             .await
             .unwrap();
 
-        simtest_utils::write_read_and_check_random_blob(&client, 31415, false)
+        let mut blobs_written = HashSet::new();
+        simtest_utils::write_read_and_check_random_blob(&client, 31415, false, &mut blobs_written)
             .await
             .expect("workload should not fail");
 

--- a/crates/walrus-simtest/tests/simtest_failure.rs
+++ b/crates/walrus-simtest/tests/simtest_failure.rs
@@ -84,11 +84,17 @@ mod tests {
 
         // Run workload and wait until a crash is triggered.
         let mut data_length = 31415;
+        let mut blobs_written = HashSet::new();
         loop {
             // TODO(#995): use stress client for better coverage of the workload.
-            simtest_utils::write_read_and_check_random_blob(&client, data_length, false)
-                .await
-                .expect("workload should not fail");
+            simtest_utils::write_read_and_check_random_blob(
+                &client,
+                data_length,
+                false,
+                &mut blobs_written,
+            )
+            .await
+            .expect("workload should not fail");
 
             data_length += 1024;
             if fail_triggered.load(std::sync::atomic::Ordering::SeqCst) {
@@ -98,11 +104,17 @@ mod tests {
 
         // Continue running the workload for another 60 seconds.
         let _ = tokio::time::timeout(Duration::from_secs(60), async {
+            let mut blobs_written = HashSet::new();
             loop {
                 // TODO(#995): use stress client for better coverage of the workload.
-                simtest_utils::write_read_and_check_random_blob(&client, data_length, false)
-                    .await
-                    .expect("workload should not fail");
+                simtest_utils::write_read_and_check_random_blob(
+                    &client,
+                    data_length,
+                    false,
+                    &mut blobs_written,
+                )
+                .await
+                .expect("workload should not fail");
 
                 data_length += 1024;
             }
@@ -391,6 +403,7 @@ mod tests {
         // stopped the workload once started crashing the node.
         let mut data_length = 64;
         let workload_start_time = Instant::now();
+        let mut blobs_written = HashSet::new();
         loop {
             if workload_start_time.elapsed() > Duration::from_secs(20) {
                 tracing::info!("generated 60s of data; stopping workload");
@@ -403,6 +416,7 @@ mod tests {
                 client_clone.as_ref(),
                 data_length,
                 true,
+                &mut blobs_written,
             )
             .await
             .expect("workload should not fail");

--- a/crates/walrus-sui/src/types/events.rs
+++ b/crates/walrus-sui/src/types/events.rs
@@ -350,6 +350,14 @@ impl BlobEvent {
             BlobEvent::DenyListBlobDeleted(_) => "DenyListBlobDeleted",
         }
     }
+
+    /// Returns true if the event is a blob extension.
+    pub fn is_blob_extension(&self) -> bool {
+        match self {
+            BlobEvent::Certified(event) => event.is_extension,
+            _ => false,
+        }
+    }
 }
 
 impl TryFrom<SuiEvent> for BlobEvent {
@@ -843,6 +851,16 @@ impl ContractEvent {
             ContractEvent::EpochChangeEvent(event) => event.event_epoch(),
             ContractEvent::PackageEvent(event) => event.event_epoch(),
             ContractEvent::DenyListEvent(event) => event.event_epoch(),
+        }
+    }
+
+    /// Returns true if the event is a blob extension.
+    pub fn is_blob_extension(&self) -> bool {
+        match self {
+            ContractEvent::BlobEvent(event) => event.is_blob_extension(),
+            ContractEvent::EpochChangeEvent(_) => false,
+            ContractEvent::PackageEvent(_) => false,
+            ContractEvent::DenyListEvent(_) => false,
         }
     }
 }


### PR DESCRIPTION
## Description

Cherry-pick #1990 

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
