### PR TITLE
feat: Add typed store and derive crate to walrus repo

### DIFF
--- a/.licensesnipignore
+++ b/.licensesnipignore
@@ -6,3 +6,13 @@ docs/mdbook-admonish.css
 docs/theme/tabs.css
 docs/theme/tabs.js
 scripts/move_coverage.sh
+crates/typed-store/src/rocks/safe_iter.rs
+crates/typed-store/src/rocks/tests.rs
+crates/typed-store/src/rocks/mod.rs
+crates/typed-store/src/metrics.rs
+crates/typed-store/src/lib.rs
+crates/typed-store/src/traits.rs
+crates/typed-store/src/rocks/errors.rs
+crates/typed-store/src/rocks/safe_iter.rs
+crates/typed-store/src/rocks/tests.rs
+crates/typed-store-derive/src/lib.rs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1863,14 +1863,14 @@ dependencies = [
  "rocksdb",
  "serde",
  "serde_with",
- "sui-macros 0.7.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
+ "sui-macros",
  "sui-rpc-api",
  "sui-types",
  "tempfile",
  "tokio",
  "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
- "typed-store 0.4.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.46.0)",
+ "typed-store 1.25.0",
  "walrus-sui",
  "walrus-utils",
 ]
@@ -2126,7 +2126,7 @@ dependencies = [
  "shared-crypto",
  "strum_macros 0.27.1",
  "sui-http",
- "sui-macros 0.7.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
+ "sui-macros",
  "sui-protocol-config",
  "sui-tls",
  "tap",
@@ -2140,7 +2140,7 @@ dependencies = [
  "tower 0.5.2",
  "tower-http",
  "tracing",
- "typed-store 0.4.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
+ "typed-store 0.4.0",
 ]
 
 [[package]]
@@ -3301,6 +3301,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c4c9e43643f5a3be4ca5b67d26b98031ff9db6806c3440ae32e02e3ceac3f1b"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "fdlimit"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e182f7dbc2ef73d9ef67351c5fbbea084729c48362d3ce9dd44c28e32e277fe5"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5430,7 +5440,7 @@ dependencies = [
  "serde_bytes",
  "serde_with",
  "thiserror 1.0.69",
- "uint",
+ "uint 0.9.5",
 ]
 
 [[package]]
@@ -5859,35 +5869,6 @@ dependencies = [
 [[package]]
 name = "msim"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=9f175e3517812929ad6bdd8db443f1bbd8107965#9f175e3517812929ad6bdd8db443f1bbd8107965"
-dependencies = [
- "ahash 0.7.8",
- "async-task",
- "bincode",
- "bytes",
- "cc",
- "downcast-rs",
- "erasable",
- "futures",
- "lazy_static",
- "libc",
- "msim-macros 0.1.0 (git+https://github.com/MystenLabs/mysten-sim.git?rev=9f175e3517812929ad6bdd8db443f1bbd8107965)",
- "naive-timer",
- "pin-project-lite",
- "rand 0.8.5",
- "real_tokio",
- "serde",
- "socket2 0.4.10",
- "tap",
- "tokio-util 0.7.13 (git+https://github.com/MystenLabs/tokio-msim-fork.git?rev=7329bff6ee996d8df6cf810a9c2e59631ad5a2fb)",
- "toml 0.5.11",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "msim"
-version = "0.1.0"
 source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=cad62679fd180a48c665f842cb80045f8fcfdee9#cad62679fd180a48c665f842cb80045f8fcfdee9"
 dependencies = [
  "ahash 0.7.8",
@@ -5900,7 +5881,7 @@ dependencies = [
  "futures",
  "lazy_static",
  "libc",
- "msim-macros 0.1.0 (git+https://github.com/MystenLabs/mysten-sim.git?rev=cad62679fd180a48c665f842cb80045f8fcfdee9)",
+ "msim-macros",
  "naive-timer",
  "pin-project-lite",
  "rand 0.8.5",
@@ -5912,17 +5893,6 @@ dependencies = [
  "toml 0.5.11",
  "tracing",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "msim-macros"
-version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=9f175e3517812929ad6bdd8db443f1bbd8107965#9f175e3517812929ad6bdd8db443f1bbd8107965"
-dependencies = [
- "darling 0.14.4",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -6014,7 +5984,7 @@ dependencies = [
  "rand 0.8.5",
  "reqwest",
  "snap",
- "sui-macros 0.7.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
+ "sui-macros",
  "sui-tls",
  "sui-types",
  "tempfile",
@@ -7117,7 +7087,7 @@ dependencies = [
  "fixed-hash",
  "impl-codec",
  "impl-serde",
- "uint",
+ "uint 0.9.5",
 ]
 
 [[package]]
@@ -7764,6 +7734,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "reqwest"
 version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7900,6 +7876,36 @@ dependencies = [
  "signature 2.2.0",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rstest"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate 3.2.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.101",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -8973,7 +8979,7 @@ dependencies = [
  "mysten-metrics",
  "parking_lot 0.12.3",
  "serde",
- "sui-macros 0.7.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
+ "sui-macros",
  "sui-move-natives-latest",
  "sui-protocol-config",
  "sui-types",
@@ -9001,7 +9007,7 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.3",
  "serde",
- "sui-macros 0.7.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
+ "sui-macros",
  "sui-move-natives-v0",
  "sui-protocol-config",
  "sui-types",
@@ -9028,7 +9034,7 @@ dependencies = [
  "move-vm-types-v1",
  "parking_lot 0.12.3",
  "serde",
- "sui-macros 0.7.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
+ "sui-macros",
  "sui-move-natives-v1",
  "sui-protocol-config",
  "sui-types",
@@ -9055,7 +9061,7 @@ dependencies = [
  "move-vm-types-v2",
  "parking_lot 0.12.3",
  "serde",
- "sui-macros 0.7.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
+ "sui-macros",
  "sui-move-natives-v2",
  "sui-protocol-config",
  "sui-types",
@@ -9199,7 +9205,7 @@ dependencies = [
  "sui-framework",
  "sui-genesis-builder",
  "sui-json-rpc-types",
- "sui-macros 0.7.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
+ "sui-macros",
  "sui-network",
  "sui-protocol-config",
  "sui-simulator",
@@ -9216,7 +9222,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "twox-hash 1.6.3",
- "typed-store 0.4.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
+ "typed-store 0.4.0",
 ]
 
 [[package]]
@@ -9245,14 +9251,6 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "sui-enum-compat-util"
-version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.46.0#e011e770764fa971d2defa6d1fd4152bb2b898d4"
-dependencies = [
- "serde_yaml 0.8.26",
 ]
 
 [[package]]
@@ -9577,7 +9575,7 @@ dependencies = [
  "sui-json",
  "sui-json-rpc-api",
  "sui-json-rpc-types",
- "sui-macros 0.7.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
+ "sui-macros",
  "sui-name-service",
  "sui-open-rpc",
  "sui-open-rpc-macros",
@@ -9592,7 +9590,7 @@ dependencies = [
  "tower 0.5.2",
  "tower-http",
  "tracing",
- "typed-store-error 0.4.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
+ "typed-store-error",
 ]
 
 [[package]]
@@ -9637,9 +9635,9 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "sui-enum-compat-util 0.1.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
+ "sui-enum-compat-util",
  "sui-json",
- "sui-macros 0.7.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
+ "sui-macros",
  "sui-package-resolver",
  "sui-protocol-config",
  "sui-types",
@@ -9669,22 +9667,11 @@ dependencies = [
 [[package]]
 name = "sui-macros"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.46.0#e011e770764fa971d2defa6d1fd4152bb2b898d4"
-dependencies = [
- "futures",
- "once_cell",
- "sui-proc-macros 0.7.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.46.0)",
- "tracing",
-]
-
-[[package]]
-name = "sui-macros"
-version = "0.7.0"
 source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0#f3e72b60708b682f1d286b8d218977c4338e39d9"
 dependencies = [
  "futures",
  "once_cell",
- "sui-proc-macros 0.7.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
+ "sui-proc-macros",
  "tracing",
 ]
 
@@ -9836,7 +9823,7 @@ dependencies = [
  "shared-crypto",
  "sui-archival",
  "sui-config",
- "sui-macros 0.7.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
+ "sui-macros",
  "sui-protocol-config",
  "sui-simulator",
  "sui-storage",
@@ -9886,7 +9873,7 @@ dependencies = [
  "sui-http",
  "sui-json-rpc",
  "sui-json-rpc-api",
- "sui-macros 0.7.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
+ "sui-macros",
  "sui-name-service",
  "sui-network",
  "sui-protocol-config",
@@ -9903,7 +9890,7 @@ dependencies = [
  "tower 0.5.2",
  "tower-http",
  "tracing",
- "typed-store 0.4.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
+ "typed-store 0.4.0",
  "url",
 ]
 
@@ -9989,24 +9976,12 @@ dependencies = [
 [[package]]
 name = "sui-proc-macros"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.46.0#e011e770764fa971d2defa6d1fd4152bb2b898d4"
-dependencies = [
- "msim-macros 0.1.0 (git+https://github.com/MystenLabs/mysten-sim.git?rev=9f175e3517812929ad6bdd8db443f1bbd8107965)",
- "proc-macro2",
- "quote",
- "sui-enum-compat-util 0.1.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.46.0)",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "sui-proc-macros"
-version = "0.7.0"
 source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0#f3e72b60708b682f1d286b8d218977c4338e39d9"
 dependencies = [
- "msim-macros 0.1.0 (git+https://github.com/MystenLabs/mysten-sim.git?rev=cad62679fd180a48c665f842cb80045f8fcfdee9)",
+ "msim-macros",
  "proc-macro2",
  "quote",
- "sui-enum-compat-util 0.1.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
+ "sui-enum-compat-util",
  "syn 2.0.101",
 ]
 
@@ -10142,7 +10117,7 @@ dependencies = [
  "fastcrypto",
  "lru 0.10.1",
  "move-package",
- "msim 0.1.0 (git+https://github.com/MystenLabs/mysten-sim.git?rev=cad62679fd180a48c665f842cb80045f8fcfdee9)",
+ "msim",
  "mysten-network",
  "rand 0.8.5",
  "serde",
@@ -10239,7 +10214,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "typed-store 0.4.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
+ "typed-store 0.4.0",
  "url",
  "zstd 0.12.4",
 ]
@@ -10256,7 +10231,7 @@ dependencies = [
  "prometheus",
  "rand 0.8.5",
  "sui-config",
- "sui-macros 0.7.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
+ "sui-macros",
  "sui-node",
  "sui-protocol-config",
  "sui-simulator",
@@ -10290,7 +10265,7 @@ dependencies = [
  "shared-crypto",
  "sui-config",
  "sui-genesis-builder",
- "sui-macros 0.7.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
+ "sui-macros",
  "sui-protocol-config",
  "sui-rpc-api",
  "sui-simulator",
@@ -10385,7 +10360,7 @@ dependencies = [
  "once_cell",
  "sui-config",
  "sui-execution",
- "sui-macros 0.7.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
+ "sui-macros",
  "sui-protocol-config",
  "sui-types",
  "tracing",
@@ -10449,15 +10424,15 @@ dependencies = [
  "static_assertions",
  "strum 0.27.1",
  "strum_macros 0.27.1",
- "sui-enum-compat-util 0.1.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
- "sui-macros 0.7.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
+ "sui-enum-compat-util",
+ "sui-macros",
  "sui-protocol-config",
  "sui-sdk-types",
  "tap",
  "thiserror 1.0.69",
  "tonic 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
- "typed-store-error 0.4.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
+ "typed-store-error",
  "x509-parser",
 ]
 
@@ -11584,35 +11559,6 @@ dependencies = [
 [[package]]
 name = "typed-store"
 version = "0.4.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.46.0#e011e770764fa971d2defa6d1fd4152bb2b898d4"
-dependencies = [
- "async-trait",
- "bcs",
- "bincode",
- "collectable",
- "eyre",
- "fdlimit",
- "hdrhistogram",
- "itertools 0.13.0",
- "msim 0.1.0 (git+https://github.com/MystenLabs/mysten-sim.git?rev=9f175e3517812929ad6bdd8db443f1bbd8107965)",
- "once_cell",
- "prometheus",
- "rand 0.8.5",
- "rocksdb",
- "serde",
- "sui-macros 0.7.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.46.0)",
- "tap",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "typed-store-derive 0.3.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.46.0)",
- "typed-store-error 0.4.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.46.0)",
- "typed-store-workspace-hack 0.0.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.46.0)",
-]
-
-[[package]]
-name = "typed-store"
-version = "0.4.0"
 source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0#f3e72b60708b682f1d286b8d218977c4338e39d9"
 dependencies = [
  "async-trait",
@@ -11621,34 +11567,52 @@ dependencies = [
  "bincode",
  "collectable",
  "eyre",
- "fdlimit",
+ "fdlimit 0.2.1",
  "hdrhistogram",
  "itertools 0.13.0",
- "msim 0.1.0 (git+https://github.com/MystenLabs/mysten-sim.git?rev=cad62679fd180a48c665f842cb80045f8fcfdee9)",
+ "msim",
  "once_cell",
  "prometheus",
  "rand 0.8.5",
  "rocksdb",
  "serde",
- "sui-macros 0.7.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
+ "sui-macros",
  "tap",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
- "typed-store-derive 0.3.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
- "typed-store-error 0.4.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
- "typed-store-workspace-hack 0.0.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
+ "typed-store-derive 0.3.0",
+ "typed-store-error",
+ "typed-store-workspace-hack",
 ]
 
 [[package]]
-name = "typed-store-derive"
-version = "0.3.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.46.0#e011e770764fa971d2defa6d1fd4152bb2b898d4"
+name = "typed-store"
+version = "1.25.0"
 dependencies = [
+ "async-trait",
+ "bcs",
+ "bincode",
+ "collectable",
+ "eyre",
+ "fdlimit 0.3.0",
+ "hdrhistogram",
  "itertools 0.13.0",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "once_cell",
+ "prometheus",
+ "rand 0.8.5",
+ "rocksdb",
+ "rstest",
+ "serde",
+ "sui-macros",
+ "sui-simulator",
+ "tap",
+ "tempfile",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+ "typed-store-derive 1.25.0",
+ "uint 0.10.0",
 ]
 
 [[package]]
@@ -11663,39 +11627,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "typed-store-error"
-version = "0.4.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.46.0#e011e770764fa971d2defa6d1fd4152bb2b898d4"
+name = "typed-store-derive"
+version = "1.25.0"
 dependencies = [
- "serde",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "typed-store-error"
-version = "0.4.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0#f3e72b60708b682f1d286b8d218977c4338e39d9"
-dependencies = [
- "serde",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "typed-store-workspace-hack"
-version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.46.0#e011e770764fa971d2defa6d1fd4152bb2b898d4"
-dependencies = [
- "cc",
- "lazy_static",
- "libc",
- "memchr",
- "nom",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "regex",
- "regex-syntax 0.7.5",
  "syn 2.0.101",
- "zstd-sys",
+]
+
+[[package]]
+name = "typed-store-error"
+version = "0.4.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0#f3e72b60708b682f1d286b8d218977c4338e39d9"
+dependencies = [
+ "serde",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -11755,6 +11702,18 @@ name = "uint"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "uint"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -12064,7 +12023,7 @@ dependencies = [
  "rand 0.8.5",
  "reqwest",
  "serde_yaml 0.9.34+deprecated",
- "sui-macros 0.7.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
+ "sui-macros",
  "sui-protocol-config",
  "sui-simulator",
  "sui-types",
@@ -12121,7 +12080,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "sui-macros 0.7.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
+ "sui-macros",
  "syn 2.0.101",
 ]
 
@@ -12272,7 +12231,7 @@ dependencies = [
  "sha2 0.10.9",
  "snap",
  "sui-config",
- "sui-macros 0.7.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
+ "sui-macros",
  "sui-package-resolver",
  "sui-protocol-config",
  "sui-rpc-api",
@@ -12293,7 +12252,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "twox-hash 2.1.0",
- "typed-store 0.4.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.46.0)",
+ "typed-store 1.25.0",
  "utoipa",
  "utoipa-redoc",
  "uuid",
@@ -12315,7 +12274,7 @@ dependencies = [
  "prometheus",
  "rand 0.8.5",
  "reqwest",
- "sui-macros 0.7.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
+ "sui-macros",
  "sui-protocol-config",
  "sui-rpc-api",
  "sui-simulator",
@@ -12421,7 +12380,7 @@ dependencies = [
  "serde_with",
  "sui-config",
  "sui-keys",
- "sui-macros 0.7.0 (git+https://github.com/MystenLabs/sui?tag=testnet-v1.47.0)",
+ "sui-macros",
  "sui-move-build",
  "sui-package-management",
  "sui-rpc-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,8 @@
 [workspace]
 default-members = [
   "crates/checkpoint-downloader",
+  "crates/typed-store",
+  "crates/typed-store-derive",
   "crates/walrus-core",
   "crates/walrus-e2e-tests",
   "crates/walrus-proc-macros",
@@ -40,17 +42,21 @@ checkpoint-downloader = { path = "crates/checkpoint-downloader" }
 chrono = "0.4"
 clap = { version = "4.5.37", features = ["derive"] }
 clap_complete = "4.5.48"
+collectable = "0.0.2"
 colored = "2.2.0"
 criterion = "0.5.1"
 diesel = { version = "2.2", features = ["chrono", "postgres", "uuid"] }
 diesel-async = { version = "0.5", features = ["postgres"] }
 diesel_migrations = { version = "2.2.0", features = ["postgres"] }
 enum_dispatch = "0.3"
+eyre = "0.6.12"
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9" }
+fdlimit = "0.3.0"
 futures = { version = "0.3.31", default-features = false, features = ["async-await", "std"] }
 futures-timer = "=3.0.3" # required for MSIM
 futures-util = "0.3.30"
 git-version = "0.3.9"
+hdrhistogram = "7.5.4"
 home = "0.5.11"
 hostname = "0.4.1"
 http-body-util = "0.1.1"
@@ -76,6 +82,7 @@ opentelemetry = { version = "=0.27.1", default-features = false, features = ["tr
 p256 = { version = "0.13.2", default-features = false }
 pin-project = "1.1.10"
 prettytable = "0.10.0"
+proc-macro2 = "1.0.95"
 prometheus = "0.13.4"
 quote = "1.0"
 rand = "0.8.5"
@@ -86,6 +93,7 @@ reed-solomon-simd = "3.0.1"
 regex = "1"
 reqwest = { version = "0.12.12", default-features = false, features = ["http2", "json", "rustls-tls"] }
 rocksdb = "0.21.0"
+rstest = "0.25.0"
 rustls = { version = "0.23.26", default-features = false, features = ["logging", "ring", "tls12"] }
 rustls-native-certs = "0.8.1"
 scoped-futures = "0.1.4"
@@ -110,6 +118,7 @@ sui-simulator = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.4
 sui-storage = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.47.0" }
 sui-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.47.0" }
 syn = "2.0"
+tap = "1.0.1"
 telemetry-subscribers = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.47.0" }
 tempfile = "3.19.1"
 test-cluster = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.47.0" }
@@ -124,8 +133,10 @@ tracing = "0.1.41"
 tracing-opentelemetry = { version = "=0.28.0", default-features = false }
 tracing-subscriber = { version = "0.3.19", default-features = false, features = ["fmt"] }
 twox-hash = "2.1.0"
+typed-store = { path = "crates/typed-store" }
+typed-store-derive = { path = "crates/typed-store-derive" }
+uint = "0.10.0"
 # TODO (WAL-790): update typed-store to >= 1.47 or remove it.
-typed-store = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.46.0" }
 url = "2.5.4"
 utoipa = { version = "5" }
 utoipa-redoc = { version = "6.0", features = ["axum"] }

--- a/crates/typed-store-derive/Cargo.toml
+++ b/crates/typed-store-derive/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "typed-store-derive"
+publish = false
+authors.workspace = true
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+itertools.workspace = true
+proc-macro2.workspace = true
+quote.workspace = true
+syn = { workspace = true, features = ["full"] }
+
+
+[lints]
+workspace = true

--- a/crates/typed-store-derive/src/lib.rs
+++ b/crates/typed-store-derive/src/lib.rs
@@ -1,0 +1,625 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Derive macros for the typed-store crate.
+//! This crate provides procedural macros for implementing type-safe database operations
+//! and utilities for the typed-store crate.
+
+use std::collections::BTreeMap;
+
+use itertools::Itertools;
+use proc_macro::TokenStream;
+use proc_macro2::Ident;
+use quote::quote;
+use syn::{
+    AngleBracketedGenericArguments,
+    Attribute,
+    Expr,
+    Generics,
+    ItemStruct,
+    Lit,
+    Meta,
+    PathArguments,
+    Type::{self},
+    parse_macro_input,
+};
+
+// This is used as default when none is specified
+const DEFAULT_DB_OPTIONS_CUSTOM_FN: &str = "typed_store::rocks::default_db_options";
+// Custom function which returns the option and overrides the defaults for this table
+const DB_OPTIONS_CUSTOM_FUNCTION: &str = "default_options_override_fn";
+// Use a different name for the column than the identifier
+const DB_OPTIONS_RENAME: &str = "rename";
+// Deprecate a column family
+const DB_OPTIONS_DEPRECATE: &str = "deprecated";
+
+/// Options can either be simplified form or
+enum GeneralTableOptions {
+    OverrideFunction(String),
+}
+
+impl Default for GeneralTableOptions {
+    fn default() -> Self {
+        Self::OverrideFunction(DEFAULT_DB_OPTIONS_CUSTOM_FN.to_owned())
+    }
+}
+
+// Extracts the field names, field types,
+// inner types (K,V in {map_type_name}<K, V>),
+// and the options attrs
+fn extract_struct_info(input: ItemStruct) -> ExtractedStructInfo {
+    let mut deprecated_cfs = vec![];
+
+    let info = input.fields.iter().map(|f| {
+        let attrs: BTreeMap<_, _> = f
+            .attrs
+            .iter()
+            .filter(|a| {
+                a.path().is_ident(DB_OPTIONS_CUSTOM_FUNCTION)
+                    || a.path().is_ident(DB_OPTIONS_RENAME)
+                    || a.path().is_ident(DB_OPTIONS_DEPRECATE)
+            })
+            .map(|a| (a.path().get_ident().unwrap().to_string(), a))
+            .collect();
+
+        let options = if let Some(options) = attrs.get(DB_OPTIONS_CUSTOM_FUNCTION) {
+            GeneralTableOptions::OverrideFunction(get_options_override_function(options).unwrap())
+        } else {
+            GeneralTableOptions::default()
+        };
+
+        let ty = &f.ty;
+        if let Type::Path(p) = ty {
+            let type_info = &p.path.segments.first().unwrap();
+            let inner_type =
+                if let PathArguments::AngleBracketed(angle_bracket_type) = &type_info.arguments {
+                    angle_bracket_type.clone()
+                } else {
+                    panic!("All struct members must be of type DBMap");
+                };
+
+            let type_str = format!("{}", &type_info.ident);
+            if type_str == "DBMap" {
+                let field_name = f.ident.as_ref().unwrap().clone();
+                let cf_name = if let Some(rename) = attrs.get(DB_OPTIONS_RENAME) {
+                    match &rename.meta {
+                        Meta::NameValue(val) => {
+                            if let Expr::Lit(expr) = &val.value {
+                                if let Lit::Str(lit_str) = &expr.lit {
+                                    lit_str.parse().expect("Rename value must be identifier")
+                                } else {
+                                    panic!("Expected string value for rename")
+                                }
+                            } else {
+                                panic!("Expected string value for rename")
+                            }
+                        }
+                        _ => panic!("Expected string value for rename"),
+                    }
+                } else {
+                    field_name.clone()
+                };
+                if attrs.contains_key(DB_OPTIONS_DEPRECATE) {
+                    deprecated_cfs.push(field_name.clone());
+                }
+
+                return ((field_name, cf_name, type_str), (inner_type, options));
+            } else {
+                panic!("All struct members must be of type DBMap");
+            }
+        }
+        panic!("All struct members must be of type DBMap");
+    });
+
+    let (field_info, inner_types_with_opts): (Vec<_>, Vec<_>) = info.unzip();
+    let (field_names, cf_names, simple_field_type_names): (Vec<_>, Vec<_>, Vec<_>) =
+        field_info.into_iter().multiunzip();
+
+    // Check for homogeneous types
+    if let Some(first) = simple_field_type_names.first() {
+        simple_field_type_names.iter().for_each(|q| {
+            if q != first {
+                panic!("All struct members must be of same type");
+            }
+        })
+    } else {
+        panic!("Cannot derive on empty struct");
+    };
+
+    let (inner_types, options): (Vec<_>, Vec<_>) = inner_types_with_opts.into_iter().unzip();
+
+    ExtractedStructInfo {
+        field_names,
+        cf_names,
+        inner_types,
+        derived_table_options: options,
+        deprecated_cfs,
+    }
+}
+
+/// Extracts the table options override function
+/// The function must take no args and return Options
+fn get_options_override_function(attr: &Attribute) -> syn::Result<String> {
+    if !attr.path().is_ident(DB_OPTIONS_CUSTOM_FUNCTION) {
+        return Err(syn::Error::new_spanned(
+            attr,
+            format!(
+                "Expected function name in format \
+                `#[{DB_OPTIONS_CUSTOM_FUNCTION} = {{function_name}}]`"
+            ),
+        ));
+    }
+    if let Meta::NameValue(meta) = &attr.meta {
+        if let Expr::Lit(expr) = &meta.value {
+            if let Lit::Str(lit_str) = &expr.lit {
+                return Ok(lit_str.value());
+            }
+        }
+    }
+
+    Err(syn::Error::new_spanned(
+        attr,
+        format!(
+            "Expected function name in format \
+            `#[{DB_OPTIONS_CUSTOM_FUNCTION} = {{function_name}}]`"
+        ),
+    ))
+}
+
+fn extract_generics_names(generics: &Generics) -> Vec<Ident> {
+    generics
+        .params
+        .iter()
+        .map(|g| match g {
+            syn::GenericParam::Type(t) => t.ident.clone(),
+            _ => panic!("Unsupported generic type"),
+        })
+        .collect()
+}
+
+struct ExtractedStructInfo {
+    field_names: Vec<Ident>,
+    cf_names: Vec<Ident>,
+    inner_types: Vec<AngleBracketedGenericArguments>,
+    derived_table_options: Vec<GeneralTableOptions>,
+    deprecated_cfs: Vec<Ident>,
+}
+
+/// Derives utility functions for DBMap operations.
+/// This macro generates helper functions for working with DBMap types,
+/// including serialization, deserialization, and key-value operations.
+#[proc_macro_derive(DBMapUtils, attributes(default_options_override_fn, rename))]
+pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as ItemStruct);
+    let name = &input.ident;
+    let generics = &input.generics;
+    let generics_names = extract_generics_names(generics);
+
+    // TODO: use `parse_quote` over `parse()`
+    let ExtractedStructInfo {
+        field_names,
+        cf_names,
+        inner_types,
+        derived_table_options,
+        deprecated_cfs,
+    } = extract_struct_info(input.clone());
+
+    let (key_names, value_names): (Vec<_>, Vec<_>) = inner_types
+        .iter()
+        .map(|q| (q.args.first().unwrap(), q.args.last().unwrap()))
+        .unzip();
+
+    let default_options_override_fn_names: Vec<proc_macro2::TokenStream> = derived_table_options
+        .iter()
+        .map(|q| {
+            let GeneralTableOptions::OverrideFunction(fn_name) = q;
+            fn_name.parse().unwrap()
+        })
+        .collect();
+
+    let generics_bounds =
+        "std::fmt::Debug + serde::Serialize + for<'de> serde::de::Deserialize<'de>";
+    let generics_bounds_token: proc_macro2::TokenStream = generics_bounds.parse().unwrap();
+
+    let config_struct_name_str = format!("{name}Configurator");
+    let config_struct_name: proc_macro2::TokenStream = config_struct_name_str.parse().unwrap();
+
+    let intermediate_db_map_struct_name_str = format!("{name}IntermediateDBMapStructPrimary");
+    let intermediate_db_map_struct_name: proc_macro2::TokenStream =
+        intermediate_db_map_struct_name_str.parse().unwrap();
+
+    let secondary_db_map_struct_name_str = format!("{name}ReadOnly");
+    let secondary_db_map_struct_name: proc_macro2::TokenStream =
+        secondary_db_map_struct_name_str.parse().unwrap();
+
+    TokenStream::from(quote! {
+
+        // <----------- This section generates the configurator struct -------------->
+
+        /// Create config structs for configuring DBMap tables
+        pub struct #config_struct_name {
+            #(
+                pub #field_names : typed_store::rocks::DBOptions,
+            )*
+        }
+
+        impl #config_struct_name {
+            /// Initialize to defaults
+            pub fn init() -> Self {
+                Self {
+                    #(
+                        #field_names : typed_store::rocks::default_db_options(),
+                    )*
+                }
+            }
+
+            /// Build a config
+            pub fn build(&self) -> typed_store::rocks::DBMapTableConfigMap {
+                typed_store::rocks::DBMapTableConfigMap::new([
+                    #(
+                        (stringify!(#field_names).to_owned(), self.#field_names.clone()),
+                    )*
+                ].into_iter().collect())
+            }
+        }
+
+        impl <
+                #(
+                    #generics_names: #generics_bounds_token,
+                )*
+            > #name #generics {
+
+                pub fn configurator() -> #config_struct_name {
+                    #config_struct_name::init()
+                }
+        }
+
+        // <----------- This section generates the core open logic for opening DBMaps ----------->
+
+        /// Create an intermediate struct used to open the DBMap tables in primary mode
+        /// This is only used internally
+        struct #intermediate_db_map_struct_name #generics {
+                #(
+                    pub #field_names : DBMap #inner_types,
+                )*
+        }
+
+
+        impl <
+                #(
+                    #generics_names: #generics_bounds_token,
+                )*
+            > #intermediate_db_map_struct_name #generics {
+            /// Opens a set of tables in read-write mode
+            /// If as_secondary_with_path is set, the DB is opened in read only mode with the
+            /// path specified
+            pub fn open_tables_impl(
+                path: std::path::PathBuf,
+                as_secondary_with_path: Option<std::path::PathBuf>,
+                metric_conf: typed_store::rocks::MetricConf,
+                global_db_options_override: Option<typed_store::rocksdb::Options>,
+                tables_db_options_override: Option<typed_store::rocks::DBMapTableConfigMap>,
+                remove_deprecated_tables: bool,
+            ) -> Self {
+                let path = &path;
+                let default_cf_opt = if let Some(opt) = global_db_options_override.as_ref() {
+                    typed_store::rocks::DBOptions {
+                        options: opt.clone(),
+                        rw_options: typed_store::rocks::default_db_options().rw_options,
+                    }
+                } else {
+                    typed_store::rocks::default_db_options()
+                };
+                let (db, rwopt_cfs) = {
+                    let opt_cfs = match tables_db_options_override {
+                        None => [
+                            #(
+                                (stringify!(#cf_names).to_owned(),
+                                #default_options_override_fn_names()),
+                            )*
+                        ],
+                        Some(o) => [
+                            #(
+                                (stringify!(#cf_names).to_owned(),
+                                o.to_map().get(stringify!(#cf_names))
+                                .unwrap_or(&default_cf_opt).clone()),
+                            )*
+                        ]
+                    };
+                    // Safe to call unwrap because we will have at least one
+                    // field_name entry in the struct
+                    let rwopt_cfs: std::collections::HashMap<String,
+                        typed_store::rocks::ReadWriteOptions> = opt_cfs.iter()
+                        .map(|q| (q.0.as_str().to_string(), q.1.rw_options.clone())).collect();
+                    let opt_cfs: Vec<_> = opt_cfs.iter()
+                        .map(|q| (q.0.as_str(), q.1.options.clone())).collect();
+                    let db = match as_secondary_with_path.clone() {
+                        Some(p) => typed_store::rocks::open_cf_opts_secondary(
+                            path, Some(&p), global_db_options_override, metric_conf, &opt_cfs),
+                        _ => typed_store::rocks::open_cf_opts(
+                            path, global_db_options_override, metric_conf, &opt_cfs)
+                    };
+                    db.map(|d| (d, rwopt_cfs))
+                }.expect(&format!("Cannot open DB at {:?}", path));
+                let deprecated_tables = vec![#(stringify!(#deprecated_cfs),)*];
+                let (
+                        #(
+                            #field_names
+                        ),*
+                ) = (#(
+                        DBMap::#inner_types::reopen(
+                            &db,
+                            Some(stringify!(#cf_names)),
+                            rwopt_cfs.get(stringify!(#cf_names))
+                                .unwrap_or(&typed_store::rocks::ReadWriteOptions::default()),
+                                    remove_deprecated_tables
+                                    && deprecated_tables.contains(
+                                        &stringify!(#cf_names))).expect(
+                                            &format!(
+                                                "Cannot open {} CF.", stringify!(#cf_names))[..])
+                    ),*);
+
+                if as_secondary_with_path.is_none() && remove_deprecated_tables {
+                    #(
+                        db.drop_cf(stringify!(#deprecated_cfs))
+                            .expect("failed to drop a deprecated cf");
+                    )*
+                }
+                Self {
+                    #(
+                        #field_names,
+                    )*
+                }
+            }
+        }
+
+
+        // <---- This section generates the read-write open logic and other common utils ---->
+
+        impl <
+                #(
+                    #generics_names: #generics_bounds_token,
+                )*
+            > #name #generics {
+            /// Opens a set of tables in read-write mode
+            /// Only one process is allowed to do this at a time
+            /// `global_db_options_override` apply to the whole DB
+            /// `tables_db_options_override` apply to each table.
+            /// If `None`, the attributes from `default_options_override_fn` are used if any
+            #[allow(unused_parens)]
+            pub fn open_tables_read_write(
+                path: std::path::PathBuf,
+                metric_conf: typed_store::rocks::MetricConf,
+                global_db_options_override: Option<typed_store::rocksdb::Options>,
+                tables_db_options_override: Option<typed_store::rocks::DBMapTableConfigMap>
+            ) -> Self {
+                let inner = #intermediate_db_map_struct_name::open_tables_impl(
+                    path,
+                    None,
+                    metric_conf,
+                    global_db_options_override,
+                    tables_db_options_override,
+                    false
+                );
+                Self {
+                    #(
+                        #field_names: inner.#field_names,
+                    )*
+                }
+            }
+
+            #[allow(unused_parens)]
+            pub fn open_tables_read_write_with_deprecation_option(
+                path: std::path::PathBuf,
+                metric_conf: typed_store::rocks::MetricConf,
+                global_db_options_override: Option<typed_store::rocksdb::Options>,
+                tables_db_options_override: Option<typed_store::rocks::DBMapTableConfigMap>,
+                remove_deprecated_tables: bool,
+            ) -> Self {
+                let inner = #intermediate_db_map_struct_name::open_tables_impl(
+                    path,
+                    None,
+                    metric_conf,
+                    global_db_options_override,
+                    tables_db_options_override,
+                    remove_deprecated_tables
+                );
+                Self {
+                    #(
+                        #field_names: inner.#field_names,
+                    )*
+                }
+            }
+
+            /// Returns a list of the tables name and type pairs
+            pub fn describe_tables() -> std::collections::BTreeMap<String, (String, String)> {
+                vec![#(
+                    (stringify!(#field_names).to_owned(), (
+                        stringify!(#key_names).to_owned(), stringify!(#value_names).to_owned())),
+                )*].into_iter().collect()
+            }
+
+            /// This opens the DB in read only mode and returns a struct which exposes debug
+            /// features
+            pub fn get_read_only_handle (
+                primary_path: std::path::PathBuf,
+                with_secondary_path: Option<std::path::PathBuf>,
+                global_db_options_override: Option<typed_store::rocksdb::Options>,
+                metric_conf: typed_store::rocks::MetricConf,
+                ) -> #secondary_db_map_struct_name #generics {
+                #secondary_db_map_struct_name::open_tables_read_only(
+                    primary_path, with_secondary_path, metric_conf, global_db_options_override)
+            }
+        }
+
+
+        // <---- This section generates the features that use read-only open logic ----->
+        /// Create an intermediate struct used to open the DBMap tables in secondary mode
+        /// This is only used internally
+        pub struct #secondary_db_map_struct_name #generics {
+            #(
+                pub #field_names : DBMap #inner_types,
+            )*
+        }
+
+        impl <
+                #(
+                    #generics_names: #generics_bounds_token,
+                )*
+            > #secondary_db_map_struct_name #generics {
+            /// Open in read only mode. No limitation on number of processes to do this
+            pub fn open_tables_read_only(
+                primary_path: std::path::PathBuf,
+                with_secondary_path: Option<std::path::PathBuf>,
+                metric_conf: typed_store::rocks::MetricConf,
+                global_db_options_override: Option<typed_store::rocksdb::Options>,
+            ) -> Self {
+                let inner = match with_secondary_path {
+                    Some(q) => #intermediate_db_map_struct_name::open_tables_impl(
+                        primary_path,
+                        Some(q),
+                        metric_conf,
+                        global_db_options_override,
+                        None,
+                        false
+                    ),
+                    None => {
+                        let p: std::path::PathBuf = tempfile::tempdir()
+                        .expect("Failed to open temporary directory")
+                        .into_path();
+                        #intermediate_db_map_struct_name::open_tables_impl(
+                            primary_path,
+                            Some(p),
+                            metric_conf,
+                            global_db_options_override,
+                            None,
+                            false)
+                    }
+                };
+                Self {
+                    #(
+                        #field_names: inner.#field_names,
+                    )*
+                }
+            }
+
+            fn cf_name_to_table_name(cf_name: &str) -> eyre::Result<&'static str> {
+                Ok(match cf_name {
+                    #(
+                        stringify!(#cf_names) => stringify!(#field_names),
+                    )*
+                    _ => eyre::bail!("No such cf name: {}", cf_name),
+                })
+            }
+
+            /// Dump all key-value pairs in the page at the given table name
+            /// Tables must be opened in read only mode using `open_tables_read_only`
+            pub fn dump(&self, cf_name: &str, page_size: u16, page_number: usize) ->
+                eyre::Result<std::collections::BTreeMap<String, String>> {
+                let table_name = Self::cf_name_to_table_name(cf_name)?;
+
+                Ok(match table_name {
+                    #(
+                        stringify!(#field_names) => {
+                            typed_store::traits::Map::try_catch_up_with_primary(
+                                &self.#field_names)?;
+                            typed_store::traits::Map::safe_iter(&self.#field_names)
+                                .skip((page_number * (page_size) as usize))
+                                .take(page_size as usize)
+                                .map(|result| result.map(|(k, v)| (
+                                    format!("{:?}", k), format!("{:?}", v))))
+                                .collect::<eyre::Result<std::collections::BTreeMap<_, _>, _>>()?
+                        }
+                    )*
+
+                    _ => eyre::bail!("No such table name: {}", table_name),
+                })
+            }
+
+            /// Get key value sizes from the db
+            /// Tables must be opened in read only mode using `open_tables_read_only`
+            pub fn table_summary(&self, table_name: &str) ->
+                eyre::Result<typed_store::traits::TableSummary> {
+                let mut count = 0;
+                let mut key_bytes = 0;
+                let mut value_bytes = 0;
+                match table_name {
+                    #(
+                        stringify!(#field_names) => {
+                            typed_store::traits::Map::try_catch_up_with_primary(
+                                &self.#field_names)?;
+                            self.#field_names.table_summary()
+                        }
+                    )*
+
+                    _ => eyre::bail!("No such table name: {}", table_name),
+                }
+            }
+
+            /// Count the keys in this table
+            /// Tables must be opened in read only mode using `open_tables_read_only`
+            pub fn count_keys(&self, table_name: &str) -> eyre::Result<usize> {
+                Ok(match table_name {
+                    #(
+                        stringify!(#field_names) => {
+                            typed_store::traits::Map::try_catch_up_with_primary(
+                                &self.#field_names)?;
+                            typed_store::traits::Map::safe_iter(&self.#field_names).count()
+                        }
+                    )*
+
+                    _ => eyre::bail!("No such table name: {}", table_name),
+                })
+            }
+
+            pub fn describe_tables() -> std::collections::BTreeMap<String, (String, String)> {
+                vec![#(
+                    (stringify!(#field_names).to_owned(), (
+                        stringify!(#key_names).to_owned(),
+                        stringify!(#value_names).to_owned())),
+                )*].into_iter().collect()
+            }
+
+            /// Try catch up with primary for all tables. This can be a slow operation
+            /// Tables must be opened in read only mode using `open_tables_read_only`
+            pub fn try_catch_up_with_primary_all(&self) -> eyre::Result<()> {
+                #(
+                    typed_store::traits::Map::try_catch_up_with_primary(&self.#field_names)?;
+                )*
+                Ok(())
+            }
+        }
+
+        impl <
+                #(
+                    #generics_names: #generics_bounds_token,
+                )*
+            > TypedStoreDebug for #secondary_db_map_struct_name #generics {
+                fn dump_table(
+                    &self,
+                    table_name: String,
+                    page_size: u16,
+                    page_number: usize,
+                ) -> eyre::Result<std::collections::BTreeMap<String, String>> {
+                    self.dump(table_name.as_str(), page_size, page_number)
+                }
+
+                fn primary_db_name(&self) -> String {
+                    stringify!(#name).to_owned()
+                }
+
+                fn describe_all_tables(&self) ->
+                    std::collections::BTreeMap<String, (String, String)> {
+                    Self::describe_tables()
+                }
+
+                fn count_table_keys(&self, table_name: String) -> eyre::Result<usize> {
+                    self.count_keys(table_name.as_str())
+                }
+
+                fn table_summary(&self, table_name: String) -> eyre::Result<TableSummary> {
+                    self.table_summary(table_name.as_str())
+                }
+        }
+    })
+}

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "typed-store"
+publish = false
+authors.workspace = true
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+async-trait.workspace = true
+bcs.workspace = true
+bincode.workspace = true
+collectable.workspace = true
+eyre.workspace = true
+fdlimit.workspace = true
+hdrhistogram.workspace = true
+itertools.workspace = true
+once_cell.workspace = true
+prometheus.workspace = true
+rand.workspace = true
+rocksdb = { version = "0.21.0", default-features = false, features = ["lz4", "multi-threaded-cf", "snappy", "zlib", "zstd"] }
+serde.workspace = true
+sui-macros.workspace = true
+tap.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["full", "test-util"] }
+tracing.workspace = true
+typed-store-derive = { path = "../typed-store-derive" }
+
+[dev-dependencies]
+once_cell.workspace = true
+rand.workspace = true
+rstest.workspace = true
+tempfile.workspace = true
+uint.workspace = true
+
+[target.'cfg(msim)'.dependencies]
+sui-simulator.workspace = true
+
+[lints]
+workspace = true

--- a/crates/typed-store/src/lib.rs
+++ b/crates/typed-store/src/lib.rs
@@ -1,0 +1,40 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! A type-safe wrapper around RocksDB that provides a key-value store interface.
+//! This crate provides functionality for storing and retrieving typed data in RocksDB,
+//! with support for column families, batch operations, and metrics.
+
+#![warn(
+    future_incompatible,
+    nonstandard_style,
+    rust_2018_idioms,
+    rust_2021_compatibility,
+    unused,
+    missing_docs
+)]
+
+/// Re-export rocksdb so that consumers can use the version of rocksdb via typed-store
+pub use rocksdb;
+
+/// The rocksdb database
+pub mod rocks;
+
+/// The traits for the typed store
+pub mod traits;
+
+/// The error type for the typed store
+pub use rocks::errors::TypedStoreError;
+/// The traits for the typed store
+pub use traits::Map;
+
+/// The error type for the typed store
+pub type StoreError = rocks::errors::TypedStoreError;
+
+/// The metrics for the typed store
+pub mod metrics;
+
+/// The metrics for the typed store
+pub use metrics::DBMetrics;
+/// The derive macros for the typed store
+pub use typed_store_derive::DBMapUtils;

--- a/crates/typed-store/src/metrics.rs
+++ b/crates/typed-store/src/metrics.rs
@@ -1,0 +1,1108 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    cell::RefCell,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Duration,
+};
+
+use once_cell::sync::OnceCell;
+use prometheus::{
+    HistogramVec,
+    IntCounterVec,
+    IntGaugeVec,
+    Registry,
+    register_histogram_vec_with_registry,
+    register_int_counter_vec_with_registry,
+    register_int_gauge_vec_with_registry,
+};
+use rocksdb::{PerfContext, PerfMetric, PerfStatsLevel, perf::set_perf_stats};
+use tap::TapFallible;
+use tracing::warn;
+
+thread_local! {
+    static PER_THREAD_ROCKS_PERF_CONTEXT: std::cell::RefCell<rocksdb::PerfContext> =
+        RefCell::new(PerfContext::default());
+}
+
+const LATENCY_SEC_BUCKETS: &[f64] = &[
+    0.00001, 0.00005, // 10 mcs, 50 mcs
+    0.0001, 0.0002, 0.0003, 0.0004, 0.0005, // 100..500 mcs
+    0.001, 0.002, 0.003, 0.004, 0.005, // 1..5ms
+    0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1., 2.5, 5., 10.,
+];
+
+#[derive(Debug, Clone)]
+/// A struct for sampling based on number of operations or duration.
+/// Sampling happens if the duration expires and after number of operations
+pub struct SamplingInterval {
+    /// Sample once every time duration
+    pub once_every_duration: Duration,
+    /// Sample once every number of operations
+    pub after_num_ops: u64,
+    /// Counter for keeping track of previous sample
+    pub counter: Arc<AtomicU64>,
+}
+
+impl Default for SamplingInterval {
+    fn default() -> Self {
+        // Enabled with 60 second interval
+        SamplingInterval::new(Duration::from_secs(60), 0)
+    }
+}
+
+impl SamplingInterval {
+    /// Create a new sampling interval
+    pub fn new(once_every_duration: Duration, after_num_ops: u64) -> Self {
+        let counter = Arc::new(AtomicU64::new(1));
+        if !once_every_duration.is_zero() {
+            let counter = counter.clone();
+            tokio::task::spawn(async move {
+                loop {
+                    if counter.load(Ordering::SeqCst) > after_num_ops {
+                        counter.store(0, Ordering::SeqCst);
+                    }
+                    tokio::time::sleep(once_every_duration).await;
+                }
+            });
+        }
+        SamplingInterval {
+            once_every_duration,
+            after_num_ops,
+            counter,
+        }
+    }
+    /// Create a new sampling interval from the current one
+    pub fn new_from_self(&self) -> SamplingInterval {
+        SamplingInterval::new(self.once_every_duration, self.after_num_ops)
+    }
+    /// Sample the metrics
+    pub fn sample(&self) -> bool {
+        if self.once_every_duration.is_zero() {
+            self.counter.fetch_add(1, Ordering::Relaxed) % (self.after_num_ops + 1) == 0
+        } else {
+            self.counter.fetch_add(1, Ordering::Relaxed) == 0
+        }
+    }
+}
+
+#[derive(Debug)]
+/// The metrics for the column families
+pub struct ColumnFamilyMetrics {
+    /// The storage size occupied by the sst files in the column family
+    pub rocksdb_total_sst_files_size: IntGaugeVec,
+    /// The storage size occupied by the blob files in the column family
+    pub rocksdb_total_blob_files_size: IntGaugeVec,
+    /// Total number of files used in the column family
+    pub rocksdb_total_num_files: IntGaugeVec,
+    /// Number of level 0 files in the column family
+    pub rocksdb_num_level0_files: IntGaugeVec,
+    /// The current approximate size of active memtable (bytes).
+    pub rocksdb_current_size_active_mem_tables: IntGaugeVec,
+    /// The memory size occupied by the column family's in-memory buffer
+    pub rocksdb_size_all_mem_tables: IntGaugeVec,
+    /// Number of snapshots held for the column family
+    pub rocksdb_num_snapshots: IntGaugeVec,
+    /// Unit timestamp of the oldest unreleased snapshot
+    pub rocksdb_oldest_snapshot_time: IntGaugeVec,
+    /// The current actual delayed write rate. 0 means no delay
+    pub rocksdb_actual_delayed_write_rate: IntGaugeVec,
+    /// Flag indicating if writes are stopped (1) or not (0) for this column family
+    pub rocksdb_is_write_stopped: IntGaugeVec,
+    /// The block cache capacity of the column family.
+    pub rocksdb_block_cache_capacity: IntGaugeVec,
+    /// The memory size used by the column family in the block cache.
+    pub rocksdb_block_cache_usage: IntGaugeVec,
+    /// The memory size used by pinned entries in block cache
+    pub rocksdb_block_cache_pinned_usage: IntGaugeVec,
+    /// The estimated memory size used for reading SST tables in this column
+    /// family such as filters and index blocks. Note that this number does not
+    /// include the memory used in block cache.
+    pub rocksdb_estimate_table_readers_mem: IntGaugeVec,
+    /// The number of immutable memtables that have not yet been flushed.
+    pub rocksdb_num_immutable_mem_tables: IntGaugeVec,
+    /// A 1 or 0 flag indicating whether a memtable flush is pending.
+    pub rocksdb_mem_table_flush_pending: IntGaugeVec,
+    /// A 1 or 0 flag indicating whether a compaction job is pending.
+    pub rocksdb_compaction_pending: IntGaugeVec,
+    /// Estimated total number of bytes compaction needs to rewrite to get all levels down
+    /// to under target size. Not valid for other compactions than level-based.
+    pub rocksdb_estimate_pending_compaction_bytes: IntGaugeVec,
+    /// The number of compactions that are currently running for the column family.
+    pub rocksdb_num_running_compactions: IntGaugeVec,
+    /// The number of flushes that are currently running for the column family.
+    pub rocksdb_num_running_flushes: IntGaugeVec,
+    /// Estimated oldest key timestamp in the DB
+    pub rocksdb_estimate_oldest_key_time: IntGaugeVec,
+    /// The accumulated number of RocksDB background errors.
+    pub rocksdb_background_errors: IntGaugeVec,
+    /// The estimated number of keys in the table
+    pub rocksdb_estimated_num_keys: IntGaugeVec,
+    /// The number of level to which L0 data will be compacted.
+    pub rocksdb_base_level: IntGaugeVec,
+}
+
+impl ColumnFamilyMetrics {
+    pub(crate) fn new(registry: &Registry) -> Self {
+        ColumnFamilyMetrics {
+            rocksdb_total_sst_files_size: register_int_gauge_vec_with_registry!(
+                "rocksdb_total_sst_files_size",
+                "The storage size occupied by the sst files in the column family",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_total_blob_files_size: register_int_gauge_vec_with_registry!(
+                "rocksdb_total_blob_files_size",
+                "The storage size occupied by the blob files in the column family",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_total_num_files: register_int_gauge_vec_with_registry!(
+                "rocksdb_total_num_files",
+                "Total number of files used in the column family",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_num_level0_files: register_int_gauge_vec_with_registry!(
+                "rocksdb_num_level0_files",
+                "Number of level 0 files in the column family",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_current_size_active_mem_tables: register_int_gauge_vec_with_registry!(
+                "rocksdb_current_size_active_mem_tables",
+                "The current approximate size of active memtable (bytes).",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_size_all_mem_tables: register_int_gauge_vec_with_registry!(
+                "rocksdb_size_all_mem_tables",
+                "The memory size occupied by the column family's in-memory buffer",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_num_snapshots: register_int_gauge_vec_with_registry!(
+                "rocksdb_num_snapshots",
+                "Number of snapshots held for the column family",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_oldest_snapshot_time: register_int_gauge_vec_with_registry!(
+                "rocksdb_oldest_snapshot_time",
+                "Unit timestamp of the oldest unreleased snapshot",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_actual_delayed_write_rate: register_int_gauge_vec_with_registry!(
+                "rocksdb_actual_delayed_write_rate",
+                "The current actual delayed write rate. 0 means no delay",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_is_write_stopped: register_int_gauge_vec_with_registry!(
+                "rocksdb_is_write_stopped",
+                "Flag indicating if writes are stopped (1) or not (0) for this column family",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_block_cache_capacity: register_int_gauge_vec_with_registry!(
+                "rocksdb_block_cache_capacity",
+                "The block cache capacity of the column family.",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_block_cache_usage: register_int_gauge_vec_with_registry!(
+                "rocksdb_block_cache_usage",
+                "The memory size used by the column family in the block cache.",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_block_cache_pinned_usage: register_int_gauge_vec_with_registry!(
+                "rocksdb_block_cache_pinned_usage",
+                "Memory size used by pinned entries in block cache",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_estimate_table_readers_mem: register_int_gauge_vec_with_registry!(
+                "rocksdb_estimate_table_readers_mem",
+                "The estimated memory size used for reading SST tables in this column
+                family such as filters and index blocks. Note that this number does not
+                include the memory used in block cache.",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_num_immutable_mem_tables: register_int_gauge_vec_with_registry!(
+                "rocksdb_num_immutable_mem_tables",
+                "The number of immutable memtables that have not yet been flushed.",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_mem_table_flush_pending: register_int_gauge_vec_with_registry!(
+                "rocksdb_mem_table_flush_pending",
+                "A 1 or 0 flag indicating whether a memtable flush is pending.
+                If this number is 1, it means a memtable is waiting for being flushed,
+                but there might be too many L0 files that prevents it from being flushed.",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_compaction_pending: register_int_gauge_vec_with_registry!(
+                "rocksdb_compaction_pending",
+                "A 1 or 0 flag indicating whether a compaction job is pending.
+                If this number is 1, it means some part of the column family requires
+                compaction in order to maintain shape of LSM tree, but the compaction
+                is pending because the desired compaction job is either waiting for
+                other dependent compactions to be finished or waiting for an available
+                compaction thread.",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_estimate_pending_compaction_bytes: register_int_gauge_vec_with_registry!(
+                "rocksdb_estimate_pending_compaction_bytes",
+                "Estimated total number of bytes compaction needs to rewrite to get all levels down
+                to under target size. Not valid for other compactions than level-based.",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_num_running_compactions: register_int_gauge_vec_with_registry!(
+                "rocksdb_num_running_compactions",
+                "The number of compactions that are currently running for the column family.",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_num_running_flushes: register_int_gauge_vec_with_registry!(
+                "rocksdb_num_running_flushes",
+                "The number of flushes that are currently running for the column family.",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_estimate_oldest_key_time: register_int_gauge_vec_with_registry!(
+                "rocksdb_estimate_oldest_key_time",
+                "Estimation of the oldest key timestamp in the DB. Only available
+                for FIFO compaction with compaction_options_fifo.allow_compaction = false.",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_estimated_num_keys: register_int_gauge_vec_with_registry!(
+                "rocksdb_estimated_num_keys",
+                "The estimated number of keys in the table",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_background_errors: register_int_gauge_vec_with_registry!(
+                "rocksdb_background_errors",
+                "The accumulated number of RocksDB background errors.",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_base_level: register_int_gauge_vec_with_registry!(
+                "rocksdb_base_level",
+                "The number of level to which L0 data will be compacted.",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+        }
+    }
+}
+
+#[derive(Debug)]
+/// The metrics for the operations
+pub struct OperationMetrics {
+    /// Rocksdb iter latency in seconds
+    pub rocksdb_iter_latency_seconds: HistogramVec,
+    /// Rocksdb iter size in bytes
+    pub rocksdb_iter_bytes: HistogramVec,
+    /// Rocksdb iter num keys
+    pub rocksdb_iter_keys: HistogramVec,
+    /// Rocksdb get latency in seconds
+    pub rocksdb_get_latency_seconds: HistogramVec,
+    /// Rocksdb get bytes
+    pub rocksdb_get_bytes: HistogramVec,
+    /// Rocksdb multiget latency in seconds
+    pub rocksdb_multiget_latency_seconds: HistogramVec,
+    /// Rocksdb multiget bytes
+    pub rocksdb_multiget_bytes: HistogramVec,
+    /// Rocksdb put latency in seconds
+    pub rocksdb_put_latency_seconds: HistogramVec,
+    /// Rocksdb put bytes
+    pub rocksdb_put_bytes: HistogramVec,
+    /// Rocksdb batch put bytes
+    pub rocksdb_batch_put_bytes: HistogramVec,
+    /// Rocksdb delete latency in seconds
+    pub rocksdb_delete_latency_seconds: HistogramVec,
+    /// Rocksdb delete calls
+    pub rocksdb_deletes: IntCounterVec,
+    /// Rocksdb schema batch commit latency in seconds
+    pub rocksdb_batch_commit_latency_seconds: HistogramVec,
+    /// Rocksdb schema batch commit size in bytes
+    pub rocksdb_batch_commit_bytes: HistogramVec,
+    /// Number of active db handles
+    pub rocksdb_num_active_db_handles: IntGaugeVec,
+    /// Number of batch writes that took more than 1 second
+    pub rocksdb_very_slow_batch_writes_count: IntCounterVec,
+    /// Total duration of batch writes that took more than 1 second
+    pub rocksdb_very_slow_batch_writes_duration_ms: IntCounterVec,
+    /// Number of puts that took more than 1 second
+    pub rocksdb_very_slow_puts_count: IntCounterVec,
+    /// Total duration of puts that took more than 1 second
+    pub rocksdb_very_slow_puts_duration_ms: IntCounterVec,
+}
+
+impl OperationMetrics {
+    pub(crate) fn new(registry: &Registry) -> Self {
+        let bucket_vec = prometheus::exponential_buckets(1.0, 4.0, 15)
+            .unwrap()
+            .to_vec();
+
+        OperationMetrics {
+            rocksdb_iter_latency_seconds: register_histogram_vec_with_registry!(
+                "rocksdb_iter_latency_seconds",
+                "Rocksdb iter latency in seconds",
+                &["cf_name"],
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            rocksdb_iter_bytes: register_histogram_vec_with_registry!(
+                "rocksdb_iter_bytes",
+                "Rocksdb iter size in bytes",
+                &["cf_name"],
+                bucket_vec.clone(),
+                registry,
+            )
+            .unwrap(),
+            rocksdb_iter_keys: register_histogram_vec_with_registry!(
+                "rocksdb_iter_keys",
+                "Rocksdb iter num keys",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_get_latency_seconds: register_histogram_vec_with_registry!(
+                "rocksdb_get_latency_seconds",
+                "Rocksdb get latency in seconds",
+                &["cf_name"],
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            rocksdb_get_bytes: register_histogram_vec_with_registry!(
+                "rocksdb_get_bytes",
+                "Rocksdb get call returned data size in bytes",
+                &["cf_name"],
+                bucket_vec.clone(),
+                registry
+            )
+            .unwrap(),
+            rocksdb_multiget_latency_seconds: register_histogram_vec_with_registry!(
+                "rocksdb_multiget_latency_seconds",
+                "Rocksdb multiget latency in seconds",
+                &["cf_name"],
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            rocksdb_multiget_bytes: register_histogram_vec_with_registry!(
+                "rocksdb_multiget_bytes",
+                "Rocksdb multiget call returned data size in bytes",
+                &["cf_name"],
+                bucket_vec.clone(),
+                registry,
+            )
+            .unwrap(),
+            rocksdb_put_latency_seconds: register_histogram_vec_with_registry!(
+                "rocksdb_put_latency_seconds",
+                "Rocksdb put latency in seconds",
+                &["cf_name"],
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            rocksdb_put_bytes: register_histogram_vec_with_registry!(
+                "rocksdb_put_bytes",
+                "Rocksdb put call puts data size in bytes",
+                &["cf_name"],
+                bucket_vec.clone(),
+                registry,
+            )
+            .unwrap(),
+            rocksdb_batch_put_bytes: register_histogram_vec_with_registry!(
+                "rocksdb_batch_put_bytes",
+                "Rocksdb batch put call puts data size in bytes",
+                &["cf_name"],
+                bucket_vec.clone(),
+                registry,
+            )
+            .unwrap(),
+            rocksdb_delete_latency_seconds: register_histogram_vec_with_registry!(
+                "rocksdb_delete_latency_seconds",
+                "Rocksdb delete latency in seconds",
+                &["cf_name"],
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            rocksdb_deletes: register_int_counter_vec_with_registry!(
+                "rocksdb_deletes",
+                "Rocksdb delete calls",
+                &["cf_name"],
+                registry
+            )
+            .unwrap(),
+            rocksdb_batch_commit_latency_seconds: register_histogram_vec_with_registry!(
+                "rocksdb_write_batch_commit_latency_seconds",
+                "Rocksdb schema batch commit latency in seconds",
+                &["db_name"],
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            rocksdb_batch_commit_bytes: register_histogram_vec_with_registry!(
+                "rocksdb_batch_commit_bytes",
+                "Rocksdb schema batch commit size in bytes",
+                &["db_name"],
+                bucket_vec,
+                registry,
+            )
+            .unwrap(),
+            rocksdb_num_active_db_handles: register_int_gauge_vec_with_registry!(
+                "rocksdb_num_active_db_handles",
+                "Number of active db handles",
+                &["db_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_very_slow_batch_writes_count: register_int_counter_vec_with_registry!(
+                "rocksdb_num_very_slow_batch_writes",
+                "Number of batch writes that took more than 1 second",
+                &["db_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_very_slow_batch_writes_duration_ms: register_int_counter_vec_with_registry!(
+                "rocksdb_very_slow_batch_writes_duration",
+                "Total duration of batch writes that took more than 1 second",
+                &["db_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_very_slow_puts_count: register_int_counter_vec_with_registry!(
+                "rocksdb_num_very_slow_puts",
+                "Number of puts that took more than 1 second",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_very_slow_puts_duration_ms: register_int_counter_vec_with_registry!(
+                "rocksdb_very_slow_puts_duration",
+                "Total duration of puts that took more than 1 second",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+        }
+    }
+}
+
+/// The performance context for RocksDB
+#[derive(Debug)]
+pub struct RocksDBPerfContext;
+
+impl Default for RocksDBPerfContext {
+    fn default() -> Self {
+        set_perf_stats(PerfStatsLevel::EnableTime);
+        PER_THREAD_ROCKS_PERF_CONTEXT.with(|perf_context| {
+            perf_context.borrow_mut().reset();
+        });
+        RocksDBPerfContext {}
+    }
+}
+
+impl Drop for RocksDBPerfContext {
+    fn drop(&mut self) {
+        set_perf_stats(PerfStatsLevel::Disable);
+    }
+}
+
+#[derive(Debug)]
+/// The metrics for the read performance
+pub struct ReadPerfContextMetrics {
+    /// Helps us figure out whether too many comparisons in binary search can be a problem,
+    /// especially when a more expensive comparator is used.
+    pub user_key_comparison_count: IntCounterVec,
+    /// Tells us how many times we read data blocks from block cache
+    pub block_cache_hit_count: IntCounterVec,
+    /// Tells us how many times we have to read blocks from the file system
+    pub block_read_count: IntCounterVec,
+    /// Total bytes read from the file system
+    pub block_read_byte: IntCounterVec,
+    /// Total nanos spent on block reads
+    pub block_read_nanos: IntCounterVec,
+    /// Total nanos spent on block checksum
+    pub block_checksum_nanos: IntCounterVec,
+    /// Total nanos spent on block decompression
+    pub block_decompress_nanos: IntCounterVec,
+    /// Total bytes for values returned by Get
+    pub get_read_bytes: IntCounterVec,
+    /// Total bytes for values returned by MultiGet
+    pub multiget_read_bytes: IntCounterVec,
+    /// Total nanos spent on getting snapshot
+    pub get_snapshot_nanos: IntCounterVec,
+    /// Total nanos spent on reading data from memtable
+    pub get_from_memtable_nanos: IntCounterVec,
+    /// Total number of memtables queried
+    pub get_from_memtable_count: IntCounterVec,
+    /// Total nanos spent after Get() finds a key
+    pub get_post_process_nanos: IntCounterVec,
+    /// Total nanos spent reading from output files
+    pub get_from_output_files_nanos: IntCounterVec,
+    /// Total nanos spent on acquiring db mutex
+    pub db_mutex_lock_nanos: IntCounterVec,
+    /// Total nanos spent waiting with a condition variable created with DB Mutex
+    pub db_condition_wait_nanos: IntCounterVec,
+    /// Total nanos spent on merge operator
+    pub merge_operator_nanos: IntCounterVec,
+    /// Total nanos spent on reading index block from block cache or SST file
+    pub read_index_block_nanos: IntCounterVec,
+    /// Total nanos spent on reading filter block from block cache or SST file
+    pub read_filter_block_nanos: IntCounterVec,
+    /// Total nanos spent on creating data block iterator
+    pub new_table_block_iter_nanos: IntCounterVec,
+    /// Total nanos spent on seeking a key in data/index blocks
+    pub block_seek_nanos: IntCounterVec,
+    /// Total nanos spent on finding or creating a table reader
+    pub find_table_nanos: IntCounterVec,
+    /// Total number of mem table bloom hits
+    pub bloom_memtable_hit_count: IntCounterVec,
+    /// Total number of mem table bloom misses
+    pub bloom_memtable_miss_count: IntCounterVec,
+    /// Total number of SST table bloom hits
+    pub bloom_sst_hit_count: IntCounterVec,
+    /// Total number of SST table bloom misses
+    pub bloom_sst_miss_count: IntCounterVec,
+    /// Total nanos spent waiting on key locks in transaction lock manager
+    pub key_lock_wait_time: IntCounterVec,
+    /// Total number of times acquiring a lock was blocked by another transaction
+    pub key_lock_wait_count: IntCounterVec,
+    /// Total number of deleted keys skipped during iteration
+    pub internal_delete_skipped_count: IntCounterVec,
+    /// Total number of internal keys skipped during iteration
+    pub internal_skipped_count: IntCounterVec,
+}
+
+impl ReadPerfContextMetrics {
+    pub(crate) fn new(registry: &Registry) -> Self {
+        ReadPerfContextMetrics {
+            user_key_comparison_count: register_int_counter_vec_with_registry!(
+                "user_key_comparison_count",
+                "Number of comparisons in binary search",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            block_cache_hit_count: register_int_counter_vec_with_registry!(
+                "block_cache_hit_count",
+                "Number of block cache hits",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            block_read_count: register_int_counter_vec_with_registry!(
+                "block_read_count",
+                "Number of blocks read from filesystem (cache miss or disabled)",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            block_read_byte: register_int_counter_vec_with_registry!(
+                "block_read_byte",
+                "Total bytes read from filesystem, including index and bloom filter blocks",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            block_read_nanos: register_int_counter_vec_with_registry!(
+                "block_read_nanos",
+                "Total nanos spent on block reads",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            block_checksum_nanos: register_int_counter_vec_with_registry!(
+                "block_checksum_nanos",
+                "Total nanos spent on verifying block checksum",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            block_decompress_nanos: register_int_counter_vec_with_registry!(
+                "block_decompress_nanos",
+                "Total nanos spent on decompressing a block",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            get_read_bytes: register_int_counter_vec_with_registry!(
+                "get_read_bytes",
+                "Total bytes for values returned by Get",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            multiget_read_bytes: register_int_counter_vec_with_registry!(
+                "multiget_read_bytes",
+                "Total bytes for values returned by MultiGet.",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            get_snapshot_nanos: register_int_counter_vec_with_registry!(
+                "get_snapshot_nanos",
+                "Time spent in getting snapshot.",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            get_from_memtable_nanos: register_int_counter_vec_with_registry!(
+                "get_from_memtable_nanos",
+                "Time spent on reading data from memtable.",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            get_from_memtable_count: register_int_counter_vec_with_registry!(
+                "get_from_memtable_count",
+                "Number of memtables queried",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            get_post_process_nanos: register_int_counter_vec_with_registry!(
+                "get_post_process_nanos",
+                "Total nanos spent after Get() finds a key",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            get_from_output_files_nanos: register_int_counter_vec_with_registry!(
+                "get_from_output_files_nanos",
+                "Total nanos reading from output files",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            db_mutex_lock_nanos: register_int_counter_vec_with_registry!(
+                "db_mutex_lock_nanos",
+                "Time spent on acquiring db mutex",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            db_condition_wait_nanos: register_int_counter_vec_with_registry!(
+                "db_condition_wait_nanos",
+                "Time spent waiting with a condition variable created with DB Mutex.",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            merge_operator_nanos: register_int_counter_vec_with_registry!(
+                "merge_operator_nanos",
+                "Time spent on merge operator.",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            read_index_block_nanos: register_int_counter_vec_with_registry!(
+                "read_index_block_nanos",
+                "Time spent on reading index block from block cache or SST file",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            read_filter_block_nanos: register_int_counter_vec_with_registry!(
+                "read_filter_block_nanos",
+                "Time spent on reading filter block from block cache or SST file",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            new_table_block_iter_nanos: register_int_counter_vec_with_registry!(
+                "new_table_block_iter_nanos",
+                "Time spent on creating data block iterator",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            block_seek_nanos: register_int_counter_vec_with_registry!(
+                "block_seek_nanos",
+                "Time spent on seeking a key in data/index blocks",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            find_table_nanos: register_int_counter_vec_with_registry!(
+                "find_table_nanos",
+                "Time spent on finding or creating a table reader",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            bloom_memtable_hit_count: register_int_counter_vec_with_registry!(
+                "bloom_memtable_hit_count",
+                "Total number of mem table bloom hits",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            bloom_memtable_miss_count: register_int_counter_vec_with_registry!(
+                "bloom_memtable_miss_count",
+                "Total number of mem table bloom misses",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            bloom_sst_hit_count: register_int_counter_vec_with_registry!(
+                "bloom_sst_hit_count",
+                "Total number of SST table bloom hits",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            bloom_sst_miss_count: register_int_counter_vec_with_registry!(
+                "bloom_sst_miss_count",
+                "Total number of SST table bloom misses",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            key_lock_wait_time: register_int_counter_vec_with_registry!(
+                "key_lock_wait_time",
+                "Time spent waiting on key locks in transaction lock manager",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            key_lock_wait_count: register_int_counter_vec_with_registry!(
+                "key_lock_wait_count",
+                "Number of times acquiring a lock was blocked by another transaction",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            internal_delete_skipped_count: register_int_counter_vec_with_registry!(
+                "internal_delete_skipped_count",
+                "Total number of deleted keys skipped during iteration",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            internal_skipped_count: register_int_counter_vec_with_registry!(
+                "internal_skipped_count",
+                "Total number of internal keys skipped during iteration",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+        }
+    }
+
+    /// Report the metrics for the read performance
+    pub fn report_metrics(&self, cf_name: &str) {
+        PER_THREAD_ROCKS_PERF_CONTEXT.with(|perf_context_cell| {
+            set_perf_stats(PerfStatsLevel::Disable);
+            let perf_context = perf_context_cell.borrow();
+            self.user_key_comparison_count
+                .with_label_values(&[cf_name])
+                .inc_by(perf_context.metric(PerfMetric::UserKeyComparisonCount));
+            self.block_cache_hit_count
+                .with_label_values(&[cf_name])
+                .inc_by(perf_context.metric(PerfMetric::BlockCacheHitCount));
+            self.block_read_count
+                .with_label_values(&[cf_name])
+                .inc_by(perf_context.metric(PerfMetric::BlockReadCount));
+            self.block_read_byte
+                .with_label_values(&[cf_name])
+                .inc_by(perf_context.metric(PerfMetric::BlockReadByte));
+            self.block_read_nanos
+                .with_label_values(&[cf_name])
+                .inc_by(perf_context.metric(PerfMetric::BlockReadTime));
+            self.block_checksum_nanos
+                .with_label_values(&[cf_name])
+                .inc_by(perf_context.metric(PerfMetric::BlockChecksumTime));
+            self.block_decompress_nanos
+                .with_label_values(&[cf_name])
+                .inc_by(perf_context.metric(PerfMetric::BlockDecompressTime));
+            self.get_read_bytes
+                .with_label_values(&[cf_name])
+                .inc_by(perf_context.metric(PerfMetric::GetReadBytes));
+            self.multiget_read_bytes
+                .with_label_values(&[cf_name])
+                .inc_by(perf_context.metric(PerfMetric::MultigetReadBytes));
+            self.get_snapshot_nanos
+                .with_label_values(&[cf_name])
+                .inc_by(perf_context.metric(PerfMetric::GetSnapshotTime));
+            self.get_from_memtable_nanos
+                .with_label_values(&[cf_name])
+                .inc_by(perf_context.metric(PerfMetric::GetFromMemtableTime));
+            self.get_from_memtable_count
+                .with_label_values(&[cf_name])
+                .inc_by(perf_context.metric(PerfMetric::GetFromMemtableCount));
+            self.get_post_process_nanos
+                .with_label_values(&[cf_name])
+                .inc_by(perf_context.metric(PerfMetric::GetPostProcessTime));
+            self.get_from_output_files_nanos
+                .with_label_values(&[cf_name])
+                .inc_by(perf_context.metric(PerfMetric::GetFromOutputFilesTime));
+            self.db_mutex_lock_nanos
+                .with_label_values(&[cf_name])
+                .inc_by(perf_context.metric(PerfMetric::DbMutexLockNanos));
+            self.db_condition_wait_nanos
+                .with_label_values(&[cf_name])
+                .inc_by(perf_context.metric(PerfMetric::DbConditionWaitNanos));
+            self.merge_operator_nanos
+                .with_label_values(&[cf_name])
+                .inc_by(perf_context.metric(PerfMetric::MergeOperatorTimeNanos));
+            self.read_index_block_nanos
+                .with_label_values(&[cf_name])
+                .inc_by(perf_context.metric(PerfMetric::ReadIndexBlockNanos));
+            self.read_filter_block_nanos
+                .with_label_values(&[cf_name])
+                .inc_by(perf_context.metric(PerfMetric::ReadFilterBlockNanos));
+            self.new_table_block_iter_nanos
+                .with_label_values(&[cf_name])
+                .inc_by(perf_context.metric(PerfMetric::NewTableBlockIterNanos));
+            self.block_seek_nanos
+                .with_label_values(&[cf_name])
+                .inc_by(perf_context.metric(PerfMetric::BlockSeekNanos));
+            self.find_table_nanos
+                .with_label_values(&[cf_name])
+                .inc_by(perf_context.metric(PerfMetric::FindTableNanos));
+            self.bloom_memtable_hit_count
+                .with_label_values(&[cf_name])
+                .inc_by(perf_context.metric(PerfMetric::BloomMemtableHitCount));
+            self.bloom_memtable_miss_count
+                .with_label_values(&[cf_name])
+                .inc_by(perf_context.metric(PerfMetric::BloomMemtableMissCount));
+            self.bloom_sst_hit_count
+                .with_label_values(&[cf_name])
+                .inc_by(perf_context.metric(PerfMetric::BloomSstHitCount));
+            self.bloom_sst_miss_count
+                .with_label_values(&[cf_name])
+                .inc_by(perf_context.metric(PerfMetric::BloomSstMissCount));
+            self.key_lock_wait_time
+                .with_label_values(&[cf_name])
+                .inc_by(perf_context.metric(PerfMetric::KeyLockWaitTime));
+            self.key_lock_wait_count
+                .with_label_values(&[cf_name])
+                .inc_by(perf_context.metric(PerfMetric::KeyLockWaitCount));
+            self.internal_delete_skipped_count
+                .with_label_values(&[cf_name])
+                .inc_by(perf_context.metric(PerfMetric::InternalDeleteSkippedCount));
+            self.internal_skipped_count
+                .with_label_values(&[cf_name])
+                .inc_by(perf_context.metric(PerfMetric::InternalKeySkippedCount));
+        });
+    }
+}
+
+#[derive(Debug)]
+/// The metrics for the write performance
+pub struct WritePerfContextMetrics {
+    /// Total nanos spent on writing to WAL
+    pub write_wal_nanos: IntCounterVec,
+    /// Total nanos spent on writing to memtable
+    pub write_memtable_nanos: IntCounterVec,
+    /// Total nanos spent on delaying or throttling write
+    pub write_delay_nanos: IntCounterVec,
+    /// Total nanos spent on writing a record, excluding the above four things
+    pub write_pre_and_post_process_nanos: IntCounterVec,
+    /// Total nanos spent on acquiring db mutex
+    pub write_db_mutex_lock_nanos: IntCounterVec,
+    /// Total nanos spent waiting with a condition variable created with DB Mutex
+    pub write_db_condition_wait_nanos: IntCounterVec,
+    /// Total nanos spent waiting on key locks in transaction lock manager
+    pub write_key_lock_wait_nanos: IntCounterVec,
+    /// Total number of times acquiring a lock was blocked by another transaction
+    pub write_key_lock_wait_count: IntCounterVec,
+}
+
+impl WritePerfContextMetrics {
+    pub(crate) fn new(registry: &Registry) -> Self {
+        WritePerfContextMetrics {
+            write_wal_nanos: register_int_counter_vec_with_registry!(
+                "write_wal_nanos",
+                "Total nanos spent on writing to WAL",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            write_memtable_nanos: register_int_counter_vec_with_registry!(
+                "write_memtable_nanos",
+                "Total nanos spent on writing to memtable",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            write_delay_nanos: register_int_counter_vec_with_registry!(
+                "write_delay_nanos",
+                "Total nanos spent on delaying or throttling write",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            write_pre_and_post_process_nanos: register_int_counter_vec_with_registry!(
+                "write_pre_and_post_process_nanos",
+                "Total nanos spent on writing a record, excluding the above four things",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            write_db_mutex_lock_nanos: register_int_counter_vec_with_registry!(
+                "write_db_mutex_lock_nanos",
+                "Time spent on acquiring db mutex",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            write_db_condition_wait_nanos: register_int_counter_vec_with_registry!(
+                "write_db_condition_wait_nanos",
+                "Time spent waiting with a condition variable created with DB Mutex.",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            write_key_lock_wait_nanos: register_int_counter_vec_with_registry!(
+                "write_key_lock_wait_time",
+                "Time spent waiting on key locks in transaction lock manager",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+            write_key_lock_wait_count: register_int_counter_vec_with_registry!(
+                "write_key_lock_wait_count",
+                "Number of times acquiring a lock was blocked by another transaction",
+                &["cf_name"],
+                registry,
+            )
+            .unwrap(),
+        }
+    }
+    /// Report the metrics for the write performance
+    pub fn report_metrics(&self, db_name: &str) {
+        PER_THREAD_ROCKS_PERF_CONTEXT.with(|perf_context_cell| {
+            set_perf_stats(PerfStatsLevel::Disable);
+            let perf_context = perf_context_cell.borrow();
+            self.write_wal_nanos
+                .with_label_values(&[db_name])
+                .inc_by(perf_context.metric(PerfMetric::WriteWalTime));
+            self.write_memtable_nanos
+                .with_label_values(&[db_name])
+                .inc_by(perf_context.metric(PerfMetric::WriteMemtableTime));
+            self.write_delay_nanos
+                .with_label_values(&[db_name])
+                .inc_by(perf_context.metric(PerfMetric::WriteDelayTime));
+            self.write_pre_and_post_process_nanos
+                .with_label_values(&[db_name])
+                .inc_by(perf_context.metric(PerfMetric::WritePreAndPostProcessTime));
+            self.write_db_mutex_lock_nanos
+                .with_label_values(&[db_name])
+                .inc_by(perf_context.metric(PerfMetric::DbMutexLockNanos));
+            self.write_db_condition_wait_nanos
+                .with_label_values(&[db_name])
+                .inc_by(perf_context.metric(PerfMetric::DbConditionWaitNanos));
+            self.write_key_lock_wait_nanos
+                .with_label_values(&[db_name])
+                .inc_by(perf_context.metric(PerfMetric::KeyLockWaitTime));
+            self.write_key_lock_wait_count
+                .with_label_values(&[db_name])
+                .inc_by(perf_context.metric(PerfMetric::KeyLockWaitCount));
+        });
+    }
+}
+
+#[derive(Debug)]
+/// The metrics for the database
+pub struct DBMetrics {
+    /// The metrics for the operations
+    pub op_metrics: OperationMetrics,
+    /// The metrics for the column families
+    pub cf_metrics: ColumnFamilyMetrics,
+    /// The metrics for the read performance
+    pub read_perf_ctx_metrics: ReadPerfContextMetrics,
+    /// The metrics for the write performance
+    pub write_perf_ctx_metrics: WritePerfContextMetrics,
+}
+
+static ONCE: OnceCell<Arc<DBMetrics>> = OnceCell::new();
+
+impl DBMetrics {
+    fn new(registry: &Registry) -> Self {
+        DBMetrics {
+            op_metrics: OperationMetrics::new(registry),
+            cf_metrics: ColumnFamilyMetrics::new(registry),
+            read_perf_ctx_metrics: ReadPerfContextMetrics::new(registry),
+            write_perf_ctx_metrics: WritePerfContextMetrics::new(registry),
+        }
+    }
+    /// Initialize the DBMetrics instance
+    pub fn init(registry: &Registry) -> &'static Arc<DBMetrics> {
+        // Initialize this before creating any instance of DBMap
+        // TODO: Remove static initialization because this basically means we can
+        // only ever initialize db metrics once with a registry whereas
+        // in the code we might want to initialize it with different
+        // registries. The problem is underlying metrics cannot be re-initialized
+        // or prometheus complains. We essentially need to pass in DBMetrics
+        // everywhere we create DBMap as the right fix
+        let _ = ONCE
+            .set(Arc::new(DBMetrics::new(registry)))
+            // this happens many times during tests
+            .tap_err(|_| warn!("DBMetrics registry overwritten"));
+        ONCE.get().unwrap()
+    }
+    /// Increment the number of active databases
+    pub fn increment_num_active_dbs(&self, db_name: &str) {
+        self.op_metrics
+            .rocksdb_num_active_db_handles
+            .with_label_values(&[db_name])
+            .inc();
+    }
+    /// Decrement the number of active databases
+    pub fn decrement_num_active_dbs(&self, db_name: &str) {
+        self.op_metrics
+            .rocksdb_num_active_db_handles
+            .with_label_values(&[db_name])
+            .dec();
+    }
+    /// Get the DBMetrics instance
+    pub fn get() -> &'static Arc<DBMetrics> {
+        ONCE.get()
+            .unwrap_or_else(|| DBMetrics::init(prometheus::default_registry()))
+    }
+}

--- a/crates/typed-store/src/rocks.rs
+++ b/crates/typed-store/src/rocks.rs
@@ -1,0 +1,2367 @@
+// Copyright (c) Walrus Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Error types and utilities for RocksDB operations
+pub mod errors;
+
+/// Safe iterator utilities for RocksDB
+pub(crate) mod safe_iter;
+
+use std::{
+    borrow::Borrow,
+    collections::{BTreeMap, HashSet},
+    env,
+    ffi::CStr,
+    fmt,
+    marker::PhantomData,
+    ops::{Bound, RangeBounds},
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
+
+use bincode::Options;
+use prometheus::{Histogram, HistogramTimer};
+use rocksdb::{
+    AsColumnFamilyRef,
+    BlockBasedOptions,
+    BottommostLevelCompaction,
+    CStrLike,
+    Cache,
+    ColumnFamilyDescriptor,
+    CompactOptions,
+    DBPinnableSlice,
+    DBWithThreadMode,
+    Error,
+    LiveFile,
+    MultiThreaded,
+    OptimisticTransactionDB,
+    ReadOptions,
+    SnapshotWithThreadMode,
+    WriteBatch,
+    WriteOptions,
+    checkpoint::Checkpoint,
+    properties,
+    properties::num_files_at_level,
+};
+use serde::{Serialize, de::DeserializeOwned};
+use sui_macros::{fail_point, nondeterministic};
+use tap::TapFallible;
+use tokio::sync::oneshot;
+use tracing::{debug, error, info, instrument, warn};
+
+use crate::{
+    TypedStoreError,
+    metrics::{DBMetrics, RocksDBPerfContext, SamplingInterval},
+    rocks::{
+        errors::{
+            typed_store_err_from_bcs_err,
+            typed_store_err_from_bincode_err,
+            typed_store_err_from_rocks_err,
+        },
+        safe_iter::{SafeIter, SafeRevIter},
+    },
+    traits::{Map, TableSummary},
+};
+
+// Write buffer size per RocksDB instance can be set via the env var below.
+// If the env var is not set, use the default value in MiB.
+const ENV_VAR_DB_WRITE_BUFFER_SIZE: &str = "DB_WRITE_BUFFER_SIZE_MB";
+const DEFAULT_DB_WRITE_BUFFER_SIZE: usize = 1024;
+
+// Write ahead log size per RocksDB instance can be set via the env var below.
+// If the env var is not set, use the default value in MiB.
+const ENV_VAR_DB_WAL_SIZE: &str = "DB_WAL_SIZE_MB";
+const DEFAULT_DB_WAL_SIZE: usize = 1024;
+
+// Environment variable to control behavior of write throughput optimized tables.
+const ENV_VAR_L0_NUM_FILES_COMPACTION_TRIGGER: &str = "L0_NUM_FILES_COMPACTION_TRIGGER";
+const DEFAULT_L0_NUM_FILES_COMPACTION_TRIGGER: usize = 4;
+const DEFAULT_UNIVERSAL_COMPACTION_L0_NUM_FILES_COMPACTION_TRIGGER: usize = 80;
+const ENV_VAR_MAX_WRITE_BUFFER_SIZE_MB: &str = "MAX_WRITE_BUFFER_SIZE_MB";
+const DEFAULT_MAX_WRITE_BUFFER_SIZE_MB: usize = 256;
+const ENV_VAR_MAX_WRITE_BUFFER_NUMBER: &str = "MAX_WRITE_BUFFER_NUMBER";
+const DEFAULT_MAX_WRITE_BUFFER_NUMBER: usize = 6;
+const ENV_VAR_TARGET_FILE_SIZE_BASE_MB: &str = "TARGET_FILE_SIZE_BASE_MB";
+const DEFAULT_TARGET_FILE_SIZE_BASE_MB: usize = 128;
+
+// Set to 1 to disable blob storage for transactions and effects.
+const ENV_VAR_DISABLE_BLOB_STORAGE: &str = "DISABLE_BLOB_STORAGE";
+
+const ENV_VAR_DB_PARALLELISM: &str = "DB_PARALLELISM";
+
+// TODO: remove this after Rust rocksdb has the TOTAL_BLOB_FILES_SIZE property built-in.
+const ROCKSDB_PROPERTY_TOTAL_BLOB_FILES_SIZE: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked("rocksdb.total-blob-file-size\0".as_bytes()) };
+
+#[cfg(test)]
+mod tests;
+
+/// A helper macro to reopen multiple column families. The macro returns
+/// a tuple of DBMap structs in the same order that the column families
+/// are defined.
+///
+/// # Arguments
+///
+/// * `db` - a reference to a rocks DB object
+/// * `cf;<ty,ty>` - a comma separated list of column families to open. For each column family a
+///   concatenation of column family name (cf) and Key-Value <ty, ty> should be provided.
+///
+/// # Examples
+///
+/// We successfully open two different column families.
+/// ```
+/// use typed_store::reopen;
+/// use typed_store::rocks::*;
+/// use tempfile::tempdir;
+/// use prometheus::Registry;
+/// use std::sync::Arc;
+/// use typed_store::metrics::DBMetrics;
+/// use core::fmt::Error;
+///
+/// #[tokio::main]
+/// async fn main() -> Result<(), Error> {
+/// const FIRST_CF: &str = "First_CF";
+/// const SECOND_CF: &str = "Second_CF";
+///
+///
+/// /// Create the rocks database reference for the desired column families
+/// let rocks = open_cf(tempdir().unwrap(), None, MetricConf::default(),
+///     &[FIRST_CF, SECOND_CF]).unwrap();
+///
+/// /// Now simply open all the column families for their expected Key-Value types
+/// let (db_map_1, db_map_2) = reopen!(&rocks, FIRST_CF;<i32, String>,
+///     SECOND_CF;<i32, String>);
+/// Ok(())
+/// }
+/// ```
+///
+#[macro_export]
+macro_rules! reopen {
+    ( $db:expr, $($cf:expr;<$K:ty, $V:ty>),*) => {
+        (
+            $(
+                DBMap::<$K, $V>::reopen($db, Some($cf), &ReadWriteOptions::default(), false)
+                    .expect(&format!("Cannot open {} CF.", $cf)[..])
+            ),*
+        )
+    };
+}
+
+#[derive(Debug)]
+/// The rocksdb database
+pub struct RocksDB {
+    /// The underlying rocksdb database
+    pub underlying: rocksdb::DBWithThreadMode<MultiThreaded>,
+    /// The metric configuration
+    pub metric_conf: MetricConf,
+    /// The path of the database
+    pub db_path: PathBuf,
+}
+
+impl Drop for RocksDB {
+    fn drop(&mut self) {
+        self.underlying.cancel_all_background_work(/* wait */ true);
+        DBMetrics::get().decrement_num_active_dbs(&self.metric_conf.db_name);
+    }
+}
+
+impl RocksDB {
+    fn new(
+        underlying: rocksdb::DBWithThreadMode<MultiThreaded>,
+        metric_conf: MetricConf,
+        db_path: PathBuf,
+    ) -> Self {
+        DBMetrics::get().increment_num_active_dbs(&metric_conf.db_name);
+        Self {
+            underlying,
+            metric_conf,
+            db_path,
+        }
+    }
+}
+
+impl RocksDB {
+    /// Get a value from the database
+    pub fn get<K: AsRef<[u8]>>(&self, key: K) -> Result<Option<Vec<u8>>, rocksdb::Error> {
+        self.underlying.get(key)
+    }
+
+    /// Get multiple values from the database
+    pub fn multi_get_cf<'a, 'b: 'a, K, I, W>(
+        &'a self,
+        keys: I,
+        readopts: &ReadOptions,
+    ) -> Vec<Result<Option<Vec<u8>>, rocksdb::Error>>
+    where
+        K: AsRef<[u8]>,
+        I: IntoIterator<Item = (&'b W, K)>,
+        W: 'b + AsColumnFamilyRef,
+    {
+        self.underlying.multi_get_cf_opt(keys, readopts)
+    }
+
+    /// Get multiple values from a specific column family
+    pub fn batched_multi_get_cf_opt<I, K>(
+        &self,
+        cf: &impl AsColumnFamilyRef,
+        keys: I,
+        sorted_input: bool,
+        readopts: &ReadOptions,
+    ) -> Vec<Result<Option<DBPinnableSlice<'_>>, Error>>
+    where
+        I: IntoIterator<Item = K>,
+        K: AsRef<[u8]>,
+    {
+        self.underlying
+            .batched_multi_get_cf_opt(cf, keys, sorted_input, readopts)
+    }
+
+    /// Get a property value from a specific column family
+    pub fn property_int_value_cf(
+        &self,
+        cf: &impl AsColumnFamilyRef,
+        name: impl CStrLike,
+    ) -> Result<Option<u64>, rocksdb::Error> {
+        self.underlying.property_int_value_cf(cf, name)
+    }
+
+    /// Get a pinned value from a specific column family
+    pub fn get_pinned_cf_opt<K: AsRef<[u8]>>(
+        &self,
+        cf: &impl AsColumnFamilyRef,
+        key: K,
+        readopts: &ReadOptions,
+    ) -> Result<Option<DBPinnableSlice<'_>>, rocksdb::Error> {
+        self.underlying.get_pinned_cf_opt(cf, key, readopts)
+    }
+
+    /// Get a column family handle by name
+    pub fn cf_handle(&self, name: &str) -> Option<Arc<rocksdb::BoundColumnFamily<'_>>> {
+        self.underlying.cf_handle(name)
+    }
+
+    /// Create a new column family
+    pub fn create_cf<N: AsRef<str>>(
+        &self,
+        name: N,
+        opts: &rocksdb::Options,
+    ) -> Result<(), rocksdb::Error> {
+        self.underlying.create_cf(name, opts)
+    }
+
+    /// Drop a column family
+    pub fn drop_cf(&self, name: &str) -> Result<(), rocksdb::Error> {
+        self.underlying.drop_cf(name)
+    }
+
+    /// Delete files in a range
+    pub fn delete_file_in_range<K: AsRef<[u8]>>(
+        &self,
+        cf: &impl AsColumnFamilyRef,
+        from: K,
+        to: K,
+    ) -> Result<(), rocksdb::Error> {
+        self.underlying.delete_file_in_range_cf(cf, from, to)
+    }
+
+    /// Delete a value from a specific column family
+    pub fn delete_cf<K: AsRef<[u8]>>(
+        &self,
+        cf: &impl AsColumnFamilyRef,
+        key: K,
+        writeopts: &WriteOptions,
+    ) -> Result<(), rocksdb::Error> {
+        fail_point!("delete-cf-before");
+        let ret = self.underlying.delete_cf_opt(cf, key, writeopts);
+        fail_point!("delete-cf-after");
+        #[allow(clippy::let_and_return)]
+        ret
+    }
+
+    /// Get the path of the database
+    pub fn path(&self) -> &Path {
+        self.underlying.path()
+    }
+
+    /// Put a value into a specific column family
+    pub fn put_cf<K, V>(
+        &self,
+        cf: &impl AsColumnFamilyRef,
+        key: K,
+        value: V,
+        writeopts: &WriteOptions,
+    ) -> Result<(), rocksdb::Error>
+    where
+        K: AsRef<[u8]>,
+        V: AsRef<[u8]>,
+    {
+        fail_point!("put-cf-before");
+        let ret = self.underlying.put_cf_opt(cf, key, value, writeopts);
+        fail_point!("put-cf-after");
+        #[allow(clippy::let_and_return)]
+        ret
+    }
+
+    /// Check if a key may exist in a specific column family
+    pub fn key_may_exist_cf<K: AsRef<[u8]>>(
+        &self,
+        cf: &impl AsColumnFamilyRef,
+        key: K,
+        readopts: &ReadOptions,
+    ) -> bool {
+        self.underlying.key_may_exist_cf_opt(cf, key, readopts)
+    }
+
+    /// Try to catch up with the primary
+    pub fn try_catch_up_with_primary(&self) -> Result<(), rocksdb::Error> {
+        self.underlying.try_catch_up_with_primary()
+    }
+
+    /// Write a batch of operations to the database
+    pub fn write(
+        &self,
+        batch: rocksdb::WriteBatch,
+        writeopts: &WriteOptions,
+    ) -> Result<(), TypedStoreError> {
+        fail_point!("batch-write-before");
+        self.underlying
+            .write_opt(batch, writeopts)
+            .map_err(typed_store_err_from_rocks_err)?;
+        fail_point!("batch-write-after");
+        #[allow(clippy::let_and_return)]
+        Ok(())
+    }
+
+    /// Get a raw iterator for a specific column family
+    pub fn raw_iterator_cf<'a: 'b, 'b>(
+        &'a self,
+        cf_handle: &impl AsColumnFamilyRef,
+        readopts: ReadOptions,
+    ) -> RocksDBRawIter<'b> {
+        self.underlying.raw_iterator_cf_opt(cf_handle, readopts)
+    }
+
+    /// Compact a range of values in a specific column family
+    pub fn compact_range_cf<K: AsRef<[u8]>>(
+        &self,
+        cf: &impl AsColumnFamilyRef,
+        start: Option<K>,
+        end: Option<K>,
+    ) {
+        self.underlying.compact_range_cf(cf, start, end)
+    }
+
+    /// Compact a range of values in a specific column family to the bottom
+    /// of the LSM tree
+    pub fn compact_range_to_bottom<K: AsRef<[u8]>>(
+        &self,
+        cf: &impl AsColumnFamilyRef,
+        start: Option<K>,
+        end: Option<K>,
+    ) {
+        let opt = &mut CompactOptions::default();
+        opt.set_bottommost_level_compaction(BottommostLevelCompaction::ForceOptimized);
+        self.underlying.compact_range_cf_opt(cf, start, end, opt)
+    }
+
+    /// Flush the database
+    pub fn flush(&self) -> Result<(), TypedStoreError> {
+        self.underlying
+            .flush()
+            .map_err(|e| TypedStoreError::RocksDBError(e.into_string()))
+    }
+
+    /// Create a checkpoint of the database
+    pub fn checkpoint(&self, path: &Path) -> Result<(), TypedStoreError> {
+        let checkpoint =
+            Checkpoint::new(&self.underlying).map_err(typed_store_err_from_rocks_err)?;
+        checkpoint
+            .create_checkpoint(path)
+            .map_err(|e| TypedStoreError::RocksDBError(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Flush a specific column family
+    pub fn flush_cf(&self, cf: &impl AsColumnFamilyRef) -> Result<(), rocksdb::Error> {
+        self.underlying.flush_cf(cf)
+    }
+
+    /// Set options for a specific column family
+    pub fn set_options_cf(
+        &self,
+        cf: &impl AsColumnFamilyRef,
+        opts: &[(&str, &str)],
+    ) -> Result<(), rocksdb::Error> {
+        self.underlying.set_options_cf(cf, opts)
+    }
+
+    /// Get the sampling interval for the database
+    pub fn get_sampling_interval(&self) -> SamplingInterval {
+        self.metric_conf.read_sample_interval.new_from_self()
+    }
+
+    /// Get the sampling interval for multi-get operations
+    pub fn multiget_sampling_interval(&self) -> SamplingInterval {
+        self.metric_conf.read_sample_interval.new_from_self()
+    }
+
+    /// Get the sampling interval for write operations
+    pub fn write_sampling_interval(&self) -> SamplingInterval {
+        self.metric_conf.write_sample_interval.new_from_self()
+    }
+
+    /// Get the sampling interval for iterator operations
+    pub fn iter_sampling_interval(&self) -> SamplingInterval {
+        self.metric_conf.iter_sample_interval.new_from_self()
+    }
+
+    /// Get the name of the database
+    pub fn db_name(&self) -> String {
+        let name = &self.metric_conf.db_name;
+        if name.is_empty() {
+            self.default_db_name()
+        } else {
+            name.clone()
+        }
+    }
+
+    /// Get the default name of the database
+    fn default_db_name(&self) -> String {
+        self.path()
+            .file_name()
+            .and_then(|f| f.to_str())
+            .unwrap_or("unknown")
+            .to_string()
+    }
+
+    /// Get the live files in the database
+    pub fn live_files(&self) -> Result<Vec<LiveFile>, Error> {
+        self.underlying.live_files()
+    }
+}
+
+/// A snapshot of the database
+pub enum RocksDBSnapshot<'a> {
+    /// The rocksdb snapshot
+    DBWithThreadMode(rocksdb::Snapshot<'a>),
+    /// The optimistic transaction db snapshot
+    OptimisticTransactionDB(SnapshotWithThreadMode<'a, OptimisticTransactionDB>),
+}
+
+impl fmt::Debug for RocksDBSnapshot<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "RocksDBSnapshot")
+    }
+}
+
+/// A snapshot of the database
+impl<'a> RocksDBSnapshot<'a> {
+    /// Get multiple values from a specific column family
+    pub fn multi_get_cf_opt<'b: 'a, K, I, W>(
+        &'a self,
+        keys: I,
+        readopts: ReadOptions,
+    ) -> Vec<Result<Option<Vec<u8>>, rocksdb::Error>>
+    where
+        K: AsRef<[u8]>,
+        I: IntoIterator<Item = (&'b W, K)>,
+        W: 'b + AsColumnFamilyRef,
+    {
+        match self {
+            Self::DBWithThreadMode(s) => s.multi_get_cf_opt(keys, readopts),
+            Self::OptimisticTransactionDB(s) => s.multi_get_cf_opt(keys, readopts),
+        }
+    }
+
+    /// Get multiple values from a specific column family
+    pub fn multi_get_cf<'b: 'a, K, I, W>(
+        &'a self,
+        keys: I,
+    ) -> Vec<Result<Option<Vec<u8>>, rocksdb::Error>>
+    where
+        K: AsRef<[u8]>,
+        I: IntoIterator<Item = (&'b W, K)>,
+        W: 'b + AsColumnFamilyRef,
+    {
+        match self {
+            Self::DBWithThreadMode(s) => s.multi_get_cf(keys),
+            Self::OptimisticTransactionDB(s) => s.multi_get_cf(keys),
+        }
+    }
+}
+
+/// A configuration for metrics
+#[derive(Debug, Default)]
+pub struct MetricConf {
+    /// The name of the database
+    pub db_name: String,
+    /// The sampling interval for read operations
+    pub read_sample_interval: SamplingInterval,
+    /// The sampling interval for write operations
+    pub write_sample_interval: SamplingInterval,
+    /// The sampling interval for iterator operations
+    pub iter_sample_interval: SamplingInterval,
+}
+
+/// A configuration for metrics
+impl MetricConf {
+    /// Create a new metric configuration
+    pub fn new(db_name: &str) -> Self {
+        if db_name.is_empty() {
+            error!("A meaningful db name should be used for metrics reporting.")
+        }
+        Self {
+            db_name: db_name.to_string(),
+            read_sample_interval: SamplingInterval::default(),
+            write_sample_interval: SamplingInterval::default(),
+            iter_sample_interval: SamplingInterval::default(),
+        }
+    }
+
+    /// Set the sampling interval for the database
+    pub fn with_sampling(self, read_interval: SamplingInterval) -> Self {
+        Self {
+            db_name: self.db_name,
+            read_sample_interval: read_interval,
+            write_sample_interval: SamplingInterval::default(),
+            iter_sample_interval: SamplingInterval::default(),
+        }
+    }
+}
+const CF_METRICS_REPORT_PERIOD_SECS: u64 = 30;
+const METRICS_ERROR: i64 = -1;
+
+/// An interface to a rocksDB database, keyed by a columnfamily
+#[derive(Clone, Debug)]
+pub struct DBMap<K, V> {
+    /// The rocksDB database
+    pub rocksdb: Arc<RocksDB>,
+    /// The phantom data
+    _phantom: PhantomData<fn(K) -> V>,
+    /// The rocksDB ColumnFamily under which the map is stored
+    cf: String,
+    /// The read-write options
+    pub opts: ReadWriteOptions,
+    /// The metrics for the database
+    db_metrics: Arc<DBMetrics>,
+    /// The sampling interval for the database
+    get_sample_interval: SamplingInterval,
+    /// The sampling interval for multi-get operations
+    multiget_sample_interval: SamplingInterval,
+    /// The sampling interval for write operations
+    write_sample_interval: SamplingInterval,
+    /// The sampling interval for iterator operations
+    iter_sample_interval: SamplingInterval,
+    /// The cancel handle for the metrics task
+    _metrics_task_cancel_handle: Arc<oneshot::Sender<()>>,
+}
+
+unsafe impl<K: Send, V: Send> Send for DBMap<K, V> {}
+
+impl<K, V> DBMap<K, V> {
+    pub(crate) fn new(
+        db: Arc<RocksDB>,
+        opts: &ReadWriteOptions,
+        opt_cf: &str,
+        is_deprecated: bool,
+    ) -> Self {
+        let db_cloned = db.clone();
+        let db_metrics = DBMetrics::get();
+        let db_metrics_cloned = db_metrics.clone();
+        let cf = opt_cf.to_string();
+        let (sender, mut recv) = tokio::sync::oneshot::channel();
+        if !is_deprecated {
+            tokio::task::spawn(async move {
+                let mut interval =
+                    tokio::time::interval(Duration::from_secs(CF_METRICS_REPORT_PERIOD_SECS));
+                loop {
+                    tokio::select! {
+                        _ = interval.tick() => {
+                            let db = db_cloned.clone();
+                            let cf = cf.clone();
+                            let db_metrics = db_metrics.clone();
+                            if let Err(e) = tokio::task::spawn_blocking(move || {
+                                Self::report_metrics(&db, &cf, &db_metrics);
+                            }).await {
+                                error!("Failed to log metrics with error: {}", e);
+                            }
+                        }
+                        _ = &mut recv => break,
+                    }
+                }
+                debug!("Returning the cf metric logging task for DBMap: {}", &cf);
+            });
+        }
+        DBMap {
+            rocksdb: db.clone(),
+            opts: opts.clone(),
+            _phantom: PhantomData,
+            cf: opt_cf.to_string(),
+            db_metrics: db_metrics_cloned,
+            _metrics_task_cancel_handle: Arc::new(sender),
+            get_sample_interval: db.get_sampling_interval(),
+            multiget_sample_interval: db.multiget_sampling_interval(),
+            write_sample_interval: db.write_sampling_interval(),
+            iter_sample_interval: db.iter_sampling_interval(),
+        }
+    }
+
+    /// Opens a database from a path, with specific options and an optional column family.
+    ///
+    /// This database is used to perform operations on single column family, and parametrizes
+    /// all operations in `DBBatch` when writing across column families.
+    #[instrument(level="debug", skip_all, fields(path = ?path.as_ref(), cf = ?opt_cf), err)]
+    pub fn open<P: AsRef<Path>>(
+        path: P,
+        metric_conf: MetricConf,
+        db_options: Option<rocksdb::Options>,
+        opt_cf: Option<&str>,
+        rw_options: &ReadWriteOptions,
+    ) -> Result<Self, TypedStoreError> {
+        let cf_key = opt_cf.unwrap_or(rocksdb::DEFAULT_COLUMN_FAMILY_NAME);
+        let cfs = vec![cf_key];
+        let rocksdb = open_cf(path, db_options, metric_conf, &cfs)?;
+        Ok(DBMap::new(rocksdb, rw_options, cf_key, false))
+    }
+
+    /// Reopens an open database as a typed map operating under a specific column family.
+    /// if no column family is passed, the default column family is used.
+    ///
+    /// ```
+    ///    use typed_store::rocks::*;
+    ///    use typed_store::metrics::DBMetrics;
+    ///    use tempfile::tempdir;
+    ///    use prometheus::Registry;
+    ///    use std::sync::Arc;
+    ///    use core::fmt::Error;
+    ///    #[tokio::main]
+    ///    async fn main() -> Result<(), Error> {
+    ///    /// Open the DB with all needed column families first.
+    ///    let rocks = open_cf(
+    ///     tempdir().unwrap(),
+    ///     None,
+    ///     MetricConf::default(),
+    ///     &["First_CF", "Second_CF"],
+    /// ).unwrap();
+    ///    /// Attach the column families to specific maps.
+    ///    let db_cf_1 = DBMap::<u32,u32>::reopen(
+    ///     &rocks,
+    ///     Some("First_CF"),
+    ///     &ReadWriteOptions::default(),
+    ///     false
+    /// ).expect("Failed to open storage");
+    ///    let db_cf_2 = DBMap::<u32,u32>::reopen(
+    ///     &rocks,
+    ///     Some("Second_CF"),
+    ///     &ReadWriteOptions::default(),
+    ///     false
+    /// ).expect("Failed to open storage");
+    ///    Ok(())
+    ///    }
+    /// ```
+    #[instrument(level = "debug", skip(db), err)]
+    pub fn reopen(
+        db: &Arc<RocksDB>,
+        opt_cf: Option<&str>,
+        rw_options: &ReadWriteOptions,
+        is_deprecated: bool,
+    ) -> Result<Self, TypedStoreError> {
+        let cf_key = opt_cf
+            .unwrap_or(rocksdb::DEFAULT_COLUMN_FAMILY_NAME)
+            .to_owned();
+
+        db.cf_handle(&cf_key)
+            .ok_or_else(|| TypedStoreError::UnregisteredColumn(cf_key.clone()))?;
+
+        Ok(DBMap::new(db.clone(), rw_options, &cf_key, is_deprecated))
+    }
+
+    /// Get the column family name
+    pub fn cf_name(&self) -> &str {
+        &self.cf
+    }
+
+    /// Create a new batch associated with a DB reference.
+    pub fn batch(&self) -> DBBatch {
+        let batch = WriteBatch::default();
+        DBBatch::new(
+            &self.rocksdb,
+            batch,
+            self.opts.writeopts(),
+            &self.db_metrics,
+            &self.write_sample_interval,
+        )
+    }
+
+    /// Compact a range of keys in a specific column family
+    pub fn compact_range<J: Serialize>(&self, start: &J, end: &J) -> Result<(), TypedStoreError> {
+        let from_buf = be_fix_int_ser(start)?;
+        let to_buf = be_fix_int_ser(end)?;
+        self.rocksdb
+            .compact_range_cf(&self.cf(), Some(from_buf), Some(to_buf));
+        Ok(())
+    }
+
+    /// Compact a range of keys in a specific column family
+    pub fn compact_range_raw(
+        &self,
+        cf_name: &str,
+        start: Vec<u8>,
+        end: Vec<u8>,
+    ) -> Result<(), TypedStoreError> {
+        let cf = self
+            .rocksdb
+            .cf_handle(cf_name)
+            .expect("compact range: column family does not exist");
+        self.rocksdb.compact_range_cf(&cf, Some(start), Some(end));
+        Ok(())
+    }
+
+    /// Compact a range of keys in a specific column family
+    pub fn compact_range_to_bottom<J: Serialize>(
+        &self,
+        start: &J,
+        end: &J,
+    ) -> Result<(), TypedStoreError> {
+        let from_buf = be_fix_int_ser(start)?;
+        let to_buf = be_fix_int_ser(end)?;
+        self.rocksdb
+            .compact_range_to_bottom(&self.cf(), Some(from_buf), Some(to_buf));
+        Ok(())
+    }
+
+    /// Get the column family
+    pub fn cf(&self) -> Arc<rocksdb::BoundColumnFamily<'_>> {
+        self.rocksdb
+            .cf_handle(&self.cf)
+            .expect("Map-keying column family should have been checked at DB creation")
+    }
+
+    /// Flush the column family
+    pub fn flush(&self) -> Result<(), TypedStoreError> {
+        self.rocksdb
+            .flush_cf(&self.cf())
+            .map_err(|e| TypedStoreError::RocksDBError(e.into_string()))
+    }
+
+    /// Set the options for the column family
+    pub fn set_options(&self, opts: &[(&str, &str)]) -> Result<(), rocksdb::Error> {
+        self.rocksdb.set_options_cf(&self.cf(), opts)
+    }
+
+    fn get_int_property(
+        rocksdb: &RocksDB,
+        cf: &impl AsColumnFamilyRef,
+        property_name: &std::ffi::CStr,
+    ) -> Result<i64, TypedStoreError> {
+        match rocksdb.property_int_value_cf(cf, property_name) {
+            Ok(Some(value)) => Ok(value.min(i64::MAX as u64).try_into().unwrap_or_default()),
+            Ok(None) => Ok(0),
+            Err(e) => Err(TypedStoreError::RocksDBError(e.into_string())),
+        }
+    }
+
+    /// Returns a vector of raw values corresponding to the keys provided.
+    fn multi_get_pinned<J>(
+        &self,
+        keys: impl IntoIterator<Item = J>,
+    ) -> Result<Vec<Option<DBPinnableSlice<'_>>>, TypedStoreError>
+    where
+        J: Borrow<K>,
+        K: Serialize,
+    {
+        let _timer = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_multiget_latency_seconds
+            .with_label_values(&[&self.cf])
+            .start_timer();
+        let perf_ctx = if self.multiget_sample_interval.sample() {
+            Some(RocksDBPerfContext)
+        } else {
+            None
+        };
+        let keys_bytes: Result<Vec<_>, TypedStoreError> = keys
+            .into_iter()
+            .map(|k| be_fix_int_ser(k.borrow()))
+            .collect();
+        let results: Result<Vec<_>, TypedStoreError> = self
+            .rocksdb
+            .batched_multi_get_cf_opt(
+                &self.cf(),
+                keys_bytes?,
+                /*sorted_keys=*/ false,
+                &self.opts.readopts(),
+            )
+            .into_iter()
+            .map(|r| r.map_err(|e| TypedStoreError::RocksDBError(e.into_string())))
+            .collect();
+        let entries = results?;
+        let entry_size = entries
+            .iter()
+            .flatten()
+            .map(|entry| entry.len())
+            .sum::<usize>();
+        self.db_metrics
+            .op_metrics
+            .rocksdb_multiget_bytes
+            .with_label_values(&[&self.cf])
+            .observe(entry_size as f64);
+        if perf_ctx.is_some() {
+            self.db_metrics
+                .read_perf_ctx_metrics
+                .report_metrics(&self.cf);
+        }
+        Ok(entries)
+    }
+
+    fn report_metrics(rocksdb: &Arc<RocksDB>, cf_name: &str, db_metrics: &Arc<DBMetrics>) {
+        let Some(cf) = rocksdb.cf_handle(cf_name) else {
+            tracing::warn!(
+                "unable to report metrics for cf {cf_name:?} in db {:?}",
+                rocksdb.db_name()
+            );
+            return;
+        };
+
+        db_metrics
+            .cf_metrics
+            .rocksdb_total_sst_files_size
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_int_property(rocksdb, &cf, properties::TOTAL_SST_FILES_SIZE)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_total_blob_files_size
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_int_property(rocksdb, &cf, ROCKSDB_PROPERTY_TOTAL_BLOB_FILES_SIZE)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        // 7 is the default number of levels in RocksDB. If we ever change the number
+        // of levels using `set_num_levels`, we need to update here as well. Note that
+        // there isn't an API to query the DB to get the number of levels (yet).
+        let total_num_files: i64 = (0..=6)
+            .map(|level| {
+                Self::get_int_property(rocksdb, &cf, &num_files_at_level(level))
+                    .unwrap_or(METRICS_ERROR)
+            })
+            .sum();
+        db_metrics
+            .cf_metrics
+            .rocksdb_total_num_files
+            .with_label_values(&[cf_name])
+            .set(total_num_files);
+        db_metrics
+            .cf_metrics
+            .rocksdb_num_level0_files
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_int_property(rocksdb, &cf, &num_files_at_level(0))
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_current_size_active_mem_tables
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_int_property(rocksdb, &cf, properties::CUR_SIZE_ACTIVE_MEM_TABLE)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_size_all_mem_tables
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_int_property(rocksdb, &cf, properties::SIZE_ALL_MEM_TABLES)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_num_snapshots
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_int_property(rocksdb, &cf, properties::NUM_SNAPSHOTS)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_oldest_snapshot_time
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_int_property(rocksdb, &cf, properties::OLDEST_SNAPSHOT_TIME)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_actual_delayed_write_rate
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_int_property(rocksdb, &cf, properties::ACTUAL_DELAYED_WRITE_RATE)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_is_write_stopped
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_int_property(rocksdb, &cf, properties::IS_WRITE_STOPPED)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_block_cache_capacity
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_int_property(rocksdb, &cf, properties::BLOCK_CACHE_CAPACITY)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_block_cache_usage
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_int_property(rocksdb, &cf, properties::BLOCK_CACHE_USAGE)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_block_cache_pinned_usage
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_int_property(rocksdb, &cf, properties::BLOCK_CACHE_PINNED_USAGE)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_estimate_table_readers_mem
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_int_property(rocksdb, &cf, properties::ESTIMATE_TABLE_READERS_MEM)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_estimated_num_keys
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_int_property(rocksdb, &cf, properties::ESTIMATE_NUM_KEYS)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_num_immutable_mem_tables
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_int_property(rocksdb, &cf, properties::NUM_IMMUTABLE_MEM_TABLE)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_mem_table_flush_pending
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_int_property(rocksdb, &cf, properties::MEM_TABLE_FLUSH_PENDING)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_compaction_pending
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_int_property(rocksdb, &cf, properties::COMPACTION_PENDING)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_estimate_pending_compaction_bytes
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_int_property(rocksdb, &cf, properties::ESTIMATE_PENDING_COMPACTION_BYTES)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_num_running_compactions
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_int_property(rocksdb, &cf, properties::NUM_RUNNING_COMPACTIONS)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_num_running_flushes
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_int_property(rocksdb, &cf, properties::NUM_RUNNING_FLUSHES)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_estimate_oldest_key_time
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_int_property(rocksdb, &cf, properties::ESTIMATE_OLDEST_KEY_TIME)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_background_errors
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_int_property(rocksdb, &cf, properties::BACKGROUND_ERRORS)
+                    .unwrap_or(METRICS_ERROR),
+            );
+        db_metrics
+            .cf_metrics
+            .rocksdb_base_level
+            .with_label_values(&[cf_name])
+            .set(
+                Self::get_int_property(rocksdb, &cf, properties::BASE_LEVEL)
+                    .unwrap_or(METRICS_ERROR),
+            );
+    }
+
+    /// Create a checkpoint of the database
+    pub fn checkpoint_db(&self, path: &Path) -> Result<(), TypedStoreError> {
+        self.rocksdb.checkpoint(path)
+    }
+
+    /// Get a summary of the table
+    pub fn table_summary(&self) -> eyre::Result<TableSummary>
+    where
+        K: Serialize + DeserializeOwned,
+        V: Serialize + DeserializeOwned,
+    {
+        let mut num_keys = 0;
+        let mut key_bytes_total = 0;
+        let mut value_bytes_total = 0;
+        let mut key_hist = hdrhistogram::Histogram::<u64>::new_with_max(100000, 2).unwrap();
+        let mut value_hist = hdrhistogram::Histogram::<u64>::new_with_max(100000, 2).unwrap();
+        for item in self.safe_iter() {
+            let (key, value) = item?;
+            num_keys += 1;
+            let key_len = be_fix_int_ser(key.borrow())?.len();
+            let value_len = bcs::to_bytes(value.borrow())?.len();
+            key_bytes_total += key_len;
+            value_bytes_total += value_len;
+            key_hist.record(key_len as u64)?;
+            value_hist.record(value_len as u64)?;
+        }
+        Ok(TableSummary {
+            num_keys,
+            key_bytes_total,
+            value_bytes_total,
+            key_hist,
+            value_hist,
+        })
+    }
+
+    // Creates metrics and context for tracking an iterator usage and performance.
+    fn create_iter_context(
+        &self,
+    ) -> (
+        Option<HistogramTimer>,
+        Option<Histogram>,
+        Option<Histogram>,
+        Option<RocksDBPerfContext>,
+    ) {
+        let timer = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_iter_latency_seconds
+            .with_label_values(&[&self.cf])
+            .start_timer();
+        let bytes_scanned = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_iter_bytes
+            .with_label_values(&[&self.cf]);
+        let keys_scanned = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_iter_keys
+            .with_label_values(&[&self.cf]);
+        let perf_ctx = if self.iter_sample_interval.sample() {
+            Some(RocksDBPerfContext)
+        } else {
+            None
+        };
+        (
+            Some(timer),
+            Some(bytes_scanned),
+            Some(keys_scanned),
+            perf_ctx,
+        )
+    }
+
+    // Creates a RocksDB read option with specified lower and upper bounds.
+    /// Lower bound is inclusive, and upper bound is exclusive.
+    fn create_read_options_with_bounds(
+        &self,
+        lower_bound: Option<K>,
+        upper_bound: Option<K>,
+    ) -> ReadOptions
+    where
+        K: Serialize,
+    {
+        let mut readopts = self.opts.readopts();
+        if let Some(lower_bound) = lower_bound {
+            let key_buf = be_fix_int_ser(&lower_bound).unwrap();
+            readopts.set_iterate_lower_bound(key_buf);
+        }
+        if let Some(upper_bound) = upper_bound {
+            let key_buf = be_fix_int_ser(&upper_bound).unwrap();
+            readopts.set_iterate_upper_bound(key_buf);
+        }
+        readopts
+    }
+
+    /// Creates a safe reversed iterator with optional bounds.
+    /// Upper bound is included.
+    pub fn reversed_safe_iter_with_bounds(
+        &self,
+        lower_bound: Option<K>,
+        upper_bound: Option<K>,
+    ) -> Result<SafeRevIter<'_, K, V>, TypedStoreError>
+    where
+        K: Serialize + DeserializeOwned,
+        V: Serialize + DeserializeOwned,
+    {
+        let upper_bound_key = upper_bound.as_ref().map(|k| be_fix_int_ser(&k));
+        let readopts = self.create_read_options_with_range((
+            lower_bound
+                .as_ref()
+                .map(Bound::Included)
+                .unwrap_or(Bound::Unbounded),
+            upper_bound
+                .as_ref()
+                .map(Bound::Included)
+                .unwrap_or(Bound::Unbounded),
+        ));
+
+        let db_iter = self.rocksdb.raw_iterator_cf(&self.cf(), readopts);
+        let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
+        let iter = SafeIter::new(
+            self.cf.clone(),
+            db_iter,
+            _timer,
+            _perf_ctx,
+            bytes_scanned,
+            keys_scanned,
+            Some(self.db_metrics.clone()),
+        );
+        Ok(SafeRevIter::new(iter, upper_bound_key.transpose()?))
+    }
+
+    // Creates a RocksDB read option with lower and upper bounds set corresponding to `range`.
+    fn create_read_options_with_range(&self, range: impl RangeBounds<K>) -> ReadOptions
+    where
+        K: Serialize,
+    {
+        let mut readopts = self.opts.readopts();
+
+        let lower_bound = range.start_bound();
+        let upper_bound = range.end_bound();
+
+        match lower_bound {
+            Bound::Included(lower_bound) => {
+                // Rocksdb lower bound is inclusive by default so nothing to do
+                let key_buf = be_fix_int_ser(&lower_bound).expect("Serialization must not fail");
+                readopts.set_iterate_lower_bound(key_buf);
+            }
+            Bound::Excluded(lower_bound) => {
+                let mut key_buf =
+                    be_fix_int_ser(&lower_bound).expect("Serialization must not fail");
+
+                // Since we want exclusive, we need to increment the key to exclude the previous
+                big_endian_saturating_add_one(&mut key_buf);
+                readopts.set_iterate_lower_bound(key_buf);
+            }
+            Bound::Unbounded => (),
+        };
+
+        match upper_bound {
+            Bound::Included(upper_bound) => {
+                let mut key_buf =
+                    be_fix_int_ser(&upper_bound).expect("Serialization must not fail");
+
+                // If the key is already at the limit, there's nowhere else to go, so no upper bound
+                if !is_max(&key_buf) {
+                    // Since we want exclusive, we need to increment the key to get the upper bound
+                    big_endian_saturating_add_one(&mut key_buf);
+                    readopts.set_iterate_upper_bound(key_buf);
+                }
+            }
+            Bound::Excluded(upper_bound) => {
+                // Rocksdb upper bound is inclusive by default so nothing to do
+                let key_buf = be_fix_int_ser(&upper_bound).expect("Serialization must not fail");
+                readopts.set_iterate_upper_bound(key_buf);
+            }
+            Bound::Unbounded => (),
+        };
+
+        readopts
+    }
+}
+
+/// Provides a mutable struct to form a collection of database write operations, and execute them.
+///
+/// Batching write and delete operations is faster than performing them one by one and ensures
+/// their atomicity, ie. they are all written or none is.
+/// This is also true of operations across column families in the same database.
+///
+/// Serializations / Deserialization, and naming of column families is performed by passing
+/// a DBMap<K,V>
+/// with each operation.
+///
+/// ```
+/// use typed_store::rocks::*;
+/// use tempfile::tempdir;
+/// use typed_store::Map;
+/// use typed_store::metrics::DBMetrics;
+/// use prometheus::Registry;
+/// use core::fmt::Error;
+/// use std::sync::Arc;
+///
+/// #[tokio::main]
+/// async fn main() -> Result<(), Error> {
+/// let rocks = open_cf(tempfile::tempdir().unwrap(), None,
+///     MetricConf::default(),
+///     &["First_CF", "Second_CF"],
+/// )
+/// .unwrap();
+///
+/// let db_cf_1 = DBMap::reopen(&rocks, Some("First_CF"), &ReadWriteOptions::default(), false)
+///     .expect("Failed to open storage");
+/// let keys_vals_1 = (1..100).map(|i| (i, i.to_string()));
+///
+/// let db_cf_2 = DBMap::reopen(&rocks, Some("Second_CF"), &ReadWriteOptions::default(), false)
+///     .expect("Failed to open storage");
+/// let keys_vals_2 = (1000..1100).map(|i| (i, i.to_string()));
+///
+/// let mut batch = db_cf_1.batch();
+/// batch
+///     .insert_batch(&db_cf_1, keys_vals_1.clone())
+///     .expect("Failed to batch insert")
+///     .insert_batch(&db_cf_2, keys_vals_2.clone())
+///     .expect("Failed to batch insert");
+///
+/// let _ = batch.write().expect("Failed to execute batch");
+/// for (k, v) in keys_vals_1 {
+///     let val = db_cf_1.get(&k).expect("Failed to get inserted key");
+///     assert_eq!(Some(v), val);
+/// }
+///
+/// for (k, v) in keys_vals_2 {
+///     let val = db_cf_2.get(&k).expect("Failed to get inserted key");
+///     assert_eq!(Some(v), val);
+/// }
+/// Ok(())
+/// }
+/// ```
+///
+pub struct DBBatch {
+    /// The rocksDB database
+    rocksdb: Arc<RocksDB>,
+    /// The batch of write operations
+    batch: rocksdb::WriteBatch,
+    /// The write options
+    opts: WriteOptions,
+    /// The metrics for the database
+    db_metrics: Arc<DBMetrics>,
+    /// The sampling interval for write operations
+    write_sample_interval: SamplingInterval,
+}
+
+impl fmt::Debug for DBBatch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "DBBatch")
+    }
+}
+
+impl DBBatch {
+    /// Create a new batch associated with a DB reference.
+    ///
+    /// Use `open_cf` to get the DB reference or an existing open database.
+    pub fn new(
+        dbref: &Arc<RocksDB>,
+        batch: rocksdb::WriteBatch,
+        opts: WriteOptions,
+        db_metrics: &Arc<DBMetrics>,
+        write_sample_interval: &SamplingInterval,
+    ) -> Self {
+        DBBatch {
+            rocksdb: dbref.clone(),
+            batch,
+            opts,
+            db_metrics: db_metrics.clone(),
+            write_sample_interval: write_sample_interval.clone(),
+        }
+    }
+
+    /// Consume the batch and write its operations to the database
+    #[instrument(level = "trace", skip_all, err)]
+    pub fn write(self) -> Result<(), TypedStoreError> {
+        let db_name = self.rocksdb.db_name();
+        let timer = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_batch_commit_latency_seconds
+            .with_label_values(&[&db_name])
+            .start_timer();
+        let batch_size = self.batch.size_in_bytes();
+
+        let perf_ctx = if self.write_sample_interval.sample() {
+            Some(RocksDBPerfContext)
+        } else {
+            None
+        };
+        self.rocksdb.write(self.batch, &self.opts)?;
+        self.db_metrics
+            .op_metrics
+            .rocksdb_batch_commit_bytes
+            .with_label_values(&[&db_name])
+            .observe(batch_size as f64);
+
+        if perf_ctx.is_some() {
+            self.db_metrics
+                .write_perf_ctx_metrics
+                .report_metrics(&db_name);
+        }
+        let elapsed = timer.stop_and_record();
+        if elapsed > 1.0 {
+            warn!(?elapsed, ?db_name, "very slow batch write");
+            self.db_metrics
+                .op_metrics
+                .rocksdb_very_slow_batch_writes_count
+                .with_label_values(&[&db_name])
+                .inc();
+            self.db_metrics
+                .op_metrics
+                .rocksdb_very_slow_batch_writes_duration_ms
+                .with_label_values(&[&db_name])
+                .inc_by((elapsed * 1000.0) as u64);
+        }
+        Ok(())
+    }
+
+    /// Get the size of the batch in bytes
+    pub fn size_in_bytes(&self) -> usize {
+        self.batch.size_in_bytes()
+    }
+}
+
+impl DBBatch {
+    /// Delete a batch of keys
+    pub fn delete_batch<J: Borrow<K>, K: Serialize, V>(
+        &mut self,
+        db: &DBMap<K, V>,
+        purged_vals: impl IntoIterator<Item = J>,
+    ) -> Result<(), TypedStoreError> {
+        if !Arc::ptr_eq(&db.rocksdb, &self.rocksdb) {
+            return Err(TypedStoreError::CrossDBBatch);
+        }
+
+        purged_vals
+            .into_iter()
+            .try_for_each::<_, Result<_, TypedStoreError>>(|k| {
+                let k_buf = be_fix_int_ser(k.borrow())?;
+                self.batch.delete_cf(&db.cf(), k_buf);
+
+                Ok(())
+            })?;
+        Ok(())
+    }
+
+    /// Deletes a range of keys between `from` (inclusive) and `to` (non-inclusive)
+    /// by writing a range delete tombstone in the db map
+    /// If the DBMap is configured with ignore_range_deletions set to false,
+    /// the effect of this write will be visible immediately i.e. you won't
+    /// see old values when you do a lookup or scan. But if it is configured
+    /// with ignore_range_deletions set to true, the old value are visible until
+    /// compaction actually deletes them which will happen sometime after. By
+    /// default ignore_range_deletions is set to true on a DBMap (unless it is
+    /// overridden in the config), so please use this function with caution
+    pub fn schedule_delete_range<K: Serialize, V>(
+        &mut self,
+        db: &DBMap<K, V>,
+        from: &K,
+        to: &K,
+    ) -> Result<(), TypedStoreError> {
+        if !Arc::ptr_eq(&db.rocksdb, &self.rocksdb) {
+            return Err(TypedStoreError::CrossDBBatch);
+        }
+
+        let from_buf = be_fix_int_ser(from)?;
+        let to_buf = be_fix_int_ser(to)?;
+
+        self.batch.delete_range_cf(&db.cf(), from_buf, to_buf);
+        Ok(())
+    }
+
+    /// inserts a range of (key, value) pairs given as an iterator
+    pub fn insert_batch<J: Borrow<K>, K: Serialize, U: Borrow<V>, V: Serialize>(
+        &mut self,
+        db: &DBMap<K, V>,
+        new_vals: impl IntoIterator<Item = (J, U)>,
+    ) -> Result<&mut Self, TypedStoreError> {
+        if !Arc::ptr_eq(&db.rocksdb, &self.rocksdb) {
+            return Err(TypedStoreError::CrossDBBatch);
+        }
+        let mut total = 0usize;
+        new_vals
+            .into_iter()
+            .try_for_each::<_, Result<_, TypedStoreError>>(|(k, v)| {
+                let k_buf = be_fix_int_ser(k.borrow())?;
+                let v_buf = bcs::to_bytes(v.borrow()).map_err(typed_store_err_from_bcs_err)?;
+                total += k_buf.len() + v_buf.len();
+                self.batch.put_cf(&db.cf(), k_buf, v_buf);
+                Ok(())
+            })?;
+        self.db_metrics
+            .op_metrics
+            .rocksdb_batch_put_bytes
+            .with_label_values(&[&db.cf])
+            .observe(total as f64);
+        Ok(self)
+    }
+
+    /// Inserts a range of (key, value) pairs given as an iterator
+    pub fn partial_merge_batch<J: Borrow<K>, K: Serialize, V: Serialize, B: AsRef<[u8]>>(
+        &mut self,
+        db: &DBMap<K, V>,
+        new_vals: impl IntoIterator<Item = (J, B)>,
+    ) -> Result<&mut Self, TypedStoreError> {
+        if !Arc::ptr_eq(&db.rocksdb, &self.rocksdb) {
+            return Err(TypedStoreError::CrossDBBatch);
+        }
+        new_vals
+            .into_iter()
+            .try_for_each::<_, Result<_, TypedStoreError>>(|(k, v)| {
+                let k_buf = be_fix_int_ser(k.borrow())?;
+                self.batch.merge_cf(&db.cf(), k_buf, v);
+                Ok(())
+            })?;
+        Ok(self)
+    }
+}
+
+/// The raw iterator for the rocksdb
+pub type RocksDBRawIter<'a> =
+    rocksdb::DBRawIteratorWithThreadMode<'a, DBWithThreadMode<MultiThreaded>>;
+
+impl<'a, K, V> Map<'a, K, V> for DBMap<K, V>
+where
+    K: Serialize + DeserializeOwned,
+    V: Serialize + DeserializeOwned,
+{
+    type Error = TypedStoreError;
+    type SafeIterator = SafeIter<'a, K, V>;
+
+    #[instrument(level = "trace", skip_all, err)]
+    fn contains_key(&self, key: &K) -> Result<bool, TypedStoreError> {
+        let key_buf = be_fix_int_ser(key)?;
+        // [`rocksdb::DBWithThreadMode::key_may_exist_cf`] can have false positives,
+        // but no false negatives. We use it to short-circuit the absent case
+        let readopts = self.opts.readopts();
+        Ok(self
+            .rocksdb
+            .key_may_exist_cf(&self.cf(), &key_buf, &readopts)
+            && self
+                .rocksdb
+                .get_pinned_cf_opt(&self.cf(), &key_buf, &readopts)
+                .map_err(typed_store_err_from_rocks_err)?
+                .is_some())
+    }
+
+    #[instrument(level = "trace", skip_all, err)]
+    fn multi_contains_keys<J>(
+        &self,
+        keys: impl IntoIterator<Item = J>,
+    ) -> Result<Vec<bool>, Self::Error>
+    where
+        J: Borrow<K>,
+    {
+        let values = self.multi_get_pinned(keys)?;
+        Ok(values.into_iter().map(|v| v.is_some()).collect())
+    }
+
+    #[instrument(level = "trace", skip_all, err)]
+    fn get(&self, key: &K) -> Result<Option<V>, TypedStoreError> {
+        let _timer = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_get_latency_seconds
+            .with_label_values(&[&self.cf])
+            .start_timer();
+        let perf_ctx = if self.get_sample_interval.sample() {
+            Some(RocksDBPerfContext)
+        } else {
+            None
+        };
+        let key_buf = be_fix_int_ser(key)?;
+        let res = self
+            .rocksdb
+            .get_pinned_cf_opt(&self.cf(), &key_buf, &self.opts.readopts())
+            .map_err(typed_store_err_from_rocks_err)?;
+        self.db_metrics
+            .op_metrics
+            .rocksdb_get_bytes
+            .with_label_values(&[&self.cf])
+            .observe(res.as_ref().map_or(0.0, |v| v.len() as f64));
+        if perf_ctx.is_some() {
+            self.db_metrics
+                .read_perf_ctx_metrics
+                .report_metrics(&self.cf);
+        }
+        match res {
+            Some(data) => Ok(Some(
+                bcs::from_bytes(&data).map_err(typed_store_err_from_bcs_err)?,
+            )),
+            None => Ok(None),
+        }
+    }
+
+    #[instrument(level = "trace", skip_all, err)]
+    fn insert(&self, key: &K, value: &V) -> Result<(), TypedStoreError> {
+        let timer = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_put_latency_seconds
+            .with_label_values(&[&self.cf])
+            .start_timer();
+        let perf_ctx = if self.write_sample_interval.sample() {
+            Some(RocksDBPerfContext)
+        } else {
+            None
+        };
+        let key_buf = be_fix_int_ser(key)?;
+        let value_buf = bcs::to_bytes(value).map_err(typed_store_err_from_bcs_err)?;
+        self.db_metrics
+            .op_metrics
+            .rocksdb_put_bytes
+            .with_label_values(&[&self.cf])
+            .observe((key_buf.len() + value_buf.len()) as f64);
+        if perf_ctx.is_some() {
+            self.db_metrics
+                .write_perf_ctx_metrics
+                .report_metrics(&self.cf);
+        }
+        self.rocksdb
+            .put_cf(&self.cf(), &key_buf, &value_buf, &self.opts.writeopts())
+            .map_err(typed_store_err_from_rocks_err)?;
+
+        let elapsed = timer.stop_and_record();
+        if elapsed > 1.0 {
+            warn!(?elapsed, cf = ?self.cf, "very slow insert");
+            self.db_metrics
+                .op_metrics
+                .rocksdb_very_slow_puts_count
+                .with_label_values(&[&self.cf])
+                .inc();
+            self.db_metrics
+                .op_metrics
+                .rocksdb_very_slow_puts_duration_ms
+                .with_label_values(&[&self.cf])
+                .inc_by((elapsed * 1000.0) as u64);
+        }
+
+        Ok(())
+    }
+
+    #[instrument(level = "trace", skip_all, err)]
+    fn remove(&self, key: &K) -> Result<(), TypedStoreError> {
+        let _timer = self
+            .db_metrics
+            .op_metrics
+            .rocksdb_delete_latency_seconds
+            .with_label_values(&[&self.cf])
+            .start_timer();
+        let perf_ctx = if self.write_sample_interval.sample() {
+            Some(RocksDBPerfContext)
+        } else {
+            None
+        };
+        let key_buf = be_fix_int_ser(key)?;
+        self.rocksdb
+            .delete_cf(&self.cf(), key_buf, &self.opts.writeopts())
+            .map_err(typed_store_err_from_rocks_err)?;
+        self.db_metrics
+            .op_metrics
+            .rocksdb_deletes
+            .with_label_values(&[&self.cf])
+            .inc();
+        if perf_ctx.is_some() {
+            self.db_metrics
+                .write_perf_ctx_metrics
+                .report_metrics(&self.cf);
+        }
+        Ok(())
+    }
+
+    /// This method first drops the existing column family and then creates a new one
+    /// with the same name. The two operations are not atomic and hence it is possible
+    /// to get into a race condition where the column family has been dropped but new
+    /// one is not created yet
+    #[instrument(level = "trace", skip_all, err)]
+    fn unsafe_clear(&self) -> Result<(), TypedStoreError> {
+        let _ = self.rocksdb.drop_cf(&self.cf);
+        self.rocksdb
+            .create_cf(self.cf.clone(), &default_db_options().options)
+            .map_err(typed_store_err_from_rocks_err)?;
+        Ok(())
+    }
+
+    /// Writes a range delete tombstone to delete all entries in the db map
+    /// If the DBMap is configured with ignore_range_deletions set to false,
+    /// the effect of this write will be visible immediately i.e. you won't
+    /// see old values when you do a lookup or scan. But if it is configured
+    /// with ignore_range_deletions set to true, the old value are visible until
+    /// compaction actually deletes them which will happen sometime after. By
+    /// default ignore_range_deletions is set to true on a DBMap (unless it is
+    /// overridden in the config), so please use this function with caution
+    #[instrument(level = "trace", skip_all, err)]
+    fn schedule_delete_all(&self) -> Result<(), TypedStoreError> {
+        let first_key = self.safe_iter().next().transpose()?.map(|(k, _v)| k);
+        let last_key = self
+            .reversed_safe_iter_with_bounds(None, None)?
+            .next()
+            .transpose()?
+            .map(|(k, _v)| k);
+        if let Some((first_key, last_key)) = first_key.zip(last_key) {
+            let mut batch = self.batch();
+            batch.schedule_delete_range(self, &first_key, &last_key)?;
+            batch.write()?;
+        }
+        Ok(())
+    }
+
+    fn is_empty(&self) -> bool {
+        self.safe_iter().next().is_none()
+    }
+
+    fn safe_iter(&'a self) -> Self::SafeIterator {
+        let db_iter = self
+            .rocksdb
+            .raw_iterator_cf(&self.cf(), self.opts.readopts());
+        let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
+        SafeIter::new(
+            self.cf.clone(),
+            db_iter,
+            _timer,
+            _perf_ctx,
+            bytes_scanned,
+            keys_scanned,
+            Some(self.db_metrics.clone()),
+        )
+    }
+
+    fn safe_iter_with_bounds(
+        &'a self,
+        lower_bound: Option<K>,
+        upper_bound: Option<K>,
+    ) -> Self::SafeIterator {
+        let readopts = self.create_read_options_with_bounds(lower_bound, upper_bound);
+        let db_iter = self.rocksdb.raw_iterator_cf(&self.cf(), readopts);
+        let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
+        SafeIter::new(
+            self.cf.clone(),
+            db_iter,
+            _timer,
+            _perf_ctx,
+            bytes_scanned,
+            keys_scanned,
+            Some(self.db_metrics.clone()),
+        )
+    }
+
+    fn safe_range_iter(&'a self, range: impl RangeBounds<K>) -> Self::SafeIterator {
+        let readopts = self.create_read_options_with_range(range);
+        let db_iter = self.rocksdb.raw_iterator_cf(&self.cf(), readopts);
+        let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
+        SafeIter::new(
+            self.cf.clone(),
+            db_iter,
+            _timer,
+            _perf_ctx,
+            bytes_scanned,
+            keys_scanned,
+            Some(self.db_metrics.clone()),
+        )
+    }
+
+    /// Returns a vector of values corresponding to the keys provided.
+    #[instrument(level = "trace", skip_all, err)]
+    fn multi_get<J>(
+        &self,
+        keys: impl IntoIterator<Item = J>,
+    ) -> Result<Vec<Option<V>>, TypedStoreError>
+    where
+        J: Borrow<K>,
+    {
+        let results = self.multi_get_pinned(keys)?;
+        let values_parsed: Result<Vec<_>, TypedStoreError> = results
+            .into_iter()
+            .map(|value_byte| match value_byte {
+                Some(data) => Ok(Some(
+                    bcs::from_bytes(&data).map_err(typed_store_err_from_bcs_err)?,
+                )),
+                None => Ok(None),
+            })
+            .collect();
+
+        values_parsed
+    }
+
+    /// Convenience method for batch insertion
+    #[instrument(level = "trace", skip_all, err)]
+    fn multi_insert<J, U>(
+        &self,
+        key_val_pairs: impl IntoIterator<Item = (J, U)>,
+    ) -> Result<(), Self::Error>
+    where
+        J: Borrow<K>,
+        U: Borrow<V>,
+    {
+        let mut batch = self.batch();
+        batch.insert_batch(self, key_val_pairs)?;
+        batch.write()
+    }
+
+    /// Convenience method for batch removal
+    #[instrument(level = "trace", skip_all, err)]
+    fn multi_remove<J>(&self, keys: impl IntoIterator<Item = J>) -> Result<(), Self::Error>
+    where
+        J: Borrow<K>,
+    {
+        let mut batch = self.batch();
+        batch.delete_batch(self, keys)?;
+        batch.write()
+    }
+
+    /// Try to catch up with primary when running as secondary
+    #[instrument(level = "trace", skip_all, err)]
+    fn try_catch_up_with_primary(&self) -> Result<(), Self::Error> {
+        self.rocksdb
+            .try_catch_up_with_primary()
+            .map_err(typed_store_err_from_rocks_err)
+    }
+}
+
+/// Read a size from an environment variable
+pub fn read_size_from_env(var_name: &str) -> Option<usize> {
+    env::var(var_name)
+        .ok()?
+        .parse::<usize>()
+        .tap_err(|e| {
+            warn!(
+                "Env var {} does not contain valid usize integer: {}",
+                var_name, e
+            )
+        })
+        .ok()
+}
+
+/// The read-write options
+#[derive(Clone, Debug)]
+pub struct ReadWriteOptions {
+    /// Whether to ignore range deletions
+    pub ignore_range_deletions: bool,
+    // Whether to sync to disk on every write.
+    sync_to_disk: bool,
+}
+
+impl ReadWriteOptions {
+    /// The read options
+    pub fn readopts(&self) -> ReadOptions {
+        let mut readopts = ReadOptions::default();
+        readopts.set_ignore_range_deletions(self.ignore_range_deletions);
+        readopts
+    }
+
+    /// The write options
+    pub fn writeopts(&self) -> WriteOptions {
+        let mut opts = WriteOptions::default();
+        opts.set_sync(self.sync_to_disk);
+        opts
+    }
+
+    /// Set the ignore range deletions
+    pub fn set_ignore_range_deletions(mut self, ignore: bool) -> Self {
+        self.ignore_range_deletions = ignore;
+        self
+    }
+}
+
+impl Default for ReadWriteOptions {
+    fn default() -> Self {
+        Self {
+            ignore_range_deletions: true,
+            sync_to_disk: std::env::var("SUI_DB_SYNC_TO_DISK").is_ok_and(|v| v != "0"),
+        }
+    }
+}
+
+/// The rocksdb options
+#[derive(Default, Clone)]
+pub struct DBOptions {
+    /// The rocksdb options
+    pub options: rocksdb::Options,
+    /// The read-write options
+    pub rw_options: ReadWriteOptions,
+}
+
+impl fmt::Debug for DBOptions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "DBOptions")
+    }
+}
+
+impl DBOptions {
+    /// Optimize lookup perf for tables where no scans are performed.
+    /// If non-trivial number of values can be > 512B in size, it is beneficial to also
+    /// specify optimize_for_large_values_no_scan().
+    pub fn optimize_for_point_lookup(mut self, block_cache_size_mb: usize) -> DBOptions {
+        // NOTE: this overwrites the block options.
+        self.options
+            .optimize_for_point_lookup(block_cache_size_mb as u64);
+        self
+    }
+
+    /// Optimize write and lookup perf for tables which are rarely scanned, and have large values.
+    /// <https://rocksdb.org/blog/2021/05/26/integrated-blob-db.html>
+    pub fn optimize_for_large_values_no_scan(mut self, min_blob_size: u64) -> DBOptions {
+        if env::var(ENV_VAR_DISABLE_BLOB_STORAGE).is_ok() {
+            info!("Large value blob storage optimization is disabled via env var.");
+            return self;
+        }
+
+        // Blob settings.
+        self.options.set_enable_blob_files(true);
+        self.options
+            .set_blob_compression_type(rocksdb::DBCompressionType::Lz4);
+        self.options.set_enable_blob_gc(true);
+        // Since each blob can have non-trivial size overhead, and
+        // compression does not work across blobs,
+        // set a min blob size in bytes to so small transactions and
+        // effects are kept in sst files.
+        self.options.set_min_blob_size(min_blob_size);
+
+        // Increase write buffer size to 256MiB.
+        let write_buffer_size = read_size_from_env(ENV_VAR_MAX_WRITE_BUFFER_SIZE_MB)
+            .unwrap_or(DEFAULT_MAX_WRITE_BUFFER_SIZE_MB)
+            * 1024
+            * 1024;
+        self.options.set_write_buffer_size(write_buffer_size);
+        // Since large blobs are not in sst files, reduce the target file size and base level
+        // target size.
+        let target_file_size_base = 64 << 20;
+        self.options
+            .set_target_file_size_base(target_file_size_base);
+        // Level 1 default to 64MiB * 4 ~ 256MiB.
+        let max_level_zero_file_num = read_size_from_env(ENV_VAR_L0_NUM_FILES_COMPACTION_TRIGGER)
+            .unwrap_or(DEFAULT_L0_NUM_FILES_COMPACTION_TRIGGER);
+        self.options
+            .set_max_bytes_for_level_base(target_file_size_base * max_level_zero_file_num as u64);
+
+        self
+    }
+
+    /// Optimize tables with a mix of lookup and scan workloads.
+    pub fn optimize_for_read(mut self, block_cache_size_mb: usize) -> DBOptions {
+        self.options
+            .set_block_based_table_factory(&get_block_options(block_cache_size_mb, 16 << 10));
+        self
+    }
+
+    /// Optimize DB receiving significant insertions.
+    pub fn optimize_db_for_write_throughput(mut self, db_max_write_buffer_gb: u64) -> DBOptions {
+        self.options
+            .set_db_write_buffer_size(db_max_write_buffer_gb as usize * 1024 * 1024 * 1024);
+        self.options
+            .set_max_total_wal_size(db_max_write_buffer_gb * 1024 * 1024 * 1024);
+        self
+    }
+
+    /// Optimize tables receiving significant insertions.
+    pub fn optimize_for_write_throughput(mut self) -> DBOptions {
+        // Increase write buffer size to 256MiB.
+        let write_buffer_size = read_size_from_env(ENV_VAR_MAX_WRITE_BUFFER_SIZE_MB)
+            .unwrap_or(DEFAULT_MAX_WRITE_BUFFER_SIZE_MB)
+            * 1024
+            * 1024;
+        self.options.set_write_buffer_size(write_buffer_size);
+        // Increase write buffers to keep to 6 before slowing down writes.
+        let max_write_buffer_number = read_size_from_env(ENV_VAR_MAX_WRITE_BUFFER_NUMBER)
+            .unwrap_or(DEFAULT_MAX_WRITE_BUFFER_NUMBER);
+        self.options
+            .set_max_write_buffer_number(max_write_buffer_number.try_into().unwrap());
+        // Keep 1 write buffer so recent writes can be read from memory.
+        self.options
+            .set_max_write_buffer_size_to_maintain((write_buffer_size).try_into().unwrap());
+
+        // Increase compaction trigger for level 0 to 6.
+        let max_level_zero_file_num = read_size_from_env(ENV_VAR_L0_NUM_FILES_COMPACTION_TRIGGER)
+            .unwrap_or(DEFAULT_L0_NUM_FILES_COMPACTION_TRIGGER);
+        self.options.set_level_zero_file_num_compaction_trigger(
+            max_level_zero_file_num.try_into().unwrap(),
+        );
+        self.options.set_level_zero_slowdown_writes_trigger(
+            (max_level_zero_file_num * 12).try_into().unwrap(),
+        );
+        self.options
+            .set_level_zero_stop_writes_trigger((max_level_zero_file_num * 16).try_into().unwrap());
+
+        // Increase sst file size to 128MiB.
+        self.options.set_target_file_size_base(
+            read_size_from_env(ENV_VAR_TARGET_FILE_SIZE_BASE_MB)
+                .unwrap_or(DEFAULT_TARGET_FILE_SIZE_BASE_MB) as u64
+                * 1024
+                * 1024,
+        );
+
+        // Increase level 1 target size to 256MiB * 6 ~ 1.5GiB.
+        self.options
+            .set_max_bytes_for_level_base((write_buffer_size * max_level_zero_file_num) as u64);
+
+        self
+    }
+
+    /// Optimize tables receiving significant insertions, without any deletions.
+    /// TODO: merge this function with optimize_for_write_throughput(), and use a flag to
+    /// indicate if deletion is received.
+    pub fn optimize_for_write_throughput_no_deletion(mut self) -> DBOptions {
+        // Increase write buffer size to 256MiB.
+        let write_buffer_size = read_size_from_env(ENV_VAR_MAX_WRITE_BUFFER_SIZE_MB)
+            .unwrap_or(DEFAULT_MAX_WRITE_BUFFER_SIZE_MB)
+            * 1024
+            * 1024;
+        self.options.set_write_buffer_size(write_buffer_size);
+        // Increase write buffers to keep to 6 before slowing down writes.
+        let max_write_buffer_number = read_size_from_env(ENV_VAR_MAX_WRITE_BUFFER_NUMBER)
+            .unwrap_or(DEFAULT_MAX_WRITE_BUFFER_NUMBER);
+        self.options
+            .set_max_write_buffer_number(max_write_buffer_number.try_into().unwrap());
+        // Keep 1 write buffer so recent writes can be read from memory.
+        self.options
+            .set_max_write_buffer_size_to_maintain((write_buffer_size).try_into().unwrap());
+
+        // Switch to universal compactions.
+        self.options
+            .set_compaction_style(rocksdb::DBCompactionStyle::Universal);
+        let mut compaction_options = rocksdb::UniversalCompactOptions::default();
+        compaction_options.set_max_size_amplification_percent(10000);
+        compaction_options.set_stop_style(rocksdb::UniversalCompactionStopStyle::Similar);
+        self.options
+            .set_universal_compaction_options(&compaction_options);
+
+        let max_level_zero_file_num = read_size_from_env(ENV_VAR_L0_NUM_FILES_COMPACTION_TRIGGER)
+            .unwrap_or(DEFAULT_UNIVERSAL_COMPACTION_L0_NUM_FILES_COMPACTION_TRIGGER);
+        self.options.set_level_zero_file_num_compaction_trigger(
+            max_level_zero_file_num.try_into().unwrap(),
+        );
+        self.options.set_level_zero_slowdown_writes_trigger(
+            (max_level_zero_file_num * 12).try_into().unwrap(),
+        );
+        self.options
+            .set_level_zero_stop_writes_trigger((max_level_zero_file_num * 16).try_into().unwrap());
+
+        // Increase sst file size to 128MiB.
+        self.options.set_target_file_size_base(
+            read_size_from_env(ENV_VAR_TARGET_FILE_SIZE_BASE_MB)
+                .unwrap_or(DEFAULT_TARGET_FILE_SIZE_BASE_MB) as u64
+                * 1024
+                * 1024,
+        );
+
+        // This should be a no-op for universal compaction but increasing it to be safe.
+        self.options
+            .set_max_bytes_for_level_base((write_buffer_size * max_level_zero_file_num) as u64);
+
+        self
+    }
+
+    /// Overrides the block options with different block cache size and block size.
+    pub fn set_block_options(
+        mut self,
+        block_cache_size_mb: usize,
+        block_size_bytes: usize,
+    ) -> DBOptions {
+        self.options
+            .set_block_based_table_factory(&get_block_options(
+                block_cache_size_mb,
+                block_size_bytes,
+            ));
+        self
+    }
+
+    /// Disables write stalling and stopping based on pending compaction bytes.
+    pub fn disable_write_throttling(mut self) -> DBOptions {
+        self.options.set_soft_pending_compaction_bytes_limit(0);
+        self.options.set_hard_pending_compaction_bytes_limit(0);
+        self
+    }
+}
+
+/// Creates a default RocksDB option, to be used when RocksDB option is unspecified.
+pub fn default_db_options() -> DBOptions {
+    let mut opt = rocksdb::Options::default();
+
+    // One common issue when running tests on Mac is that the default ulimit is too low,
+    // leading to I/O errors such as "Too many open files". Raising fdlimit to bypass it.
+    if let Ok(outcome) = fdlimit::raise_fd_limit() {
+        let limit = match outcome {
+            fdlimit::Outcome::LimitRaised { to, .. } => to,
+            fdlimit::Outcome::Unsupported => {
+                warn!("Failed to raise fdlimit, defaulting to 1024");
+                1024
+            }
+        };
+        // on windows raise_fd_limit return None
+        opt.set_max_open_files((limit / 8) as i32);
+    }
+
+    // The table cache is locked for updates and this determines the number
+    // of shards, ie 2^10. Increase in case of lock contentions.
+    opt.set_table_cache_num_shard_bits(10);
+
+    // LSM compression settings
+    opt.set_compression_type(rocksdb::DBCompressionType::Lz4);
+    opt.set_bottommost_compression_type(rocksdb::DBCompressionType::Zstd);
+    opt.set_bottommost_zstd_max_train_bytes(1024 * 1024, true);
+
+    // Sui uses multiple RocksDB in a node, so total sizes of write buffers and WAL can be higher
+    // than the limits below.
+    //
+    // RocksDB also exposes the option to configure total write buffer size across
+    // multiple instances. But the write buffer flush policy (flushing the buffer
+    // receiving the next write) may not work well. So sticking to per-db write buffer
+    // size limit for now.
+    //
+    // The environment variables are only meant to be emergency overrides.
+    // They may go away in future.
+    // It is preferable to update the default value, or override the option in code.
+    opt.set_db_write_buffer_size(
+        read_size_from_env(ENV_VAR_DB_WRITE_BUFFER_SIZE).unwrap_or(DEFAULT_DB_WRITE_BUFFER_SIZE)
+            * 1024
+            * 1024,
+    );
+    opt.set_max_total_wal_size(
+        read_size_from_env(ENV_VAR_DB_WAL_SIZE).unwrap_or(DEFAULT_DB_WAL_SIZE) as u64 * 1024 * 1024,
+    );
+
+    // Num threads for compactions and memtable flushes.
+    opt.increase_parallelism(read_size_from_env(ENV_VAR_DB_PARALLELISM).unwrap_or(8) as i32);
+
+    opt.set_enable_pipelined_write(true);
+
+    // Increase block size to 16KiB.
+    // https://github.com/EighteenZi/rocksdb_wiki/blob/master/
+    // Memory-usage-in-RocksDB.md#indexes-and-filter-blocks
+    opt.set_block_based_table_factory(&get_block_options(128, 16 << 10));
+
+    // Set memtable bloomfilter.
+    opt.set_memtable_prefix_bloom_ratio(0.02);
+
+    DBOptions {
+        options: opt,
+        rw_options: ReadWriteOptions::default(),
+    }
+}
+
+fn get_block_options(block_cache_size_mb: usize, block_size_bytes: usize) -> BlockBasedOptions {
+    // Set options mostly similar to those used in optimize_for_point_lookup(),
+    // except non-default binary and hash index, to hopefully reduce lookup latencies
+    // without causing any regression for scanning, with slightly more memory usages.
+    // https://github.com/facebook/rocksdb/blob/
+    // 11cb6af6e5009c51794641905ca40ce5beec7fee/options/options.cc#L611-L621
+    let mut block_options = BlockBasedOptions::default();
+    // Overrides block size.
+    block_options.set_block_size(block_size_bytes);
+    // Configure a block cache.
+    block_options.set_block_cache(&Cache::new_lru_cache(block_cache_size_mb << 20));
+    // Set a bloomfilter with 1% false positive rate.
+    block_options.set_bloom_filter(10.0, false);
+    // From https://github.com/EighteenZi/rocksdb_wiki/blob/master/
+    // Block-Cache.md#caching-index-and-filter-blocks
+    block_options.set_pin_l0_filter_and_index_blocks_in_cache(true);
+    block_options
+}
+
+/// Opens a database with options, and a number of column families that are created
+/// if they do not exist.
+#[instrument(level="debug", skip_all, fields(path = ?path.as_ref(), cf = ?opt_cfs), err)]
+pub fn open_cf<P: AsRef<Path>>(
+    path: P,
+    db_options: Option<rocksdb::Options>,
+    metric_conf: MetricConf,
+    opt_cfs: &[&str],
+) -> Result<Arc<RocksDB>, TypedStoreError> {
+    let options = db_options.unwrap_or_else(|| default_db_options().options);
+    let column_descriptors: Vec<_> = opt_cfs
+        .iter()
+        .map(|name| (*name, options.clone()))
+        .collect();
+    open_cf_opts(
+        path,
+        Some(options.clone()),
+        metric_conf,
+        &column_descriptors[..],
+    )
+}
+
+fn prepare_db_options(db_options: Option<rocksdb::Options>) -> rocksdb::Options {
+    // Customize database options
+    let mut options = db_options.unwrap_or_else(|| default_db_options().options);
+    options.create_if_missing(true);
+    options.create_missing_column_families(true);
+    options
+}
+
+/// Opens a database with options, and a number of column families with individual options that
+/// are created if they do not exist.
+#[instrument(level="debug", skip_all, fields(path = ?path.as_ref()), err)]
+pub fn open_cf_opts<P: AsRef<Path>>(
+    path: P,
+    db_options: Option<rocksdb::Options>,
+    metric_conf: MetricConf,
+    opt_cfs: &[(&str, rocksdb::Options)],
+) -> Result<Arc<RocksDB>, TypedStoreError> {
+    let path = path.as_ref();
+    // In the simulator, we intercept the wall clock in the test thread only. This causes problems
+    // because rocksdb uses the simulated clock when creating its background threads, but then
+    // those threads see the real wall clock (because they are not the test thread), which causes
+    // rocksdb to panic. The `nondeterministic` macro evaluates expressions in new threads, which
+    // resolves the issue.
+    //
+    // This is a no-op in non-simulator builds.
+
+    let cfs = populate_missing_cfs(opt_cfs, path).map_err(typed_store_err_from_rocks_err)?;
+    nondeterministic!({
+        let options = prepare_db_options(db_options);
+        let rocksdb = {
+            rocksdb::DBWithThreadMode::<MultiThreaded>::open_cf_descriptors(
+                &options,
+                path,
+                cfs.into_iter()
+                    .map(|(name, opts)| ColumnFamilyDescriptor::new(name, opts)),
+            )
+            .map_err(typed_store_err_from_rocks_err)?
+        };
+        Ok(Arc::new(RocksDB::new(
+            rocksdb,
+            metric_conf,
+            PathBuf::from(path),
+        )))
+    })
+}
+
+/// Opens a database with options, and a number of column families with individual options that
+/// are created if they do not exist.
+pub fn open_cf_opts_secondary<P: AsRef<Path>>(
+    primary_path: P,
+    secondary_path: Option<P>,
+    db_options: Option<rocksdb::Options>,
+    metric_conf: MetricConf,
+    opt_cfs: &[(&str, rocksdb::Options)],
+) -> Result<Arc<RocksDB>, TypedStoreError> {
+    let primary_path = primary_path.as_ref();
+    let secondary_path = secondary_path.as_ref().map(|p| p.as_ref());
+    // See comment above for explanation of why nondeterministic is necessary here.
+    nondeterministic!({
+        // Customize database options
+        let mut options = db_options.unwrap_or_else(|| default_db_options().options);
+
+        fdlimit::raise_fd_limit().map_err(|e| TypedStoreError::RocksDBError(e.to_string()))?;
+        // This is a requirement by RocksDB when opening as secondary
+        options.set_max_open_files(-1);
+
+        let mut opt_cfs: std::collections::HashMap<_, _> = opt_cfs.iter().cloned().collect();
+        let cfs = rocksdb::DBWithThreadMode::<MultiThreaded>::list_cf(&options, primary_path)
+            .ok()
+            .unwrap_or_default();
+
+        let default_db_options = default_db_options();
+        // Add CFs not explicitly listed
+        for cf_key in cfs.iter() {
+            if !opt_cfs.contains_key(&cf_key[..]) {
+                opt_cfs.insert(cf_key, default_db_options.options.clone());
+            }
+        }
+
+        let primary_path = primary_path.to_path_buf();
+        let secondary_path = secondary_path.map(|q| q.to_path_buf()).unwrap_or_else(|| {
+            let mut s = primary_path.clone();
+            s.pop();
+            s.push("SECONDARY");
+            s.as_path().to_path_buf()
+        });
+
+        let rocksdb = {
+            options.create_if_missing(true);
+            options.create_missing_column_families(true);
+            let db = rocksdb::DBWithThreadMode::<MultiThreaded>::open_cf_descriptors_as_secondary(
+                &options,
+                &primary_path,
+                &secondary_path,
+                opt_cfs
+                    .iter()
+                    .map(|(name, opts)| ColumnFamilyDescriptor::new(*name, (*opts).clone())),
+            )
+            .map_err(typed_store_err_from_rocks_err)?;
+            db.try_catch_up_with_primary()
+                .map_err(typed_store_err_from_rocks_err)?;
+            db
+        };
+        Ok(Arc::new(RocksDB::new(rocksdb, metric_conf, secondary_path)))
+    })
+}
+
+/// List the tables in the database
+pub fn list_tables(path: std::path::PathBuf) -> eyre::Result<Vec<String>> {
+    const DB_DEFAULT_CF_NAME: &str = "default";
+
+    let opts = rocksdb::Options::default();
+    rocksdb::DBWithThreadMode::<rocksdb::MultiThreaded>::list_cf(&opts, path)
+        .map_err(|e| e.into())
+        .map(|q| {
+            q.iter()
+                .filter_map(|s| {
+                    // The `default` table is not used
+                    if s != DB_DEFAULT_CF_NAME {
+                        Some(s.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        })
+}
+
+/// TODO: Good description of why we're doing this :
+/// RocksDB stores keys in BE and has a seek operator
+/// on iterators, see `https://github.com/facebook/rocksdb/wiki/Iterator#introduction`
+#[inline]
+pub fn be_fix_int_ser<S>(t: &S) -> Result<Vec<u8>, TypedStoreError>
+where
+    S: ?Sized + serde::Serialize,
+{
+    bincode::DefaultOptions::new()
+        .with_big_endian()
+        .with_fixint_encoding()
+        .serialize(t)
+        .map_err(typed_store_err_from_bincode_err)
+}
+
+/// The map of table names to DB options
+#[derive(Clone, Debug)]
+pub struct DBMapTableConfigMap(BTreeMap<String, DBOptions>);
+impl DBMapTableConfigMap {
+    /// Create a new DBMapTableConfigMap
+    pub fn new(map: BTreeMap<String, DBOptions>) -> Self {
+        Self(map)
+    }
+
+    /// Convert the DBMapTableConfigMap to a BTreeMap
+    pub fn to_map(&self) -> BTreeMap<String, DBOptions> {
+        self.0.clone()
+    }
+}
+
+/// The type of database access
+#[derive(Debug)]
+pub enum RocksDBAccessType {
+    /// The primary database
+    Primary,
+    /// The secondary database
+    Secondary(Option<PathBuf>),
+}
+
+/// Safe drop the database
+pub fn safe_drop_db(path: PathBuf) -> Result<(), rocksdb::Error> {
+    rocksdb::DB::destroy(&rocksdb::Options::default(), path)
+}
+
+/// Populate missing column families
+fn populate_missing_cfs(
+    input_cfs: &[(&str, rocksdb::Options)],
+    path: &Path,
+) -> Result<Vec<(String, rocksdb::Options)>, rocksdb::Error> {
+    let mut cfs = vec![];
+    let input_cf_index: HashSet<_> = input_cfs.iter().map(|(name, _)| *name).collect();
+    let existing_cfs =
+        rocksdb::DBWithThreadMode::<MultiThreaded>::list_cf(&rocksdb::Options::default(), path)
+            .ok()
+            .unwrap_or_default();
+
+    for cf_name in existing_cfs {
+        if !input_cf_index.contains(&cf_name[..]) {
+            cfs.push((cf_name, rocksdb::Options::default()));
+        }
+    }
+    cfs.extend(
+        input_cfs
+            .iter()
+            .map(|(name, opts)| (name.to_string(), (*opts).clone())),
+    );
+    Ok(cfs)
+}
+
+/// Given a vec<u8>, find the value which is one more than the vector
+/// if the vector was a big endian number.
+/// If the vector is already minimum, don't change it.
+fn big_endian_saturating_add_one(v: &mut [u8]) {
+    if is_max(v) {
+        return;
+    }
+    for i in (0..v.len()).rev() {
+        if v[i] == u8::MAX {
+            v[i] = 0;
+        } else {
+            v[i] += 1;
+            break;
+        }
+    }
+}
+
+/// Check if all the bytes in the vector are 0xFF
+fn is_max(v: &[u8]) -> bool {
+    v.iter().all(|&x| x == u8::MAX)
+}
+
+#[allow(clippy::assign_op_pattern)]
+#[allow(clippy::manual_div_ceil)]
+#[test]
+fn test_helpers() {
+    let v = vec![];
+    assert!(is_max(&v));
+
+    fn check_add(v: Vec<u8>) {
+        let mut v = v;
+        let num = Num32::from_big_endian(&v);
+        big_endian_saturating_add_one(&mut v);
+        assert!(num + 1 == Num32::from_big_endian(&v));
+    }
+
+    uint::construct_uint! {
+        // 32 byte number
+        struct Num32(4);
+    }
+
+    let mut v = vec![255; 32];
+    big_endian_saturating_add_one(&mut v);
+    assert!(Num32::MAX == Num32::from_big_endian(&v));
+
+    check_add(vec![1; 32]);
+    check_add(vec![6; 32]);
+    check_add(vec![254; 32]);
+
+    // TBD: More tests coming with randomized arrays
+}

--- a/crates/typed-store/src/rocks/errors.rs
+++ b/crates/typed-store/src/rocks/errors.rs
@@ -1,0 +1,122 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{fmt, fmt::Display};
+
+use bincode::ErrorKind as BincodeErrorKind;
+use rocksdb::Error as RocksError;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Serialize, Deserialize, Clone, Eq, PartialEq, Hash, Debug, Error)]
+pub(crate) struct RocksErrorDef {
+    message: String,
+}
+
+impl Display for RocksErrorDef {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> std::result::Result<(), fmt::Error> {
+        self.message.fmt(formatter)
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug, Error)]
+pub(crate) enum BincodeErrorDef {
+    Io(String),
+    InvalidUtf8Encoding(String),
+    InvalidBoolEncoding(u8),
+    InvalidCharEncoding,
+    InvalidTagEncoding(usize),
+    DeserializeAnyNotSupported,
+    SizeLimit,
+    SequenceMustHaveLength,
+    Custom(String),
+}
+
+impl fmt::Display for BincodeErrorDef {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            BincodeErrorDef::Io(ref ioerr) => write!(fmt, "io error: {ioerr}"),
+            BincodeErrorDef::InvalidUtf8Encoding(ref e) => {
+                write!(fmt, "{e}")
+            }
+            BincodeErrorDef::InvalidBoolEncoding(b) => {
+                write!(fmt, "expected 0 or 1, found {b}")
+            }
+            BincodeErrorDef::InvalidCharEncoding => write!(fmt, "{self:?}"),
+            BincodeErrorDef::InvalidTagEncoding(tag) => {
+                write!(fmt, "found {tag}")
+            }
+            BincodeErrorDef::SequenceMustHaveLength => write!(fmt, "{self:?}"),
+            BincodeErrorDef::SizeLimit => write!(fmt, "{self:?}"),
+            BincodeErrorDef::DeserializeAnyNotSupported => write!(
+                fmt,
+                "Bincode does not support the serde::Deserializer::deserialize_any method"
+            ),
+            BincodeErrorDef::Custom(ref s) => s.fmt(fmt),
+        }
+    }
+}
+
+impl From<bincode::Error> for BincodeErrorDef {
+    fn from(err: bincode::Error) -> Self {
+        match err.as_ref() {
+            BincodeErrorKind::Io(ioerr) => BincodeErrorDef::Io(ioerr.to_string()),
+            BincodeErrorKind::InvalidUtf8Encoding(utf8err) => {
+                BincodeErrorDef::InvalidUtf8Encoding(utf8err.to_string())
+            }
+            BincodeErrorKind::InvalidBoolEncoding(byte) => {
+                BincodeErrorDef::InvalidBoolEncoding(*byte)
+            }
+            BincodeErrorKind::InvalidCharEncoding => BincodeErrorDef::InvalidCharEncoding,
+            BincodeErrorKind::InvalidTagEncoding(tag) => BincodeErrorDef::InvalidTagEncoding(*tag),
+            BincodeErrorKind::DeserializeAnyNotSupported => {
+                BincodeErrorDef::DeserializeAnyNotSupported
+            }
+            BincodeErrorKind::SizeLimit => BincodeErrorDef::SizeLimit,
+            BincodeErrorKind::SequenceMustHaveLength => BincodeErrorDef::SequenceMustHaveLength,
+            BincodeErrorKind::Custom(str) => BincodeErrorDef::Custom(str.to_owned()),
+        }
+    }
+}
+
+/// Convert the bincode error to the typed store error
+pub fn typed_store_err_from_bincode_err(err: bincode::Error) -> TypedStoreError {
+    TypedStoreError::SerializationError(format!("{err}"))
+}
+
+/// Convert the bcs error to the typed store error
+pub fn typed_store_err_from_bcs_err(err: bcs::Error) -> TypedStoreError {
+    TypedStoreError::SerializationError(format!("{err}"))
+}
+
+/// Convert the rocksdb error to the typed store error
+pub fn typed_store_err_from_rocks_err(err: RocksError) -> TypedStoreError {
+    TypedStoreError::RocksDBError(format!("{err}"))
+}
+
+#[non_exhaustive]
+#[derive(Error, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone, Ord, PartialOrd)]
+/// The error type for the typed store
+pub enum TypedStoreError {
+    /// The rocksdb error
+    #[error("rocksdb error: {0}")]
+    RocksDBError(String),
+    /// The serialization error
+    #[error("(de)serialization error: {0}")]
+    SerializationError(String),
+    /// The column family was not registered with the database
+    #[error("the column family {0} was not registered with the database")]
+    UnregisteredColumn(String),
+    /// A batch operation can't operate across databases
+    #[error("a batch operation can't operate across databases")]
+    CrossDBBatch,
+    /// The metric reporting thread failed with error
+    #[error("Metric reporting thread failed with error")]
+    MetricsReporting,
+    /// The transaction should be retried
+    #[error("Transaction should be retried")]
+    RetryableTransactionError,
+}
+
+/// The result type for the typed store
+pub type Result<T> = std::result::Result<T, TypedStoreError>;

--- a/crates/typed-store/src/rocks/safe_iter.rs
+++ b/crates/typed-store/src/rocks/safe_iter.rs
@@ -1,0 +1,151 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{fmt, marker::PhantomData, sync::Arc};
+
+use bincode::Options;
+use prometheus::{Histogram, HistogramTimer};
+use rocksdb::Direction;
+use serde::de::DeserializeOwned;
+
+use super::RocksDBRawIter;
+use crate::{
+    TypedStoreError,
+    metrics::{DBMetrics, RocksDBPerfContext},
+};
+
+/// An iterator over all key-value pairs in a data map.
+pub struct SafeIter<'a, K, V> {
+    cf_name: String,
+    db_iter: RocksDBRawIter<'a>,
+    _phantom: PhantomData<(K, V)>,
+    direction: Direction,
+    is_initialized: bool,
+    _timer: Option<HistogramTimer>,
+    _perf_ctx: Option<RocksDBPerfContext>,
+    bytes_scanned: Option<Histogram>,
+    keys_scanned: Option<Histogram>,
+    db_metrics: Option<Arc<DBMetrics>>,
+    bytes_scanned_counter: usize,
+    keys_returned_counter: usize,
+}
+
+impl<K: DeserializeOwned, V: DeserializeOwned> fmt::Debug for SafeIter<'_, K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SafeIter")
+    }
+}
+
+impl<'a, K: DeserializeOwned, V: DeserializeOwned> SafeIter<'a, K, V> {
+    pub(super) fn new(
+        cf_name: String,
+        db_iter: RocksDBRawIter<'a>,
+        _timer: Option<HistogramTimer>,
+        _perf_ctx: Option<RocksDBPerfContext>,
+        bytes_scanned: Option<Histogram>,
+        keys_scanned: Option<Histogram>,
+        db_metrics: Option<Arc<DBMetrics>>,
+    ) -> Self {
+        Self {
+            cf_name,
+            db_iter,
+            _phantom: PhantomData,
+            direction: Direction::Forward,
+            is_initialized: false,
+            _timer,
+            _perf_ctx,
+            bytes_scanned,
+            keys_scanned,
+            db_metrics,
+            bytes_scanned_counter: 0,
+            keys_returned_counter: 0,
+        }
+    }
+}
+
+impl<K: DeserializeOwned, V: DeserializeOwned> Iterator for SafeIter<'_, K, V> {
+    type Item = Result<(K, V), TypedStoreError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Implicitly set iterator to the first entry in the column
+        // family if it hasn't been initialized used for backward
+        // compatibility
+        if !self.is_initialized {
+            self.db_iter.seek_to_first();
+            self.is_initialized = true;
+        }
+        if self.db_iter.valid() {
+            let config = bincode::DefaultOptions::new()
+                .with_big_endian()
+                .with_fixint_encoding();
+            let raw_key = self
+                .db_iter
+                .key()
+                .expect("Valid iterator failed to get key");
+            let raw_value = self
+                .db_iter
+                .value()
+                .expect("Valid iterator failed to get value");
+            self.bytes_scanned_counter += raw_key.len() + raw_value.len();
+            self.keys_returned_counter += 1;
+            let key = config.deserialize(raw_key).ok();
+            let value = bcs::from_bytes(raw_value).ok();
+            match self.direction {
+                Direction::Forward => self.db_iter.next(),
+                Direction::Reverse => self.db_iter.prev(),
+            }
+            key.and_then(|k| value.map(|v| Ok((k, v))))
+        } else {
+            match self.db_iter.status() {
+                Ok(_) => None,
+                Err(err) => Some(Err(TypedStoreError::RocksDBError(format!("{err}")))),
+            }
+        }
+    }
+}
+
+impl<K, V> Drop for SafeIter<'_, K, V> {
+    fn drop(&mut self) {
+        if let Some(bytes_scanned) = self.bytes_scanned.take() {
+            bytes_scanned.observe(self.bytes_scanned_counter as f64);
+        }
+        if let Some(keys_scanned) = self.keys_scanned.take() {
+            keys_scanned.observe(self.keys_returned_counter as f64);
+        }
+        if let Some(db_metrics) = self.db_metrics.take() {
+            db_metrics
+                .read_perf_ctx_metrics
+                .report_metrics(&self.cf_name);
+        }
+    }
+}
+
+/// An iterator with a reverted direction to the original. The `RevIter`
+/// is hosting an iteration which is consuming in the opposing direction.
+/// It's not possible to do further manipulation (ex re-reverse) to the
+/// iterator.
+#[derive(Debug)]
+pub struct SafeRevIter<'a, K: DeserializeOwned, V: DeserializeOwned> {
+    iter: SafeIter<'a, K, V>,
+}
+
+impl<'a, K: DeserializeOwned, V: DeserializeOwned> SafeRevIter<'a, K, V> {
+    pub(crate) fn new(mut iter: SafeIter<'a, K, V>, upper_bound: Option<Vec<u8>>) -> Self {
+        iter.is_initialized = true;
+        iter.direction = Direction::Reverse;
+        match upper_bound {
+            None => iter.db_iter.seek_to_last(),
+            Some(key) => iter.db_iter.seek_for_prev(&key),
+        }
+        Self { iter }
+    }
+}
+
+impl<K: DeserializeOwned, V: DeserializeOwned> Iterator for SafeRevIter<'_, K, V> {
+    type Item = Result<(K, V), TypedStoreError>;
+
+    /// Will give the next item backwards
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+}

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -1,0 +1,785 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use rstest::rstest;
+
+use super::*;
+use crate::{
+    reopen,
+    rocks::safe_iter::{SafeIter, SafeRevIter},
+};
+
+fn temp_dir() -> std::path::PathBuf {
+    tempfile::tempdir()
+        .expect("Failed to open temporary directory")
+        .into_path()
+}
+
+enum TestIteratorWrapper<'a, K, V> {
+    SafeIter(SafeIter<'a, K, V>),
+}
+
+// Implement Iterator for TestIteratorWrapper that returns the same type
+// result for different types of Iterator.
+// For non-safe Iterator, it returns the key value pair. For SafeIterator,
+// it consumes the result (assuming no error),
+// and return they key value pairs.
+impl<K: DeserializeOwned, V: DeserializeOwned> Iterator for TestIteratorWrapper<'_, K, V> {
+    type Item = (K, V);
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            TestIteratorWrapper::SafeIter(iter) => iter.next().map(|result| result.unwrap()),
+        }
+    }
+}
+
+fn get_iter<K, V>(db: &DBMap<K, V>) -> TestIteratorWrapper<'_, K, V>
+where
+    K: Serialize + DeserializeOwned,
+    V: Serialize + DeserializeOwned,
+{
+    TestIteratorWrapper::SafeIter(db.safe_iter())
+}
+
+fn get_reverse_iter<K, V>(
+    db: &DBMap<K, V>,
+    lower_bound: Option<K>,
+    upper_bound: Option<K>,
+) -> SafeRevIter<'_, K, V>
+where
+    K: Serialize + DeserializeOwned,
+    V: Serialize + DeserializeOwned,
+{
+    db.reversed_safe_iter_with_bounds(lower_bound, upper_bound)
+        .unwrap()
+}
+
+fn get_iter_with_bounds<K, V>(
+    db: &DBMap<K, V>,
+    lower_bound: Option<K>,
+    upper_bound: Option<K>,
+) -> TestIteratorWrapper<'_, K, V>
+where
+    K: Serialize + DeserializeOwned,
+    V: Serialize + DeserializeOwned,
+{
+    TestIteratorWrapper::SafeIter(db.safe_iter_with_bounds(lower_bound, upper_bound))
+}
+
+fn get_range_iter<K, V>(
+    db: &DBMap<K, V>,
+    range: impl RangeBounds<K>,
+) -> TestIteratorWrapper<'_, K, V>
+where
+    K: Serialize + DeserializeOwned,
+    V: Serialize + DeserializeOwned,
+{
+    TestIteratorWrapper::SafeIter(db.safe_range_iter(range))
+}
+
+#[tokio::test]
+async fn test_open() {
+    let _db = open_map::<_, u32, String>(temp_dir(), None);
+}
+
+#[tokio::test]
+async fn test_reopen() {
+    let arc = {
+        let db = open_map::<_, u32, String>(temp_dir(), None);
+        db.insert(&123456789, &"123456789".to_string())
+            .expect("Failed to insert");
+        db
+    };
+    let db = DBMap::<u32, String>::reopen(&arc.rocksdb, None, &ReadWriteOptions::default(), false)
+        .expect("Failed to re-open storage");
+    assert!(
+        db.contains_key(&123456789)
+            .expect("Failed to retrieve item in storage")
+    );
+}
+
+#[tokio::test]
+async fn test_reopen_macro() {
+    const FIRST_CF: &str = "First_CF";
+    const SECOND_CF: &str = "Second_CF";
+
+    let rocks = open_cf(
+        temp_dir(),
+        None,
+        MetricConf::default(),
+        &[FIRST_CF, SECOND_CF],
+    )
+    .unwrap();
+
+    let (db_map_1, db_map_2) = reopen!(&rocks, FIRST_CF;<i32, String>, SECOND_CF;<i32, String>);
+
+    let keys_vals_cf1 = (1..100).map(|i| (i, i.to_string()));
+    let keys_vals_cf2 = (1..100).map(|i| (i, i.to_string()));
+
+    assert_eq!(db_map_1.cf, FIRST_CF);
+    assert_eq!(db_map_2.cf, SECOND_CF);
+
+    assert!(db_map_1.multi_insert(keys_vals_cf1).is_ok());
+    assert!(db_map_2.multi_insert(keys_vals_cf2).is_ok());
+}
+
+#[tokio::test]
+async fn test_wrong_reopen() {
+    let rocks = open_rocksdb(temp_dir(), &["foo", "bar", "baz"]);
+    let db = DBMap::<u8, u8>::reopen(&rocks, Some("quux"), &ReadWriteOptions::default(), false);
+    assert!(db.is_err());
+}
+
+#[tokio::test]
+async fn test_contains_key() {
+    let db = open_map(temp_dir(), None);
+
+    db.insert(&123456789, &"123456789".to_string())
+        .expect("Failed to insert");
+    assert!(
+        db.contains_key(&123456789)
+            .expect("Failed to call contains key")
+    );
+    assert!(
+        !db.contains_key(&000000000)
+            .expect("Failed to call contains key")
+    );
+}
+
+#[tokio::test]
+async fn test_multi_contain() {
+    let db = open_map(temp_dir(), None);
+
+    db.insert(&123, &"123".to_string())
+        .expect("Failed to insert");
+    db.insert(&456, &"456".to_string())
+        .expect("Failed to insert");
+    db.insert(&789, &"789".to_string())
+        .expect("Failed to insert");
+
+    let result = db
+        .multi_contains_keys([123, 456])
+        .expect("Failed to check multi keys existence");
+
+    assert_eq!(result.len(), 2);
+    assert!(result[0]);
+    assert!(result[1]);
+
+    let result = db
+        .multi_contains_keys([123, 987, 789])
+        .expect("Failed to check multi keys existence");
+
+    assert_eq!(result.len(), 3);
+    assert!(result[0]);
+    assert!(!result[1]);
+    assert!(result[2]);
+}
+
+#[tokio::test]
+async fn test_get() {
+    let db = open_map(temp_dir(), None);
+
+    db.insert(&123456789, &"123456789".to_string())
+        .expect("Failed to insert");
+    assert_eq!(
+        Some("123456789".to_string()),
+        db.get(&123456789).expect("Failed to get")
+    );
+    assert_eq!(None, db.get(&000000000).expect("Failed to get"));
+}
+
+#[tokio::test]
+async fn test_multi_get() {
+    let db = open_map(temp_dir(), None);
+
+    db.insert(&123, &"123".to_string())
+        .expect("Failed to insert");
+    db.insert(&456, &"456".to_string())
+        .expect("Failed to insert");
+
+    let result = db.multi_get([123, 456, 789]).expect("Failed to multi get");
+
+    assert_eq!(result.len(), 3);
+    assert_eq!(result[0], Some("123".to_string()));
+    assert_eq!(result[1], Some("456".to_string()));
+    assert_eq!(result[2], None);
+}
+
+#[tokio::test]
+async fn test_skip() {
+    let db = open_map(temp_dir(), None);
+
+    db.insert(&123, &"123".to_string())
+        .expect("Failed to insert");
+    db.insert(&456, &"456".to_string())
+        .expect("Failed to insert");
+    db.insert(&789, &"789".to_string())
+        .expect("Failed to insert");
+
+    // Skip all smaller
+    let key_vals: Vec<_> = get_iter_with_bounds(&db, Some(456), None).collect();
+    assert_eq!(key_vals.len(), 2);
+    assert_eq!(key_vals[0], (456, "456".to_string()));
+    assert_eq!(key_vals[1], (789, "789".to_string()));
+
+    // Skip to the end
+    assert_eq!(get_iter_with_bounds(&db, Some(999), None).count(), 0);
+
+    // Skip to last
+    assert_eq!(
+        get_reverse_iter(&db, None, None).next(),
+        Some(Ok((789, "789".to_string()))),
+    );
+
+    // Skip to successor of first value
+    assert_eq!(get_iter_with_bounds(&db, Some(000), None).count(), 3);
+    assert_eq!(get_iter_with_bounds(&db, Some(000), None).count(), 3);
+}
+
+#[tokio::test]
+async fn test_reverse_iter_with_bounds() {
+    let db = open_map(temp_dir(), None);
+    db.insert(&123, &"123".to_string())
+        .expect("Failed to insert");
+    db.insert(&456, &"456".to_string())
+        .expect("Failed to insert");
+    db.insert(&789, &"789".to_string())
+        .expect("Failed to insert");
+
+    let mut iter = get_reverse_iter(&db, None, Some(999));
+    assert_eq!(iter.next().unwrap(), Ok((789, "789".to_string())));
+
+    db.insert(&999, &"999".to_string())
+        .expect("Failed to insert");
+    let mut iter = get_reverse_iter(&db, None, Some(999));
+    assert_eq!(iter.next().unwrap(), Ok((999, "999".to_string())));
+
+    let mut iter = get_reverse_iter(&db, None, None);
+    assert_eq!(iter.next().unwrap(), Ok((999, "999".to_string())));
+}
+
+#[tokio::test]
+async fn test_remove() {
+    let db = open_map(temp_dir(), None);
+
+    db.insert(&123456789, &"123456789".to_string())
+        .expect("Failed to insert");
+    assert!(db.get(&123456789).expect("Failed to get").is_some());
+
+    db.remove(&123456789).expect("Failed to remove");
+    assert!(db.get(&123456789).expect("Failed to get").is_none());
+}
+
+#[tokio::test]
+async fn test_iter() {
+    let db = open_map(temp_dir(), None);
+    db.insert(&123456789, &"123456789".to_string())
+        .expect("Failed to insert");
+    db.insert(&987654321, &"987654321".to_string())
+        .expect("Failed to insert");
+
+    let mut iter = get_iter(&db);
+
+    assert_eq!(Some((123456789, "123456789".to_string())), iter.next());
+    assert_eq!(Some((987654321, "987654321".to_string())), iter.next());
+    assert_eq!(None, iter.next());
+}
+
+#[tokio::test]
+async fn test_iter_reverse() {
+    let db = open_map(temp_dir(), None);
+
+    db.insert(&1, &"1".to_string()).expect("Failed to insert");
+    db.insert(&2, &"2".to_string()).expect("Failed to insert");
+    db.insert(&3, &"3".to_string()).expect("Failed to insert");
+
+    let mut iter = get_reverse_iter(&db, None, None);
+    assert_eq!(Some(Ok((3, "3".to_string()))), iter.next());
+    assert_eq!(Some(Ok((2, "2".to_string()))), iter.next());
+    assert_eq!(Some(Ok((1, "1".to_string()))), iter.next());
+    assert_eq!(None, iter.next());
+
+    let mut iter = get_iter_with_bounds(&db, Some(1), None);
+    assert_eq!(Some((1, "1".to_string())), iter.next());
+    assert_eq!(Some((2, "2".to_string())), iter.next());
+}
+
+#[tokio::test]
+async fn test_insert_batch() {
+    let db = open_map(temp_dir(), None);
+    let keys_vals = (1..100).map(|i| (i, i.to_string()));
+    let mut insert_batch = db.batch();
+    insert_batch
+        .insert_batch(&db, keys_vals.clone())
+        .expect("Failed to batch insert");
+    insert_batch.write().expect("Failed to execute batch");
+    for (k, v) in keys_vals {
+        let val = db.get(&k).expect("Failed to get inserted key");
+        assert_eq!(Some(v), val);
+    }
+}
+
+#[tokio::test]
+async fn test_insert_batch_across_cf() {
+    let rocks = open_rocksdb(temp_dir(), &["First_CF", "Second_CF"]);
+
+    let db_cf_1 = DBMap::reopen(
+        &rocks,
+        Some("First_CF"),
+        &ReadWriteOptions::default(),
+        false,
+    )
+    .expect("Failed to open storage");
+    let keys_vals_1 = (1..100).map(|i| (i, i.to_string()));
+
+    let db_cf_2 = DBMap::reopen(
+        &rocks,
+        Some("Second_CF"),
+        &ReadWriteOptions::default(),
+        false,
+    )
+    .expect("Failed to open storage");
+    let keys_vals_2 = (1000..1100).map(|i| (i, i.to_string()));
+
+    let mut batch = db_cf_1.batch();
+    batch
+        .insert_batch(&db_cf_1, keys_vals_1.clone())
+        .expect("Failed to batch insert")
+        .insert_batch(&db_cf_2, keys_vals_2.clone())
+        .expect("Failed to batch insert");
+
+    batch.write().expect("Failed to execute batch");
+    for (k, v) in keys_vals_1 {
+        let val = db_cf_1.get(&k).expect("Failed to get inserted key");
+        assert_eq!(Some(v), val);
+    }
+
+    for (k, v) in keys_vals_2 {
+        let val = db_cf_2.get(&k).expect("Failed to get inserted key");
+        assert_eq!(Some(v), val);
+    }
+}
+
+#[tokio::test]
+async fn test_insert_batch_across_different_db() {
+    let rocks = open_rocksdb(temp_dir(), &["First_CF", "Second_CF"]);
+    let rocks2 = open_rocksdb(temp_dir(), &["First_CF", "Second_CF"]);
+
+    let db_cf_1: DBMap<i32, String> = DBMap::reopen(
+        &rocks,
+        Some("First_CF"),
+        &ReadWriteOptions::default(),
+        false,
+    )
+    .expect("Failed to open storage");
+    let keys_vals_1 = (1..100).map(|i| (i, i.to_string()));
+
+    let db_cf_2: DBMap<i32, String> = DBMap::reopen(
+        &rocks2,
+        Some("Second_CF"),
+        &ReadWriteOptions::default(),
+        false,
+    )
+    .expect("Failed to open storage");
+    let keys_vals_2 = (1000..1100).map(|i| (i, i.to_string()));
+
+    assert!(
+        db_cf_1
+            .batch()
+            .insert_batch(&db_cf_1, keys_vals_1)
+            .expect("Failed to batch insert")
+            .insert_batch(&db_cf_2, keys_vals_2)
+            .is_err()
+    );
+}
+
+#[tokio::test]
+async fn test_delete_batch() {
+    let db = DBMap::<i32, String>::open(
+        temp_dir(),
+        MetricConf::default(),
+        None,
+        None,
+        &ReadWriteOptions::default(),
+    )
+    .expect("Failed to open storage");
+
+    let keys_vals = (1..100).map(|i| (i, i.to_string()));
+    let mut batch = db.batch();
+    batch
+        .insert_batch(&db, keys_vals)
+        .expect("Failed to batch insert");
+
+    // delete the odd-index keys
+    let deletion_keys = (1..100).step_by(2);
+    batch
+        .delete_batch(&db, deletion_keys)
+        .expect("Failed to batch delete");
+
+    batch.write().expect("Failed to execute batch");
+
+    for (k, _) in get_iter(&db) {
+        assert_eq!(k % 2, 0);
+    }
+}
+
+#[tokio::test]
+async fn test_delete_range() {
+    let db: DBMap<i32, String> = DBMap::open(
+        temp_dir(),
+        MetricConf::default(),
+        None,
+        None,
+        &ReadWriteOptions::default().set_ignore_range_deletions(false),
+    )
+    .expect("Failed to open storage");
+
+    // Note that the last element is (100, "100".to_owned()) here
+    let keys_vals = (0..101).map(|i| (i, i.to_string()));
+    let mut batch = db.batch();
+    batch
+        .insert_batch(&db, keys_vals)
+        .expect("Failed to batch insert");
+
+    batch
+        .schedule_delete_range(&db, &50, &100)
+        .expect("Failed to delete range");
+
+    batch.write().expect("Failed to execute batch");
+
+    for k in 0..50 {
+        assert!(db.contains_key(&k).expect("Failed to query legal key"),);
+    }
+    for k in 50..100 {
+        assert!(!db.contains_key(&k).expect("Failed to query legal key"));
+    }
+
+    // range operator is not inclusive of to
+    assert!(db.contains_key(&100).expect("Failed to query legal key"));
+}
+
+#[tokio::test]
+async fn test_clear() {
+    let db = DBMap::<i32, String>::open(
+        temp_dir(),
+        MetricConf::default(),
+        None,
+        Some("table"),
+        &ReadWriteOptions::default(),
+    )
+    .expect("Failed to open storage");
+    // Test clear of empty map
+    let _ = db.unsafe_clear();
+
+    let keys_vals = (0..101).map(|i| (i, i.to_string()));
+    let mut insert_batch = db.batch();
+    insert_batch
+        .insert_batch(&db, keys_vals)
+        .expect("Failed to batch insert");
+
+    insert_batch.write().expect("Failed to execute batch");
+
+    // Check we have multiple entries
+    assert!(db.safe_iter().count() > 1);
+    let _ = db.unsafe_clear();
+    assert_eq!(db.safe_iter().count(), 0);
+    // Clear again to ensure safety when clearing empty map
+    let _ = db.unsafe_clear();
+    assert_eq!(db.safe_iter().count(), 0);
+    // Clear with one item
+    let _ = db.insert(&1, &"e".to_string());
+    assert_eq!(db.safe_iter().count(), 1);
+    let _ = db.unsafe_clear();
+    assert_eq!(db.safe_iter().count(), 0);
+}
+
+#[tokio::test]
+async fn test_iter_with_bounds() {
+    let db = open_map(temp_dir(), None);
+
+    // Add [1, 50) and (50, 100) in the db
+    for i in 1..100 {
+        if i != 50 {
+            db.insert(&i, &i.to_string()).unwrap();
+        }
+    }
+
+    // Tests basic bounded scan.
+    let db_iter = get_iter_with_bounds(&db, Some(20), Some(90));
+    assert_eq!(
+        (20..50)
+            .chain(51..90)
+            .map(|i| (i, i.to_string()))
+            .collect::<Vec<_>>(),
+        db_iter.collect::<Vec<_>>()
+    );
+
+    // Don't specify upper bound.
+    let db_iter = get_iter_with_bounds(&db, Some(20), None);
+    assert_eq!(
+        (20..50)
+            .chain(51..100)
+            .map(|i| (i, i.to_string()))
+            .collect::<Vec<_>>(),
+        db_iter.collect::<Vec<_>>()
+    );
+
+    // Don't specify lower bound.
+    let db_iter = get_iter_with_bounds(&db, None, Some(90));
+    assert_eq!(
+        (1..50)
+            .chain(51..90)
+            .map(|i| (i, i.to_string()))
+            .collect::<Vec<_>>(),
+        db_iter.collect::<Vec<_>>()
+    );
+
+    // Don't specify any bounds.
+    let db_iter = get_iter_with_bounds(&db, None, None);
+    assert_eq!(
+        (1..50)
+            .chain(51..100)
+            .map(|i| (i, i.to_string()))
+            .collect::<Vec<_>>(),
+        db_iter.collect::<Vec<_>>()
+    );
+
+    // Specify a bound outside of dataset.
+    let db_iter = db.safe_iter_with_bounds(Some(200), Some(300));
+    assert!(db_iter.collect::<Vec<_>>().is_empty());
+
+    // Skip to first key in the bound (bound is [1, 50))
+    let db_iter = get_iter_with_bounds(&db, Some(1), Some(50));
+    assert_eq!(
+        (1..50).map(|i| (i, i.to_string())).collect::<Vec<_>>(),
+        db_iter.collect::<Vec<_>>()
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_range_iter() {
+    let db = open_map(temp_dir(), None);
+
+    // Add [1, 50) and (50, 100) in the db
+    for i in 1..100 {
+        if i != 50 {
+            db.insert(&i, &i.to_string()).unwrap();
+        }
+    }
+
+    // Tests basic range iterating with inclusive end.
+    let db_iter = get_range_iter(&db, 10..=20);
+    assert_eq!(
+        (10..21).map(|i| (i, i.to_string())).collect::<Vec<_>>(),
+        db_iter.collect::<Vec<_>>()
+    );
+
+    // Tests range with min start and exclusive end.
+    let db_iter = get_range_iter(&db, ..20);
+    assert_eq!(
+        (1..20).map(|i| (i, i.to_string())).collect::<Vec<_>>(),
+        db_iter.collect::<Vec<_>>()
+    );
+
+    // Tests range with max end.
+    let db_iter = get_range_iter(&db, 60..);
+    assert_eq!(
+        (60..100).map(|i| (i, i.to_string())).collect::<Vec<_>>(),
+        db_iter.collect::<Vec<_>>()
+    );
+
+    // Skip to first key in the bound (bound is [1, 49))
+    let db_iter = get_range_iter(&db, 1..49);
+    assert_eq!(
+        (1..49).map(|i| (i, i.to_string())).collect::<Vec<_>>(),
+        db_iter.collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
+async fn test_is_empty() {
+    let db = DBMap::<i32, String>::open(
+        temp_dir(),
+        MetricConf::default(),
+        None,
+        Some("table"),
+        &ReadWriteOptions::default(),
+    )
+    .expect("Failed to open storage");
+
+    // Test empty map is truly empty
+    assert!(db.is_empty());
+    let _ = db.unsafe_clear();
+    assert!(db.is_empty());
+
+    let keys_vals = (0..101).map(|i| (i, i.to_string()));
+    let mut insert_batch = db.batch();
+    insert_batch
+        .insert_batch(&db, keys_vals)
+        .expect("Failed to batch insert");
+
+    insert_batch.write().expect("Failed to execute batch");
+
+    // Check we have multiple entries and not empty
+    assert!(db.safe_iter().count() > 1);
+    assert!(!db.is_empty());
+
+    // Clear again to ensure empty works after clearing
+    let _ = db.unsafe_clear();
+    assert_eq!(db.safe_iter().count(), 0);
+    assert!(db.is_empty());
+}
+
+#[tokio::test]
+async fn test_multi_insert() {
+    // Init a DB
+    let db: DBMap<i32, String> = open_map(temp_dir(), Some("table"));
+    // Create kv pairs
+    let keys_vals = (0..101).map(|i| (i, i.to_string()));
+
+    db.multi_insert(keys_vals.clone())
+        .expect("Failed to multi-insert");
+
+    for (k, v) in keys_vals {
+        let val = db.get(&k).expect("Failed to get inserted key");
+        assert_eq!(Some(v), val);
+    }
+}
+
+#[tokio::test]
+async fn test_checkpoint() {
+    let path_prefix = temp_dir();
+    let db_path = path_prefix.join("db");
+    let db: DBMap<i32, String> = open_map(db_path, Some("table"));
+    // Create kv pairs
+    let keys_vals = (0..101).map(|i| (i, i.to_string()));
+
+    db.multi_insert(keys_vals.clone())
+        .expect("Failed to multi-insert");
+    let checkpointed_path = path_prefix.join("checkpointed_db");
+    db.rocksdb
+        .checkpoint(&checkpointed_path)
+        .expect("Failed to create db checkpoint");
+    // Create more kv pairs
+    let new_keys_vals = (101..201).map(|i| (i, i.to_string()));
+    db.multi_insert(new_keys_vals.clone())
+        .expect("Failed to multi-insert");
+    // Verify checkpoint
+    let checkpointed_db: DBMap<i32, String> = open_map(checkpointed_path, Some("table"));
+    // Ensure keys inserted before checkpoint are present in original and checkpointed db
+    for (k, v) in keys_vals {
+        let val = db.get(&k).expect("Failed to get inserted key");
+        assert_eq!(Some(v.clone()), val);
+        let val = checkpointed_db.get(&k).expect("Failed to get inserted key");
+        assert_eq!(Some(v), val);
+    }
+    // Ensure keys inserted after checkpoint are only present in original db but not
+    // in checkpointed db
+    for (k, v) in new_keys_vals {
+        let val = db.get(&k).expect("Failed to get inserted key");
+        assert_eq!(Some(v.clone()), val);
+        let val = checkpointed_db.get(&k).expect("Failed to get inserted key");
+        assert_eq!(None, val);
+    }
+}
+
+#[tokio::test]
+async fn test_multi_remove() {
+    // Init a DB
+    let db: DBMap<i32, String> = open_map(temp_dir(), Some("table"));
+
+    // Create kv pairs
+    let keys_vals = (0..101).map(|i| (i, i.to_string()));
+
+    db.multi_insert(keys_vals.clone())
+        .expect("Failed to multi-insert");
+
+    // Check insertion
+    for (k, v) in keys_vals.clone() {
+        let val = db.get(&k).expect("Failed to get inserted key");
+        assert_eq!(Some(v), val);
+    }
+
+    // Remove 50 items
+    db.multi_remove(keys_vals.clone().map(|kv| kv.0).take(50))
+        .expect("Failed to multi-remove");
+    assert_eq!(db.safe_iter().count(), 101 - 50);
+
+    // Check that the remaining are present
+    for (k, v) in keys_vals.skip(50) {
+        let val = db.get(&k).expect("Failed to get inserted key");
+        assert_eq!(Some(v), val);
+    }
+}
+
+#[tokio::test]
+async fn open_as_secondary_test() {
+    let primary_path = temp_dir();
+
+    // Init a DB
+    let primary_db = DBMap::<i32, String>::open(
+        primary_path.clone(),
+        MetricConf::default(),
+        None,
+        Some("table"),
+        &ReadWriteOptions::default(),
+    )
+    .expect("Failed to open storage");
+    // Create kv pairs
+    let keys_vals = (0..101).map(|i| (i, i.to_string()));
+
+    primary_db
+        .multi_insert(keys_vals.clone())
+        .expect("Failed to multi-insert");
+
+    let opt = rocksdb::Options::default();
+    let secondary_store = open_cf_opts_secondary(
+        primary_path,
+        None,
+        None,
+        MetricConf::default(),
+        &[("table", opt)],
+    )
+    .unwrap();
+    let secondary_db = DBMap::<i32, String>::reopen(
+        &secondary_store,
+        Some("table"),
+        &ReadWriteOptions::default(),
+        false,
+    )
+    .unwrap();
+
+    secondary_db.try_catch_up_with_primary().unwrap();
+    // Check secondary
+    for (k, v) in keys_vals {
+        assert_eq!(secondary_db.get(&k).unwrap(), Some(v));
+    }
+
+    // Update the value from 0 to 10
+    primary_db.insert(&0, &"10".to_string()).unwrap();
+
+    // This should still be stale since secondary is behind
+    assert_eq!(secondary_db.get(&0).unwrap(), Some("0".to_string()));
+
+    // Try force catchup
+    secondary_db.try_catch_up_with_primary().unwrap();
+
+    // New value should be present
+    assert_eq!(secondary_db.get(&0).unwrap(), Some("10".to_string()));
+}
+
+fn open_map<P: AsRef<Path>, K, V>(path: P, opt_cf: Option<&str>) -> DBMap<K, V> {
+    DBMap::<K, V>::open(
+        path,
+        MetricConf::default(),
+        None,
+        opt_cf,
+        &ReadWriteOptions::default(),
+    )
+    .expect("failed to open rocksdb")
+}
+
+fn open_rocksdb<P: AsRef<Path>>(path: P, opt_cfs: &[&str]) -> Arc<RocksDB> {
+    open_cf(path, None, MetricConf::default(), opt_cfs).expect("failed to open rocksdb")
+}

--- a/crates/typed-store/src/traits.rs
+++ b/crates/typed-store/src/traits.rs
@@ -1,0 +1,139 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{borrow::Borrow, collections::BTreeMap, error::Error, ops::RangeBounds};
+
+use serde::{Serialize, de::DeserializeOwned};
+
+use crate::TypedStoreError;
+
+/// The trait for the typed store to manage the map
+pub trait Map<'a, K, V>
+where
+    K: Serialize + DeserializeOwned,
+    V: Serialize + DeserializeOwned,
+{
+    /// The error type for the map
+    type Error: Error;
+    /// The safe iterator type for the map
+    type SafeIterator: Iterator<Item = Result<(K, V), TypedStoreError>>;
+
+    /// Returns true if the map contains a value for the specified key.
+    fn contains_key(&self, key: &K) -> Result<bool, Self::Error>;
+
+    /// Returns true if the map contains a value for the specified key.
+    fn multi_contains_keys<J>(
+        &self,
+        keys: impl IntoIterator<Item = J>,
+    ) -> Result<Vec<bool>, Self::Error>
+    where
+        J: Borrow<K>,
+    {
+        keys.into_iter()
+            .map(|key| self.contains_key(key.borrow()))
+            .collect()
+    }
+
+    /// Returns the value for the given key from the map, if it exists.
+    fn get(&self, key: &K) -> Result<Option<V>, Self::Error>;
+
+    /// Inserts the given key-value pair into the map.
+    fn insert(&self, key: &K, value: &V) -> Result<(), Self::Error>;
+
+    /// Removes the entry for the given key from the map.
+    fn remove(&self, key: &K) -> Result<(), Self::Error>;
+
+    /// Removes every key-value pair from the map.
+    fn unsafe_clear(&self) -> Result<(), Self::Error>;
+
+    /// Uses delete range on the entire key range
+    fn schedule_delete_all(&self) -> Result<(), TypedStoreError>;
+
+    /// Returns true if the map is empty, otherwise false.
+    fn is_empty(&self) -> bool;
+
+    /// Same as `iter` but performs status check.
+    fn safe_iter(&'a self) -> Self::SafeIterator;
+
+    /// Same as `iter_with_bounds` but performs status check.
+    fn safe_iter_with_bounds(
+        &'a self,
+        lower_bound: Option<K>,
+        upper_bound: Option<K>,
+    ) -> Self::SafeIterator;
+
+    /// Same as `range_iter` but performs status check.
+    fn safe_range_iter(&'a self, range: impl RangeBounds<K>) -> Self::SafeIterator;
+
+    /// Returns a vector of values corresponding to the keys provided, non-atomically.
+    fn multi_get<J>(&self, keys: impl IntoIterator<Item = J>) -> Result<Vec<Option<V>>, Self::Error>
+    where
+        J: Borrow<K>,
+    {
+        keys.into_iter().map(|key| self.get(key.borrow())).collect()
+    }
+
+    /// Inserts key-value pairs, non-atomically.
+    fn multi_insert<J, U>(
+        &self,
+        key_val_pairs: impl IntoIterator<Item = (J, U)>,
+    ) -> Result<(), Self::Error>
+    where
+        J: Borrow<K>,
+        U: Borrow<V>,
+    {
+        key_val_pairs
+            .into_iter()
+            .try_for_each(|(key, value)| self.insert(key.borrow(), value.borrow()))
+    }
+
+    /// Removes keys, non-atomically.
+    fn multi_remove<J>(&self, keys: impl IntoIterator<Item = J>) -> Result<(), Self::Error>
+    where
+        J: Borrow<K>,
+    {
+        keys.into_iter()
+            .try_for_each(|key| self.remove(key.borrow()))
+    }
+
+    /// Try to catch up with primary when running as secondary
+    fn try_catch_up_with_primary(&self) -> Result<(), Self::Error>;
+}
+
+/// The summary of the table
+#[derive(Debug)]
+pub struct TableSummary {
+    /// The number of keys in the table
+    pub num_keys: u64,
+    /// The total number of key bytes in the table
+    pub key_bytes_total: usize,
+    /// The total number of value bytes in the table
+    pub value_bytes_total: usize,
+    /// The histogram of key sizes
+    pub key_hist: hdrhistogram::Histogram<u64>,
+    /// The histogram of value sizes
+    pub value_hist: hdrhistogram::Histogram<u64>,
+}
+
+/// The trait for the typed store to dump the table
+pub trait TypedStoreDebug {
+    /// Dump a DB table with pagination
+    fn dump_table(
+        &self,
+        table_name: String,
+        page_size: u16,
+        page_number: usize,
+    ) -> eyre::Result<BTreeMap<String, String>>;
+
+    /// Get the name of the DB. This is simply the name of the struct
+    fn primary_db_name(&self) -> String;
+
+    /// Get a map of table names to key-value types
+    fn describe_all_tables(&self) -> BTreeMap<String, (String, String)>;
+
+    /// Count the entries in the table
+    fn count_table_keys(&self, table_name: String) -> eyre::Result<usize>;
+
+    /// Return table summary of the input table
+    fn table_summary(&self, table_name: String) -> eyre::Result<TableSummary>;
+}

--- a/crates/typed-store/tests/macro_tests.rs
+++ b/crates/typed-store/tests/macro_tests.rs
@@ -1,0 +1,336 @@
+// Copyright (c) Walrus Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for the derive macros for the typed-store crate.
+#![allow(dead_code)]
+#![allow(missing_docs)]
+
+use std::{borrow::Borrow, collections::HashSet, fmt::Debug, sync::Mutex, time::Duration};
+
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+use typed_store::{
+    DBMapUtils,
+    metrics::SamplingInterval,
+    rocks::{DBMap, MetricConf, be_fix_int_ser, list_tables},
+    traits::{Map, TableSummary, TypedStoreDebug},
+};
+
+fn temp_dir() -> std::path::PathBuf {
+    tempfile::tempdir()
+        .expect("Failed to open temporary directory")
+        .into_path()
+}
+/// This struct is used to illustrate how the utility works
+#[derive(DBMapUtils)]
+struct Tables {
+    table1: DBMap<String, String>,
+    table2: DBMap<i32, String>,
+}
+
+/// Check that generics work
+#[derive(DBMapUtils)]
+struct TablesGenerics<Q, W> {
+    table1: DBMap<String, String>,
+    table2: DBMap<u32, Generic<Q, W>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Generic<T, V> {
+    field1: T,
+    field2: V,
+}
+
+#[derive(DBMapUtils)]
+struct RenameTables1 {
+    table: DBMap<String, String>,
+}
+
+#[derive(DBMapUtils)]
+struct RenameTables2 {
+    #[rename = "table"]
+    renamed_table: DBMap<String, String>,
+}
+
+impl<
+    T: Eq + Debug + Serialize + for<'de> Deserialize<'de>,
+    V: Eq + Debug + Serialize + for<'de> Deserialize<'de>,
+> Generic<T, V>
+{
+}
+
+/// This struct shows that single elem structs work
+#[derive(DBMapUtils)]
+struct TablesSingle {
+    table1: DBMap<String, String>,
+}
+
+#[tokio::test]
+async fn macro_test() {
+    let primary_path = temp_dir();
+    let tbls_primary =
+        Tables::open_tables_read_write(primary_path.clone(), MetricConf::default(), None, None);
+
+    // Write to both tables
+    let mut raw_key_bytes1 = 0;
+    let mut raw_value_bytes1 = 0;
+    let kv_range = 1..10;
+    for i in kv_range.clone() {
+        let key = i.to_string();
+        let value = i.to_string();
+        let k_buf = be_fix_int_ser::<String>(&key).unwrap();
+        let value_buf = bcs::to_bytes::<String>(&value).unwrap();
+        raw_key_bytes1 += k_buf.len();
+        raw_value_bytes1 += value_buf.len();
+    }
+    let keys_vals_1 = kv_range.map(|i| (i.to_string(), i.to_string()));
+    tbls_primary
+        .table1
+        .multi_insert(keys_vals_1.clone())
+        .expect("Failed to multi-insert");
+
+    let mut raw_key_bytes2 = 0;
+    let mut raw_value_bytes2 = 0;
+    let kv_range = 3..10;
+    for i in kv_range.clone() {
+        let key = i;
+        let value = i.to_string();
+        let k_buf = be_fix_int_ser(key.borrow()).unwrap();
+        let value_buf = bcs::to_bytes::<String>(&value).unwrap();
+        raw_key_bytes2 += k_buf.len();
+        raw_value_bytes2 += value_buf.len();
+    }
+    let keys_vals_2 = kv_range.map(|i| (i, i.to_string()));
+    tbls_primary
+        .table2
+        .multi_insert(keys_vals_2.clone())
+        .expect("Failed to multi-insert");
+
+    // Open in secondary mode
+    let tbls_secondary =
+        Tables::get_read_only_handle(primary_path.clone(), None, None, MetricConf::default());
+
+    // Check all the tables can be listed
+    let actual_table_names: HashSet<_> = list_tables(primary_path).unwrap().into_iter().collect();
+    let observed_table_names: HashSet<_> = Tables::describe_tables()
+        .iter()
+        .map(|q| q.0.clone())
+        .collect();
+
+    let exp: HashSet<String> =
+        HashSet::from_iter(vec!["table1", "table2"].into_iter().map(|s| s.to_owned()));
+    assert_eq!(HashSet::from_iter(actual_table_names), exp);
+    assert_eq!(HashSet::from_iter(observed_table_names), exp);
+
+    // Check the counts
+    assert_eq!(9, tbls_secondary.count_keys("table1").unwrap());
+    assert_eq!(7, tbls_secondary.count_keys("table2").unwrap());
+
+    // check raw byte sizes of key and values
+    let summary1 = tbls_secondary.table_summary("table1").unwrap();
+    assert_eq!(9, summary1.num_keys);
+    assert_eq!(raw_key_bytes1, summary1.key_bytes_total);
+    assert_eq!(raw_value_bytes1, summary1.value_bytes_total);
+    let summary2 = tbls_secondary.table_summary("table2").unwrap();
+    assert_eq!(7, summary2.num_keys);
+    assert_eq!(raw_key_bytes2, summary2.key_bytes_total);
+    assert_eq!(raw_value_bytes2, summary2.value_bytes_total);
+
+    // Test all entries
+    let m = tbls_secondary.dump("table1", 100, 0).unwrap();
+    for (k, v) in keys_vals_1 {
+        assert_eq!(format!("\"{v}\""), *m.get(&format!("\"{k}\"")).unwrap());
+    }
+
+    let m = tbls_secondary.dump("table2", 100, 0).unwrap();
+    for (k, v) in keys_vals_2 {
+        assert_eq!(format!("\"{v}\""), *m.get(&k.to_string()).unwrap());
+    }
+
+    // Check that catchup logic works
+    let keys_vals_1 = (100..110).map(|i| (i.to_string(), i.to_string()));
+    tbls_primary
+        .table1
+        .multi_insert(keys_vals_1)
+        .expect("Failed to multi-insert");
+    // New entries should be present in secondary
+    assert_eq!(19, tbls_secondary.count_keys("table1").unwrap());
+
+    // Test pagination
+    let m = tbls_secondary.dump("table1", 2, 0).unwrap();
+    assert_eq!(2, m.len());
+    assert_eq!(format!("\"1\""), *m.get("\"1\"").unwrap());
+    assert_eq!(format!("\"2\""), *m.get("\"2\"").unwrap());
+
+    let m = tbls_secondary.dump("table1", 3, 2).unwrap();
+    assert_eq!(3, m.len());
+    assert_eq!(format!("\"7\""), *m.get("\"7\"").unwrap());
+    assert_eq!(format!("\"8\""), *m.get("\"8\"").unwrap());
+}
+
+#[tokio::test]
+async fn rename_test() {
+    let dbdir = temp_dir();
+
+    let key = "key".to_string();
+    let value = "value".to_string();
+    {
+        let original_db =
+            RenameTables1::open_tables_read_write(dbdir.clone(), MetricConf::default(), None, None);
+        original_db.table.insert(&key, &value).unwrap();
+    }
+
+    // sleep for 1 second
+    tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+
+    {
+        let renamed_db =
+            RenameTables2::open_tables_read_write(dbdir.clone(), MetricConf::default(), None, None);
+        assert_eq!(renamed_db.renamed_table.get(&key), Ok(Some(value)));
+    }
+}
+
+#[derive(DBMapUtils)]
+struct DeprecatedTables {
+    table1: DBMap<String, String>,
+    #[deprecated]
+    table2: DBMap<i32, String>,
+}
+
+#[tokio::test]
+async fn deprecate_test() {
+    let dbdir = temp_dir();
+    let key = "key".to_string();
+    let value = "value".to_string();
+    {
+        let original_db =
+            Tables::open_tables_read_write(dbdir.clone(), MetricConf::default(), None, None);
+        original_db.table1.insert(&key, &value).unwrap();
+        original_db.table2.insert(&0, &value).unwrap();
+    }
+    for _ in 0..2 {
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+        let db = DeprecatedTables::open_tables_read_write_with_deprecation_option(
+            dbdir.clone(),
+            MetricConf::default(),
+            None,
+            None,
+            true,
+        );
+        assert_eq!(db.table1.get(&key), Ok(Some(value.clone())));
+    }
+}
+
+/// We show that custom functions can be applied
+#[derive(DBMapUtils)]
+struct TablesCustomOptions {
+    #[default_options_override_fn = "another_custom_fn_name"]
+    table1: DBMap<String, String>,
+    table2: DBMap<i32, String>,
+    #[default_options_override_fn = "custom_fn_name"]
+    table3: DBMap<i32, String>,
+    #[default_options_override_fn = "another_custom_fn_name"]
+    table4: DBMap<i32, String>,
+}
+
+static TABLE1_OPTIONS_SET_FLAG: Lazy<Mutex<Vec<bool>>> = Lazy::new(|| Mutex::new(vec![]));
+static TABLE2_OPTIONS_SET_FLAG: Lazy<Mutex<Vec<bool>>> = Lazy::new(|| Mutex::new(vec![]));
+
+fn custom_fn_name() -> typed_store::rocks::DBOptions {
+    TABLE1_OPTIONS_SET_FLAG.lock().unwrap().push(false);
+    typed_store::rocks::DBOptions::default()
+}
+
+fn another_custom_fn_name() -> typed_store::rocks::DBOptions {
+    TABLE2_OPTIONS_SET_FLAG.lock().unwrap().push(false);
+    TABLE2_OPTIONS_SET_FLAG.lock().unwrap().push(false);
+    TABLE2_OPTIONS_SET_FLAG.lock().unwrap().push(false);
+    typed_store::rocks::DBOptions::default()
+}
+
+#[tokio::test]
+async fn macro_test_configure() {
+    let primary_path = temp_dir();
+
+    // Get a configurator for this table
+    let mut config = Tables::configurator();
+    // Config table 1
+    config.table1 = typed_store::rocks::DBOptions::default();
+    config.table1.options.create_if_missing(true);
+    config.table1.options.set_write_buffer_size(123456);
+
+    // Config table 2
+    config.table2 = config.table1.clone();
+
+    config.table2.options.create_if_missing(false);
+
+    // Build and open with new config
+    let _ = Tables::open_tables_read_write(
+        primary_path,
+        MetricConf::default(),
+        None,
+        Some(config.build()),
+    );
+
+    // Test the static config options
+    let primary_path = temp_dir();
+
+    assert_eq!(TABLE1_OPTIONS_SET_FLAG.lock().unwrap().len(), 0);
+
+    let _ = TablesCustomOptions::open_tables_read_write(
+        primary_path,
+        MetricConf::default(),
+        None,
+        None,
+    );
+
+    // Ensures that the function to set options was called
+    assert_eq!(TABLE1_OPTIONS_SET_FLAG.lock().unwrap().len(), 1);
+
+    // `another_custom_fn_name` is called twice, so 6 items in vec
+    assert_eq!(TABLE2_OPTIONS_SET_FLAG.lock().unwrap().len(), 6);
+}
+
+/// We show that custom functions can be applied
+#[derive(DBMapUtils)]
+struct TablesMemUsage {
+    table1: DBMap<String, String>,
+    table2: DBMap<i32, String>,
+    table3: DBMap<i32, String>,
+    table4: DBMap<i32, String>,
+}
+
+#[tokio::test]
+async fn test_sampling() {
+    let sampling_interval = SamplingInterval::new(Duration::ZERO, 10);
+    for _i in 0..10 {
+        assert!(!sampling_interval.sample());
+    }
+    assert!(sampling_interval.sample());
+    for _i in 0..10 {
+        assert!(!sampling_interval.sample());
+    }
+    assert!(sampling_interval.sample());
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_sampling_time() {
+    let sampling_interval = SamplingInterval::new(Duration::from_secs(1), 10);
+    for _i in 0..10 {
+        assert!(!sampling_interval.sample());
+    }
+    assert!(!sampling_interval.sample());
+    tokio::time::advance(Duration::from_secs(1)).await;
+    tokio::task::yield_now().await;
+    assert!(sampling_interval.sample());
+    for _i in 0..10 {
+        assert!(!sampling_interval.sample());
+    }
+    assert!(!sampling_interval.sample());
+    tokio::time::advance(Duration::from_secs(1)).await;
+    tokio::task::yield_now().await;
+    assert!(sampling_interval.sample());
+}


### PR DESCRIPTION
## Description

Add typed store crate. The reasons for this change are as follows:
1. We can control Rocksdb version independent of Sui
2. The storage interface that Walrus needs is probably simpler than what typed-store provides and we also want to control this interface going forward (and likely simplify/change it according to our needs)
3. Using vanilla rust rocksdb is not enough since we lose out on metrics, perf context, etc. The plan is to first fork and then update rocksdb version.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
