### PR TITLE
test: retry storing metadata during cluster creation

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -3406,7 +3406,10 @@ mod tests {
                 && (store_at_shard(&shard, SliverType::Primary)
                     || store_at_shard(&shard, SliverType::Secondary))
             {
-                node.client().store_metadata(&blob.metadata).await?;
+                retry_until_success_or_timeout(TIMEOUT, || {
+                    node.client().store_metadata(&blob.metadata)
+                })
+                .await?;
                 metadata_stored.push(node.public_key());
             }
 


### PR DESCRIPTION
## Description

Before this change, some unit tests, specifically `recovers_sliver_from_only_symbols_of_one_type` were failing from time to time with an error `the blob has not been registered or has already expired`. This error occurs when attempting to store the metadata before the node received the registration event. With this change, storing the metadata is retried, thus avoiding the issue.

## Test plan

Test suite + stress testing the corresponding test with [cargo-stress](https://github.com/danhhz/cargo-stress):

```sh
cargo stress recovers_sliver_from_only_symbols_of_one_type
```
