### PR TITLE
chore: add register_blob call to subsidies contract

### DIFF
--- a/contracts/subsidies/Move.lock
+++ b/contracts/subsidies/Move.lock
@@ -40,7 +40,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.47.0"
+compiler-version = "1.46.3"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/contracts/subsidies/Move.lock
+++ b/contracts/subsidies/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "E796F3002DAB1A928B475FF3B73F42AF9036B570D87F6F8E8A09ECDF0A6A41B7"
+manifest_digest = "C8CDFE3465A9A9D4E9E9181FF2AA73860783105D612DE114A7C7B424B805878F"
 deps_digest = "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -40,7 +40,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.46.3"
+compiler-version = "1.48.1"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/contracts/subsidies/sources/subsidies.move
+++ b/contracts/subsidies/sources/subsidies.move
@@ -224,6 +224,33 @@ public fun reserve_space(
     storage
 }
 
+/// Proxy Register blob by calling the system contract
+public fun register_blob(
+    self: &mut Subsidies,
+    system: &mut System,
+    storage: Storage,
+    blob_id: u256,
+    root_hash: u256,
+    size: u64,
+    encoding_type: u8,
+    deletable: bool,
+    write_payment: &mut Coin<WAL>,
+    ctx: &mut TxContext,
+): Blob {
+    assert!(self.version == VERSION, EWrongVersion);
+    let blob = system.register_blob(
+        storage,
+        blob_id,
+        root_hash,
+        size,
+        encoding_type,
+        deletable,
+        write_payment,
+        ctx,
+    );
+    blob
+}
+
 entry fun migrate(subsidies: &mut Subsidies, admin_cap: &AdminCap, package_id: ID) {
     check_admin(subsidies, admin_cap);
     check_version_upgrade(subsidies);

--- a/contracts/subsidies/tests/subsidies_tests.move
+++ b/contracts/subsidies/tests/subsidies_tests.move
@@ -212,7 +212,7 @@ fun test_extend_blob_no_funds_no_subsidies(): (System, Coin<WAL>, Blob) {
 
     let storage = get_storage_resource(&mut system, ENCODED_SIZE, 3);
 
-    let mut blob = register_default_blob(&mut system, storage, false);
+    let mut blob = register_default_blob(&mut subsidies, &mut system, storage, false);
     let certify_message = messages::certified_permanent_blob_message_for_testing(blob.blob_id());
     // Set certify
     blob.certify_with_certified_msg_for_testing(system.epoch(), certify_message);
@@ -243,7 +243,7 @@ fun test_extend_blob_no_funds_buyer_subsidies(): (System, Coin<WAL>, Blob) {
 
     let storage = get_storage_resource(&mut system, ENCODED_SIZE, 3);
 
-    let mut blob = register_default_blob(&mut system, storage, false);
+    let mut blob = register_default_blob(&mut subsidies, &mut system, storage, false);
     let certify_message = messages::certified_permanent_blob_message_for_testing(blob.blob_id());
     // Set certify
     blob.certify_with_certified_msg_for_testing(system.epoch(), certify_message);
@@ -272,7 +272,7 @@ fun test_extend_blob_no_funds_storage_node_subsidies(): (System, Coin<WAL>, Blob
 
     let storage = get_storage_resource(&mut system, ENCODED_SIZE, 3);
 
-    let mut blob = register_default_blob(&mut system, storage, false);
+    let mut blob = register_default_blob(&mut subsidies, &mut system, storage, false);
     let certify_message = messages::certified_permanent_blob_message_for_testing(blob.blob_id());
     // Set certify
     blob.certify_with_certified_msg_for_testing(system.epoch(), certify_message);
@@ -304,7 +304,7 @@ fun test_extend_blob_funds_with_subsidies(): (System, Coin<WAL>, Blob) {
     let mut payment = mint_frost(1000, ctx);
     let storage = get_storage_resource(&mut system, ENCODED_SIZE, 3);
 
-    let mut blob = register_default_blob(&mut system, storage, false);
+    let mut blob = register_default_blob(&mut subsidies, &mut system, storage, false);
     let certify_message = messages::certified_permanent_blob_message_for_testing(blob.blob_id());
     // Set certify
     blob.certify_with_certified_msg_for_testing(system.epoch(), certify_message);
@@ -479,7 +479,7 @@ fun test_extend_blob_funds_with_subsidies_full_pool_consumption(): (System, Coin
     let mut payment = mint_frost(1000, ctx);
     let storage = get_storage_resource(&mut system, ENCODED_SIZE, 3);
 
-    let mut blob = register_default_blob(&mut system, storage, false);
+    let mut blob = register_default_blob(&mut subsidies, &mut system, storage, false);
     let certify_message = messages::certified_permanent_blob_message_for_testing(blob.blob_id());
     // Set certify
     blob.certify_with_certified_msg_for_testing(system.epoch(), certify_message);
@@ -542,12 +542,18 @@ fun test_subsidies_with_zero_system_rate(): (System, Coin<WAL>, Storage) {
     (system, payment, storage)
 }
 
-fun register_default_blob(system: &mut System, storage: Storage, deletable: bool): Blob {
+fun register_default_blob(
+    subsidies: &mut Subsidies,
+    system: &mut System,
+    storage: Storage,
+    deletable: bool,
+): Blob {
     let ctx = &mut tx_context::dummy();
     let mut fake_coin = mint_frost(N_COINS, ctx);
     // Register a Blob
     let blob_id = blob::derive_blob_id(ROOT_HASH, RS2, UNENCODED_SIZE);
-    let blob = system.register_blob(
+    let blob = subsidies.register_blob(
+        system,
         storage,
         blob_id,
         ROOT_HASH,

--- a/contracts/subsidies/tests/subsidies_tests.move
+++ b/contracts/subsidies/tests/subsidies_tests.move
@@ -280,6 +280,7 @@ fun test_extend_blob_no_funds_storage_node_subsidies(): (System, Coin<WAL>, Blob
     assert!(blob.certified_epoch().is_some());
     let initial_blob_storage_end = blob.storage().end_epoch();
 
+    assert_eq!(payment.value(), 1000);
     subsidies.extend_blob(&mut system, &mut blob, 3, &mut payment, ctx);
 
     assert_eq!(payment.value(), 925);
@@ -301,7 +302,7 @@ fun test_extend_blob_funds_with_subsidies(): (System, Coin<WAL>, Blob) {
     subsidies.set_buyer_subsidy_rate(&admin_cap, 10_00); // 10%
     subsidies.set_system_subsidy_rate(&admin_cap, 10_00); // 10%
 
-    let mut payment = mint_frost(1000, ctx);
+    let mut payment = mint_frost(68, ctx);
     let storage = get_storage_resource(&mut system, ENCODED_SIZE, 3);
 
     let mut blob = register_default_blob(&mut subsidies, &mut system, storage, false);
@@ -313,6 +314,12 @@ fun test_extend_blob_funds_with_subsidies(): (System, Coin<WAL>, Blob) {
     let initial_blob_storage_end = blob.storage().end_epoch();
 
     subsidies.extend_blob(&mut system, &mut blob, 3, &mut payment, ctx);
+
+    assert_eq!(payment.value(), 0);
+    assert_eq!(system.get_system_rewards_balance(0).value(), 29);
+    assert_eq!(system.get_system_rewards_balance(1).value(), 27);
+    assert_eq!(system.get_system_rewards_balance(2).value(), 27);
+    assert_eq!(subsidies.subsidy_pool_value(), 999_986);
 
     assert_eq!(blob.storage().end_epoch(), initial_blob_storage_end + 3);
 
@@ -416,6 +423,9 @@ fun test_reserve_space_funds_with_subsidies_full_pool_consumption(): (System, Co
 
     assert_eq!(payment.value(), 932);
     assert_eq!(subsidies.subsidy_pool_value(), 86);
+    assert_eq!(system.get_system_rewards_balance(0).value(), 28);
+    assert_eq!(system.get_system_rewards_balance(1).value(), 27);
+    assert_eq!(system.get_system_rewards_balance(2).value(), 27);
 
     subsidies::destroy_admin_cap(admin_cap);
     subsidies::destroy_subsidies(subsidies);
@@ -427,17 +437,48 @@ fun test_reserve_space_insufficient_funds_with_subsidies(): (System, Coin<WAL>, 
     let ctx = &mut tx_context::dummy();
     let mut system = system::new_for_testing(ctx);
     let (mut subsidies, admin_cap) = subsidies::new_for_testing(ctx);
-    let initial_funds_value = 100;
+    let initial_funds_value = 10;
     subsidies.add_funds(mint_frost(initial_funds_value, ctx));
-    subsidies.set_buyer_subsidy_rate(&admin_cap, 10_00); // 10%
+    subsidies.set_buyer_subsidy_rate(&admin_cap, 20_00); // 20%
     subsidies.set_system_subsidy_rate(&admin_cap, 10_00); // 10%
 
     let mut payment = mint_frost(1000, ctx);
 
     let storage = subsidies.reserve_space(&mut system, ENCODED_SIZE, 3, &mut payment, ctx);
 
-    assert_eq!(payment.value(), 932);
-    assert_eq!(subsidies.subsidy_pool_value(), 86);
+    // split funds porpotionally => buyer subsidy: pool_value * 0.6666 = 6
+    // original cost = 75 => remaining: 1000 - 75 + 6 = 931
+    assert_eq!(payment.value(), 931);
+    // system subsidy: pool_value * 0.3333 = 3
+    // pool remaining: 10 - 6 - 3 = 1
+    assert_eq!(subsidies.subsidy_pool_value(), 1);
+    assert_eq!(system.get_system_rewards_balance(0).value(), 26);
+    assert_eq!(system.get_system_rewards_balance(1).value(), 26);
+    assert_eq!(system.get_system_rewards_balance(2).value(), 26);
+
+    subsidies::destroy_admin_cap(admin_cap);
+    subsidies::destroy_subsidies(subsidies);
+    (system, payment, storage)
+}
+
+#[test]
+fun test_reserve_space_with_credits(): (System, Coin<WAL>, Storage) {
+    let ctx = &mut tx_context::dummy();
+    let mut system = system::new_for_testing(ctx);
+    let (mut subsidies, admin_cap) = subsidies::new_for_testing(ctx);
+    let initial_funds_value = 100;
+    subsidies.add_funds(mint_frost(initial_funds_value, ctx));
+    subsidies.set_buyer_subsidy_rate(&admin_cap, 100_00); // 100%
+    subsidies.set_system_subsidy_rate(&admin_cap, 10_00); // 10%
+
+    let mut payment = mint_frost(0, ctx);
+    assert_eq!(payment.value(), 0);
+
+    let storage = subsidies.reserve_space(&mut system, ENCODED_SIZE, 3, &mut payment, ctx);
+
+    // buyer subsidy: 75, system_subsidy: 7
+    // 100 - 75 - 7 = 18
+    assert_eq!(subsidies.subsidy_pool_value(), 18);
 
     subsidies::destroy_admin_cap(admin_cap);
     subsidies::destroy_subsidies(subsidies);
@@ -491,6 +532,41 @@ fun test_extend_blob_funds_with_subsidies_full_pool_consumption(): (System, Coin
 
     assert_eq!(blob.storage().end_epoch(), initial_blob_storage_end + 3);
     assert_eq!(subsidies.subsidy_pool_value(), 136);
+
+    subsidies::destroy_admin_cap(admin_cap);
+    subsidies::destroy_subsidies(subsidies);
+
+    (system, payment, blob)
+}
+
+#[test]
+fun test_extend_blob_with_credits(): (System, Coin<WAL>, Blob) {
+    let ctx = &mut tx_context::dummy();
+    let mut system = system::new_for_testing(ctx);
+    let (mut subsidies, admin_cap) = subsidies::new_for_testing(ctx);
+    let initial_funds_value = 100;
+    subsidies.add_funds(mint_frost(initial_funds_value, ctx));
+    subsidies.set_buyer_subsidy_rate(&admin_cap, 100_00); // 100%
+    subsidies.set_system_subsidy_rate(&admin_cap, 10_00); // 10%
+
+    let mut payment = mint_frost(0, ctx);
+    let storage = get_storage_resource(&mut system, ENCODED_SIZE, 3);
+
+    let mut blob = register_default_blob(&mut subsidies, &mut system, storage, false);
+    let certify_message = messages::certified_permanent_blob_message_for_testing(blob.blob_id());
+    // Set certify
+    blob.certify_with_certified_msg_for_testing(system.epoch(), certify_message);
+    // Assert certified
+    assert!(blob.certified_epoch().is_some());
+    let initial_blob_storage_end = blob.storage().end_epoch();
+
+    assert_eq!(payment.value(), 0);
+    subsidies.extend_blob(&mut system, &mut blob, 3, &mut payment, ctx);
+
+    assert_eq!(blob.storage().end_epoch(), initial_blob_storage_end + 3);
+    // buyer subsidy: 75, system subsidy: 7
+    // 100 - 75 - 7 = 18
+    assert_eq!(subsidies.subsidy_pool_value(), 18);
 
     subsidies::destroy_admin_cap(admin_cap);
     subsidies::destroy_subsidies(subsidies);

--- a/contracts/wal/Move.lock
+++ b/contracts/wal/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "4B20DD2D2B852A95DD10064E13B34E79BC028F0885F38A605D73E517DFFB7E99"
+manifest_digest = "730E66FED4B22D8FACFEC1D1BCD6143BAB8647564B8E8B4B92F392266BB67A42"
 deps_digest = "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -21,7 +21,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.46.3"
+compiler-version = "1.48.1"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/contracts/wal/Move.lock
+++ b/contracts/wal/Move.lock
@@ -21,7 +21,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.47.0"
+compiler-version = "1.46.3"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/contracts/wal_exchange/Move.lock
+++ b/contracts/wal_exchange/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "910B4E86853ECAC3285308A8CA8ACCD38617E623A5388B08B76CA544240C2771"
+manifest_digest = "58C5FD87D6D33EF5CEF2FE8BF88C649AAA8F977601F8EDF79EBFF01AD051D9B4"
 deps_digest = "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -30,6 +30,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.46.3"
+compiler-version = "1.48.1"
 edition = "2024.beta"
 flavor = "sui"

--- a/contracts/wal_exchange/Move.lock
+++ b/contracts/wal_exchange/Move.lock
@@ -30,6 +30,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.47.0"
+compiler-version = "1.46.3"
 edition = "2024.beta"
 flavor = "sui"

--- a/contracts/walrus/Move.lock
+++ b/contracts/walrus/Move.lock
@@ -30,7 +30,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.47.0"
+compiler-version = "1.46.3"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/contracts/walrus/Move.lock
+++ b/contracts/walrus/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "116508ED768AD756A6B1570A7E1337FC0241EB65FAA05CBB4E8E5491A60A42BA"
+manifest_digest = "34769CAF45FEFC1E78BF228F869EBE37A4B2F048255CF75D8525BF3FF1C0F74D"
 deps_digest = "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -30,7 +30,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.46.3"
+compiler-version = "1.48.1"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/contracts/walrus/sources/system.move
+++ b/contracts/walrus/sources/system.move
@@ -335,3 +335,8 @@ public(package) fun new_package_id(system: &System): Option<ID> {
 public(package) fun destroy_for_testing(self: System) {
     sui::test_utils::destroy(self);
 }
+
+#[test_only]
+public fun get_system_rewards_balance(self: &mut System, epoch_in_future: u32): &mut Balance<WAL> {
+    self.inner_mut().future_accounting_mut().ring_lookup_mut(epoch_in_future).rewards_balance()
+}

--- a/crates/walrus-sui/src/contracts.rs
+++ b/crates/walrus-sui/src/contracts.rs
@@ -420,6 +420,7 @@ pub mod subsidies {
     contract_ident!(fn subsidies::set_system_subsidy_rate);
     contract_ident!(fn subsidies::extend_blob);
     contract_ident!(fn subsidies::reserve_space);
+    contract_ident!(fn subsidies::register_blob);
 }
 
 /// Module for tags corresponding to the Move module `dynamic_field` from the `sui` package.


### PR DESCRIPTION
## Description

Add register_blob proxy call to subsidies contract. This would enable custom subsidies contract without modifying the client CLI significantly.

Also updated the subsidy calculation logic so that a buyer only needs to supply the post-subsidy portion of the WAL to pay for `extend_blob` and `reserve_space` calls. Before the update, a buyer has to supply the full amount of WAL of wall and then get refunded through the old `apply_subsidies` logic

## Test plan

Move test

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
