### PR TITLE
chore: ignore GH links during linkcheck

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -15,6 +15,7 @@ theme = "docs/theme"
 
 [output.linkcheck]
 exclude = [
+  'github\.com',
   'google\.com',
   'x\.com',
 ]


### PR DESCRIPTION
## Description

This is necessary as the linkcheck keeps failing due to 429 responses from GitHub.
