### PR TITLE
fix(node): reduce level of some logging events

### DIFF
--- a/crates/walrus-service/src/common/utils.rs
+++ b/crates/walrus-service/src/common/utils.rs
@@ -313,7 +313,7 @@ impl MetricPushRuntime {
                             // clone because we serialize this with our metrics
                             mp_config.config.labels.clone(),
                         ).await {
-                            tracing::error!(?error, "unable to push metrics");
+                            tracing::warn!(?error, "unable to push metrics");
                             client = create_push_client();
                         }
                     }
@@ -387,12 +387,12 @@ async fn push_metrics(
 
     // serialize the MetricPayload to JSON using serde_json and then compress the entire thing
     let serialized = serde_json::to_vec(&MetricPayload { labels, buf }).inspect_err(|error| {
-        tracing::error!(?error, "unable to serialize MetricPayload to JSON");
+        tracing::warn!(?error, "unable to serialize MetricPayload to JSON");
     })?;
 
     let mut s = snap::raw::Encoder::new();
     let compressed = s.compress_vec(&serialized).inspect_err(|error| {
-        tracing::error!(?error, "unable to snappy encode");
+        tracing::warn!(?error, "unable to snappy encode metrics");
     })?;
 
     let uid = Uuid::now_v7();

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -1127,11 +1127,22 @@ impl StorageNode {
         epoch_change_event: EpochChangeEvent,
     ) -> anyhow::Result<()> {
         mysten_metrics::monitored_scope("ProcessEvent::EpochChangeEvent");
-        tracing::info!(
-            ?epoch_change_event,
-            "{} event received",
-            epoch_change_event.name()
-        );
+        match epoch_change_event {
+            EpochChangeEvent::ShardsReceived(_) => {
+                tracing::debug!(
+                    ?epoch_change_event,
+                    "{} event received",
+                    epoch_change_event.name()
+                );
+            }
+            _ => {
+                tracing::info!(
+                    ?epoch_change_event,
+                    "{} event received",
+                    epoch_change_event.name()
+                );
+            }
+        }
         match epoch_change_event {
             EpochChangeEvent::EpochParametersSelected(event) => {
                 mysten_metrics::monitored_scope(

--- a/crates/walrus-service/src/node/committee/committee_service.rs
+++ b/crates/walrus-service/src/node/committee/committee_service.rs
@@ -709,9 +709,7 @@ async fn add_members_from_committee<T: NodeService>(
     encoding_config: &Arc<EncodingConfig>,
 ) -> Result<(), anyhow::Error> {
     if committee.epoch == 0 {
-        tracing::info!(
-            "we are in the genesis epoch, not creating any services for committee members"
-        );
+        tracing::debug!("not creating any services for committee members in the genesis epoch");
         return Ok(());
     }
 

--- a/crates/walrus-service/src/node/config_synchronizer.rs
+++ b/crates/walrus-service/src/node/config_synchronizer.rs
@@ -89,7 +89,7 @@ impl ConfigSynchronizer {
             tokio::time::sleep(self.check_interval).await;
 
             if let Err(error) = self.committee_service.sync_committee_members().await {
-                tracing::error!(%error, "failed to sync committee");
+                tracing::warn!(%error, "failed to sync committee");
             }
 
             let Some(config_loader) = &self.config_loader else {
@@ -112,7 +112,7 @@ impl ConfigSynchronizer {
                     tracing::warn!(%error, "going to reboot node");
                     return Err(error);
                 }
-                tracing::error!(%error, "failed to sync node params");
+                tracing::warn!(%error, "failed to sync node params");
             }
 
             let new_cert_hash = self.load_tls_cert_hash(&config.tls).await?;


### PR DESCRIPTION
## Description

This PR reduces the verbosity level of a few types of log events:
- During each epoch change, there is a `ShardsReceived` event emitted for every node, so ~100 on our public networks. These don't need to be logged at the INFO level.
- Problems with pushing metrics don't affect the node operation itself and should thus be reduced from ERROR to WARN.
- Similarly, problems with config sync should only be WARN, not ERROR.
- The log entry `we are in the genesis epoch, not creating any services for committee members` is confusing, in particular as it is also emitted in epoch 1 when attempting to (re-)create services for committee members in the previous epoch. This is reformulated and reduced to DEBUG.

## Test plan

None.

---

## Release notes

- [x] Storage node: Reduce verbosity levels of problems with metrics and config sync from ERROR to WARN.
