### PR TITLE
feat: allow SafeIter to seek to a specific key

### DIFF
--- a/crates/typed-store/src/rocks/errors.rs
+++ b/crates/typed-store/src/rocks/errors.rs
@@ -116,6 +116,9 @@ pub enum TypedStoreError {
     /// The transaction should be retried
     #[error("Transaction should be retried")]
     RetryableTransactionError,
+    /// The iterator is not initialized
+    #[error("Iterator is not initialized")]
+    IteratorNotInitialized,
 }
 
 /// The result type for the typed store

--- a/crates/typed-store/src/traits.rs
+++ b/crates/typed-store/src/traits.rs
@@ -16,7 +16,7 @@ where
     /// The error type for the map
     type Error: Error;
     /// The safe iterator type for the map
-    type SafeIterator: Iterator<Item = Result<(K, V), TypedStoreError>>;
+    type SafeIterator: Iterator<Item = Result<(K, V), TypedStoreError>> + SeekableIterator<K>;
 
     /// Returns true if the map contains a value for the specified key.
     fn contains_key(&self, key: &K) -> Result<bool, Self::Error>;
@@ -98,6 +98,24 @@ where
 
     /// Try to catch up with primary when running as secondary
     fn try_catch_up_with_primary(&self) -> Result<(), Self::Error>;
+}
+
+/// The trait for seekable iterator.
+pub trait SeekableIterator<K> {
+    /// Seeks to the first key in the iterator.
+    fn seek_to_first(&mut self);
+
+    /// Seeks to the last key in the iterator.
+    fn seek_to_last(&mut self);
+
+    /// Seeks to the specified key. If the key does not exist, it will seek to the next key.
+    fn seek(&mut self, key: &K) -> Result<(), TypedStoreError>;
+
+    /// Seeks to the previous key. If the key does not exist, it will seek to the previous key.
+    fn seek_to_prev(&mut self, key: &K) -> Result<(), TypedStoreError>;
+
+    /// Returns the current key.
+    fn key(&self) -> Result<Option<K>, TypedStoreError>;
 }
 
 /// The summary of the table


### PR DESCRIPTION
## Description

Will be used in node wide sliver existence check, so that we can do sequential scan instead of point lookup.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
