### PR TITLE
fix: replace deprecated #[clap(...)] with #[command(...)] and #[arg(...)]

### DIFF
--- a/crates/walrus-service/src/node/dbtool.rs
+++ b/crates/walrus-service/src/node/dbtool.rs
@@ -203,7 +203,7 @@ pub enum DbToolCommands {
     /// Read event processor metadata from the RocksDB database.
     EventProcessor {
         /// Path to the RocksDB database directory.
-        #[clap(long)]
+        #[arg(long)]
         db_path: PathBuf,
         /// Commands to read event processor metadata.
         #[command(subcommand)]
@@ -239,7 +239,7 @@ pub enum EventBlobWriterCommands {
 /// Commands for reading event processor metadata.
 #[derive(Subcommand, Debug, Clone, Serialize, Deserialize)]
 #[serde_as]
-#[clap(rename_all = "kebab-case")]
+#[command(rename_all = "kebab-case")]
 pub enum EventProcessorCommands {
     /// Read event processor metadata.
     ReadInitState,


### PR DESCRIPTION
## Description
Continues #1945
Closes #1944 

We had already made many of these changes in #1944. I noticed that two deprecated usages were reintroduced, so I opened this PR to fix them.
As a suggestion, we could consider adding `cargo check --features clap/deprecated` to a CI step to prevent future reintroductions of deprecated code. I can create PR to solve it.

## Test plan

![image](https://github.com/user-attachments/assets/72554b53-596d-4e7c-b275-1d1950bbdb21)


