### PR TITLE
test: simtest improvements: add event fail points to trigger node crash, and use checkpoint based event processor in all simtests

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -897,17 +897,21 @@ impl StorageNode {
                 ensure!(should_write || should_process, "event stream out of sync");
 
                 if should_process {
+                    sui_macros::fail_point!("process-event-before");
                     self.process_event(
                         stream_element.clone(),
                         element_index,
                         &mut maybe_epoch_at_start,
                     )
                     .await?;
+                    sui_macros::fail_point!("process-event-after");
                 }
 
                 if should_write {
                     if let Some(writer) = &mut event_blob_writer {
+                        sui_macros::fail_point!("write-event-before");
                         writer.write(stream_element.clone(), element_index).await?;
+                        sui_macros::fail_point!("write-event-after");
                     }
                 }
 

--- a/crates/walrus-simtest/src/test_utils.rs
+++ b/crates/walrus-simtest/src/test_utils.rs
@@ -29,9 +29,9 @@ pub mod simtest_utils {
     use walrus_sui::client::{BlobPersistence, PostStoreAction, SuiContractClient};
     use walrus_test_utils::WithTempDir;
 
-    /// The fail points related to DB access that can be used to trigger failures in the storage
+    /// The fail points related to node crash that can be used to trigger failures in the storage
     /// node.
-    pub const DB_FAIL_POINTS: &[&str] = &[
+    pub const CRASH_NODE_FAIL_POINTS: &[&str] = &[
         "batch-write-before",
         "batch-write-after",
         "put-cf-before",
@@ -39,6 +39,10 @@ pub mod simtest_utils {
         "delete-cf-before",
         "delete-cf-after",
         "create-cf-before",
+        "process-event-before",
+        "process-event-after",
+        "write-event-before",
+        "write-event-after",
     ];
 
     /// Helper function to write a random blob, read it back and check that it is the same.

--- a/crates/walrus-simtest/tests/simtest.rs
+++ b/crates/walrus-simtest/tests/simtest.rs
@@ -31,7 +31,7 @@ mod tests {
     use walrus_simtest::test_utils::simtest_utils::{
         self,
         BlobInfoConsistencyCheck,
-        DB_FAIL_POINTS,
+        CRASH_NODE_FAIL_POINTS,
     };
     use walrus_sui::client::ReadClient;
 
@@ -121,7 +121,7 @@ mod tests {
             .with_epoch_duration(Duration::from_secs(30))
             .with_test_nodes_config(TestNodesConfig {
                 node_weights: node_weights.clone(),
-                use_legacy_event_processor: true,
+                use_legacy_event_processor: false,
                 disable_event_blob_writer: false,
                 blocklist_dir: None,
                 enable_node_config_synchronizer: false,
@@ -287,7 +287,8 @@ mod tests {
                 .node_id
                 .expect("node id should be set");
             let fail_triggered_clone = fail_triggered.clone();
-            register_fail_points(DB_FAIL_POINTS, move || {
+
+            register_fail_points(CRASH_NODE_FAIL_POINTS, move || {
                 crash_target_node(
                     target_fail_node_id,
                     fail_triggered_clone.clone(),
@@ -394,7 +395,7 @@ mod tests {
             .with_epoch_duration(Duration::from_secs(30))
             .with_test_nodes_config(TestNodesConfig {
                 node_weights: vec![1, 2, 3, 3, 4],
-                use_legacy_event_processor: true,
+                use_legacy_event_processor: false,
                 disable_event_blob_writer: false,
                 blocklist_dir: None,
                 enable_node_config_synchronizer: false,
@@ -433,8 +434,7 @@ mod tests {
             .expect("node id should be set");
         let fail_triggered_clone = fail_triggered.clone();
 
-        // Trigger node crash during some DB access.
-        register_fail_points(DB_FAIL_POINTS, move || {
+        register_fail_points(CRASH_NODE_FAIL_POINTS, move || {
             crash_target_node(
                 target_fail_node_id,
                 fail_triggered_clone.clone(),

--- a/crates/walrus-simtest/tests/simtest_failure.rs
+++ b/crates/walrus-simtest/tests/simtest_failure.rs
@@ -25,7 +25,7 @@ mod tests {
     use walrus_simtest::test_utils::simtest_utils::{
         self,
         BlobInfoConsistencyCheck,
-        DB_FAIL_POINTS,
+        CRASH_NODE_FAIL_POINTS,
     };
     use walrus_sui::client::ReadClient;
 
@@ -68,7 +68,7 @@ mod tests {
         do_not_fail_nodes.insert(sui_cluster.lock().await.sim_node_handle().id());
 
         let fail_triggered_clone = fail_triggered.clone();
-        sui_macros::register_fail_points(DB_FAIL_POINTS, move || {
+        sui_macros::register_fail_points(CRASH_NODE_FAIL_POINTS, move || {
             handle_failpoint_and_crash_node_once(
                 do_not_fail_nodes.clone(),
                 fail_triggered_clone.clone(),
@@ -196,7 +196,7 @@ mod tests {
             .with_epoch_duration(Duration::from_secs(30))
             .with_test_nodes_config(TestNodesConfig {
                 node_weights: vec![1, 2, 3, 3, 4],
-                use_legacy_event_processor: true,
+                use_legacy_event_processor: false,
                 disable_event_blob_writer: false,
                 blocklist_dir: None,
                 enable_node_config_synchronizer: false,
@@ -229,8 +229,7 @@ mod tests {
             .expect("node id should be set");
         let fail_triggered_clone = fail_triggered.clone();
 
-        // Trigger node crash during some DB access.
-        sui_macros::register_fail_points(DB_FAIL_POINTS, move || {
+        sui_macros::register_fail_points(CRASH_NODE_FAIL_POINTS, move || {
             crash_target_node(
                 target_fail_node_id,
                 fail_triggered_clone.clone(),
@@ -352,7 +351,7 @@ mod tests {
             .with_epoch_duration(Duration::from_secs(10))
             .with_test_nodes_config(TestNodesConfig {
                 node_weights: vec![2, 2, 3, 3, 3],
-                use_legacy_event_processor: true,
+                use_legacy_event_processor: false,
                 disable_event_blob_writer: false,
                 blocklist_dir: None,
                 enable_node_config_synchronizer: false,
@@ -422,8 +421,7 @@ mod tests {
         let next_fail_triggered_clone = next_fail_triggered.clone();
         let crash_end_time = Instant::now() + Duration::from_secs(2 * 60);
 
-        // Trigger node crash during some DB access.
-        sui_macros::register_fail_points(DB_FAIL_POINTS, move || {
+        sui_macros::register_fail_points(CRASH_NODE_FAIL_POINTS, move || {
             repeatedly_crash_target_node(
                 target_fail_node_id,
                 next_fail_triggered_clone.clone(),


### PR DESCRIPTION
## Description

We've seen cases where DB fail points may take longer to trigger.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
