### PR TITLE
chore: make ClientErrorKind non-exhaustive

### DIFF
--- a/crates/walrus-sdk/src/error.rs
+++ b/crates/walrus-sdk/src/error.rs
@@ -126,6 +126,7 @@ impl From<SuiClientError> for ClientError {
 /// Inner error type, raised when the client operation fails.
 #[derive(Debug, thiserror::Error)]
 #[error(transparent)]
+#[non_exhaustive]
 pub enum ClientErrorKind {
     /// The certification of the blob failed.
     #[error("blob certification failed: {0}")]

--- a/crates/walrus-service/src/node/metrics.rs
+++ b/crates/walrus-service/src/node/metrics.rs
@@ -291,6 +291,8 @@ impl TelemetryLabel for ClientErrorKind {
             ClientErrorKind::FailedToLoadCerts(_) => "failed-to-load-certs",
             ClientErrorKind::Other(_) => "unknown",
             ClientErrorKind::StoreBlobInternal(_) => "store-blob-internal",
+            // Note: this is required due to the `#[non_exhaustive]` attribute on the enum.
+            _ => "telemetry-label-unhandled",
         }
     }
 }


### PR DESCRIPTION
## Description

As per https://github.com/MystenLabs/walrus/pull/2049#pullrequestreview-2817348865, we would like to make `ClientErrorKind` non-exhaustive.

## Test plan

CI Pipeline.