### PR TITLE
feat: enable buying storage resources for future epochs

### DIFF
--- a/contracts/walrus/sources/system.move
+++ b/contracts/walrus/sources/system.move
@@ -95,6 +95,22 @@ public fun reserve_space(
     self.inner_mut().reserve_space(storage_amount, epochs_ahead, payment, ctx)
 }
 
+/// Allows buying a storage reservation for a given period of epochs.
+///
+/// Returns a storage resource for the period between `start_epoch` (inclusive) and
+/// `end_epoch` (exclusive). If `start_epoch` has already passed, reserves space starting
+/// from the current epoch.
+public fun reserve_space_for_epochs(
+    self: &mut System,
+    storage_amount: u64,
+    start_epoch: u32,
+    end_epoch: u32,
+    payment: &mut Coin<WAL>,
+    ctx: &mut TxContext,
+): Storage {
+    self.inner_mut().reserve_space_for_epochs(storage_amount, start_epoch, end_epoch, payment, ctx)
+}
+
 /// Registers a new blob in the system.
 /// `size` is the size of the unencoded blob. The reserved space in `storage` must be at
 /// least the size of the encoded blob.

--- a/crates/walrus-sui/src/client.rs
+++ b/crates/walrus-sui/src/client.rs
@@ -2648,6 +2648,7 @@ impl SuiContractClientInner {
         post_store: PostStoreAction,
         subsidies_package_id: ObjectID,
     ) -> SuiClientResult<Vec<CertifyAndExtendBlobResult>> {
+        // TODO(WAL-835): buy single storage resource to extend multiple blobs
         self.certify_and_extend_blobs_impl(
             blobs_with_certificates,
             post_store,
@@ -2672,6 +2673,7 @@ impl SuiContractClientInner {
         blobs_with_certificates: &[CertifyAndExtendBlobParams<'_>],
         post_store: PostStoreAction,
     ) -> SuiClientResult<Vec<CertifyAndExtendBlobResult>> {
+        // TODO(WAL-835): buy single storage resource to extend multiple blobs
         self.certify_and_extend_blobs_impl(
             blobs_with_certificates,
             post_store,


### PR DESCRIPTION
## Description

Enables buying storage resources for future epochs, closes WAL-812

## Test plan

added test + existing tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
