### PR TITLE
refactor: remove ClientErrorKind and some cleanup

### DIFF
--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -93,7 +93,7 @@ async fn read_blob_with_wait_for_certification(
             Ok(data) => return Ok(data),
             Err(err) => {
                 // Check if the error is BlobIdDoesNotExist.
-                if matches!(err.kind(), ClientErrorKind::BlobIdDoesNotExist) {
+                if matches!(err, ClientError::BlobIdDoesNotExist) {
                     tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
                     continue;
                 }

--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -37,15 +37,12 @@ use walrus_core::{
 use walrus_proc_macros::walrus_simtest;
 use walrus_sdk::{
     client::{Blocklist, Client, WalrusStoreBlob, WalrusStoreBlobApi, responses::BlobStoreResult},
-    error::{
-        ClientError,
-        ClientErrorKind::{
-            self,
-            NoMetadataReceived,
-            NoValidStatusReceived,
-            NotEnoughConfirmations,
-            NotEnoughSlivers,
-        },
+    error::ClientError::{
+        self,
+        NoMetadataReceived,
+        NoValidStatusReceived,
+        NotEnoughConfirmations,
+        NotEnoughSlivers,
     },
     store_when::StoreWhen,
 };
@@ -222,7 +219,7 @@ async_param_test! {
 async fn test_store_and_read_blob_with_crash_failures(
     failed_shards_write: &[usize],
     failed_shards_read: &[usize],
-    expected_errors: &[ClientErrorKind],
+    expected_errors: &[ClientError],
 ) {
     telemetry_subscribers::init_for_testing();
     let result =
@@ -235,12 +232,11 @@ async fn test_store_and_read_blob_with_crash_failures(
             Ok(client_err) => {
                 if !expected_errs
                     .iter()
-                    .any(|expected_err| error_kind_matches(client_err.kind(), expected_err))
+                    .any(|expected_err| error_kind_matches(&client_err, expected_err))
                 {
                     panic!(
                         "client error mismatch; expected=({:?}); actual=({:?});",
-                        expected_errs,
-                        client_err.kind()
+                        expected_errs, client_err
                     )
                 }
             }
@@ -406,17 +402,17 @@ async fn test_inconsistency(failed_nodes: &[usize]) -> TestResult {
     Ok(())
 }
 
-fn error_kind_matches(actual: &ClientErrorKind, expected: &ClientErrorKind) -> bool {
+fn error_kind_matches(actual: &ClientError, expected: &ClientError) -> bool {
     match (actual, expected) {
         (
-            ClientErrorKind::NotEnoughConfirmations(act_a, act_b),
-            ClientErrorKind::NotEnoughConfirmations(exp_a, exp_b),
+            ClientError::NotEnoughConfirmations(act_a, act_b),
+            ClientError::NotEnoughConfirmations(exp_a, exp_b),
         ) => act_a == exp_a && act_b == exp_b,
-        (ClientErrorKind::NotEnoughSlivers, ClientErrorKind::NotEnoughSlivers) => true,
-        (ClientErrorKind::BlobIdDoesNotExist, ClientErrorKind::BlobIdDoesNotExist) => true,
-        (ClientErrorKind::NoMetadataReceived, ClientErrorKind::NoMetadataReceived) => true,
-        (ClientErrorKind::NoValidStatusReceived, ClientErrorKind::NoValidStatusReceived) => true,
-        (ClientErrorKind::Other(_), ClientErrorKind::Other(_)) => true,
+        (ClientError::NotEnoughSlivers, ClientError::NotEnoughSlivers) => true,
+        (ClientError::BlobIdDoesNotExist, ClientError::BlobIdDoesNotExist) => true,
+        (ClientError::NoMetadataReceived, ClientError::NoMetadataReceived) => true,
+        (ClientError::NoValidStatusReceived, ClientError::NoValidStatusReceived) => true,
+        (ClientError::Other(_), ClientError::Other(_)) => true,
         (_, _) => false,
     }
 }
@@ -967,8 +963,8 @@ async fn test_storage_nodes_delete_data_for_deleted_blobs() -> TestResult {
         .read_blob::<Primary>(&blob_id.expect("blob id should be present"))
         .await;
     assert!(matches!(
-        read_result.unwrap_err().kind(),
-        ClientErrorKind::BlobIdDoesNotExist,
+        read_result.unwrap_err(),
+        ClientError::BlobIdDoesNotExist,
     ));
 
     Ok(())
@@ -1044,7 +1040,7 @@ async fn test_blocklist() -> TestResult {
     let error = blob_read_result.expect_err("result must be an error");
 
     assert!(
-        matches!(error.kind(), ClientErrorKind::BlobIdBlocked(_)),
+        matches!(error, ClientError::BlobIdBlocked(_)),
         "unexpected error {:?}",
         error
     );

--- a/crates/walrus-sdk/src/client/resource.rs
+++ b/crates/walrus-sdk/src/client/resource.rs
@@ -26,7 +26,7 @@ use super::{
 };
 use crate::{
     client::WalrusStoreBlobApi,
-    error::{ClientError, ClientErrorKind, ClientResult},
+    error::{ClientError, ClientResult},
     store_when::StoreWhen,
 };
 
@@ -313,18 +313,15 @@ impl<'a> ResourceManager<'a> {
         persistence: BlobPersistence,
         store_when: StoreWhen,
     ) -> ClientResult<Vec<(Blob, RegisterBlobOp)>> {
-        let encoded_lengths: Result<Vec<_>, _> =
-            metadata_list
-                .iter()
-                .map(|m| {
-                    m.metadata().encoded_size().ok_or_else(|| {
-                        ClientError::other(ClientErrorKind::Other(
+        let encoded_lengths: Result<Vec<_>, ClientError> = metadata_list
+            .iter()
+            .map(|m| {
+                m.metadata().encoded_size().ok_or_else(|| {
                     anyhow!("the provided metadata is invalid: could not compute the encoded size")
-                        .into(),
-                ))
-                    })
+                        .into()
                 })
-                .collect();
+            })
+            .collect();
 
         if store_when.is_ignore_resources() {
             tracing::debug!(

--- a/crates/walrus-sdk/src/lib.rs
+++ b/crates/walrus-sdk/src/lib.rs
@@ -9,7 +9,6 @@ pub mod client;
 pub mod config;
 pub mod error;
 pub mod store_when;
-/// Utilities for the Walrus SDK.
 pub mod utils;
 
 pub use sui_types::event::EventID;

--- a/crates/walrus-sdk/src/utils.rs
+++ b/crates/walrus-sdk/src/utils.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+//! Utility functions for the Walrus SDK.
+
 use std::{
     collections::HashMap,
     fmt::{self, Debug, Display},

--- a/crates/walrus-service/src/client/cli.rs
+++ b/crates/walrus-service/src/client/cli.rs
@@ -60,7 +60,7 @@ pub async fn get_read_client(
         .refresh_config
         .build_refresher_and_run(sui_read_client.clone())
         .await?;
-    let client = Client::new_read_client(config, refresh_handle, sui_read_client).await?;
+    let client = Client::new(config, refresh_handle, sui_read_client).await?;
 
     if blocklist_path.is_some() {
         Ok(client.with_blocklist(Blocklist::new(blocklist_path)?))
@@ -83,7 +83,7 @@ pub async fn get_contract_client(
         .refresh_config
         .build_refresher_and_run(sui_client.read_client().clone())
         .await?;
-    let client = Client::new_contract_client(config, refresh_handle, sui_client).await?;
+    let client = Client::new(config, refresh_handle, sui_client).await?;
 
     if blocklist_path.is_some() {
         Ok(client.with_blocklist(Blocklist::new(blocklist_path)?))

--- a/crates/walrus-service/src/client/cli/runner.rs
+++ b/crates/walrus-service/src/client/cli/runner.rs
@@ -38,7 +38,7 @@ use walrus_core::{
 use walrus_sdk::{
     client::{Client, NodeCommunicationFactory, resource::RegisterBlobOp},
     config::load_configuration,
-    error::ClientErrorKind,
+    error::ClientError,
     store_when::StoreWhen,
     sui::{
         client::{
@@ -518,10 +518,10 @@ impl ClientCommandRunner {
         encoding_type: Option<EncodingType>,
     ) -> Result<()> {
         epoch_arg.exactly_one_is_some()?;
-        if encoding_type.is_some_and(|encoding| !encoding.is_supported()) {
-            anyhow::bail!(ClientErrorKind::UnsupportedEncodingType(
-                encoding_type.expect("just checked that option is Some")
-            ));
+        if let Some(encoding) = encoding_type {
+            if !encoding.is_supported() {
+                anyhow::bail!(ClientError::UnsupportedEncodingType(encoding));
+            }
         }
 
         let client = get_contract_client(self.config?, self.wallet, self.gas_budget, &None).await?;
@@ -640,7 +640,7 @@ impl ClientCommandRunner {
             .refresh_config
             .build_refresher_and_run(sui_read_client.clone())
             .await?;
-        let client = Client::new(config, refresher_handle).await?;
+        let client = Client::new(config, refresher_handle, ()).await?;
 
         let file = file_or_blob_id.file.clone();
         let blob_id =

--- a/crates/walrus-service/src/client/daemon/routes.rs
+++ b/crates/walrus-service/src/client/daemon/routes.rs
@@ -25,11 +25,7 @@ use tracing::Level;
 use utoipa::IntoParams;
 use walrus_core::{BlobId, EncodingType, EpochCount};
 use walrus_proc_macros::RestApiError;
-use walrus_sdk::{
-    client::responses::BlobStoreResult,
-    error::{ClientError, ClientErrorKind},
-    store_when::StoreWhen,
-};
+use walrus_sdk::{client::responses::BlobStoreResult, error::ClientError, store_when::StoreWhen};
 use walrus_storage_node_client::api::errors::DAEMON_ERROR_DOMAIN as ERROR_DOMAIN;
 use walrus_sui::{
     ObjectIdSchema,
@@ -226,9 +222,9 @@ pub(crate) enum GetBlobError {
 
 impl From<ClientError> for GetBlobError {
     fn from(error: ClientError) -> Self {
-        match error.kind() {
-            ClientErrorKind::BlobIdDoesNotExist => Self::BlobNotFound,
-            ClientErrorKind::BlobIdBlocked(_) => Self::Blocked,
+        match error {
+            ClientError::BlobIdDoesNotExist => Self::BlobNotFound,
+            ClientError::BlobIdBlocked(_) => Self::Blocked,
             _ => anyhow::anyhow!(error).into(),
         }
     }
@@ -356,9 +352,9 @@ pub(crate) enum StoreBlobError {
 
 impl From<ClientError> for StoreBlobError {
     fn from(error: ClientError) -> Self {
-        match error.kind() {
-            ClientErrorKind::NotEnoughConfirmations(_, _) => Self::NotEnoughConfirmations,
-            ClientErrorKind::BlobIdBlocked(_) => Self::Blocked,
+        match error {
+            ClientError::NotEnoughConfirmations(_, _) => Self::NotEnoughConfirmations,
+            ClientError::BlobIdBlocked(_) => Self::Blocked,
             _ => Self::Internal(anyhow!(error)),
         }
     }

--- a/crates/walrus-service/src/client/multiplexer.rs
+++ b/crates/walrus-service/src/client/multiplexer.rs
@@ -77,7 +77,7 @@ impl ClientMultiplexer {
             .refresh_config
             .build_refresher_and_run(sui_read_client.clone())
             .await?;
-        let read_client = Client::new_read_client(
+        let read_client = Client::new(
             config.clone(),
             refresh_handle.clone(),
             sui_read_client.clone(),
@@ -345,9 +345,7 @@ impl<'a> SubClientLoader<'a> {
         // Merge existing coins to avoid fragmentation.
         sui_client.merge_coins().await?;
 
-        let client =
-            Client::new_contract_client(self.config.clone(), refresh_handle, sui_client).await?;
-        Ok(client)
+        Ok(Client::new(self.config.clone(), refresh_handle, sui_client).await?)
     }
 
     /// Creates or loads a new wallet to use with the multiplexer.

--- a/crates/walrus-service/src/common/event_blob_downloader.rs
+++ b/crates/walrus-service/src/common/event_blob_downloader.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 
 use anyhow::Result;
 use walrus_core::BlobId;
-use walrus_sdk::{client::Client as WalrusClient, error::ClientErrorKind};
+use walrus_sdk::{client::Client as WalrusClient, error::ClientError};
 use walrus_storage_node_client::api::BlobStatus;
 use walrus_sui::client::{ReadClient, SuiReadClient};
 
@@ -65,7 +65,7 @@ impl EventBlobDownloader {
 
             let Ok(blob_status) = result else {
                 let err = result.err().unwrap();
-                if matches!(err.kind(), ClientErrorKind::BlobIdDoesNotExist) {
+                if matches!(err, ClientError::BlobIdDoesNotExist) {
                     // We've reached an expired blob, safe to terminate
                     break;
                 } else {

--- a/crates/walrus-service/src/node/metrics.rs
+++ b/crates/walrus-service/src/node/metrics.rs
@@ -11,7 +11,7 @@ use prometheus::{
     IntGaugeVec,
     core::{AtomicU64, GenericGauge, GenericGaugeVec},
 };
-use walrus_sdk::error::ClientErrorKind;
+use walrus_sdk::error::ClientError;
 use walrus_sui::types::{
     BlobCertified,
     BlobEvent,
@@ -277,28 +277,28 @@ impl TelemetryLabel for BlobCertified {
     }
 }
 
-impl TelemetryLabel for ClientErrorKind {
+impl TelemetryLabel for ClientError {
     fn label(&self) -> &'static str {
         match self {
-            ClientErrorKind::CertificationFailed(_) => "certification-failed",
-            ClientErrorKind::NotEnoughConfirmations(_, _) => "not-enough-confirmations",
-            ClientErrorKind::NotEnoughSlivers => "not-enough-slivers",
-            ClientErrorKind::BlobIdDoesNotExist => "blob-id-does-not-exist",
-            ClientErrorKind::NoMetadataReceived => "no-metadata-received",
-            ClientErrorKind::NoValidStatusReceived => "no-valid-status-received",
-            ClientErrorKind::InvalidConfig => "invalid-config",
-            ClientErrorKind::BlobIdBlocked(_) => "blob-id-blocked",
-            ClientErrorKind::NoCompatiblePaymentCoin => "no-compatible-payment-coin",
-            ClientErrorKind::NoCompatibleGasCoins(_) => "no-compatible-gas-coins",
-            ClientErrorKind::AllConnectionsFailed(_) => "all-connections-failed",
-            ClientErrorKind::BehindCurrentEpoch { .. } => "behind-current-epoch",
-            ClientErrorKind::UnsupportedEncodingType(_) => "unsupported-encoding-type",
-            ClientErrorKind::CommitteeChangeNotified => "committee-change-notified",
-            ClientErrorKind::EmptyCommittee => "empty-committee",
-            ClientErrorKind::StakeBelowThreshold(_) => "stake-below-threshold",
-            ClientErrorKind::FailedToLoadCerts(_) => "failed-to-load-certs",
-            ClientErrorKind::Other(_) => "unknown",
-            ClientErrorKind::StoreBlobInternal(_) => "store-blob-internal",
+            ClientError::CertificationFailed(_) => "certification-failed",
+            ClientError::NotEnoughConfirmations(_, _) => "not-enough-confirmations",
+            ClientError::NotEnoughSlivers => "not-enough-slivers",
+            ClientError::BlobIdDoesNotExist => "blob-id-does-not-exist",
+            ClientError::NoMetadataReceived => "no-metadata-received",
+            ClientError::NoValidStatusReceived => "no-valid-status-received",
+            ClientError::InvalidConfig => "invalid-config",
+            ClientError::BlobIdBlocked(_) => "blob-id-blocked",
+            ClientError::NoCompatiblePaymentCoin => "no-compatible-payment-coin",
+            ClientError::NoCompatibleGasCoins(_) => "no-compatible-gas-coins",
+            ClientError::AllConnectionsFailed(_) => "all-connections-failed",
+            ClientError::BehindCurrentEpoch { .. } => "behind-current-epoch",
+            ClientError::UnsupportedEncodingType(_) => "unsupported-encoding-type",
+            ClientError::CommitteeChangeNotified => "committee-change-notified",
+            ClientError::EmptyCommittee => "empty-committee",
+            ClientError::StakeBelowThreshold(_) => "stake-below-threshold",
+            ClientError::FailedToLoadCerts(_) => "failed-to-load-certs",
+            ClientError::Other(_) => "unknown",
+            ClientError::StoreBlobInternal(_) => "store-blob-internal",
         }
     }
 }

--- a/crates/walrus-stress/src/generator.rs
+++ b/crates/walrus-stress/src/generator.rs
@@ -84,7 +84,7 @@ impl LoadGenerator {
             .build_refresher_and_run(sui_read_client.clone())
             .await?;
         for read_client in try_join_all((0..n_clients).map(|_| {
-            Client::new_read_client(
+            Client::new(
                 client_config.clone(),
                 refresher_handle.clone(),
                 sui_read_client.clone(),

--- a/crates/walrus-stress/src/generator/write_client.rs
+++ b/crates/walrus-stress/src/generator/write_client.rs
@@ -156,8 +156,7 @@ impl WriteClient {
             .as_ref()
             .encoding_config()
             .get_for_type(DEFAULT_ENCODING)
-            .encode_with_metadata(blob)
-            .map_err(ClientError::other)?;
+            .encode_with_metadata(blob)?;
 
         let mut metadata = metadata.metadata().to_owned();
         let n_members = self
@@ -254,7 +253,7 @@ async fn new_client(
 
     let client = sui_contract_client
         .and_then_async(|contract_client| {
-            Client::new_contract_client(config.clone(), refresher_handle, contract_client)
+            Client::new(config.clone(), refresher_handle, contract_client)
         })
         .await?;
     Ok(client)


### PR DESCRIPTION
## Description

This is primarily cleanup. The ClientErrorKind type was unnecessary and caused bloat in various places. This PR removes it, and removes a couple extra methods placed on the walrus_sdk::client::Client, unifying them for both the read and write paths.

## Test plan

CI Pipeline.