### PR TITLE
docs: add missing doc comments for public functions

### DIFF
--- a/crates/walrus-core/src/encoding/utils.rs
+++ b/crates/walrus-core/src/encoding/utils.rs
@@ -57,6 +57,10 @@ pub fn source_symbols_per_blob(
         .expect("product of two u16 always fits into a u32")
 }
 
+/// Extracts the data portion from an [`EncodingPacket`].
+///
+/// The packet is split into its header and payload components, and
+/// this function returns the payload part as a `Vec<u8>`.
 #[inline]
 pub fn packet_to_data(packet: EncodingPacket) -> Vec<u8> {
     packet.split().1

--- a/crates/walrus-service/src/common/telemetry.rs
+++ b/crates/walrus-service/src/common/telemetry.rs
@@ -332,6 +332,7 @@ pub(crate) struct MetricsMiddlewareState {
 }
 
 impl MetricsMiddlewareState {
+    /// Creates a new [`MetricsMiddlewareState`] with initialized HTTP metrics and task monitors.
     pub fn new(registry: &Registry) -> Self {
         Self {
             inner: Arc::new(MetricsMiddlewareStateInner {
@@ -512,6 +513,9 @@ impl<E> BodyVisitor<Bytes, E> for ResponseBodyVisitor {
 pub(crate) struct CurrentEpochMetric(GenericGauge<AtomicU64>);
 
 impl CurrentEpochMetric {
+    /// Creates a new [`CurrentEpochMetric`] with default configuration.
+    ///
+    /// The metric records the current Walrus epoch under the name `walrus_current_epoch`.
     pub fn new() -> Self {
         Self(walrus_utils::metrics::create_metric!(
             GenericGauge<AtomicU64>,

--- a/crates/walrus-service/src/common/utils.rs
+++ b/crates/walrus-service/src/common/utils.rs
@@ -131,6 +131,12 @@ where
     Fut: Future,
     F: FnOnce(Option<&Fut::Output>) -> [&'static str; N],
 {
+    /// Creates a new [`Observe`] wrapper around a future.
+    ///
+    /// This function takes:
+    /// - `inner`: The future to observe,
+    /// - `histograms`: A Prometheus histogram vector for timing,
+    /// - `get_labels`: A closure to generate label values from the output of the future.
     pub fn new(inner: Fut, histograms: HistogramVec, get_labels: F) -> Self {
         Self {
             inner,

--- a/crates/walrus-service/src/node/committee/committee_service.rs
+++ b/crates/walrus-service/src/node/committee/committee_service.rs
@@ -74,27 +74,35 @@ impl Default for NodeCommitteeServiceBuilder {
 }
 
 impl NodeCommitteeServiceBuilder {
+    /// Sets the local public identity key for the node.
     pub fn local_identity(mut self, id: PublicKey) -> Self {
         self.local_identity = Some(id);
         self
     }
 
+    /// Sets the configuration to be used for the committee service.
     pub fn config(mut self, config: CommitteeServiceConfig) -> Self {
         self.config = config;
         self
     }
 
+    /// Registers a Prometheus metrics registry to enable metrics tracking.
     pub fn metrics_registry(mut self, registry: &Registry) -> Self {
         self.registry = Some(registry.clone());
         self
     }
 
+    /// Sets a custom RNG instance for testing purposes.
     #[cfg(test)]
     pub fn randomness(mut self, rng: StdRng) -> Self {
         self.rng = rng;
         self
     }
 
+    /// Builds a `NodeCommitteeService` using the provided committee lookup service.
+    ///
+    /// Automatically creates a default node service factory (with or without metrics),
+    /// and passes it to `build_with_factory`.
     pub async fn build<S>(
         self,
         lookup_service: S,
@@ -112,6 +120,9 @@ impl NodeCommitteeServiceBuilder {
             .await
     }
 
+    /// Builds a `NodeCommitteeService` using a custom node service factory and lookup service.
+    ///
+    /// This method provides fine-grained control over the service instantiation process.
     pub async fn build_with_factory<T, S, F>(
         self,
         lookup_service: S,
@@ -158,6 +169,7 @@ pub(crate) struct NodeCommitteeService<T = RemoteStorageNode> {
 }
 
 impl NodeCommitteeService<RemoteStorageNode> {
+    /// Creates a new [`NodeCommitteeServiceBuilder`] with default settings.
     pub fn builder() -> NodeCommitteeServiceBuilder {
         Default::default()
     }

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -289,6 +289,7 @@ struct SimStorageNodeConfigLoader {
 
 #[cfg(msim)]
 impl SimStorageNodeConfigLoader {
+    /// Creates a new [`SimStorageNodeConfigLoader`] with the given shared configuration.
     pub fn new(config: Arc<RwLock<StorageNodeConfig>>) -> Self {
         Self { config }
     }

--- a/crates/walrus-storage-node-client/src/client/middleware.rs
+++ b/crates/walrus-storage-node-client/src/client/middleware.rs
@@ -386,6 +386,10 @@ struct RequestMonitor {
 }
 
 impl RequestMonitor {
+    /// Creates a new [`RequestMonitor`] for the given HTTP request.
+    ///
+    /// This function initializes metrics, tracing spans, and tracking state needed
+    /// to monitor the request lifecycle until a response is received.
     pub fn new(request: &Request, url_template: &'static str, metrics: HttpClientMetrics) -> Self {
         let labels = HttpLabels::new(request, url_template);
         let request_body_size = request
@@ -412,6 +416,9 @@ impl RequestMonitor {
         }
     }
 
+    /// Returns a reference to the HTTP tracing span, if available.
+    ///
+    /// Useful for instrumentation or propagating the span context.
     pub fn http_span(&self) -> Option<&Span> {
         self.inner.as_ref().map(|inner| &inner.http_span)
     }


### PR DESCRIPTION
## Description

Related #2079

This PR adds missing Rust doc comments (`///`) to public functions across several modules.

The focus is on documenting `pub fn` items to improve clarity, maintainability, and developer experience.  
As suggested in [this comment](https://github.com/MystenLabs/walrus/issues/2079#issuecomment-2871048954), I am working **only within the main crate files** .

This is part 1 of the documentation effort. To keep the scope manageable, the remaining undocumented functions will be addressed in future PRs.

