### PR TITLE
fix(client): do not create transactions with more than 256 gas coins

### DIFF
--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -65,9 +65,13 @@ use walrus_sui::{
         SuiClientError,
         SuiContractClient,
         UpgradeType,
+        retry_client::RetriableSuiClient,
     },
     system_setup::copy_recursively,
-    test_utils::system_setup::{development_contract_dir, testnet_contract_dir},
+    test_utils::{
+        self,
+        system_setup::{development_contract_dir, testnet_contract_dir},
+    },
     types::{
         Blob,
         BlobEvent,
@@ -77,6 +81,7 @@ use walrus_sui::{
     },
 };
 use walrus_test_utils::{Result as TestResult, WithTempDir, assert_unordered_eq, async_param_test};
+use walrus_utils::backoff::ExponentialBackoffConfig;
 
 async_param_test! {
     #[ignore = "ignore E2E tests by default"]
@@ -2146,5 +2151,80 @@ async fn test_ptb_retriable_error() -> TestResult {
 
     // Clean up the fail point
     clear_fail_point("ptb_executor_stake_pool_retriable_error");
+    Ok(())
+}
+
+/// Tests the select_coins function on the retriable sui client works as expected when dealing
+/// with a large number of coins.
+#[ignore = "ignore E2E tests by default"]
+#[walrus_simtest]
+pub async fn test_select_coins_max_objects() -> TestResult {
+    telemetry_subscribers::init_for_testing();
+    let (sui_cluster_handle, _, _, _) = test_cluster::E2eTestSetupBuilder::new().build().await?;
+
+    // Create a new wallet on the cluster.
+    let cluster_wallet = walrus_sui::config::load_wallet_context_from_path(
+        Some(
+            sui_cluster_handle
+                .lock()
+                .await
+                .wallet_path()
+                .await
+                .as_path(),
+        ),
+        None,
+    )?;
+    let env = cluster_wallet.config.get_active_env()?.to_owned();
+    let mut wallet = test_utils::temp_dir_wallet(None, env)?;
+
+    let sui = |sui: u64| (sui * 1_000_000_000);
+
+    // Add 4 coins with 1 SUI each to the wallet.
+    let address = wallet.as_mut().active_address()?;
+    for _ in 0..4 {
+        sui_cluster_handle
+            .lock()
+            .await
+            .fund_addresses_with_sui(vec![address], Some(sui(1)))
+            .await?;
+    }
+
+    // Create a new client with the funded wallet.
+    let retry_client =
+        RetriableSuiClient::new_from_wallet(&wallet.inner, ExponentialBackoffConfig::default())
+            .await?;
+
+    // The maximum number of coins that can be selected to reach the amount.
+    let max_num_coins = 2;
+
+    let result = retry_client
+        .select_coins_with_limit(address, None, sui(1).into(), vec![], max_num_coins)
+        .await;
+    assert!(result.is_ok(), "1 SUI can be constructed with <= 2 coins");
+
+    let result = retry_client
+        .select_coins_with_limit(address, None, sui(3).into(), vec![], max_num_coins)
+        .await;
+    if let Err(error) = result {
+        assert!(
+            matches!(error, SuiClientError::InsufficientFundsWithMaxCoins(_)),
+            "expected InsufficientFundsWithMaxCoins error"
+        );
+    } else {
+        panic!("3 SUI cannot be achieved with 2 coins, but the wallet has 4 SUI");
+    }
+
+    let result = retry_client
+        .select_coins_with_limit(address, None, sui(5).into(), vec![], max_num_coins)
+        .await;
+    if let Err(error) = result {
+        assert!(
+            matches!(error, SuiClientError::SuiSdkError(_)),
+            "expected SuiSdkError error"
+        );
+    } else {
+        panic!("the wallet does not have 5 SUI");
+    }
+
     Ok(())
 }

--- a/crates/walrus-sui/src/client.rs
+++ b/crates/walrus-sui/src/client.rs
@@ -189,8 +189,9 @@ pub enum SuiClientError {
     StakeBelowThreshold(u64),
     /// The required coin balance cannot be achieved with the maximum number of coins allowed.
     #[error(
-        "the required coin balance for coins of type {0} cannot be achieved with the maximum \
-        number of coins allowed ({MAX_GAS_PAYMENT_OBJECTS}); consider merging the coins in the wallet and retrying"
+        "there is enough balance to cover the requested amount of type {0}, but cannot be achieved \
+        with less than the maximum number of coins allowed ({MAX_GAS_PAYMENT_OBJECTS}); consider \
+        merging the coins in the wallet and retrying"
     )]
     InsufficientFundsWithMaxCoins(String),
 }

--- a/crates/walrus-sui/src/client.rs
+++ b/crates/walrus-sui/src/client.rs
@@ -17,7 +17,7 @@ use anyhow::{Context, Result, anyhow};
 use contract_config::ContractConfig;
 use futures::future::BoxFuture;
 use move_package::BuildConfig as MoveBuildConfig;
-use retry_client::RetriableSuiClient;
+use retry_client::{RetriableSuiClient, retriable_sui_client::MAX_GAS_PAYMENT_OBJECTS};
 use sui_package_management::LockCommand;
 use sui_sdk::{
     rpc_types::{
@@ -187,6 +187,12 @@ pub enum SuiClientError {
         FROST for staking"
     )]
     StakeBelowThreshold(u64),
+    /// The required coin balance cannot be achieved with the maximum number of coins allowed.
+    #[error(
+        "the required coin balance for coins of type {0} cannot be achieved with the maximum \
+        number of coins allowed ({MAX_GAS_PAYMENT_OBJECTS}); consider merging the coins in the wallet and retrying"
+    )]
+    InsufficientFundsWithMaxCoins(String),
 }
 
 impl SuiClientError {

--- a/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
@@ -303,11 +303,12 @@ impl RetriableSuiClient {
             } else {
                 // We already have too many objects in the set, but we don't have enough total
                 // value. Try to replace the minimum with the current coin.
-                let min_bal_coin = selected_coins
+                let min_balance = selected_coins
                     .peek()
-                    .expect("since we have >= MAX_GAS_PAYMENT_OBJECTS, the root must exist");
+                    .expect("since we have >= MAX_GAS_PAYMENT_OBJECTS, the root must exist")
+                    .0
+                    .balance() as u128;
 
-                let min_balance = min_bal_coin.0.balance() as u128;
                 if coin_balance >= min_balance {
                     // Replace the minimum.
                     total_selected += coin_balance - min_balance;

--- a/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
@@ -309,7 +309,7 @@ impl RetriableSuiClient {
                     .0
                     .balance() as u128;
 
-                if coin_balance >= min_balance {
+                if coin_balance > min_balance {
                     // Replace the minimum.
                     total_selected += coin_balance - min_balance;
                     selected_coins.pop();

--- a/crates/walrus-sui/src/test_utils.rs
+++ b/crates/walrus-sui/src/test_utils.rs
@@ -533,7 +533,7 @@ pub async fn wallet_for_testing(
 
 /// Funds the `recipients` with gas objects with `amount` or with [`DEFAULT_FUNDING_PER_COIN`]
 /// SUI each if no amount is provided.
-async fn fund_addresses(
+pub(crate) async fn fund_addresses(
     funding_wallet: &mut WalletContext,
     recipients: Vec<SuiAddress>,
     amount: Option<u64>,

--- a/crates/walrus-sui/src/test_utils.rs
+++ b/crates/walrus-sui/src/test_utils.rs
@@ -70,7 +70,8 @@ use crate::{
 
 /// Default gas budget for some transactions in tests and benchmarks.
 const DEFAULT_GAS_BUDGET: u64 = 500_000_000;
-const DEFAULT_FUNDING_PER_COIN: u64 = 1_000_000_000_000;
+/// Default amount of coin sent when funding a wallet.
+pub const DEFAULT_FUNDING_PER_COIN: u64 = 1_000_000_000_000;
 
 /// Returns a random `EventID` for testing.
 pub fn event_id_for_testing() -> EventID {
@@ -533,7 +534,7 @@ pub async fn wallet_for_testing(
 
 /// Funds the `recipients` with gas objects with `amount` or with [`DEFAULT_FUNDING_PER_COIN`]
 /// SUI each if no amount is provided.
-pub(crate) async fn fund_addresses(
+pub async fn fund_addresses(
     funding_wallet: &mut WalletContext,
     recipients: Vec<SuiAddress>,
     amount: Option<u64>,


### PR DESCRIPTION
## Description

Ensures that the coin selection process always returns 256 objects or less.
Since the coins are not returned in sorted order by balance, this change introduces a min-heap to keep track of the largest 256 coins encountered.

Closes WAL-429

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
