### PR TITLE
Mlegner/v1.26.1 cherry picks

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -30,7 +30,7 @@ env:
   # Don't emit giant backtraces in the CI logs.
   RUST_BACKTRACE: short
   RUSTDOCFLAGS: -D warnings
-  SUI_TAG: testnet-v1.48.0
+  SUI_TAG: testnet-v1.49.1
 
 jobs:
   diff:

--- a/.github/workflows/scheduled_reports.yml
+++ b/.github/workflows/scheduled_reports.yml
@@ -30,7 +30,7 @@ env:
   # Don't emit giant backtraces in the CI logs.
   RUST_BACKTRACE: short
   RUSTDOCFLAGS: -D warnings
-  SUI_TAG: testnet-v1.48.0
+  SUI_TAG: testnet-v1.49.1
 
 jobs:
   test-coverage:

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
       pull-requests: write
     env:
-      SUI_TAG: testnet-v1.48.0
+      SUI_TAG: testnet-v1.49.1
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # pin@v5.6.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,8 +1475,8 @@ dependencies = [
 
 [[package]]
 name = "bin-version"
-version = "1.48.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+version = "1.49.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "const-str 0.5.7",
  "git-version",
@@ -2174,7 +2174,7 @@ dependencies = [
 [[package]]
 name = "consensus-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "fastcrypto",
  "mysten-network",
@@ -2186,7 +2186,7 @@ dependencies = [
 [[package]]
 name = "consensus-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -3228,7 +3228,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -5064,6 +5064,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
+name = "lcov"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ccfa6d5e585a884db65b37f38184e4364eaf74d884ac35d0a90fe9baf80b723"
+dependencies = [
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "leb128"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5531,7 +5540,7 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "move-binary-format",
  "move-bytecode-verifier-meter",
@@ -5540,7 +5549,7 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "move-binary-format",
 ]
@@ -5548,12 +5557,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "enum-compat-util",
@@ -5568,12 +5577,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5589,7 +5598,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "indexmap 2.9.0",
@@ -5602,7 +5611,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -5617,7 +5626,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -5627,7 +5636,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
@@ -5642,7 +5651,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
@@ -5657,7 +5666,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
@@ -5672,7 +5681,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5693,7 +5702,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5728,7 +5737,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5752,7 +5761,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5760,12 +5769,15 @@ dependencies = [
  "codespan",
  "colored",
  "indexmap 2.9.0",
+ "lcov",
  "move-abstract-interpreter",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-command-line-common",
+ "move-compiler",
  "move-core-types",
  "move-ir-types",
+ "move-trace-format",
  "petgraph 0.5.1",
  "serde",
 ]
@@ -5773,7 +5785,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5794,7 +5806,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "clap",
@@ -5817,7 +5829,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -5835,7 +5847,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "hex",
@@ -5848,7 +5860,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -5861,7 +5873,7 @@ dependencies = [
 [[package]]
 name = "move-model-2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5884,7 +5896,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "clap",
@@ -5920,7 +5932,7 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "enum-compat-util",
  "quote",
@@ -5930,7 +5942,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -5945,7 +5957,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v0"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -5960,7 +5972,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v1"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -5975,7 +5987,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v2"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -5990,7 +6002,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "once_cell",
  "phf",
@@ -6000,7 +6012,7 @@ dependencies = [
 [[package]]
 name = "move-trace-format"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -6012,7 +6024,7 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "move-binary-format",
  "once_cell",
@@ -6021,7 +6033,7 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "move-vm-config",
  "once_cell",
@@ -6033,7 +6045,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "better_any",
  "fail",
@@ -6053,7 +6065,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "better_any",
  "fail",
@@ -6072,7 +6084,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "better_any",
  "fail",
@@ -6091,7 +6103,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "better_any",
  "fail",
@@ -6110,7 +6122,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6124,7 +6136,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -6137,7 +6149,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -6150,7 +6162,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -6163,7 +6175,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -6277,7 +6289,7 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 [[package]]
 name = "mysten-common"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "antithesis_sdk",
  "anyhow",
@@ -6299,7 +6311,7 @@ dependencies = [
 [[package]]
 name = "mysten-metrics"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "async-trait",
  "axum 0.8.1",
@@ -6320,7 +6332,7 @@ dependencies = [
 [[package]]
 name = "mysten-network"
 version = "0.2.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -6353,7 +6365,7 @@ dependencies = [
 [[package]]
 name = "mysten-service"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "axum 0.8.1",
@@ -7491,7 +7503,7 @@ dependencies = [
 [[package]]
 name = "prometheus-closure-metric"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -8978,7 +8990,7 @@ dependencies = [
 [[package]]
 name = "shared-crypto"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "bcs",
  "eyre",
@@ -9080,7 +9092,7 @@ dependencies = [
 [[package]]
 name = "simulacrum"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9467,7 +9479,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 [[package]]
 name = "sui-adapter-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9497,7 +9509,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9525,7 +9537,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9552,7 +9564,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9577,34 +9589,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "sui-archival"
-version = "1.48.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
-dependencies = [
- "anyhow",
- "byteorder",
- "bytes",
- "fastcrypto",
- "futures",
- "indicatif",
- "num_enum",
- "object_store",
- "prometheus",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "sui-config",
- "sui-simulator",
- "sui-storage",
- "sui-types",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "sui-authority-aggregation"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "futures",
  "mysten-metrics",
@@ -9616,7 +9603,7 @@ dependencies = [
 [[package]]
 name = "sui-config"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anemo",
  "anyhow",
@@ -9650,7 +9637,7 @@ dependencies = [
 [[package]]
 name = "sui-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anemo",
  "antithesis_sdk",
@@ -9708,7 +9695,6 @@ dependencies = [
  "static_assertions",
  "strum 0.27.1",
  "strum_macros 0.27.1",
- "sui-archival",
  "sui-authority-aggregation",
  "sui-config",
  "sui-execution",
@@ -9738,7 +9724,7 @@ dependencies = [
 [[package]]
 name = "sui-data-ingestion-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9748,6 +9734,7 @@ dependencies = [
  "mysten-metrics",
  "notify",
  "object_store",
+ "once_cell",
  "prometheus",
  "serde",
  "serde_json",
@@ -9766,7 +9753,7 @@ dependencies = [
 [[package]]
 name = "sui-enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -9774,7 +9761,7 @@ dependencies = [
 [[package]]
 name = "sui-execution"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-interpreter-v2",
@@ -9812,16 +9799,16 @@ dependencies = [
 
 [[package]]
 name = "sui-field-count"
-version = "1.48.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+version = "1.49.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "sui-field-count-derive",
 ]
 
 [[package]]
 name = "sui-field-count-derive"
-version = "1.48.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+version = "1.49.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -9830,7 +9817,7 @@ dependencies = [
 [[package]]
 name = "sui-framework"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -9843,8 +9830,8 @@ dependencies = [
 
 [[package]]
 name = "sui-framework-snapshot"
-version = "1.48.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+version = "1.49.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9859,7 +9846,7 @@ dependencies = [
 [[package]]
 name = "sui-genesis-builder"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9887,7 +9874,7 @@ dependencies = [
 [[package]]
 name = "sui-http"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "bytes",
  "http 1.3.1",
@@ -9906,8 +9893,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer"
-version = "1.48.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+version = "1.49.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9945,7 +9932,6 @@ dependencies = [
  "simulacrum",
  "strum 0.27.1",
  "strum_macros 0.27.1",
- "sui-archival",
  "sui-config",
  "sui-core",
  "sui-data-ingestion-core",
@@ -9978,8 +9964,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-framework"
-version = "1.48.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+version = "1.49.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9997,10 +9983,9 @@ dependencies = [
  "scoped-futures",
  "serde",
  "sui-field-count",
+ "sui-indexer-alt-framework-store-traits",
  "sui-indexer-alt-metrics",
- "sui-pg-db",
  "sui-rpc-api",
- "sui-sql-macro",
  "sui-storage",
  "sui-types",
  "tempfile",
@@ -10014,9 +9999,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sui-indexer-alt-framework-store-traits"
+version = "1.49.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "scoped-futures",
+]
+
+[[package]]
 name = "sui-indexer-alt-metrics"
-version = "1.48.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+version = "1.49.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "axum 0.8.1",
@@ -10031,7 +10027,7 @@ dependencies = [
 [[package]]
 name = "sui-json"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "bcs",
@@ -10048,7 +10044,7 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -10106,7 +10102,7 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc-api"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -10126,7 +10122,7 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc-types"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "bcs",
@@ -10158,7 +10154,7 @@ dependencies = [
 [[package]]
 name = "sui-keys"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "bip32",
@@ -10177,7 +10173,7 @@ dependencies = [
 [[package]]
 name = "sui-macros"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "futures",
  "once_cell",
@@ -10188,7 +10184,7 @@ dependencies = [
 [[package]]
 name = "sui-metrics-push-client"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -10205,8 +10201,8 @@ dependencies = [
 
 [[package]]
 name = "sui-move-build"
-version = "1.48.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+version = "1.49.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -10230,7 +10226,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "bcs",
  "better_any",
@@ -10253,7 +10249,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "bcs",
  "better_any",
@@ -10274,7 +10270,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "bcs",
  "better_any",
@@ -10295,7 +10291,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "bcs",
  "better_any",
@@ -10315,8 +10311,8 @@ dependencies = [
 
 [[package]]
 name = "sui-name-service"
-version = "1.48.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+version = "1.49.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "bcs",
  "move-core-types",
@@ -10328,7 +10324,7 @@ dependencies = [
 [[package]]
 name = "sui-network"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -10349,8 +10345,8 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "shared-crypto",
- "sui-archival",
  "sui-config",
+ "sui-data-ingestion-core",
  "sui-macros",
  "sui-protocol-config",
  "sui-simulator",
@@ -10367,8 +10363,8 @@ dependencies = [
 
 [[package]]
 name = "sui-node"
-version = "1.48.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+version = "1.49.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -10395,7 +10391,6 @@ dependencies = [
  "prometheus",
  "reqwest",
  "serde",
- "sui-archival",
  "sui-config",
  "sui-core",
  "sui-http",
@@ -10425,8 +10420,8 @@ dependencies = [
 
 [[package]]
 name = "sui-open-rpc"
-version = "1.48.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+version = "1.49.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "bcs",
  "schemars",
@@ -10438,7 +10433,7 @@ dependencies = [
 [[package]]
 name = "sui-open-rpc-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -10450,8 +10445,8 @@ dependencies = [
 
 [[package]]
 name = "sui-package-management"
-version = "1.48.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+version = "1.49.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -10469,7 +10464,7 @@ dependencies = [
 [[package]]
 name = "sui-package-resolver"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "async-trait",
  "bcs",
@@ -10487,16 +10482,22 @@ dependencies = [
 
 [[package]]
 name = "sui-pg-db"
-version = "1.48.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+version = "1.49.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bb8",
+ "chrono",
  "clap",
  "diesel",
  "diesel-async",
  "diesel_migrations",
  "futures",
+ "scoped-futures",
+ "sui-field-count",
+ "sui-indexer-alt-framework-store-traits",
+ "sui-sql-macro",
  "tempfile",
  "tokio",
  "tracing",
@@ -10506,7 +10507,7 @@ dependencies = [
 [[package]]
 name = "sui-proc-macros"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -10518,7 +10519,7 @@ dependencies = [
 [[package]]
 name = "sui-protocol-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "clap",
  "move-vm-config",
@@ -10533,7 +10534,7 @@ dependencies = [
 [[package]]
 name = "sui-protocol-config-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10543,7 +10544,7 @@ dependencies = [
 [[package]]
 name = "sui-rpc-api"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -10585,8 +10586,8 @@ dependencies = [
 
 [[package]]
 name = "sui-sdk"
-version = "1.48.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+version = "1.49.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10638,7 +10639,7 @@ dependencies = [
 [[package]]
 name = "sui-simulator"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -10662,7 +10663,7 @@ dependencies = [
 [[package]]
 name = "sui-snapshot"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "bcs",
@@ -10690,8 +10691,8 @@ dependencies = [
 
 [[package]]
 name = "sui-sql-macro"
-version = "1.48.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+version = "1.49.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -10701,7 +10702,7 @@ dependencies = [
 [[package]]
 name = "sui-storage"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10751,7 +10752,7 @@ dependencies = [
 [[package]]
 name = "sui-swarm"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "futures",
@@ -10778,7 +10779,7 @@ dependencies = [
 [[package]]
 name = "sui-swarm-config"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anemo",
  "anyhow",
@@ -10805,7 +10806,7 @@ dependencies = [
 [[package]]
 name = "sui-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "reqwest",
  "serde",
@@ -10816,7 +10817,7 @@ dependencies = [
 [[package]]
 name = "sui-test-transaction-builder"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "bcs",
  "move-core-types",
@@ -10830,7 +10831,7 @@ dependencies = [
 [[package]]
 name = "sui-tls"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -10852,7 +10853,7 @@ dependencies = [
 [[package]]
 name = "sui-transaction-builder"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10869,7 +10870,7 @@ dependencies = [
 [[package]]
 name = "sui-transaction-checks"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "fastcrypto-zkp",
  "once_cell",
@@ -10884,7 +10885,7 @@ dependencies = [
 [[package]]
 name = "sui-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anemo",
  "anyhow",
@@ -10912,6 +10913,7 @@ dependencies = [
  "move-core-types",
  "move-vm-profiler",
  "move-vm-test-utils",
+ "mysten-common",
  "mysten-metrics",
  "mysten-network",
  "nonempty",
@@ -10954,7 +10956,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -10970,7 +10972,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -10986,7 +10988,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -11001,7 +11003,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -11113,7 +11115,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "telemetry-subscribers"
 version = "0.2.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -11189,7 +11191,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 [[package]]
 name = "test-cluster"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "anyhow",
  "bcs",
@@ -12092,7 +12094,7 @@ dependencies = [
 [[package]]
 name = "typed-store"
 version = "0.4.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "async-trait",
  "backoff",
@@ -12153,7 +12155,7 @@ dependencies = [
 [[package]]
 name = "typed-store-derive"
 version = "0.3.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -12164,7 +12166,7 @@ dependencies = [
 [[package]]
 name = "typed-store-error"
 version = "0.4.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "serde",
  "thiserror 1.0.69",
@@ -12173,7 +12175,7 @@ dependencies = [
 [[package]]
 name = "typed-store-workspace-hack"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.48.0#1d646f736c8b4fdb8f5a3a35e3a3a1a0d193ff25"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
 dependencies = [
  "cc",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,7 +1931,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "checkpoint-downloader"
-version = "1.26.0"
+version = "1.26.1"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1949,7 +1949,7 @@ dependencies = [
  "tokio",
  "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
- "typed-store 1.26.0",
+ "typed-store 1.26.1",
  "walrus-sui",
  "walrus-utils",
 ]
@@ -12124,7 +12124,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store"
-version = "1.26.0"
+version = "1.26.1"
 dependencies = [
  "async-trait",
  "bcs",
@@ -12515,7 +12515,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-core"
-version = "1.26.0"
+version = "1.26.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -12541,7 +12541,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-e2e-tests"
-version = "1.26.0"
+version = "1.26.1"
 dependencies = [
  "anyhow",
  "futures",
@@ -12572,7 +12572,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-orchestrator"
-version = "1.26.0"
+version = "1.26.1"
 dependencies = [
  "aws-config",
  "aws-runtime",
@@ -12602,7 +12602,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-proc-macros"
-version = "1.26.0"
+version = "1.26.1"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
@@ -12613,7 +12613,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-proxy"
-version = "1.26.0"
+version = "1.26.1"
 dependencies = [
  "anyhow",
  "axum 0.8.1",
@@ -12652,7 +12652,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-sdk"
-version = "1.26.0"
+version = "1.26.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -12692,7 +12692,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-service"
-version = "1.26.0"
+version = "1.26.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12780,7 +12780,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "twox-hash 2.1.0",
- "typed-store 1.26.0",
+ "typed-store 1.26.1",
  "utoipa",
  "utoipa-redoc",
  "uuid",
@@ -12795,7 +12795,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-simtest"
-version = "1.26.0"
+version = "1.26.1"
 dependencies = [
  "anyhow",
  "futures",
@@ -12820,7 +12820,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-storage-node-client"
-version = "1.26.0"
+version = "1.26.1"
 dependencies = [
  "axum 0.8.1",
  "axum-server 0.7.2",
@@ -12858,7 +12858,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-stress"
-version = "1.26.0"
+version = "1.26.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -12883,7 +12883,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-sui"
-version = "1.26.0"
+version = "1.26.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12936,7 +12936,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-test-utils"
-version = "1.26.0"
+version = "1.26.1"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -12946,7 +12946,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-utils"
-version = "1.26.0"
+version = "1.26.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ resolver = "2"
 authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024"
 license = "Apache-2.0"
-version = "1.26.0"
+version = "1.26.1"
 
 [workspace.dependencies]
 anyhow = "1.0.98"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,9 +72,9 @@ jsonwebtoken = "9.3.1"
 md5 = "0.7.0"
 mime = "0.3.17"
 mockall = "0.12.1"
-move-core-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.48.0" }
-move-package = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.48.0" }
-mysten-metrics = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.48.0" }
+move-core-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.49.1" }
+move-package = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.49.1" }
+mysten-metrics = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.49.1" }
 num-bigint = { version = "0.4.5", default-features = false }
 object_store = { version = "0.11.2", features = ["gcp"] }
 once_cell = { version = "1.21.3" }
@@ -104,25 +104,25 @@ serde_with = { version = "3.12", features = ["base64"] }
 serde_yaml = "0.9"
 sha2 = "0.10.9"
 snap = "1.1.0"
-sui-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.48.0" }
-sui-json-rpc-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.48.0" }
-sui-keys = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.48.0" }
-sui-macros = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.48.0" }
-sui-move-build = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.48.0" }
-sui-package-management = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.48.0" }
-sui-package-resolver = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.48.0" }
-sui-protocol-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.48.0" }
-sui-rpc-api = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.48.0" }
-sui-sdk = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.48.0" }
-sui-simulator = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.48.0" }
-sui-storage = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.48.0" }
-sui-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.48.0" }
+sui-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.49.1" }
+sui-json-rpc-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.49.1" }
+sui-keys = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.49.1" }
+sui-macros = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.49.1" }
+sui-move-build = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.49.1" }
+sui-package-management = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.49.1" }
+sui-package-resolver = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.49.1" }
+sui-protocol-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.49.1" }
+sui-rpc-api = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.49.1" }
+sui-sdk = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.49.1" }
+sui-simulator = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.49.1" }
+sui-storage = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.49.1" }
+sui-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.49.1" }
 syn = "2.0"
 tap = "1.0.1"
-telemetry-subscribers = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.48.0" }
+telemetry-subscribers = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.49.1" }
 # TODO (WAL-834): Update to the latest version after sui testnet-v1.50 is used.
 tempfile = "=3.19.0"
-test-cluster = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.48.0" }
+test-cluster = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.49.1" }
 thiserror = "2.0.12"
 tokio = { version = "=1.44.2", features = ["macros", "rt-multi-thread", "signal"] }
 tokio-stream = "0.1.17"

--- a/contracts/subsidies/Move.lock
+++ b/contracts/subsidies/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "C8CDFE3465A9A9D4E9E9181FF2AA73860783105D612DE114A7C7B424B805878F"
+manifest_digest = "FDB57BEED108EE7FC9A42405078A5EE89943E3567ED410E8EC005F588D9F35C9"
 deps_digest = "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -12,11 +12,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.48.0", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.49.1", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.48.0", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.49.1", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },

--- a/contracts/subsidies/Move.toml
+++ b/contracts/subsidies/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.48.0" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.49.1" }
 WAL = { local = "../wal" }
 Walrus = { local = "../walrus" }
 

--- a/contracts/wal/Move.lock
+++ b/contracts/wal/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "730E66FED4B22D8FACFEC1D1BCD6143BAB8647564B8E8B4B92F392266BB67A42"
+manifest_digest = "51CB714557C4E8C9F741CAFF9C078A8BEFF7782BBEBDC46DFF34743EE0F81B20"
 deps_digest = "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -10,11 +10,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.48.0", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.49.1", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.48.0", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.49.1", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },

--- a/contracts/wal/Move.toml
+++ b/contracts/wal/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.48.0" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.49.1" }
 
 [addresses]
 wal = "0x0"

--- a/contracts/wal_exchange/Move.lock
+++ b/contracts/wal_exchange/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "58C5FD87D6D33EF5CEF2FE8BF88C649AAA8F977601F8EDF79EBFF01AD051D9B4"
+manifest_digest = "80A026835683A6C1D4F7E24881BA4748E8519E576E168876CF8148F72AD8C762"
 deps_digest = "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -11,11 +11,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.48.0", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.49.1", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.48.0", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.49.1", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },

--- a/contracts/wal_exchange/Move.toml
+++ b/contracts/wal_exchange/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.48.0" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.49.1" }
 WAL = { local = "../wal" }
 
 [addresses]

--- a/contracts/walrus/Move.lock
+++ b/contracts/walrus/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "34769CAF45FEFC1E78BF228F869EBE37A4B2F048255CF75D8525BF3FF1C0F74D"
+manifest_digest = "BB08DBA0DA9A723E04427642B78C97A7F0921CE453ED0E142EC982B2D2906B48"
 deps_digest = "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -11,11 +11,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.48.0", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.49.1", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.48.0", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.49.1", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },

--- a/contracts/walrus/Move.toml
+++ b/contracts/walrus/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.48.0" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.49.1" }
 WAL = { local = "../wal" }
 
 [addresses]

--- a/crates/walrus-sui/src/config.rs
+++ b/crates/walrus-sui/src/config.rs
@@ -110,7 +110,10 @@ impl WalletConfig {
         let path = path_or_defaults_if_exist(wallet_config.and_then(|c| c.path()), &default_paths)
             .ok_or(anyhow!("could not find a valid wallet config file"))?;
         tracing::info!("using Sui wallet configuration from '{}'", path.display());
-        let mut wallet_context: WalletContext = WalletContext::new(&path, request_timeout, None)?;
+        let mut wallet_context: WalletContext = WalletContext::new(&path)?;
+        if let Some(request_timeout) = request_timeout {
+            wallet_context = wallet_context.with_request_timeout(request_timeout);
+        }
         if let Some(active_env) = wallet_config.and_then(|wallet_config| wallet_config.active_env())
         {
             if !wallet_context

--- a/docker/walrus-antithesis/sui_version.toml
+++ b/docker/walrus-antithesis/sui_version.toml
@@ -1,1 +1,1 @@
-SUI_VERSION = "testnet-v1.48.0"
+SUI_VERSION = "testnet-v1.49.1"


### PR DESCRIPTION
## Description

Contains a version bump to `v1.26.1` and cherry-picks of important PRs for the `v1.26` release:
- #2115 

## Test plan

Automatic tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
