### PR TITLE
fix(node): set optimized default params for blob recovery

### DIFF
--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -545,7 +545,7 @@ pub struct BlobRecoveryConfig {
 impl Default for BlobRecoveryConfig {
     fn default() -> Self {
         Self {
-            max_concurrent_blob_syncs: 100,
+            max_concurrent_blob_syncs: 1_000,
             max_concurrent_sliver_syncs: 2_000,
             max_proof_cache_elements: 7_500,
             committee_service_config: CommitteeServiceConfig::default(),
@@ -593,9 +593,9 @@ impl Default for CommitteeServiceConfig {
     fn default() -> Self {
         Self {
             retry_interval_min: Duration::from_secs(1),
-            retry_interval_max: Duration::from_secs(3600),
+            retry_interval_max: Duration::from_secs(30),
             metadata_request_timeout: Duration::from_secs(5),
-            sliver_request_timeout: Duration::from_secs(300),
+            sliver_request_timeout: Duration::from_secs(10),
             invalidity_sync_timeout: Duration::from_secs(300),
             max_concurrent_metadata_requests: NonZeroUsize::new(1).unwrap(),
             node_connect_timeout: Duration::from_secs(1),


### PR DESCRIPTION
## Description

The blob recovery seems to massively improve with these changes. Tested on our Mysten Labs nodes and by Natsai, they increase the sliver-recovery rate from ~10 to >200 per second. See the following metrics after making the change on Mysten Labs 0 (change applied and node restarted around 8:00):

<img width="1472" alt="image" src="https://github.com/user-attachments/assets/778de769-eee2-4c00-9101-d16f841687c4" />

## Test plan

Already tested on a few nodes on Mainnet.

---

## Release notes

- [x] Storage node: Optimize default parameters for blob recovery to increase the recovery performance.