### PR TITLE
feat(client): add `walrus completion` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1960,6 +1960,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06f5378ea264ad4f82bbc826628b5aad714a75abf6ece087e923010eb937fb6"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12107,6 +12116,7 @@ dependencies = [
  "checkpoint-downloader",
  "chrono",
  "clap",
+ "clap_complete",
  "colored",
  "diesel",
  "diesel-async",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ bytes = { version = "1.10.1", default-features = false, features = ["serde"] }
 checkpoint-downloader = { path = "crates/checkpoint-downloader" }
 chrono = "0.4"
 clap = { version = "4.5.37", features = ["derive"] }
+clap_complete = "4.5.47"
 colored = "2.2.0"
 criterion = "0.5.1"
 diesel = { version = "2.2", features = ["chrono", "postgres", "uuid"] }

--- a/crates/walrus-service/Cargo.toml
+++ b/crates/walrus-service/Cargo.toml
@@ -85,6 +85,7 @@ bytes = { workspace = true, optional = true }
 checkpoint-downloader = { workspace = true, optional = true }
 chrono.workspace = true
 clap.workspace = true
+clap_complete.workspace = true
 colored = { workspace = true, optional = true }
 diesel = { workspace = true, optional = true }
 diesel-async = { workspace = true, optional = true }

--- a/crates/walrus-service/bin/client.rs
+++ b/crates/walrus-service/bin/client.rs
@@ -5,9 +5,12 @@
 
 use std::process::ExitCode;
 
-use anyhow::Result;
+
+use anyhow::{anyhow, Result};
 use chrono::{DateTime, Duration, Utc};
-use clap::Parser;
+use clap::{CommandFactory, Parser, ValueEnum as _};
+use clap_complete::Shell;
+use itertools::Itertools;
 use serde::Deserialize;
 use walrus_service::{
     client::cli::{error, App, ClientCommandRunner, Commands},
@@ -85,6 +88,27 @@ fn client() -> Result<()> {
             tracing::debug!(%metrics_address, "started metrics and logging on separate runtime");
 
             runner.run_daemon_app(command, runtime)
+        }
+        Commands::Completion { shell } => {
+            let sh = if let Some(shell) = shell {
+                Shell::from_str(&shell, true).map_err(|e| {
+                    let possible_shells: String = Shell::value_variants()
+                        .into_iter()
+                        .map(|s| s.to_string())
+                        .join(",");
+
+                    anyhow!("{e}. Possible values: {}", possible_shells)
+                })
+            } else {
+                Shell::from_env().ok_or(anyhow!("Could not auto-detect shell"))
+            }?;
+            clap_complete::generate(
+                sh,
+                &mut App::command(),
+                env!("CARGO_BIN_NAME"),
+                &mut std::io::stdout(),
+            );
+            return Ok(());
         }
         Commands::Json { .. } => unreachable!("we have extracted the json command above"),
     }

--- a/crates/walrus-service/bin/client.rs
+++ b/crates/walrus-service/bin/client.rs
@@ -92,7 +92,7 @@ fn client() -> Result<()> {
             let sh = if let Some(shell) = shell {
                 Shell::from_str(&shell, true).map_err(|e| {
                     let possible_shells: String = Shell::value_variants()
-                        .into_iter()
+                        .iter()
                         .map(|s| s.to_string())
                         .join(",");
 
@@ -107,7 +107,7 @@ fn client() -> Result<()> {
                 env!("CARGO_BIN_NAME"),
                 &mut std::io::stdout(),
             );
-            return Ok(());
+            Ok(())
         }
         Commands::Json { .. } => unreachable!("we have extracted the json command above"),
     }

--- a/crates/walrus-service/bin/client.rs
+++ b/crates/walrus-service/bin/client.rs
@@ -5,7 +5,6 @@
 
 use std::process::ExitCode;
 
-
 use anyhow::{anyhow, Result};
 use chrono::{DateTime, Duration, Utc};
 use clap::{CommandFactory, Parser, ValueEnum as _};

--- a/crates/walrus-service/src/client/cli/args.rs
+++ b/crates/walrus-service/src/client/cli/args.rs
@@ -155,7 +155,6 @@ pub enum Commands {
         command_string: Option<String>,
     },
     /// Generate autocompletion script
-    #[clap(name = "completion")]
     Completion {
         /// Shell type to generate completion script for the specified shell.
         #[arg(long)]

--- a/crates/walrus-service/src/client/cli/args.rs
+++ b/crates/walrus-service/src/client/cli/args.rs
@@ -154,6 +154,13 @@ pub enum Commands {
         #[arg(verbatim_doc_comment)]
         command_string: Option<String>,
     },
+    /// Generate autocompletion script
+    #[clap(name = "completion")]
+    Completion {
+        /// Shell type to generate completion script for the specified shell.
+        #[arg(long)]
+        shell: Option<String>,
+    },
     /// Commands to run the binary in CLI mode.
     #[command(flatten)]
     #[serde(untagged)]
@@ -543,7 +550,7 @@ pub enum CliCommands {
     },
     /// Administration subcommands for storage node operators.
     NodeAdmin {
-        #[arg(long, global = true)]
+        #[arg(long, global = true, required = false)]
         /// The ID of the node for which the operation should be performed.
         node_id: ObjectID,
         /// The specific node admin command to run.

--- a/docs/book/usage/client-cli.md
+++ b/docs/book/usage/client-cli.md
@@ -16,6 +16,9 @@ If you have multiple *contexts* in your configuration file (as in the default on
 [setup page](./setup.md#configuration)), you can specify the context for each command through the
 `--context` option.
 
+You can generate a bash/zsh/fish completion script with `walrus completion` and place it in the appropriate
+directory like `~/.local/share/bash-completion/completions`.
+
 ## Walrus system information
 
 Information about the Walrus system is available through the `walrus info` command. It provides an


### PR DESCRIPTION
## Description

Generates shell completion scripts that can be used for walrus packages. Optionally use --shell for specific shell output.

## Test plan

```
target/debug/walrus completion > comp
source comp
export PATH=$PATH:./target/debug
walrus <tab tab>

checked output of
target/debug/walrus completion --shell=zsh
```

---

## Release notes

- [x] CLI: Add new `completion` command to generate completion scripts for various shells.
