### PR TITLE
docs: keep wallet path in client config until `v1.26` is released

### DIFF
--- a/.github/workflows/pages-preview.yaml
+++ b/.github/workflows/pages-preview.yaml
@@ -12,6 +12,7 @@ on:
       - "docs/book/**"
       - "docs/theme/**"
       - "docs/mdbook-admonish.css"
+      - "setup/**"
       - ".github/actions/build-mdbook/action.yaml"
       - ".github/workflows/pages-preview.yaml"
 

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -9,6 +9,7 @@ on:
       - "docs/book/**"
       - "docs/theme/**"
       - "docs/mdbook-admonish.css"
+      - "setup/**"
       - ".github/actions/build-mdbook/action.yaml"
       - ".github/workflows/publish-docs.yaml"
   workflow_dispatch:

--- a/setup/client_config.yaml
+++ b/setup/client_config.yaml
@@ -5,10 +5,10 @@ contexts:
     subsidies_object: 0xb606eb177899edc2130c93bf65985af7ec959a2755dc126c953755e59324209e
     exchange_objects: []
     wallet_config:
+      # Path to the wallet config file.
+      path: ~/.sui/sui_config/client.yaml
       # Sui environment to use.
       active_env: mainnet
-      # Optional path to the wallet config file.
-      # path: ~/.sui/sui_config/client.yaml
       # Optional override for the Sui address to use.
       # active_address: 0x0000000000000000000000000000000000000000000000000000000000000000
     rpc_urls:
@@ -23,10 +23,10 @@ contexts:
       - 0x83b454e524c71f30803f4d6c302a86fb6a39e96cdfb873c2d1e93bc1c26a3bc5
       - 0x8d63209cf8589ce7aef8f262437163c67577ed09f3e636a9d8e0813843fb8bf1
     wallet_config:
+      # Path to the wallet config file.
+      path: ~/.sui/sui_config/client.yaml
       # Sui environment to use.
       active_env: testnet
-      # Optional path to the wallet config file.
-      # path: ~/.sui/sui_config/client.yaml
       # Optional override for the Sui address to use.
       # active_address: 0x0000000000000000000000000000000000000000000000000000000000000000
     rpc_urls:


### PR DESCRIPTION
## Description

The wallet path was made optional in #2065, but this change is not yet included in the released version. This reverts the corresponding changes to the config file and also makes sure that the docs are updated when the config files change.

## Test plan

Look at docs preview and re-run the [compatibility test](https://github.com/MystenLabs/sui-operations/actions/workflows/walrus-scheduled-compatibility.yaml).