### PR TITLE
fix: RPC node failure resistance improvement

### DIFF
--- a/crates/walrus-simtest/tests/simtest_event_blob.rs
+++ b/crates/walrus-simtest/tests/simtest_event_blob.rs
@@ -217,13 +217,14 @@ mod tests {
     #[ignore = "ignore integration simtests by default"]
     #[walrus_simtest]
     async fn test_checkpoint_downloader_with_additional_fullnodes() {
-        let (sui_cluster, walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
+        let checkpoints_per_event_blob = 20;
+        let (sui_cluster, mut walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
             .with_epoch_duration(Duration::from_secs(15))
             .with_test_nodes_config(TestNodesConfig {
                 node_weights: vec![2, 2, 3, 3, 3],
                 ..Default::default()
             })
-            .with_num_checkpoints_per_blob(20)
+            .with_num_checkpoints_per_blob(checkpoints_per_event_blob)
             .with_communication_config(
                 ClientCommunicationConfig::default_for_test_with_reqwest_timeout(
                     Duration::from_secs(2),
@@ -238,10 +239,14 @@ mod tests {
         sui_macros::register_fail_point_if("fallback_client_inject_error", move || true);
         let primary_rpc_url = sui_cluster.lock().await.rpc_url();
         let primary_rpc_url_clone = primary_rpc_url.clone();
+
+        // Always fail sui client creation for the primary rpc node.
         sui_macros::register_fail_point_arg(
             "failpoint_sui_client_build_client",
             move || -> Option<String> { Some(primary_rpc_url.clone()) },
         );
+
+        // Always fail rpc client creation for the primary rpc node.
         sui_macros::register_fail_point_arg(
             "failpoint_rpc_client_build_client",
             move || -> Option<String> { Some(primary_rpc_url_clone.clone()) },
@@ -252,6 +257,9 @@ mod tests {
             sui_cluster.lock().await.additional_rpc_urls()
         );
         let client_arc = Arc::new(client);
+
+        // Restart all nodes, this should still form a cluster with all nodes running.
+        restart_nodes_with_checkpoints(&mut walrus_cluster, |_| checkpoints_per_event_blob).await;
 
         // Wait for the cluster to process some events.
         let workload_handle = simtest_utils::start_background_workload(client_arc.clone(), false);

--- a/crates/walrus-sui/src/client/retry_client.rs
+++ b/crates/walrus-sui/src/client/retry_client.rs
@@ -94,7 +94,7 @@ where
                 }
             }
             Err(error) => {
-                tracing::debug!("non-retriable error, returning last failure value");
+                tracing::debug!(?error, "non-retriable error, returning last failure value");
                 return Err(error);
             }
         }

--- a/crates/walrus-sui/src/client/retry_client/failover.rs
+++ b/crates/walrus-sui/src/client/retry_client/failover.rs
@@ -185,9 +185,10 @@ impl<ClientT, BuilderT: LazyClientBuilder<ClientT> + std::fmt::Debug>
         loop {
             // PLAN phase.
             if tried_client_indices.len() >= self.max_tries {
-                return Err(FailoverError::FailedToGetClient(
-                    "max failovers exceeded".to_string(),
-                ));
+                return Err(FailoverError::FailedToGetClient(format!(
+                    "max failovers {} exceeded",
+                    self.max_tries
+                )));
             }
 
             if !tried_client_indices.insert(next_index) {
@@ -204,7 +205,10 @@ impl<ClientT, BuilderT: LazyClientBuilder<ClientT> + std::fmt::Debug>
                 Ok(client) => client,
                 Err(error) => {
                     // Log the error and failover to the next client.
-                    tracing::warn!("Failed to get client from url: {}", error);
+                    tracing::warn!(
+                        "Failed to get client from url: {}, failover to next client",
+                        error
+                    );
                     continue;
                 }
             };

--- a/crates/walrus-sui/src/client/retry_client/failover.rs
+++ b/crates/walrus-sui/src/client/retry_client/failover.rs
@@ -230,6 +230,7 @@ impl<ClientT, BuilderT: LazyClientBuilder<ClientT> + std::fmt::Debug>
                         "Failed to get client from url: {}, failover to next client",
                         error
                     );
+                    next_index = (next_index + 1) % self.client_count();
                     continue;
                 }
             };

--- a/crates/walrus-sui/src/client/retry_client/retriable_rpc_client.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_rpc_client.rs
@@ -104,6 +104,30 @@ impl LazyClientBuilder<FallibleRpcClient> for LazyFallibleRpcClientBuilder {
     const DEFAULT_MAX_TRIES: usize = 3;
 
     async fn lazy_build_client(&self) -> Result<Arc<FallibleRpcClient>, FailoverError> {
+        #[allow(unused_mut)]
+        let mut fail_client_creation = false;
+        sui_macros::fail_point_arg!(
+            "failpoint_rpc_client_build_client",
+            |url_to_fail: String| {
+                match self {
+                    Self::Url { rpc_url, .. } => {
+                        if *rpc_url == url_to_fail {
+                            fail_client_creation = true;
+                        }
+                    }
+                    Self::Client(_) => {}
+                }
+            }
+        );
+
+        if fail_client_creation {
+            tracing::info!("injected rpc client build failure {:?}", self.get_rpc_url());
+            return Err(FailoverError::FailedToGetClient(format!(
+                "injected rpc client build failure {:?}",
+                self.get_rpc_url()
+            )));
+        }
+
         match self {
             Self::Url {
                 rpc_url,

--- a/crates/walrus-sui/src/client/retry_client/retriable_rpc_client.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_rpc_client.rs
@@ -101,31 +101,34 @@ pub enum LazyFallibleRpcClientBuilder {
 }
 
 impl LazyClientBuilder<FallibleRpcClient> for LazyFallibleRpcClientBuilder {
-    const DEFAULT_MAX_TRIES: usize = 3;
+    const DEFAULT_MAX_TRIES: usize = 5;
 
     async fn lazy_build_client(&self) -> Result<Arc<FallibleRpcClient>, FailoverError> {
-        #[allow(unused_mut)]
-        let mut fail_client_creation = false;
-        sui_macros::fail_point_arg!(
-            "failpoint_rpc_client_build_client",
-            |url_to_fail: String| {
-                match self {
-                    Self::Url { rpc_url, .. } => {
-                        if *rpc_url == url_to_fail {
-                            fail_client_creation = true;
+        // Inject rpc client build failure for simtests.
+        #[cfg(msim)]
+        {
+            let mut fail_client_creation = false;
+            sui_macros::fail_point_arg!(
+                "failpoint_rpc_client_build_client",
+                |url_to_fail: String| {
+                    match self {
+                        Self::Url { rpc_url, .. } => {
+                            if *rpc_url == url_to_fail {
+                                fail_client_creation = true;
+                            }
                         }
+                        Self::Client(_) => {}
                     }
-                    Self::Client(_) => {}
                 }
-            }
-        );
+            );
 
-        if fail_client_creation {
-            tracing::info!("injected rpc client build failure {:?}", self.get_rpc_url());
-            return Err(FailoverError::FailedToGetClient(format!(
-                "injected rpc client build failure {:?}",
-                self.get_rpc_url()
-            )));
+            if fail_client_creation {
+                tracing::info!("injected rpc client build failure {:?}", self.get_rpc_url());
+                return Err(FailoverError::FailedToGetClient(format!(
+                    "injected rpc client build failure {:?}",
+                    self.get_rpc_url()
+                )));
+            }
         }
 
         match self {

--- a/crates/walrus-sui/src/client/retry_client/retriable_rpc_client.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_rpc_client.rs
@@ -332,8 +332,12 @@ impl RetriableRpcClient {
             self.last_success.load(Ordering::Relaxed),
             self.num_failures.load(Ordering::Relaxed),
         ) {
+            let last_success = self.last_success.load(Ordering::Relaxed);
+            let num_failures = self.num_failures.load(Ordering::Relaxed);
             tracing::debug!(
-                "primary client error while fetching checkpoint is not eligible for fallback"
+                "primary client error while fetching checkpoint is not eligible for fallback, last_success: {:?}, num_failures: {:?}",
+                last_success,
+                num_failures
             );
             if let Some(metrics) = self.metrics.as_ref() {
                 metrics.record_rpc_latency(
@@ -529,7 +533,7 @@ impl RetriableClientError {
     /// The time window during which failures are counted.
     const FAILURE_WINDOW: Duration = Duration::from_secs(300);
     /// The maximum number of failures allowed.
-    const MAX_FAILURES: usize = 100;
+    const MAX_FAILURES: usize = 10;
 
     /// Returns `true` if the error is eligible for fallback.
     ///

--- a/crates/walrus-sui/src/client/retry_client/retriable_rpc_client.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_rpc_client.rs
@@ -333,7 +333,11 @@ impl RetriableRpcClient {
                 if let Some(metrics) = self.metrics.as_ref() {
                     metrics.record_rpc_latency(
                         "get_full_checkpoint",
-                        &self.client.get_current_rpc_url().await,
+                        &self
+                            .client
+                            .get_current_rpc_url()
+                            .await
+                            .unwrap_or_else(|_| "unknown_url".to_string()),
                         "success",
                         start_time.elapsed(),
                     );
@@ -350,7 +354,11 @@ impl RetriableRpcClient {
             if let Some(metrics) = self.metrics.as_ref() {
                 metrics.record_rpc_latency(
                     "get_full_checkpoint",
-                    &self.client.get_current_rpc_url().await,
+                    &self
+                        .client
+                        .get_current_rpc_url()
+                        .await
+                        .unwrap_or_else(|_| "unknown_url".to_string()),
                     "failure",
                     start_time.elapsed(),
                 )
@@ -370,7 +378,11 @@ impl RetriableRpcClient {
             if let Some(metrics) = self.metrics.as_ref() {
                 metrics.record_rpc_latency(
                     "get_full_checkpoint",
-                    &self.client.get_current_rpc_url().await,
+                    &self
+                        .client
+                        .get_current_rpc_url()
+                        .await
+                        .unwrap_or_else(|_| "unknown_url".to_string()),
                     "failure",
                     start_time.elapsed(),
                 );
@@ -561,7 +573,7 @@ impl RetriableClientError {
     /// The time window during which failures are counted.
     const FAILURE_WINDOW: Duration = Duration::from_secs(300);
     /// The maximum number of failures allowed.
-    const MAX_FAILURES: usize = 20;
+    const MAX_FAILURES: usize = 100;
 
     /// Returns `true` if the error is eligible for fallback.
     ///

--- a/crates/walrus-sui/src/client/retry_client/retriable_rpc_error.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_rpc_error.rs
@@ -76,6 +76,11 @@ impl RetriableRpcError for CheckpointRpcError {
             return !self.status.message().contains("missing event");
         }
 
+        // If the checkpoint is not produced, this is retryable.
+        if self.is_checkpoint_not_produced() {
+            return true;
+        }
+
         self.status.is_retriable_rpc_error()
     }
 }

--- a/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
@@ -778,7 +778,10 @@ impl RetriableSuiClient {
         note = "please implement a full treatment in RetriableSuiClient for your use case"
     )]
     pub async fn get_current_client(&self) -> Arc<SuiClient> {
-        self.failover_sui_client.get_current_client().await
+        self.failover_sui_client
+            .get_current_client()
+            .await
+            .expect("client must have been created")
     }
 
     /// Returns a [`SuiObjectResponse`] based on the provided [`ObjectID`].
@@ -1040,6 +1043,7 @@ impl RetriableSuiClient {
             .failover_sui_client
             .get_current_client()
             .await
+            .expect("client must have been created")
             .transaction_builder()
             .tx_data_for_dry_run(signer, kind, MAX_GAS_BUDGET, gas_price, None, None)
             .await;

--- a/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
@@ -134,7 +134,7 @@ impl LazySuiClientBuilder {
 impl LazyClientBuilder<SuiClient> for LazySuiClientBuilder {
     // TODO: WAL-796 Out of concern for consistency, we are disabling the failover mechanism for
     // SuiClient for now.
-    const DEFAULT_MAX_TRIES: usize = 1;
+    const DEFAULT_MAX_TRIES: usize = 3;
 
     async fn lazy_build_client(&self) -> Result<Arc<SuiClient>, FailoverError> {
         match self {


### PR DESCRIPTION
## Description

- For both RPC client and Sui client, we only create it when using it. 
- Before this change, the primary RPC node must be available when node is starting up. This PR removes this setup and finds an available RPC node to use when need.
- For checkpoint not produced error, before we constantly switching to other clients. Instead, we should treat the error as retriable error and retry shortly.

## Test plan

simtest

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
