### PR TITLE
feat: Enable recovery from local node forking of event blobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12803,10 +12803,12 @@ name = "walrus-simtest"
 version = "1.27.0"
 dependencies = [
  "anyhow",
+ "bcs",
  "futures",
  "prometheus",
  "rand 0.8.5",
  "reqwest",
+ "rocksdb",
  "sui-macros",
  "sui-protocol-config",
  "sui-rpc-api",
@@ -12814,6 +12816,7 @@ dependencies = [
  "sui-types",
  "tokio",
  "tracing",
+ "typed-store 1.27.0",
  "walrus-core",
  "walrus-proc-macros",
  "walrus-sdk",

--- a/crates/walrus-service/src/common/event_blob_downloader.rs
+++ b/crates/walrus-service/src/common/event_blob_downloader.rs
@@ -6,15 +6,56 @@
 use std::path::Path;
 
 use anyhow::Result;
-use walrus_core::BlobId;
+use walrus_core::{BlobId, Epoch};
 use walrus_sdk::{client::Client as WalrusClient, error::ClientErrorKind};
 use walrus_storage_node_client::api::BlobStatus;
-use walrus_sui::client::{ReadClient, SuiReadClient};
+use walrus_sui::{
+    client::{ReadClient, SuiReadClient},
+    types::move_structs::EventBlob,
+};
 
 use crate::node::events::{
+    EventStreamCursor,
     event_blob::EventBlob as LocalEventBlob,
     event_processor::EventProcessorMetrics,
 };
+
+/// A struct that contains the metadata of an event blob.
+#[derive(Debug, Clone)]
+pub struct EventBlobWithMetadata {
+    /// The ID of the event blob.
+    pub blob_id: BlobId,
+    /// The cursor of the event stream.
+    pub event_stream_cursor: EventStreamCursor,
+    /// The epoch of the event blob.
+    pub epoch: Epoch,
+    /// The ending checkpoint sequence number of the event blob.
+    pub ending_checkpoint_sequence_number: u64,
+}
+
+impl EventBlobWithMetadata {
+    /// Returns the ending checkpoint sequence number of the event blob.
+    pub fn end(&self) -> u64 {
+        self.event_stream_cursor.element_index
+    }
+
+    /// Returns a reference to the event blob.
+    pub fn blob(&self) -> EventBlob {
+        EventBlob {
+            blob_id: self.blob_id,
+            ending_checkpoint_sequence_number: self.ending_checkpoint_sequence_number,
+        }
+    }
+}
+
+/// A struct that contains the metadata of an event blob.
+#[derive(Debug, Clone)]
+pub enum LastCertifiedEventBlob {
+    /// A struct that contains the metadata of an event blob.
+    EventBlobWithMetadata(EventBlobWithMetadata),
+    /// A reference to an event blob.
+    EventBlob(EventBlob),
+}
 
 /// Responsible for downloading and managing event blobs
 #[derive(Debug)]
@@ -29,6 +70,41 @@ impl EventBlobDownloader {
         Self {
             walrus_client,
             sui_read_client,
+        }
+    }
+
+    /// Returns the metadata of the last certified event blob.
+    pub async fn get_latest_certified_event_blob(&self) -> Result<Option<EventBlobWithMetadata>> {
+        let blob = self.sui_read_client.last_certified_event_blob().await?;
+        match blob {
+            Some(blob) => {
+                let blob_id = blob.blob_id;
+                let result = self
+                    .walrus_client
+                    .read_blob::<walrus_core::encoding::Primary>(&blob_id)
+                    .await?;
+                let blob = LocalEventBlob::new(&result)?;
+                let prev_blob_id = blob.prev_blob_id();
+                if prev_blob_id == BlobId::ZERO {
+                    return Ok(None);
+                }
+                let blob_epoch = blob.epoch();
+                let blob_ending_checkpoint_sequence_number = blob.end_checkpoint_sequence_number();
+                let blob_iter = blob.into_iter();
+                let blob_event = blob_iter
+                    .last()
+                    .ok_or(anyhow::anyhow!("No events in blob"))?;
+                Ok(Some(EventBlobWithMetadata {
+                    blob_id,
+                    event_stream_cursor: EventStreamCursor::new(
+                        blob_event.element.element.event_id(),
+                        blob_event.index + 1,
+                    ),
+                    epoch: blob_epoch,
+                    ending_checkpoint_sequence_number: blob_ending_checkpoint_sequence_number,
+                }))
+            }
+            None => Ok(None),
         }
     }
 

--- a/crates/walrus-service/src/node/events/event_blob_writer.rs
+++ b/crates/walrus-service/src/node/events/event_blob_writer.rs
@@ -46,7 +46,7 @@ use walrus_sui::{
 use walrus_utils::metrics::Registry;
 
 use crate::{
-    common::event_blob_downloader::LastCertifiedEventBlob,
+    common::event_blob_downloader::{EventBlobWithMetadata, LastCertifiedEventBlob},
     node::{
         DatabaseConfig,
         StorageNodeInner,
@@ -281,13 +281,7 @@ impl EventBlobWriterFactory {
     }
 
     /// Cleans up orphaned blob files from the filesystem that don't exist in any database.
-    fn cleanup_orphaned_blobs(
-        blobs_path: &Path,
-        pending: &DBMap<u64, PendingEventBlobMetadata>,
-        attested: &DBMap<(), AttestedEventBlobMetadata>,
-        failed_to_attest: &DBMap<(), FailedToAttestEventBlobMetadata>,
-        certified: &DBMap<(), CertifiedEventBlobMetadata>,
-    ) -> Result<()> {
+    fn cleanup_orphaned_blobs(&self, blobs_path: &Path) -> Result<()> {
         if !blobs_path.exists() {
             return Ok(());
         }
@@ -306,23 +300,26 @@ impl EventBlobWriterFactory {
                 .and_then(|name| name.parse::<u64>().ok());
             if let Some(event_index) = event_index {
                 // Check if blob exists in any database
-                let exists_in_db = pending.safe_iter().any(|result| {
+                let exists_in_db = self.pending.safe_iter().any(|result| {
                     result
                         .map(|(_, metadata)| metadata.event_cursor.element_index == event_index)
                         .unwrap_or(false)
-                }) || attested
+                }) || self
+                    .attested
                     .get(&())
                     .ok()
                     .flatten()
                     .map(|metadata| metadata.event_cursor.element_index == event_index)
                     .unwrap_or(false)
-                    || failed_to_attest
+                    || self
+                        .failed_to_attest
                         .get(&())
                         .ok()
                         .flatten()
                         .map(|metadata| metadata.event_cursor.element_index == event_index)
                         .unwrap_or(false)
-                    || certified
+                    || self
+                        .certified
                         .get(&())
                         .ok()
                         .flatten()
@@ -416,61 +413,69 @@ impl EventBlobWriterFactory {
             false,
         )?;
 
-        let blobs_path = Self::blobs_path(root_dir_path);
-        Self::cleanup_orphaned_blobs(
-            &blobs_path,
-            &pending,
-            &attested,
-            &failed_to_attest,
-            &certified,
-        )?;
-        let mut wb = pending.batch();
-        if let Some(LastCertifiedEventBlob::EventBlobWithMetadata(latest)) =
-            last_certified_event_blob
+        let mut factory = Self {
+            root_dir_path: root_dir_path.to_path_buf(),
+            node,
+            metrics: Arc::new(EventBlobWriterMetrics::new(registry)),
+            event_cursor: None,
+            epoch: None,
+            prev_certified_blob_id: None,
+            certified,
+            attested,
+            pending,
+            failed_to_attest,
+            num_checkpoints_per_blob,
+        };
+
+        // Touch a file in msim environment to notify that last certified blob is
+        // with or without metadata
+        #[cfg(msim)]
         {
-            if certified
-                .get(&())?
-                .filter(|current_certified| {
-                    latest.event_stream_cursor.element_index
-                        > current_certified.event_cursor.element_index
-                })
-                .is_some()
-            {
-                let certified_metadata = CertifiedEventBlobMetadata::new(
-                    latest.blob_id,
-                    latest.event_stream_cursor,
-                    latest.epoch,
-                );
-                wb.insert_batch(&certified, std::iter::once(((), certified_metadata)))?;
-                wb.delete_batch(&attested, std::iter::once(()))?;
-                wb.delete_batch(&failed_to_attest, std::iter::once(()))?;
-                for entry in pending.safe_iter() {
-                    wb.delete_batch(&pending, std::iter::once(entry?.0))?;
+            match last_certified_event_blob {
+                Some(LastCertifiedEventBlob::EventBlobWithMetadata(_)) => {
+                    let file_path =
+                        Self::db_path(root_dir_path).join("last_certified_blob_with_metadata");
+                    fs::File::create(file_path)?;
+                    // Remove file without metadata
+                    let file_path =
+                        Self::db_path(root_dir_path).join("last_certified_blob_without_metadata");
+                    if file_path.exists() {
+                        fs::remove_file(file_path)?;
+                    }
                 }
-            } else {
-                tracing::info!("No certified metadata to update");
+                None | Some(LastCertifiedEventBlob::EventBlob(_)) => {
+                    let file_path =
+                        Self::db_path(root_dir_path).join("last_certified_blob_without_metadata");
+                    fs::File::create(file_path)?;
+                    // Remove file with metadata
+                    let file_path =
+                        Self::db_path(root_dir_path).join("last_certified_blob_with_metadata");
+                    if file_path.exists() {
+                        fs::remove_file(file_path)?;
+                    }
+                }
             }
-            Self::reset_uncertified_blobs(
-                &pending,
-                &attested,
-                &failed_to_attest,
-                num_uncertified_blob_threshold,
-                Some(latest.blob()),
-                &blobs_path,
-                &mut wb,
-            )?;
-        } else if let Some(LastCertifiedEventBlob::EventBlob(event_blob)) =
-            last_certified_event_blob
-        {
-            Self::reset_uncertified_blobs(
-                &pending,
-                &attested,
-                &failed_to_attest,
-                num_uncertified_blob_threshold,
-                Some(event_blob),
-                &blobs_path,
-                &mut wb,
-            )?;
+        }
+
+        let mut wb = factory.pending.batch();
+        match last_certified_event_blob {
+            Some(LastCertifiedEventBlob::EventBlobWithMetadata(latest)) => {
+                factory.handle_event_blob_with_metadata(
+                    latest,
+                    num_uncertified_blob_threshold,
+                    &mut wb,
+                )?;
+            }
+            Some(LastCertifiedEventBlob::EventBlob(event_blob)) => {
+                factory.handle_event_blob_without_metadata(
+                    event_blob,
+                    num_uncertified_blob_threshold,
+                    &mut wb,
+                )?;
+            }
+            None => {
+                tracing::info!("No certified event blob exists");
+            }
         }
 
         wb.write()?;
@@ -479,79 +484,159 @@ impl EventBlobWriterFactory {
         #[cfg(msim)]
         {
             tracing::info!("flushing db");
-            certified.flush()?;
+            factory.certified.flush()?;
         }
 
-        let event_cursor = pending
+        let blobs_path = Self::blobs_path(root_dir_path);
+        factory.cleanup_orphaned_blobs(&blobs_path)?;
+
+        let event_cursor = factory
+            .pending
             .safe_iter()
             .last()
             .map(|result| result.map(|(_, metadata)| metadata.event_cursor))
             .transpose()?
             .or_else(|| {
-                failed_to_attest
+                factory
+                    .failed_to_attest
                     .get(&())
                     .ok()
                     .flatten()
                     .map(|metadata| metadata.event_cursor)
             })
             .or_else(|| {
-                attested
+                factory
+                    .attested
                     .get(&())
                     .ok()
                     .flatten()
                     .map(|metadata| metadata.event_cursor)
             })
             .or_else(|| {
-                certified
+                factory
+                    .certified
                     .get(&())
                     .ok()
                     .flatten()
                     .map(|metadata| metadata.event_cursor)
             });
-        let epoch = pending
+        let epoch = factory
+            .pending
             .safe_iter()
             .last()
             .map(|result| result.map(|(_, metadata)| metadata.epoch))
             .transpose()?
             .or_else(|| {
-                failed_to_attest
+                factory
+                    .failed_to_attest
                     .get(&())
                     .ok()
                     .flatten()
                     .map(|metadata| metadata.epoch)
             })
             .or_else(|| {
-                attested
+                factory
+                    .attested
                     .get(&())
                     .ok()
                     .flatten()
                     .map(|metadata| metadata.epoch)
             })
             .or_else(|| {
-                certified
+                factory
+                    .certified
                     .get(&())
                     .ok()
                     .flatten()
                     .map(|metadata| metadata.epoch)
             });
-        let prev_certified_blob_id = certified
+        let prev_certified_blob_id = factory
+            .certified
             .get(&())
             .ok()
             .flatten()
             .map(|metadata| metadata.blob_id);
-        Ok(Self {
-            root_dir_path: root_dir_path.to_path_buf(),
-            node,
-            metrics: Arc::new(EventBlobWriterMetrics::new(registry)),
-            event_cursor,
-            epoch,
-            prev_certified_blob_id,
-            certified,
-            attested,
-            pending,
-            failed_to_attest,
-            num_checkpoints_per_blob,
-        })
+
+        factory.event_cursor = event_cursor;
+        factory.epoch = epoch;
+        factory.prev_certified_blob_id = prev_certified_blob_id;
+
+        Ok(factory)
+    }
+
+    /// Handles the case where the last certified event blob has metadata.
+    fn handle_event_blob_with_metadata(
+        &self,
+        latest: EventBlobWithMetadata,
+        num_uncertified_blob_threshold: Option<usize>,
+        wb: &mut DBBatch,
+    ) -> Result<()> {
+        tracing::info!(
+            "Found last certified event blob with metadata: {:?}",
+            latest
+        );
+        let current_certified = self.certified.get(&())?;
+        tracing::info!("current certified: {:?}", current_certified);
+        if current_certified.is_some_and(|current_certified| {
+            latest.event_stream_cursor.element_index > current_certified.event_cursor.element_index
+        }) {
+            // The last certified event blob is ahead of the local certified event blob.
+            // We skip past all the blobs until the last certified event blob and delete
+            // all the uncertified blobs. If this was a local fork, the pending blobs
+            // will also be in bad shape and discarding them is needed to recover.
+            tracing::info!("Skipping past all the blobs until the last certified event blob");
+            let certified_metadata = CertifiedEventBlobMetadata::new(
+                latest.blob_id,
+                latest.event_stream_cursor,
+                latest.epoch,
+            );
+            wb.insert_batch(&self.certified, std::iter::once(((), certified_metadata)))?;
+            wb.delete_batch(&self.attested, std::iter::once(()))?;
+            wb.delete_batch(&self.failed_to_attest, std::iter::once(()))?;
+            for entry in self.pending.safe_iter() {
+                wb.delete_batch(&self.pending, std::iter::once(entry?.0))?;
+            }
+        } else {
+            // The last certified event blob is same as the local certified event blob.
+            // We reset the uncertified blobs to recover from potential global fork where
+            // nodes cannot agree on the last certified event blob.
+            Self::reset_uncertified_blobs(
+                &self.pending,
+                &self.attested,
+                &self.failed_to_attest,
+                num_uncertified_blob_threshold,
+                Some(latest.blob()),
+                &Self::blobs_path(&self.root_dir_path),
+                wb,
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Handles the case where the last certified event blob does not have metadata.
+    fn handle_event_blob_without_metadata(
+        &self,
+        event_blob: SuiEventBlob,
+        num_uncertified_blob_threshold: Option<usize>,
+        wb: &mut DBBatch,
+    ) -> Result<()> {
+        // Without metadata, we don't have enough information to skip past any blobs.
+        // We reset the uncertified blobs to recover from potential global fork where
+        // nodes cannot agree on the last certified event blob.
+        tracing::info!(
+            "Found last certified event blob without metadata: {:?}",
+            event_blob
+        );
+        Self::reset_uncertified_blobs(
+            &self.pending,
+            &self.attested,
+            &self.failed_to_attest,
+            num_uncertified_blob_threshold,
+            Some(event_blob),
+            &Self::blobs_path(&self.root_dir_path),
+            wb,
+        )?;
+        Ok(())
     }
 
     /// Returns a clone of the current event cursor position.

--- a/crates/walrus-simtest/Cargo.toml
+++ b/crates/walrus-simtest/Cargo.toml
@@ -7,21 +7,24 @@ license.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+bcs.workspace = true
 futures.workspace = true
 prometheus.workspace = true
 rand.workspace = true
 # explicitly import reqwest in test to disable its system proxy cache. It causes indeterminism in simtest.
 reqwest = { version = "0.12.12", default-features = false, features = ["__internal_proxy_sys_no_cache", "http2", "json", "rustls-tls"] }
+rocksdb.workspace = true
 sui-macros.workspace = true
 sui-protocol-config.workspace = true
 sui-rpc-api.workspace = true
 sui-types.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+typed-store.workspace = true
 walrus-core.workspace = true
 walrus-proc-macros = { workspace = true, features = ["walrus-simtest"] }
 walrus-sdk.workspace = true
-walrus-service = { workspace = true, features = ["test-utils"] }
+walrus-service = { workspace = true, features = ["node", "test-utils"] }
 walrus-storage-node-client.workspace = true
 walrus-sui.workspace = true
 walrus-test-utils.workspace = true

--- a/crates/walrus-simtest/tests/simtest_event_blob.rs
+++ b/crates/walrus-simtest/tests/simtest_event_blob.rs
@@ -12,16 +12,17 @@ mod tests {
         time::{Duration, Instant},
     };
 
+    use rocksdb::{DB, Options as RocksdbOptions, ReadOptions};
+    use sui_macros::{clear_fail_point, register_fail_point_if};
     use sui_rpc_api::Client as RpcClient;
     use tokio::sync::RwLock;
-    use walrus_core::test_utils;
+    use typed_store::rocks::be_fix_int_ser;
+    use walrus_core::{BlobId, test_utils};
     use walrus_proc_macros::walrus_simtest;
     use walrus_sdk::{client::Client, config::ClientCommunicationConfig};
-    use walrus_service::test_utils::{
-        SimStorageNodeHandle,
-        TestCluster,
-        TestNodesConfig,
-        test_cluster,
+    use walrus_service::{
+        node::events::event_blob_writer::CertifiedEventBlobMetadata,
+        test_utils::{SimStorageNodeHandle, TestCluster, TestNodesConfig, test_cluster},
     };
     use walrus_simtest::test_utils::{simtest_utils, simtest_utils::BlobInfoConsistencyCheck};
     use walrus_sui::{
@@ -64,6 +65,96 @@ mod tests {
         last_blob
     }
 
+    async fn wait_for_event_blob_writer_to_fork(
+        walrus_cluster: &mut TestCluster<SimStorageNodeHandle>,
+        client: &Arc<WithTempDir<Client<SuiContractClient>>>,
+        node_index: usize,
+    ) -> Result<(), anyhow::Error> {
+        let node = &walrus_cluster.nodes[node_index];
+
+        let mut last_certified_blob = get_last_certified_event_blob_must_succeed(client).await;
+        loop {
+            let current_blob = get_last_certified_event_blob_must_succeed(client).await;
+
+            if current_blob.blob_id != last_certified_blob.blob_id {
+                tracing::info!("New event blob seen during fork wait: {:?}", current_blob);
+                last_certified_blob = current_blob;
+                tokio::time::sleep(Duration::from_secs(30)).await;
+
+                let node_blob_id = get_last_certified_event_blob_from_node(node).await?;
+                if node_blob_id != last_certified_blob.blob_id {
+                    tracing::info!("Node forked");
+                    break;
+                }
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+        Ok(())
+    }
+
+    async fn wait_for_node_to_recover(
+        node: &SimStorageNodeHandle,
+        client: &Arc<WithTempDir<Client<SuiContractClient>>>,
+    ) -> Result<(), anyhow::Error> {
+        let mut last_certified_blob = get_last_certified_event_blob_from_node(node).await?;
+        let mut previous_blob = BlobId::ZERO;
+        let mut num_certified_updates = 0;
+        // Wait for 4 certified updates to ensure the node has recovered
+        // and is certifying blobs again.
+        while num_certified_updates < 4 {
+            if last_certified_blob.blob_id == previous_blob {
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                last_certified_blob = get_last_certified_event_blob_from_node(node).await?;
+                continue;
+            }
+            previous_blob = last_certified_blob.blob_id;
+            num_certified_updates += 1;
+        }
+        Ok(())
+    }
+
+    async fn get_last_certified_event_blob_from_node(
+        node: &SimStorageNodeHandle,
+    ) -> Result<CertifiedEventBlobMetadata, anyhow::Error> {
+        let db_path = node
+            .storage_node_config
+            .storage_path
+            .join("event_blob_writer")
+            .join("db");
+        let db = Arc::new(rocksdb::DB::open_cf_with_opts_for_read_only(
+            &RocksdbOptions::default(),
+            db_path,
+            [
+                (
+                    "pending_blob_store",
+                    DatabaseConfig::default().pending().to_options(),
+                ),
+                (
+                    "attested_blob_store",
+                    DatabaseConfig::default().attested().to_options(),
+                ),
+                (
+                    "certified_blob_store",
+                    DatabaseConfig::default().certified().to_options(),
+                ),
+                (
+                    "failed_to_attest_blob_store",
+                    DatabaseConfig::default().failed_to_attest().to_options(),
+                ),
+            ],
+            false,
+        )?);
+        let cf = db
+            .cf_handle("certified_blob_store")
+            .expect("Certified blob store column family should exist");
+        let key = be_fix_int_ser(&())?;
+        let data = db
+            .get_cf(&cf, &key)?
+            .expect("Node certified blob should exist");
+        let metadata: CertifiedEventBlobMetadata = bcs::from_bytes(&data)?;
+        Ok(metadata)
+    }
+
     /// Gets the last certified event blob from the client.
     /// Returns the last certified event blob if it exists, otherwise panics.
     async fn get_last_certified_event_blob_must_succeed(
@@ -96,6 +187,11 @@ mod tests {
         }
     }
 
+    async fn kill_node(node_id: sui_simulator::task::NodeId) {
+        let handle = sui_simulator::runtime::Handle::current();
+        handle.delete_node(node_id);
+    }
+
     async fn restart_nodes_with_checkpoints(
         walrus_cluster: &mut TestCluster<SimStorageNodeHandle>,
         checkpoint_fn: impl Fn(usize) -> u32,
@@ -119,6 +215,24 @@ mod tests {
                 .id(),
             );
         }
+    }
+
+    async fn restart_node_with_checkpoints(
+        walrus_cluster: &mut TestCluster<SimStorageNodeHandle>,
+        node_index: usize,
+        checkpoint_fn: impl Fn(usize) -> u32,
+    ) {
+        kill_node(walrus_cluster.nodes[node_index].node_id.unwrap()).await;
+        let node = &mut walrus_cluster.nodes[node_index];
+        node.node_id = Some(
+            SimStorageNodeHandle::spawn_node(
+                Arc::new(RwLock::new(node.storage_node_config.clone())),
+                Some(checkpoint_fn(node_index)),
+                node.cancel_token.clone(),
+            )
+            .await
+            .id(),
+        );
     }
 
     /// This test verifies that the node can correctly recover from a forked event blob.
@@ -159,13 +273,53 @@ mod tests {
         restart_nodes_with_checkpoints(&mut walrus_cluster, |_| 20).await;
 
         // Verify recovery
-        tokio::time::sleep(Duration::from_secs(30)).await;
         let recovered_blob = get_last_certified_event_blob_must_succeed(&client).await;
 
         // Event blob should make progress again.
         assert_ne!(stuck_blob.blob_id, recovered_blob.blob_id);
 
         blob_info_consistency_check.check_storage_node_consistency();
+    }
+
+    /// This test verifies that the node can correctly recover from a forked event blob.
+    #[ignore = "ignore integration simtests by default"]
+    #[walrus_simtest]
+    async fn test_event_blob_local_fork_recovery() {
+        let (_sui_cluster, mut walrus_cluster, client, _) =
+            test_cluster::E2eTestSetupBuilder::new()
+                .with_epoch_duration(Duration::from_secs(15))
+                .with_test_nodes_config(TestNodesConfig {
+                    node_weights: vec![2, 2, 3, 3, 3],
+                    ..Default::default()
+                })
+                .with_num_checkpoints_per_blob(20)
+                .with_communication_config(
+                    ClientCommunicationConfig::default_for_test_with_reqwest_timeout(
+                        Duration::from_secs(2),
+                    ),
+                )
+                .build_generic::<SimStorageNodeHandle>()
+                .await
+                .unwrap();
+
+        let client = Arc::new(client);
+
+        // Run workload to get some event blobs certified
+        tokio::time::sleep(Duration::from_secs(30)).await;
+
+        // Restart nodes with different checkpoint numbers to create fork
+        restart_node_with_checkpoints(&mut walrus_cluster, 0, |i| 30 + i as u32).await;
+
+        // Wait for event blob certification to get stuck
+        wait_for_event_blob_writer_to_fork(&mut walrus_cluster, &client, 0)
+            .await
+            .unwrap();
+
+        // Restart nodes with same checkpoint number to recover
+        restart_node_with_checkpoints(&mut walrus_cluster, 0, |_| 20).await;
+
+        // Verify recovery
+        wait_for_node_to_recover(&walrus_cluster.nodes[0], &client).await;
     }
 
     /// Waits for all nodes to download checkpoints up to the specified sequence number


### PR DESCRIPTION
## Description

This PR does:
1. Read latest certified event blob upon startup
2. Updates local state with latest certified if local state is behind
3. Delete previous local state

## Test plan

Added a new sim test to test

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
