### PR TITLE
chore: v1.24.1 cherry-picks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1847,7 +1847,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "checkpoint-downloader"
-version = "1.24.0"
+version = "1.24.1"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12025,7 +12025,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-core"
-version = "1.24.0"
+version = "1.24.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -12049,7 +12049,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-e2e-tests"
-version = "1.24.0"
+version = "1.24.1"
 dependencies = [
  "anyhow",
  "futures",
@@ -12080,7 +12080,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-orchestrator"
-version = "1.24.0"
+version = "1.24.1"
 dependencies = [
  "aws-config",
  "aws-runtime",
@@ -12110,7 +12110,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-proc-macros"
-version = "1.24.0"
+version = "1.24.1"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
@@ -12121,7 +12121,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-proxy"
-version = "1.24.0"
+version = "1.24.1"
 dependencies = [
  "anyhow",
  "axum 0.8.1",
@@ -12160,7 +12160,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-rest-client"
-version = "1.24.0"
+version = "1.24.1"
 dependencies = [
  "axum 0.8.1",
  "axum-server 0.7.2",
@@ -12198,7 +12198,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-sdk"
-version = "1.24.0"
+version = "1.24.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -12237,7 +12237,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-service"
-version = "1.24.0"
+version = "1.24.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12340,7 +12340,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-simtest"
-version = "1.24.0"
+version = "1.24.1"
 dependencies = [
  "anyhow",
  "futures",
@@ -12365,7 +12365,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-stress"
-version = "1.24.0"
+version = "1.24.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -12390,7 +12390,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-sui"
-version = "1.24.0"
+version = "1.24.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12441,7 +12441,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-test-utils"
-version = "1.24.0"
+version = "1.24.1"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -12451,7 +12451,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-utils"
-version = "1.24.0"
+version = "1.24.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ resolver = "2"
 authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024"
 license = "Apache-2.0"
-version = "1.24.0"
+version = "1.24.1"
 
 [workspace.dependencies]
 anyhow = "1.0.98"

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -549,10 +549,15 @@ impl StorageNode {
             .await?;
 
         tracing::info!(
-            walrus.node.id = %node_capability.id.to_hex_uncompressed(),
+            walrus.node.node_id = %node_capability.node_id.to_hex_uncompressed(),
+            walrus.node.capability_id = %node_capability.id.to_hex_uncompressed(),
             "selected storage node capability object"
         );
-        walrus_utils::with_label!(metrics.node_id, node_capability.id.to_hex_uncompressed()).set(1);
+        walrus_utils::with_label!(
+            metrics.node_id,
+            node_capability.node_id.to_hex_uncompressed()
+        )
+        .set(1);
 
         let config_synchronizer =
             config


### PR DESCRIPTION
## Description

Contains a version bump to `v1.24.1` and important cherry-picks for the `v1.24` release:

- #2050

## Test plan

Automatic tests.
