### PR TITLE
docs: clean up links in old blog posts

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -16,7 +16,6 @@ theme = "docs/theme"
 [output.linkcheck]
 exclude = [
   'google\.com',
-  'walrus\.site',
   'x\.com',
 ]
 follow-web-links = true

--- a/docs/book/blog/00_intro.md
+++ b/docs/book/blog/00_intro.md
@@ -4,5 +4,6 @@ This part of the Walrus documentation is used to publish news and updates about 
 development!
 
 ```admonish warning
-Older blog posts may contain information that is no longer accurate and broken links.
+We generally keep older blog posts unchanged besides possibly fixing typos and updating or removing
+broken links. As a result they may contain information that is no longer accurate.
 ```

--- a/docs/book/blog/01_announcing_walrus.md
+++ b/docs/book/blog/01_announcing_walrus.md
@@ -3,8 +3,8 @@
 Published on: 2024-06-18
 
 ```admonish warning
-This blog post is shown in its original form. It may contain information that is no longer accurate
-and broken links.
+This blog post is shown in its original form and may contain information that is no longer accurate.
+Some broken links may have been updated or removed.
 ```
 
 Walrus is an innovative decentralized storage network for blockchain apps and autonomous agents. The
@@ -81,10 +81,9 @@ Stay tuned for more updates on how Walrus will revolutionize data storage in the
 ## What can developers build?
 
 As part of this developer preview, we provide a binary client (currently macOS, ubuntu) that can be
-operated from the [command line interface](https://docs.walrus.site/usage/client-cli.html), a [JSON
-API](https://docs.walrus.site/usage/json-api.html), and an [HTTP
-API](https://docs.walrus.site/usage/web-api.html). We also offer the community an aggregator and
-publisher service and a Devnet deployment of 10 storage nodes operated by Mysten Labs.
+operated from the [command line interface](../usage/client-cli.md), a [JSON API](../usage/json-api.md),
+and an [HTTP API](../usage/web-api.md). We also offer the community an aggregator and publisher
+service and a Devnet deployment of 10 storage nodes operated by Mysten Labs.
 
 We hope developers will experiment with building applications that leverage the Walrus Decentralized
 Store in a variety of ways. As examples, we hope to see the community build:
@@ -122,7 +121,7 @@ We are excited to see what else the web3 developer community can imagine!
 ## Getting Started
 
 For this developer preview the public Walrus Devnet is openly available to all developers. Developer
-documentation is available at <https://docs.walrus.site>.
+documentation is available at <https://docs.wal.app>.
 
 SUI Testnet token is the main currency for interacting with Walrus. Developers pay for Walrus Devnet
 storage using SUI Testnet tokens which can be acquired at the [Sui Testnet Discord
@@ -130,6 +129,5 @@ faucet](https://discord.com/channels/916379725201563759/1037811694564560966).
 
 ## One more thing …
 
-The [Walrus Sites website](https://walrus.site), the [Walrus docs](https://docs.walrus.site), and
-[this very blog](https://blog.walrus.site) are hosted on Walrus. To learn more about Walrus Sites
-and how you can deploy your own, [click here](https://docs.walrus.site/walrus-sites/intro.html).
+The Walrus Sites website, the Walrus docs, and this very blog are hosted on Walrus. To learn more
+about Walrus Sites and how you can deploy your own, [click here](../walrus-sites/intro.md).

--- a/docs/book/blog/02_devnet_update.md
+++ b/docs/book/blog/02_devnet_update.md
@@ -3,8 +3,8 @@
 Published on: 2024-08-12
 
 ```admonish warning
-This blog post is shown in its original form. It may contain information that is no longer accurate
-and broken links.
+This blog post is shown in its original form and may contain information that is no longer accurate.
+Some broken links may have been updated or removed.
 ```
 
 We have redeployed the Walrus Devnet to incorporate various improvements to the Walrus storage nodes

--- a/docs/book/blog/03_whitepaper.md
+++ b/docs/book/blog/03_whitepaper.md
@@ -3,12 +3,12 @@
 Published on: 2024-09-17
 
 ```admonish warning
-This blog post is shown in its original form. It may contain information that is no longer accurate
-and broken links.
+This blog post is shown in its original form and may contain information that is no longer accurate.
+Some broken links may have been updated or removed.
 ```
 
 In June, Mysten Labs announced Walrus, a new decentralized secure blob store design, and introduced
-a developer preview that currently stores over [12TiB](https://capacity.walrus.site/) of data.
+a developer preview that currently stores over 12TiB of data.
 [Breaking the Ice](https://info.breakingtheice.sui.io/) gathered over 200 developers to build apps
 leveraging decentralized storage.
 

--- a/docs/book/blog/04_testnet_update.md
+++ b/docs/book/blog/04_testnet_update.md
@@ -3,8 +3,8 @@
 Published on: 2024-10-17
 
 ```admonish warning
-This blog post is shown in its original form. It may contain information that is no longer accurate
-and broken links.
+This blog post is shown in its original form and may contain information that is no longer accurate.
+Some broken links may have been updated or removed.
 ```
 
 Today, a community of operators launches the first public Walrus Testnet.
@@ -88,7 +88,7 @@ storage node committee changes: better shard allocation mechanisms upon changes 
 stake; efficient ways to sync state between storage nodes; as well as better ways for storage nodes
 to follow Sui event streams.
 
-- Explore the [Walrus staking dApp](https://stake.walrus.site).
+- Explore the Walrus staking dApp.
 - Look at recent activity on the [Walrus Explorer](https://walruscan.com/testnet/home).
 
 ## New Move contracts & documentation

--- a/docs/book/blog/05_testnet_redeployment.md
+++ b/docs/book/blog/05_testnet_redeployment.md
@@ -3,8 +3,8 @@
 Published on: 2025-01-16
 
 ```admonish warning
-This blog post is shown in its original form. It may contain information that is no longer accurate
-and broken links.
+This blog post is shown in its original form and may contain information that is no longer accurate.
+Some broken links may have been updated or removed.
 ```
 
 We are today redeploying the Walrus Testnet to incorporate various improvements, including some


### PR DESCRIPTION
## Description

This updates or removes links in older blog posts and clarifies the corresponding warning admonitions.

## Test plan

Inspect preview.
