### PR TITLE
feat: optimize call to reserve storage for multiple blobs

### DIFF
--- a/crates/walrus-sui/src/client/transaction_builder.rs
+++ b/crates/walrus-sui/src/client/transaction_builder.rs
@@ -303,6 +303,26 @@ impl WalrusPtbBuilder {
         Ok(result_arg)
     }
 
+    /// Adds a call to `storage_resource::split_by_size` to the `pt_builder` and returns
+    /// the result [`Argument`].
+    ///
+    /// The call modifies the input argument to cover `split_size` and a new object covering
+    /// the initial size minus `split_size` is created.
+    pub async fn split_storage_by_size(
+        &mut self,
+        storage_resource: ArgumentOrOwnedObject,
+        split_size: u64,
+    ) -> SuiClientResult<Argument> {
+        let split_arguments = vec![
+            self.argument_from_arg_or_obj(storage_resource).await?,
+            self.pt_builder.pure(split_size)?,
+        ];
+        let result_arg =
+            self.walrus_move_call(contracts::storage_resource::split_by_size, split_arguments)?;
+        self.add_result_to_be_consumed(result_arg);
+        Ok(result_arg)
+    }
+
     /// Adds a call to `register_blob` to the `pt_builder` and returns the result [`Argument`].
     pub async fn register_blob(
         &mut self,


### PR DESCRIPTION
## Description

Reduces the gas cost for calls to reserve storage when storing multiple blobs by buying one large storage object and splitting it instead of buying an individual storage resource for each blob.

The plots below show the computation cost before and after the optimization (note the different y-axis scales, 1e7 vs 1e6).

### Before

![reserve_and_register_computation_cost_per_blob](https://github.com/user-attachments/assets/964d0e59-a2dc-4752-a38f-ae0392ae0128)

### After

![reserve_and_register_computation_cost_per_blob](https://github.com/user-attachments/assets/6ae567a8-0018-4985-a796-306115243373)


## Test plan

- existing tests
- gas cost benchmarks (see #2001 )

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
