### PR TITLE
docs: link RedStuff encoding documentation from setup guide

### DIFF
--- a/docs/book/usage/setup.md
+++ b/docs/book/usage/setup.md
@@ -232,3 +232,9 @@ wallet_config:
 # blob due to timeouts or other networking errors.
 {{ #include ../setup/client_config_example.yaml:8: }}
 ```
+
+## Learn more
+
+```admonish info title="RedStuff Encoding Algorithm"
+Walrus uses an optimized erasure coding algorithm called **RedStuff** to achieve efficient and fault-tolerant data storage.  
+You can learn more about this algorithm in [the detailed documentation](https://github.com/MystenLabs/walrus/blob/main/docs/red-stuff.md)


### PR DESCRIPTION
## Description

Closes #307

This PR adds a reference to the RedStuff encoding documentation at the end of the `setup.md` file.

Since RedStuff is a core part of how Walrus handles fault-tolerant blob storage, it is now linked from the setup guide to help users understand the underlying encoding mechanism early on.