### PR TITLE
fix(node): increase limit for number of pending accept reset streams

### DIFF
--- a/crates/walrus-service/node_config_example.yaml
+++ b/crates/walrus-service/node_config_example.yaml
@@ -65,7 +65,7 @@ rest_server:
   http2_max_concurrent_streams: 1000
   http2_initial_stream_window_size: null
   http2_initial_connection_window_size: null
-  http2_max_pending_accept_reset_streams: 100
+  http2_max_pending_accept_reset_streams: 4294967295
   http2_adaptive_window: true
 rest_graceful_shutdown_period_secs: 60
 sui:

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -984,7 +984,9 @@ impl Default for Http2Config {
     fn default() -> Self {
         Self {
             http2_max_concurrent_streams: defaults::REST_HTTP2_MAX_CONCURRENT_STREAMS,
-            http2_max_pending_accept_reset_streams: 100,
+            http2_max_pending_accept_reset_streams: u32::MAX
+                .try_into()
+                .expect("assuming at least 32-bit architecture"),
             http2_initial_stream_window_size: None,
             http2_initial_connection_window_size: None,
             http2_adaptive_window: true,


### PR DESCRIPTION
## Description

Storage nodes frequently cancel pending requests to other storage nodes when they are no longer relevant. This triggers a limit within the `h2` crate and an associated warning that pollutes the logs.

Until we change the behavior of cancelling pending requests, we can increase the limit to a very high value to effectively disable the check.

Contributes to WAL-660.

## Test plan

Set this value in our Mysten Labs 1 node on Mainnet.

---

## Release notes

- [x] Storage node: Increase default value of `http2_max_pending_accept_reset_streams` parameter to disable warnings from the `h2` crate.
