### PR TITLE
fix: remove mysten_metrics initialization

### DIFF
--- a/crates/walrus-service/src/common/utils.rs
+++ b/crates/walrus-service/src/common/utils.rs
@@ -245,9 +245,6 @@ impl MetricsAndLoggingRuntime {
         let registry_service = mysten_metrics::start_prometheus_server(metrics_address);
         let walrus_registry = registry_service.default_registry();
 
-        // Initialize mysten metrics used to track all metrics under `mysten_metrics` namespace.
-        mysten_metrics::init_metrics(&walrus_registry);
-
         // Initialize logging subscriber
         let (telemetry_guards, tracing_handle) = telemetry_subscribers::TelemetryConfig::new()
             .with_env()


### PR DESCRIPTION
## Description

The same label `name` walrus widely uses is also used in monitored_scope.

Remove it for now, until we change it.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
