### PR TITLE
feat: add getters to SharedBlob

### DIFF
--- a/contracts/walrus/sources/system/shared_blob.move
+++ b/contracts/walrus/sources/system/shared_blob.move
@@ -50,3 +50,13 @@ public fun extend(
     system.extend_blob(&mut self.blob, extended_epochs, &mut coin);
     self.funds.join(coin.into_balance());
 }
+
+/// Returns a reference to the wrapped `Blob`.
+public fun blob(self: &SharedBlob): &Blob {
+    &self.blob
+}
+
+/// Returns the balance of funds stored in the `SharedBlob`.
+public fun funds(self: &SharedBlob): &Balance<WAL> {
+    &self.funds
+}


### PR DESCRIPTION
## Description

Describe the changes or additions included in this PR.

Added getters that return references to the `Blob` and `Balance<WAL>` in the `SharedBlob` object. Right now, smart contracts onchain have no insight into `Blob` stored within a `SharedBlob`. For example, imagine a `Table<u256, ID>` that maps a Blob ID to an ID of a `SharedBlob`. Without access to the underlying `Blob`, it's not possible to validate that Blob ID is correct.