### PR TITLE
chore: temporarily rollback tempfile dependency version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11139,9 +11139,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.20.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+checksum = "488960f40a3fd53d72c2a29a58722561dee8afdd175bd88e3db4677d7b2ba600"
 dependencies = [
  "fastrand",
  "getrandom 0.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,8 @@ sui-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.48.0"
 syn = "2.0"
 tap = "1.0.1"
 telemetry-subscribers = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.48.0" }
-tempfile = "3.20.0"
+# TODO (WAL-834): Update to the latest version after sui testnet-v1.50 is used.
+tempfile = "=3.19.0"
 test-cluster = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.48.0" }
 thiserror = "2.0.12"
 tokio = { version = "=1.44.2", features = ["macros", "rt-multi-thread", "signal"] }
@@ -135,7 +136,6 @@ tracing-subscriber = { version = "0.3.19", default-features = false, features = 
 twox-hash = "2.1.0"
 typed-store = { path = "crates/typed-store" }
 uint = "0.10.0"
-# TODO (WAL-790): update typed-store to >= 1.47 or remove it.
 url = "2.5.4"
 utoipa = { version = "5" }
 utoipa-redoc = { version = "6.0", features = ["axum"] }

--- a/crates/checkpoint-downloader/src/downloader.rs
+++ b/crates/checkpoint-downloader/src/downloader.rs
@@ -552,7 +552,7 @@ mod tests {
         db_opts.create_if_missing(true);
         let root_dir_path = tempfile::tempdir()
             .expect("Failed to open temporary directory")
-            .keep();
+            .into_path();
         let database = {
             let _lock = global_test_lock().lock().await;
             rocks::open_cf_opts(

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -9,7 +9,7 @@ use crate::rocks::safe_iter::{SafeIter, SafeRevIter};
 fn temp_dir() -> std::path::PathBuf {
     tempfile::tempdir()
         .expect("Failed to open temporary directory")
-        .keep()
+        .into_path()
 }
 
 enum TestIteratorWrapper<'a, K, V> {

--- a/crates/walrus-orchestrator/src/settings.rs
+++ b/crates/walrus-orchestrator/src/settings.rs
@@ -282,7 +282,7 @@ impl Settings {
     #[cfg(test)]
     pub fn new_for_test() -> Self {
         // Create a temporary public key file.
-        let mut path = tempfile::tempdir().unwrap().keep();
+        let mut path = tempfile::tempdir().unwrap().into_path();
         path.push("test_public_key.pub");
         let public_key = "This is a fake public key for tests";
         fs::write(&path, public_key).unwrap();

--- a/crates/walrus-service/src/node/events/event_blob_writer.rs
+++ b/crates/walrus-service/src/node/events/event_blob_writer.rs
@@ -1647,7 +1647,7 @@ mod tests {
         const NUM_BLOBS: u64 = 10;
         const NUM_EVENTS_PER_CHECKPOINT: u64 = 2;
 
-        let dir: PathBuf = tempfile::tempdir()?.keep();
+        let dir: PathBuf = tempfile::tempdir()?.into_path();
         let registry = Registry::default();
         let node = create_test_node().await?;
         let blob_writer_factory = EventBlobWriterFactory::new(
@@ -1699,7 +1699,7 @@ mod tests {
         const NUM_BLOBS: u64 = 10;
         const NUM_EVENTS_PER_CHECKPOINT: u64 = 1;
 
-        let dir: PathBuf = tempfile::tempdir()?.keep();
+        let dir: PathBuf = tempfile::tempdir()?.into_path();
         let node = create_test_node().await?;
         let registry = Registry::default();
 
@@ -1783,7 +1783,7 @@ mod tests {
         const NUM_BLOBS: u64 = 10;
         const NUM_EVENTS_PER_CHECKPOINT: u64 = 1;
 
-        let dir: PathBuf = tempfile::tempdir()?.keep();
+        let dir: PathBuf = tempfile::tempdir()?.into_path();
         let node = create_test_node().await?;
         let registry = Registry::default();
         let blob_writer_factory = EventBlobWriterFactory::new(

--- a/crates/walrus-service/src/node/events/event_processor.rs
+++ b/crates/walrus-service/src/node/events/event_processor.rs
@@ -1306,7 +1306,7 @@ mod tests {
         db_opts.create_if_missing(true);
         let root_dir_path = tempfile::tempdir()
             .expect("Failed to open temporary directory")
-            .keep();
+            .into_path();
         let database = {
             let _lock = global_test_lock().lock().await;
             rocks::open_cf_opts(


### PR DESCRIPTION
## Description

Too many warning when running simtest. We can roll forward once Sui 1.50 is released.

Related to WAL-834
Close WAL-790

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
