### PR TITLE
feat(client): log warning for old clients

### DIFF
--- a/crates/walrus-service/Cargo.toml
+++ b/crates/walrus-service/Cargo.toml
@@ -174,6 +174,9 @@ walrus-proc-macros = { workspace = true, features = ["walrus-simtest"] }
 walrus-test-utils.workspace = true
 walrus-utils = { workspace = true, features = ["test-utils"] }
 
+[build-dependencies]
+chrono.workspace = true
+
 [lints]
 workspace = true
 

--- a/crates/walrus-service/build.rs
+++ b/crates/walrus-service/build.rs
@@ -2,7 +2,28 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Build script for the walrus-service crate.
+
+use std::env;
+
+use chrono::{DateTime, Utc};
+
 fn main() {
     #[cfg(feature = "backup")]
     println!("cargo:rerun-if-changed=migrations");
+
+    // Check the SOURCE_DATE_EPOCH environment variable to enable reproducible builds, see
+    // https://reproducible-builds.org/docs/source-date-epoch/.
+    let build_time = if let Ok(timestamp) = env::var("SOURCE_DATE_EPOCH") {
+        DateTime::from_timestamp(
+            timestamp
+                .parse::<i64>()
+                .expect("SOURCE_DATE_EPOCH must be set to a valid UNIX timestamp"),
+            0,
+        )
+        .expect("SOURCE_DATE_EPOCH must be set to a valid UNIX timestamp")
+    } else {
+        Utc::now()
+    };
+    println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
+    println!("cargo::rustc-env=BUILD_TIME={}", build_time.timestamp());
 }


### PR DESCRIPTION
## Description

This embeds the build time in the binary and logs a warning at runtime if the binary is more than 30 days old.

## Test plan

```console
$ export RUST_LOG=warn
$ unset SOURCE_DATE_EPOCH

$ cargo run --bin walrus -- -V
   Compiling walrus-service v1.23.0 (/Users/markuslegner/github/walrus/crates/walrus-service)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.68s
     Running `target/debug/walrus -V`
walrus 1.23.0-22cb042e62af

$ SOURCE_DATE_EPOCH=0 cargo run --bin walrus -- -V 
   Compiling walrus-service v1.23.0 (/Users/markuslegner/github/walrus/crates/walrus-service)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.79s
     Running `target/debug/walrus -V`
2025-04-24T10:40:56.566762Z  WARN walrus: This build of the Walrus client is older than 30 days. Please update to the latest version.
walrus 1.23.0-22cb042e62af

$ SOURCE_DATE_EPOCH="aoeu" cargo run --bin walrus -- -V
   Compiling walrus-service v1.23.0 (/Users/markuslegner/github/walrus/crates/walrus-service)
error: failed to run custom build command for `walrus-service v1.23.0 (/Users/markuslegner/github/walrus/crates/walrus-service)`
note: To improve backtraces for build dependencies, set the CARGO_PROFILE_DEV_BUILD_OVERRIDE_DEBUG=true environment variable to enable debug information generation.

Caused by:
  process didn't exit successfully: `/Users/markuslegner/github/walrus/target/debug/build/walrus-service-b4ed5ac9d76b42b8/build-script-build` (exit status: 101)
  --- stderr

  thread 'main' panicked at crates/walrus-service/build.rs:20:18:
  SOURCE_DATE_EPOCH must be set to a valid UNIX timestamp: ParseIntError { kind: InvalidDigit }
  stack backtrace:
     0: rust_begin_unwind
               at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/std/src/panicking.rs:695:5
     1: core::panicking::panic_fmt
               at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/core/src/panicking.rs:75:14
     2: core::result::unwrap_failed
               at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/core/src/result.rs:1704:5
     3: core::result::Result<T,E>::expect
     4: build_script_build::main
     5: core::ops::function::FnOnce::call_once
  note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```
