### PR TITLE
fix: e2e test race condition

### DIFF
--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -83,6 +83,7 @@ use walrus_sui::{
 use walrus_test_utils::{Result as TestResult, WithTempDir, assert_unordered_eq, async_param_test};
 use walrus_utils::backoff::ExponentialBackoffConfig;
 
+/// Read a blob with retries if the blob is registered but not certified.
 async fn read_blob_with_wait_for_certification(
     client: &Client<SuiContractClient>,
     blob_id: &BlobId,


### PR DESCRIPTION
## Description

Some of the e2e tests started failing, the symptom is the blob event is slow, e.g., after storing a blob successfully, read could fail because the certify event is not processed by majority of storage nodes.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
