### PR TITLE
chore: add simtest config option in vscode setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,10 @@
   "rust-analyzer.rustfmt.extraArgs": [
     "--config",
     "group_imports=StdExternalCrate,imports_granularity=Crate,imports_layout=HorizontalVertical"
-  ]
+  ],
+  // Uncomment this option to allow rust analyzer to work with simtests.
+  // "rust-analyzer.cargo.extraEnv": {
+  //   "RUSTFLAGS": "--cfg msim",
+  //   "SIMTEST_STATIC_INIT_MOVE": "$root_dir/contracts/walrus"
+  // },
 }


### PR DESCRIPTION
## Description

I often use multiple local repos, and by setting this in user setting doesn't work for me.

Since we are tracking the vscode setting now, adding the rust analyzer simtest option so that we don't need to always look for the option somewhere else.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
