### PR TITLE
fix: skip fetching checkpoint from rpc nodes when encounter extended primary failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1935,6 +1935,7 @@ version = "1.26.0"
 dependencies = [
  "anyhow",
  "async-channel",
+ "mockall 0.13.1",
  "mysten-metrics",
  "prometheus",
  "rand 0.8.5",
@@ -1944,6 +1945,7 @@ dependencies = [
  "sui-macros",
  "sui-rpc-api",
  "sui-types",
+ "telemetry-subscribers",
  "tempfile",
  "tokio",
  "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5482,6 +5484,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive 0.13.1",
+ "predicates 3.1.3",
+ "predicates-tree",
+]
+
+[[package]]
 name = "mockall_derive"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5498,6 +5514,18 @@ name = "mockall_derive"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
 dependencies = [
  "cfg-if",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1935,7 +1935,6 @@ version = "1.26.0"
 dependencies = [
  "anyhow",
  "async-channel",
- "mockall 0.13.1",
  "mysten-metrics",
  "prometheus",
  "rand 0.8.5",
@@ -5484,20 +5483,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mockall"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
-dependencies = [
- "cfg-if",
- "downcast",
- "fragile",
- "mockall_derive 0.13.1",
- "predicates 3.1.3",
- "predicates-tree",
-]
-
-[[package]]
 name = "mockall_derive"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5514,18 +5499,6 @@ name = "mockall_derive"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "mockall_derive"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
 dependencies = [
  "cfg-if",
  "proc-macro2",

--- a/crates/checkpoint-downloader/Cargo.toml
+++ b/crates/checkpoint-downloader/Cargo.toml
@@ -31,4 +31,3 @@ workspace = true
 [dev-dependencies]
 rocksdb.workspace = true
 tempfile.workspace = true
-mockall = "0.13.1"

--- a/crates/checkpoint-downloader/Cargo.toml
+++ b/crates/checkpoint-downloader/Cargo.toml
@@ -17,6 +17,7 @@ serde_with.workspace = true
 sui-macros.workspace = true
 sui-rpc-api.workspace = true
 sui-types.workspace = true
+telemetry-subscribers.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tokio-util.workspace = true
 tracing.workspace = true
@@ -30,3 +31,4 @@ workspace = true
 [dev-dependencies]
 rocksdb.workspace = true
 tempfile.workspace = true
+mockall = "0.13.1"

--- a/crates/checkpoint-downloader/src/config.rs
+++ b/crates/checkpoint-downloader/src/config.rs
@@ -19,7 +19,8 @@ use crate::metrics::AdaptiveDownloaderMetrics;
 #[serde(default)]
 pub struct ParallelDownloaderConfig {
     /// Number of retries per checkpoint before giving up.
-    pub min_retries: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_retries: Option<u32>,
     /// Initial delay before the first retry.
     #[serde_as(as = "DurationMilliSeconds")]
     #[serde(rename = "initial_delay_millis")]
@@ -56,7 +57,7 @@ impl Default for ParallelDownloaderConfig {
         // - Not waiting too long (which would cause us to fall behind)
         // TODO: Use adaptive retry delay based on RTT and error type (#1123)
         Self {
-            min_retries: 10,
+            min_retries: None,
             initial_delay: Duration::from_millis(150),
             max_delay: Duration::from_secs(2),
         }

--- a/crates/checkpoint-downloader/src/config.rs
+++ b/crates/checkpoint-downloader/src/config.rs
@@ -20,7 +20,7 @@ use crate::metrics::AdaptiveDownloaderMetrics;
 pub struct ParallelDownloaderConfig {
     /// Number of retries per checkpoint before giving up.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub min_retries: Option<u32>,
+    pub retries: Option<u32>,
     /// Initial delay before the first retry.
     #[serde_as(as = "DurationMilliSeconds")]
     #[serde(rename = "initial_delay_millis")]
@@ -57,7 +57,7 @@ impl Default for ParallelDownloaderConfig {
         // - Not waiting too long (which would cause us to fall behind)
         // TODO: Use adaptive retry delay based on RTT and error type (#1123)
         Self {
-            min_retries: None,
+            retries: None,
             initial_delay: Duration::from_millis(150),
             max_delay: Duration::from_secs(2),
         }
@@ -111,6 +111,9 @@ pub struct AdaptiveDownloaderConfig {
     pub base_config: ParallelDownloaderConfig,
     /// Channel configuration.
     pub channel_config: ChannelConfig,
+    /// Maximum number of consecutive pool monitor failures until the downloader uses a fixed number
+    /// of workers.
+    pub max_consecutive_pool_monitor_failures: usize,
 }
 
 impl Default for AdaptiveDownloaderConfig {
@@ -124,6 +127,7 @@ impl Default for AdaptiveDownloaderConfig {
             scale_cooldown: Duration::from_secs(10),
             base_config: ParallelDownloaderConfig::default(),
             channel_config: ChannelConfig::default(),
+            max_consecutive_pool_monitor_failures: 10,
         }
     }
 }

--- a/crates/checkpoint-downloader/src/downloader.rs
+++ b/crates/checkpoint-downloader/src/downloader.rs
@@ -9,16 +9,14 @@ use std::{
 };
 
 use anyhow::{Result, anyhow};
-use rand::{SeedableRng, rngs::StdRng};
+use rand::{RngCore, SeedableRng, rngs::StdRng};
 use sui_rpc_api::client::ResponseExt;
 use sui_types::messages_checkpoint::{CheckpointSequenceNumber, TrustedCheckpoint};
 use tokio::{sync::mpsc, time::Instant};
 use tokio_util::sync::CancellationToken;
 use typed_store::{Map, rocks::DBMap};
 use walrus_sui::client::retry_client::{RetriableClientError, RetriableRpcClient};
-#[cfg(not(test))]
-use walrus_utils::backoff::ExponentialBackoff;
-use walrus_utils::{metrics::Registry, tracing_sampled};
+use walrus_utils::{backoff::ExponentialBackoff, metrics::Registry, tracing_sampled};
 
 use crate::{
     ParallelDownloaderConfig,
@@ -428,76 +426,42 @@ impl ParallelCheckpointDownloaderInner {
     }
 
     /// Downloads a checkpoint with retries.
-    #[cfg(not(test))]
     async fn download_with_retry(
         client: &RetriableRpcClient,
         sequence_number: CheckpointSequenceNumber,
         config: &ParallelDownloaderConfig,
         rng: &mut StdRng,
     ) -> CheckpointEntry {
-        let mut backoff = create_backoff(rng, config);
+        let mut backoff = ExponentialBackoff::new_with_seed(
+            config.initial_delay,
+            config.max_delay,
+            config.min_retries,
+            rng.next_u64(),
+        );
         loop {
             let result = client.get_full_checkpoint(sequence_number).await;
             let Ok(checkpoint) = result else {
-                let err = result.err();
-                handle_checkpoint_error(err.as_ref(), sequence_number);
+                let err = result.unwrap_err();
+                handle_checkpoint_error(&err, sequence_number);
 
-                let delay = backoff.next().expect("backoff should not be exhausted");
+                if let Some(delay) = backoff.next() {
+                    tokio::time::sleep(delay).await;
+                    continue;
+                }
 
-                tokio::time::sleep(delay).await;
-                continue;
+                return CheckpointEntry::new(sequence_number, Err(err.into()));
             };
 
             return CheckpointEntry::new(sequence_number, Ok(checkpoint));
         }
     }
 
-    #[cfg(test)]
-    async fn download_with_retry(
-        client: &RetriableRpcClient,
-        sequence_number: CheckpointSequenceNumber,
-        _config: &ParallelDownloaderConfig,
-        _rng: &mut StdRng,
-    ) -> CheckpointEntry {
-        let res = tokio::time::timeout(
-            Duration::from_secs(1),
-            client.get_full_checkpoint(sequence_number),
-        )
-        .await;
-        match res {
-            Ok(Ok(checkpoint)) => CheckpointEntry {
-                sequence_number,
-                result: Ok(checkpoint),
-            },
-            Ok(Err(e)) => {
-                handle_checkpoint_error(Some(&e), sequence_number);
-                CheckpointEntry::new(sequence_number, Err(e.into()))
-            }
-            Err(_) => {
-                let err = anyhow!("Timeout while downloading checkpoint");
-                handle_checkpoint_error(None, sequence_number);
-                CheckpointEntry::new(sequence_number, Err(err))
-            }
-        }
-    }
-}
-
-/// Helper function to create backoff with consistent settings.
-#[cfg(not(test))]
-fn create_backoff(
-    rng: &mut StdRng,
-    config: &ParallelDownloaderConfig,
-) -> ExponentialBackoff<StdRng> {
-    use rand::RngCore;
-    ExponentialBackoff::new_with_seed(config.initial_delay, config.max_delay, None, rng.next_u64())
-}
-
 /// Handles an error that occurred while reading the next checkpoint.
 /// If the error is due to a checkpoint that is already present on the server,
 /// it is logged as an error.
 /// Otherwise, it is logged as a debug.
-fn handle_checkpoint_error(err: Option<&RetriableClientError>, next_checkpoint: u64) {
-    if let Some(RetriableClientError::RpcError(rpc_error)) = err {
+fn handle_checkpoint_error(err: &RetriableClientError, next_checkpoint: u64) {
+    if let RetriableClientError::RpcError(rpc_error) = err {
         if let Some(checkpoint_height) = rpc_error.status.checkpoint_height() {
             if next_checkpoint > checkpoint_height {
                 return tracing::trace!(
@@ -529,20 +493,25 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn test_parallel_fetcher() -> Result<()> {
+        telemetry_subscribers::init_for_testing();
         let rest_url = "http://localhost:9000";
         let retriable_client = RetriableRpcClient::new(
             vec![LazyFallibleRpcClientBuilder::Url {
                 rpc_url: rest_url.to_string(),
                 ensure_experimental_rest_endpoint: false,
             }],
-            Duration::from_secs(5),
-            ExponentialBackoffConfig::default(),
+            Duration::from_millis(100),
+            ExponentialBackoffConfig {
+                min_backoff: Duration::from_millis(100),
+                max_backoff: Duration::from_secs(1),
+                max_retries: Some(0),
+            },
             None,
             None,
         )
         .await?;
         let parallel_config = ParallelDownloaderConfig {
-            min_retries: 10,
+            min_retries: Some(0),
             initial_delay: Duration::from_millis(250),
             max_delay: Duration::from_secs(2),
         };
@@ -556,7 +525,7 @@ mod tests {
             initial_workers: 5,
             scale_up_lag_threshold: 100,
             scale_down_lag_threshold: 50,
-            scale_cooldown: Duration::from_secs(30),
+            scale_cooldown: Duration::from_secs(300),
             base_config: parallel_config,
             channel_config,
         };

--- a/crates/checkpoint-downloader/src/downloader.rs
+++ b/crates/checkpoint-downloader/src/downloader.rs
@@ -433,6 +433,7 @@ impl ParallelCheckpointDownloaderInner {
         rng: &mut StdRng,
     ) -> CheckpointEntry {
         let mut backoff = if cfg!(test) {
+            // Note that we only return error in test mode.
             ExponentialBackoff::new_with_seed(
                 config.initial_delay,
                 config.max_delay,
@@ -440,6 +441,8 @@ impl ParallelCheckpointDownloaderInner {
                 rng.next_u64(),
             )
         } else {
+            // In production, we should never stop trying to fetch the checkpoint. This is critical
+            // for the node to make progress.
             ExponentialBackoff::new_with_seed(
                 config.initial_delay,
                 config.max_delay,
@@ -467,6 +470,7 @@ impl ParallelCheckpointDownloaderInner {
             return CheckpointEntry::new(sequence_number, Ok(checkpoint));
         }
     }
+}
 
 /// Handles an error that occurred while reading the next checkpoint.
 /// If the error is due to a checkpoint that is already present on the server,

--- a/crates/walrus-service/node_config_example.yaml
+++ b/crates/walrus-service/node_config_example.yaml
@@ -117,12 +117,12 @@ event_processor_config:
     scale_down_lag_threshold: 10
     scale_cooldown_secs: 10
     base_config:
-      min_retries: 10
       initial_delay_millis: 150
       max_delay_millis: 2000
     channel_config:
       work_queue_buffer_factor: 3
       result_queue_buffer_factor: 3
+    max_consecutive_pool_monitor_failures: 10
   event_stream_catchup_min_checkpoint_lag: 20000
 use_legacy_event_provider: false
 disable_event_blob_writer: false

--- a/crates/walrus-sui/src/client/retry_client/retriable_rpc_client.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_rpc_client.rs
@@ -373,7 +373,7 @@ impl RetriableRpcClient {
                 || !self
                     .fallback_client
                     .as_ref()
-                    .unwrap()
+                    .expect("fallback client must set")
                     .is_eligible_for_fallback(sequence_number, &error, last_success, num_failures)
             {
                 tracing::debug!(

--- a/crates/walrus-sui/src/client/retry_client/retriable_rpc_client/fallback_client.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_rpc_client/fallback_client.rs
@@ -103,7 +103,7 @@ impl FallbackClient {
     /// the number of failures exceeds `self.min_failures_to_start_fallback` and if the last
     /// successful RPC call was more than `self.failure_window_to_start_fallback_duration` minutes
     /// ago.
-    fn is_failure_window_exceeded(&self, last_success: Instant, num_failures: usize) -> bool {
+    pub fn is_failure_window_exceeded(&self, last_success: Instant, num_failures: usize) -> bool {
         last_success.elapsed() > self.failure_window_to_start_fallback_duration
             && num_failures > self.min_failures_to_start_fallback
     }

--- a/crates/walrus-sui/src/client/retry_client/retriable_rpc_client/fallback_client.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_rpc_client/fallback_client.rs
@@ -2,13 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Implements a fallback client for downloading checkpoints from a remote server.
-use std::{fmt::Debug, time::Duration};
+use std::{
+    fmt::Debug,
+    time::{Duration, Instant},
+};
 
 use reqwest::Url;
 use sui_storage::blob::Blob;
 use sui_types::full_checkpoint_content::CheckpointData;
 use thiserror::Error;
 use url::ParseError;
+
+use super::RetriableClientError;
 
 /// Error type for checkpoint download errors.
 #[derive(Error, Debug)]
@@ -31,16 +36,31 @@ pub enum FallbackError {
 pub(crate) struct FallbackClient {
     client: reqwest::Client,
     base_url: Url,
+    skip_rpc_for_checkpoint_duration: Duration,
+    min_failures_to_start_fallback: usize,
+    failure_window_to_start_fallback_duration: Duration,
 }
 
 impl FallbackClient {
     /// Creates a new fallback client.
-    pub fn new(base_url: Url, timeout: Duration) -> Self {
+    pub fn new(
+        base_url: Url,
+        timeout: Duration,
+        skip_rpc_for_checkpoint_duration: Duration,
+        min_failures_to_start_fallback: usize,
+        failure_window_to_start_fallback_duration: Duration,
+    ) -> Self {
         let client = reqwest::Client::builder()
             .timeout(timeout)
             .build()
             .expect("should be able to build reqwest client");
-        Self { client, base_url }
+        Self {
+            client,
+            base_url,
+            skip_rpc_for_checkpoint_duration,
+            min_failures_to_start_fallback,
+            failure_window_to_start_fallback_duration,
+        }
     }
 
     /// Downloads a checkpoint from the remote server.
@@ -56,5 +76,35 @@ impl FallbackClient {
             .map_err(|e| FallbackError::DeserializationError(e.to_string()))?;
         tracing::debug!(sequence_number, "checkpoint download successful");
         Ok(checkpoint)
+    }
+
+    pub fn skip_rpc_for_checkpoint_duration(&self) -> Duration {
+        self.skip_rpc_for_checkpoint_duration
+    }
+
+    /// Returns `true` if
+    ///   - the error indicates that a immediate fallback is needed, or
+    ///   - the failure window has been exceeded.
+    pub fn is_eligible_for_fallback(
+        &self,
+        next_checkpoint: u64,
+        error: &RetriableClientError,
+        last_success: Instant,
+        num_failures: usize,
+    ) -> bool {
+        if error.is_eligible_for_fallback_immediately(next_checkpoint) {
+            return true;
+        }
+
+        self.is_failure_window_exceeded(last_success, num_failures)
+    }
+
+    /// Returns `true` if the failure window has been exceeded. Failure window is exceeded if
+    /// the number of failures exceeds `self.min_failures_to_start_fallback` and if the last
+    /// successful RPC call was more than `self.failure_window_to_start_fallback_duration` minutes
+    /// ago.
+    fn is_failure_window_exceeded(&self, last_success: Instant, num_failures: usize) -> bool {
+        last_success.elapsed() > self.failure_window_to_start_fallback_duration
+            && num_failures > self.min_failures_to_start_fallback
     }
 }

--- a/crates/walrus-sui/src/client/rpc_config.rs
+++ b/crates/walrus-sui/src/client/rpc_config.rs
@@ -19,6 +19,18 @@ pub struct RpcFallbackConfig {
     /// endpoint before falling back to the checkpoint bucket.
     #[serde(default = "RpcFallbackConfig::default_quick_retry_config")]
     pub quick_retry_config: ExponentialBackoffConfig,
+
+    /// The minimum number of failures to start the fallback.
+    #[serde(default = "RpcFallbackConfig::default_min_failures_to_start_fallback")]
+    pub min_failures_to_start_fallback: usize,
+
+    /// The duration of the failure window to start the fallback.
+    #[serde(default = "RpcFallbackConfig::default_failure_window_to_start_fallback_duration")]
+    pub failure_window_to_start_fallback_duration: Duration,
+
+    /// The duration to skip the RPC for checkpoint download if fallback is configured.
+    #[serde(default = "RpcFallbackConfig::default_skip_rpc_for_checkpoint_duration")]
+    pub skip_rpc_for_checkpoint_duration: Duration,
 }
 
 impl RpcFallbackConfig {
@@ -28,6 +40,18 @@ impl RpcFallbackConfig {
             max_backoff: Duration::from_millis(300),
             max_retries: None,
         }
+    }
+
+    fn default_min_failures_to_start_fallback() -> usize {
+        10
+    }
+
+    fn default_failure_window_to_start_fallback_duration() -> Duration {
+        Duration::from_secs(300)
+    }
+
+    fn default_skip_rpc_for_checkpoint_duration() -> Duration {
+        Duration::from_secs(300)
     }
 }
 
@@ -75,6 +99,12 @@ impl RpcFallbackConfigArgs {
             RpcFallbackConfig {
                 checkpoint_bucket: url.clone(),
                 quick_retry_config: backoff,
+                min_failures_to_start_fallback:
+                    RpcFallbackConfig::default_min_failures_to_start_fallback(),
+                failure_window_to_start_fallback_duration:
+                    RpcFallbackConfig::default_failure_window_to_start_fallback_duration(),
+                skip_rpc_for_checkpoint_duration:
+                    RpcFallbackConfig::default_skip_rpc_for_checkpoint_duration(),
             }
         })
     }


### PR DESCRIPTION
## Description

When an RetriableRpcClient encounters failures for extended period of time when fetching checkpoints from RPC nodes, the node should just skip RPC for short period of time, and directly fetch checkpoints from archival. Otherwise, the RPC request + retry + failure takes 40s to 60s, which significantly limits the checkpoint downloading throughput.

## Test plan

Tested archival catchup in PTN
<img width="1235" alt="Screenshot 2025-05-14 at 1 17 00 AM" src="https://github.com/user-attachments/assets/6d410007-bb1d-487f-ac01-2402d50d3b58" />

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
