### PR TITLE
chore: check for clap deprecations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ byteorder = "1.5.0"
 bytes = { version = "1.10.1", default-features = false, features = ["serde"] }
 checkpoint-downloader = { path = "crates/checkpoint-downloader" }
 chrono = "0.4"
-clap = { version = "4.5.38", features = ["derive", "deprecated"] }
+clap = { version = "4.5.38", features = ["deprecated", "derive"] }
 clap_complete = "4.5.50"
 collectable = "0.0.2"
 colored = "2.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,8 @@ byteorder = "1.5.0"
 bytes = { version = "1.10.1", default-features = false, features = ["serde"] }
 checkpoint-downloader = { path = "crates/checkpoint-downloader" }
 chrono = "0.4"
-clap = { version = "4.5.37", features = ["derive", "deprecated"] }
-clap_complete = "4.5.48"
+clap = { version = "4.5.38", features = ["derive", "deprecated"] }
+clap_complete = "4.5.50"
 collectable = "0.0.2"
 colored = "2.2.0"
 criterion = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ byteorder = "1.5.0"
 bytes = { version = "1.10.1", default-features = false, features = ["serde"] }
 checkpoint-downloader = { path = "crates/checkpoint-downloader" }
 chrono = "0.4"
-clap = { version = "4.5.37", features = ["derive"] }
+clap = { version = "4.5.37", features = ["derive", "deprecated"] }
 clap_complete = "4.5.48"
 collectable = "0.0.2"
 colored = "2.2.0"


### PR DESCRIPTION
## Description

Ref : https://github.com/MystenLabs/walrus/pull/2076#pullrequestreview-2831985232

This PR adds a CI check step to prevent the reintroduction of deprecated `clap` attributes (`#[clap(...)]`).

```sh
cargo check --workspace --features clap/deprecated
```
