### PR TITLE
ci: remove release branch builds trigger

### DIFF
--- a/.github/workflows/trigger-artifacts-builds.yml
+++ b/.github/workflows/trigger-artifacts-builds.yml
@@ -5,7 +5,6 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - releases/walrus-*-release
       - devnet
       - testnet
       - mainnet


### PR DESCRIPTION
## Description
Since https://github.com/MystenLabs/sui-operations/actions/workflows/walrus-build-artifacts.yml expects to have `devnet`, `testnet`, and `mainnet` branches, so that it can build binaries for all platforms, the `releases/walrus-v1.25.0-release` branch does not make sense, since we re producing binaries `walrus-devnet-latest-windows-x86_64.tgz`

## Test plan
👀 
