### PR TITLE
refactor: limit concurrent requests sent to remote nodes

### DIFF
--- a/crates/walrus-service/src/node/committee/node_service.rs
+++ b/crates/walrus-service/src/node/committee/node_service.rs
@@ -24,7 +24,7 @@ use std::{
 };
 
 use futures::{FutureExt, future::BoxFuture};
-use tower::Service;
+use tower::{Service, limit::ConcurrencyLimit};
 use walrus_core::{
     BlobId,
     Epoch,
@@ -50,6 +50,7 @@ use walrus_sui::types::StorageNode as SuiStorageNode;
 use walrus_utils::metrics::Registry;
 
 use super::{DefaultRecoverySymbol, NodeServiceFactory};
+use crate::node::config::defaults::REST_HTTP2_MAX_CONCURRENT_STREAMS;
 
 /// Requests used with a [`NodeService`].
 #[derive(Debug, Clone)]
@@ -172,14 +173,23 @@ where
 {
 }
 
+<<<<<<< HEAD
 /// A [`NodeService`] that is reachable via a [`walrus_storage_node_client::client::Client`].
 #[derive(Clone, Debug)]
 pub(crate) struct RemoteStorageNode {
     client: StorageNodeClient,
+=======
+pub(crate) type RemoteStorageNode = ConcurrencyLimit<UnboundedRemoteStorageNode>;
+
+/// A [`NodeService`] that is reachable via a [`walrus_rest_client::client::Client`].
+#[derive(Clone, Debug)]
+pub(crate) struct UnboundedRemoteStorageNode {
+    client: Client,
+>>>>>>> ef3cfa00 (refactor: limit concurrent requests sent to remote nodes)
     encoding_config: Arc<EncodingConfig>,
 }
 
-impl Service<Request> for RemoteStorageNode {
+impl Service<Request> for UnboundedRemoteStorageNode {
     type Error = NodeServiceError;
     type Response = Response;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
@@ -305,7 +315,7 @@ impl Service<Request> for RemoteStorageNode {
 // pub(crate) type LocalStorageNode = Weak<StorageNodeInner>;
 
 /// A [`NodeServiceFactory`] creating [`RemoteStorageNode`] services.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub(crate) struct DefaultNodeServiceFactory {
     /// If true, disables the use of proxies.
     ///
@@ -322,6 +332,22 @@ pub(crate) struct DefaultNodeServiceFactory {
 
     /// The registry to use for registering node metrics.
     pub registry: Option<Registry>,
+
+    /// The maximum number of outstanding requests at a time.
+    pub concurrency_limit: usize,
+}
+
+impl Default for DefaultNodeServiceFactory {
+    fn default() -> Self {
+        Self {
+            disable_use_proxy: Default::default(),
+            disable_loading_native_certs: Default::default(),
+            connect_timeout: Default::default(),
+            registry: Default::default(),
+            concurrency_limit: usize::try_from(REST_HTTP2_MAX_CONCURRENT_STREAMS)
+                .expect("number of concurrent streams fits in usize"),
+        }
+    }
 }
 
 impl DefaultNodeServiceFactory {
@@ -374,12 +400,15 @@ impl NodeServiceFactory for DefaultNodeServiceFactory {
             builder = builder.metric_registry(registry.clone());
         }
 
-        builder
-            .build(&member.network_address.0)
-            .map(|client| RemoteStorageNode {
-                client,
-                encoding_config: encoding_config.clone(),
-            })
+        builder.build(&member.network_address.0).map(|client| {
+            ConcurrencyLimit::new(
+                UnboundedRemoteStorageNode {
+                    client,
+                    encoding_config: encoding_config.clone(),
+                },
+                self.concurrency_limit,
+            )
+        })
     }
 
     fn connect_timeout(&mut self, timeout: Duration) {

--- a/crates/walrus-service/src/node/committee/node_service.rs
+++ b/crates/walrus-service/src/node/committee/node_service.rs
@@ -173,19 +173,12 @@ where
 {
 }
 
-<<<<<<< HEAD
-/// A [`NodeService`] that is reachable via a [`walrus_storage_node_client::client::Client`].
-#[derive(Clone, Debug)]
-pub(crate) struct RemoteStorageNode {
-    client: StorageNodeClient,
-=======
 pub(crate) type RemoteStorageNode = ConcurrencyLimit<UnboundedRemoteStorageNode>;
 
-/// A [`NodeService`] that is reachable via a [`walrus_rest_client::client::Client`].
+/// A [`NodeService`] that is reachable via a [`walrus_storage_node_client::client::Client`].
 #[derive(Clone, Debug)]
 pub(crate) struct UnboundedRemoteStorageNode {
-    client: Client,
->>>>>>> ef3cfa00 (refactor: limit concurrent requests sent to remote nodes)
+    client: StorageNodeClient,
     encoding_config: Arc<EncodingConfig>,
 }
 

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -673,6 +673,8 @@ pub mod defaults {
     pub const BALANCE_CHECK_FREQUENCY: Duration = Duration::from_secs(60 * 60);
     /// SUI MIST threshold under which balance checks log a warning.
     pub const BALANCE_CHECK_WARNING_THRESHOLD_MIST: u64 = 5_000_000_000;
+    /// The default number of max concurrent streams for the rest API.
+    pub const REST_HTTP2_MAX_CONCURRENT_STREAMS: u32 = 1000;
 
     /// Returns the default metrics port.
     pub fn metrics_port() -> u16 {
@@ -977,7 +979,7 @@ pub struct Http2Config {
 impl Default for Http2Config {
     fn default() -> Self {
         Self {
-            http2_max_concurrent_streams: 1000,
+            http2_max_concurrent_streams: defaults::REST_HTTP2_MAX_CONCURRENT_STREAMS,
             http2_max_pending_accept_reset_streams: 100,
             http2_initial_stream_window_size: None,
             http2_initial_connection_window_size: None,

--- a/crates/walrus-sui/benches/gas_cost_bench.rs
+++ b/crates/walrus-sui/benches/gas_cost_bench.rs
@@ -110,7 +110,7 @@ struct Args {
 
 async fn gas_cost_for_contract_calls(args: Args) -> anyhow::Result<()> {
     let mut out_file = std::fs::File::create(args.out)?;
-    out_file.write(
+    out_file.write_all(
         format!(
             "{},{},{},{},{},{},{},{},{}\n",
             "label",


### PR DESCRIPTION
## Description

Limits the number of concurrent requests that are sent to each individual storage node. In the event that the limit has been reached for an individual storage node, the node is skipped when collecting nodes to send requests to. When coupled with the exponential backoff that is already implemented, requests that fail to find sufficient ready nodes will enter exponential backoff.

## Test plan

Existing tests. The performance impact has not been measured, but will need to be observed on PTN.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
