### PR TITLE
fix: use config PRC endpoints when creating SuiContractClient from wallet

### DIFF
--- a/crates/walrus-service/src/common/config.rs
+++ b/crates/walrus-service/src/common/config.rs
@@ -71,19 +71,19 @@ impl SuiConfig {
     }
 
     /// Creates a [`SuiContractClient`] based on the configuration.
+    /// Always use the RPC endpoints supplied in the configuration instead of the wallet's RPC URL
+    /// to allow for failover.
     pub async fn new_contract_client(
         &self,
         metrics: Option<Arc<SuiClientMetricSet>>,
     ) -> Result<SuiContractClient, SuiClientError> {
         let wallet = WalletConfig::load_wallet(Some(&self.wallet_config), self.request_timeout)?;
 
-        #[allow(deprecated)]
-        let rpc_urls = &[wallet.get_rpc_url()?];
-
+        let rpc_urls = combine_rpc_urls(&self.rpc, &self.additional_rpc_endpoints);
         if let Some(metrics) = metrics {
             SuiContractClient::new_with_metrics(
                 wallet,
-                rpc_urls,
+                &rpc_urls,
                 &self.contract_config,
                 self.backoff_config.clone(),
                 self.gas_budget,
@@ -93,7 +93,7 @@ impl SuiConfig {
         } else {
             SuiContractClient::new(
                 wallet,
-                rpc_urls,
+                &rpc_urls,
                 &self.contract_config,
                 self.backoff_config.clone(),
                 self.gas_budget,

--- a/crates/walrus-service/src/common/config.rs
+++ b/crates/walrus-service/src/common/config.rs
@@ -79,7 +79,11 @@ impl SuiConfig {
     ) -> Result<SuiContractClient, SuiClientError> {
         let wallet = WalletConfig::load_wallet(Some(&self.wallet_config), self.request_timeout)?;
 
-        let rpc_urls = combine_rpc_urls(&self.rpc, &self.additional_rpc_endpoints);
+        #[allow(deprecated)]
+        let rpc_urls = combine_rpc_urls(
+            wallet.get_rpc_url()?,
+            &combine_rpc_urls(&self.rpc, &self.additional_rpc_endpoints),
+        );
         if let Some(metrics) = metrics {
             SuiContractClient::new_with_metrics(
                 wallet,

--- a/crates/walrus-sui/src/client/retry_client/retriable_rpc_client.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_rpc_client.rs
@@ -103,14 +103,26 @@ pub enum LazyFallibleRpcClientBuilder {
 impl LazyClientBuilder<FallibleRpcClient> for LazyFallibleRpcClientBuilder {
     const DEFAULT_MAX_TRIES: usize = 5;
 
-    async fn lazy_build_client(
-        &self,
-        _is_last_chance: bool,
-    ) -> Result<Arc<FallibleRpcClient>, FailoverError> {
+    async fn lazy_build_client(&self) -> Result<Arc<FallibleRpcClient>, FailoverError> {
         // Inject rpc client build failure for simtests.
         #[cfg(msim)]
         {
-            if !_is_last_chance {
+            let mut fail_client_creation = false;
+            sui_macros::fail_point_arg!(
+                "failpoint_rpc_client_build_client",
+                |url_to_fail: String| {
+                    match self {
+                        Self::Url { rpc_url, .. } => {
+                            if *rpc_url == url_to_fail {
+                                fail_client_creation = true;
+                            }
+                        }
+                        Self::Client(_) => {}
+                    }
+                }
+            );
+
+            if fail_client_creation {
                 tracing::info!("injected rpc client build failure {:?}", self.get_rpc_url());
                 return Err(FailoverError::FailedToGetClient(format!(
                     "injected rpc client build failure {:?}",


### PR DESCRIPTION
## Description

This was missed during the last round of GRPC proxy testing, and thanks @wbbradley for making the great
improvement to easily set RPC endpoints when creating SuiContractClient from a wallet!

Before this PR, if the endpoint specified in the wallet is unavailable, restarting the node won't work even other
RPC endpoints specified in the node config are still available. By only using the RPC endpoints from the config,
now SuiContractClient can correctly fall to the next client.

Changed back some simtest semantics from before #2052 since now the fall over should work.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
