### PR TITLE
docs: add module and function documentations-2

### DIFF
--- a/crates/walrus-service/src/node/blob_sync.rs
+++ b/crates/walrus-service/src/node/blob_sync.rs
@@ -61,6 +61,13 @@ pub(crate) struct BlobSyncHandler {
 }
 
 impl BlobSyncHandler {
+    /// Creates a new [`BlobSyncHandler`] with concurrency limits for blob and sliver syncs.
+    ///
+    /// # Parameters
+    ///
+    /// - `node`: The storage node instance associated with this handler.
+    /// - `max_concurrent_blob_syncs`: Maximum number of blobs that can be synced concurrently.
+    /// - `max_concurrent_sliver_syncs`: Maximum number of sliver pairs that can be synced concurrently.
     pub fn new(
         node: Arc<StorageNodeInner>,
         max_concurrent_blob_syncs: usize,
@@ -424,6 +431,14 @@ pub(super) struct BlobSynchronizer {
 }
 
 impl BlobSynchronizer {
+    /// Creates a new [`BlobSynchronizer`] for the given blob and node context.
+    ///
+    /// # Parameters
+    ///
+    /// - `blob_id`: Identifier of the blob to be synchronized.
+    /// - `certified_epoch`: The certified epoch in which the blob is valid.
+    /// - `node`: The associated storage node context.
+    /// - `cancel_token`: Cancellation token to allow cooperative shutdown of the sync process.
     pub fn new(
         blob_id: BlobId,
         certified_epoch: Epoch,

--- a/crates/walrus-service/src/node/shard_sync.rs
+++ b/crates/walrus-service/src/node/shard_sync.rs
@@ -53,6 +53,7 @@ pub struct ShardSyncHandler {
 }
 
 impl ShardSyncHandler {
+    /// Creates a new `ShardSyncHandler` to manage shard syncing tasks with the provided node and config.
     pub fn new(node: Arc<StorageNodeInner>, config: ShardSyncConfig) -> Self {
         Self {
             node,

--- a/crates/walrus-service/src/node/storage/blob_info.rs
+++ b/crates/walrus-service/src/node/storage/blob_info.rs
@@ -68,6 +68,7 @@ pub(crate) fn per_object_blob_info_cf_options(db_config: &DatabaseConfig) -> Opt
 }
 
 impl BlobInfoTable {
+    /// Reopens the blob info tables from the given RocksDB instance.
     pub fn reopen(database: &Arc<RocksDB>) -> Result<Self, TypedStoreError> {
         let aggregate_blob_info = DBMap::reopen(
             database,
@@ -95,6 +96,7 @@ impl BlobInfoTable {
         })
     }
 
+    /// Returns the column family options for blob info tables.
     pub fn options(db_config: &DatabaseConfig) -> Vec<(&'static str, Options)> {
         vec![
             (
@@ -154,6 +156,7 @@ impl BlobInfoTable {
         latest_handled_index.is_some_and(|i| event_index <= i)
     }
 
+    /// Adds a metadata stored merge operand to the batch for the given blob.    
     pub fn set_metadata_stored<'a>(
         &self,
         batch: &'a mut DBBatch,
@@ -220,10 +223,12 @@ impl BlobInfoTable {
 // TODO(mlegner): Rewrite other tests without relying on blob-info internals. (#900)
 #[cfg(test)]
 impl BlobInfoTable {
+    /// Creates a new database batch for the aggregate blob info table.
     pub fn batch(&self) -> DBBatch {
         self.aggregate_blob_info.batch()
     }
 
+    /// Merges a given operand into the aggregate blob info for the specified blob.
     pub fn merge_blob_info(
         &self,
         blob_id: &BlobId,
@@ -234,14 +239,17 @@ impl BlobInfoTable {
         batch.write()
     }
 
+    /// Inserts the blob info for the given blob ID.
     pub fn insert(&self, blob_id: &BlobId, blob_info: &BlobInfo) -> Result<(), TypedStoreError> {
         self.aggregate_blob_info.insert(blob_id, blob_info)
     }
 
+    /// Removes the blob info for the given blob ID.
     pub fn remove(&self, blob_id: &BlobId) -> Result<(), TypedStoreError> {
         self.aggregate_blob_info.remove(blob_id)
     }
 
+    /// Returns a list of all blob IDs in the aggregate blob info table.
     pub fn keys(&self) -> Result<Vec<BlobId>, TypedStoreError> {
         self.aggregate_blob_info
             .safe_iter()
@@ -249,6 +257,7 @@ impl BlobInfoTable {
             .collect()
     }
 
+    /// Inserts multiple blob info entries into the aggregate blob info table using the provided batch.
     pub fn insert_batch<'a>(
         &self,
         batch: &mut DBBatch,
@@ -258,6 +267,7 @@ impl BlobInfoTable {
         Ok(())
     }
 
+    /// Inserts multiple per-object blob info entries using the provided batch.
     pub fn insert_per_object_batch<'a>(
         &self,
         batch: &mut DBBatch,

--- a/crates/walrus-service/src/node/storage/constants.rs
+++ b/crates/walrus-service/src/node/storage/constants.rs
@@ -55,6 +55,7 @@ pub fn event_cursor_cf_name() -> &'static str {
     EVENT_CURSOR_COLUMN_FAMILY_NAME
 }
 
+/// Returns the key used for storing the event cursor.
 pub fn event_cursor_key() -> &'static [u8; 6] {
     &EVENT_CURSOR_KEY
 }

--- a/crates/walrus-service/src/node/storage/database_config.rs
+++ b/crates/walrus-service/src/node/storage/database_config.rs
@@ -143,6 +143,7 @@ impl DatabaseTableOptions {
         }
     }
 
+    /// Converts the table configuration into a RocksDB `Options` instance.
     pub fn to_options(&self) -> Options {
         let mut options = Options::default();
         if let Some(enable_blob_files) = self.enable_blob_files {

--- a/crates/walrus-service/src/node/storage/event_sequencer.rs
+++ b/crates/walrus-service/src/node/storage/event_sequencer.rs
@@ -57,6 +57,10 @@ impl EventSequencer {
         }
     }
 
+    /// Returns the number of events that are currently in the queue but have not yet been processed.
+    ///
+    /// This represents the count of event IDs that have been observed but are not yet contiguous
+    /// from the current `head_index`, and therefore not ready to be returned by [`ready_events`].
     pub fn remaining(&self) -> u64 {
         self.queue.len().try_into().expect("usize is at most u64")
     }

--- a/crates/walrus-service/src/node/storage/metrics.rs
+++ b/crates/walrus-service/src/node/storage/metrics.rs
@@ -27,6 +27,7 @@ walrus_utils::metrics::define_metric_set! {
 }
 
 impl CommonDatabaseMetrics {
+    /// Records the duration of a database operation using provided labels.
     pub fn observe_operation_duration(&self, labels: Labels, duration: Duration) {
         walrus_utils::with_label!(
             self.operation_duration_seconds,

--- a/crates/walrus-service/src/node/system_events.rs
+++ b/crates/walrus-service/src/node/system_events.rs
@@ -65,6 +65,7 @@ pub(super) struct EventHandle {
 }
 
 impl EventHandle {
+    /// Creates a new [`EventHandle`] instance for the given event.
     pub fn new(index: u64, event_id: Option<EventID>, node: Arc<StorageNodeInner>) -> Self {
         Self {
             index,
@@ -74,10 +75,12 @@ impl EventHandle {
         }
     }
 
+    /// Returns the index of the event.
     pub fn index(&self) -> u64 {
         self.index
     }
 
+    /// Returns the [`EventID`] associated with the event.
     pub fn event_id(&self) -> EventID {
         self.event_id
     }


### PR DESCRIPTION
## Description

Continues #2084

This PR adds missing Rust doc comments (///) to public functions across several modules.
