### PR TITLE
chore: combination of a few unrelated chores

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -98,7 +98,10 @@ jobs:
     name: Check license headers
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
-      - run: cargo install licensesnip
+      - name: Install licensesnip
+        uses: taiki-e/install-action@970d55e3ce02a46d60ffae7b4fab3dedace6e769 # pin@v2.49.13
+        with:
+          tool: licensesnip@1.7.0
       - run: licensesnip check
 
   check-all:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,7 @@ repos:
     rev: 0.18.2
     hooks:
       - id: cargo-deny
+        args: ["--all-features", "check", "--hide-inclusion-graph"]
   - repo: local
     hooks:
       - id: taplo-format

--- a/crates/walrus-service/src/testbed.rs
+++ b/crates/walrus-service/src/testbed.rs
@@ -280,12 +280,12 @@ pub async fn deploy_walrus_contract(
     }: DeployTestbedContractParameters<'_>,
 ) -> anyhow::Result<TestbedConfig> {
     const WAL_AMOUNT_EXCHANGE: u64 = 10_000_000 * 1_000_000_000;
-    // 1000 WAL for subsidies that will be used to fund the subsidy pool
-    const SUBSIDIES_AMOUNT: u64 = 1000 * 1_000_000_000;
-    // 5% buyer subsidy rate
-    const INITIAL_BUYER_SUBSIDY_RATE: u16 = 500;
-    // 10% system subsidy rate
-    const INITIAL_SYSTEM_SUBSIDY_RATE: u16 = 1000;
+    // 10M WAL for subsidies that will be used to fund the subsidy pool
+    const SUBSIDIES_AMOUNT: u64 = 10_000_000 * 1_000_000_000;
+    // 80% buyer subsidy rate
+    const INITIAL_BUYER_SUBSIDY_RATE: u16 = 8000;
+    // 80% system subsidy rate
+    const INITIAL_SYSTEM_SUBSIDY_RATE: u16 = 8000;
     // Check whether the testbed collocates the storage nodes on the same machine
     // (that is, local testbed).
     let hosts_set = hosts.iter().collect::<HashSet<_>>();

--- a/crates/walrus-sui/src/client/metrics.rs
+++ b/crates/walrus-sui/src/client/metrics.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-// Copyright (c) Mysten Labs, Inc.
-// SPDX-License-Identifier: Apache-2.0
-
 use std::time::Duration;
 
 use prometheus::{HistogramVec, IntCounterVec};


### PR DESCRIPTION
## Description

- Add `--hide-inclusion-graph` to `cargo deny` in precommit to reduce the amount of output.
- Use `taiki-e/install-action` to install `licensesnip` in CI.
- Update some default values for deploying subsidies to those currently used on Mainnet.
- Remove an old Mysten Labs copyright header.

## Test plan

Automatic tests.