### PR TITLE
chore: enable walrus-sdk to be linked by reference in external tools

### DIFF
--- a/crates/walrus-sdk/Cargo.toml
+++ b/crates/walrus-sdk/Cargo.toml
@@ -40,11 +40,11 @@ tokio.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true
 utoipa.workspace = true
-walrus-core.workspace = true
+walrus-core = { workspace = true, features = ["sui-types", "utoipa"] }
 walrus-storage-node-client.workspace = true
 walrus-sui.workspace = true
 walrus-test-utils.workspace = true
-walrus-utils.workspace = true
+walrus-utils = { workspace = true, features = ["log"] }
 
 [lints]
 workspace = true

--- a/crates/walrus-sdk/Cargo.toml
+++ b/crates/walrus-sdk/Cargo.toml
@@ -42,7 +42,7 @@ tracing.workspace = true
 utoipa.workspace = true
 walrus-core = { workspace = true, features = ["sui-types", "utoipa"] }
 walrus-storage-node-client.workspace = true
-walrus-sui.workspace = true
+walrus-sui = { workspace = true, features = ["utoipa"] }
 walrus-test-utils.workspace = true
 walrus-utils = { workspace = true, features = ["log"] }
 

--- a/crates/walrus-sdk/src/lib.rs
+++ b/crates/walrus-sdk/src/lib.rs
@@ -13,6 +13,7 @@ pub mod store_when;
 pub mod utils;
 
 pub use sui_types::event::EventID;
+pub use walrus_core as core;
 pub use walrus_sui as sui;
 
 /// Format the event ID as the transaction digest and the sequence number.

--- a/crates/walrus-sdk/src/lib.rs
+++ b/crates/walrus-sdk/src/lib.rs
@@ -12,7 +12,7 @@ pub mod store_when;
 /// Utilities for the Walrus SDK.
 pub mod utils;
 
-pub use sui_types::event::EventID;
+pub use sui_types::{base_types::ObjectID, event::EventID};
 pub use walrus_core as core;
 pub use walrus_sui as sui;
 

--- a/crates/walrus-sdk/src/lib.rs
+++ b/crates/walrus-sdk/src/lib.rs
@@ -9,12 +9,12 @@ pub mod client;
 pub mod config;
 pub mod error;
 pub mod store_when;
-/// Utilities for the Walrus SDK.
 pub mod utils;
 
 pub use sui_types::{base_types::ObjectID, event::EventID};
 pub use walrus_core as core;
 pub use walrus_sui as sui;
+pub use walrus_utils as core_utils;
 
 /// Format the event ID as the transaction digest and the sequence number.
 pub fn format_event_id(event_id: &EventID) -> String {

--- a/crates/walrus-sdk/src/utils.rs
+++ b/crates/walrus-sdk/src/utils.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+//! Utilities for the Walrus SDK.
 use std::{
     collections::HashMap,
     fmt::{self, Debug, Display},

--- a/crates/walrus-sui/Cargo.toml
+++ b/crates/walrus-sui/Cargo.toml
@@ -58,7 +58,7 @@ tracing.workspace = true
 url.workspace = true
 utoipa = { workspace = true, optional = true }
 walkdir = "2.5.0"
-walrus-core = { workspace = true, features = ["sui-types"] }
+walrus-core = { workspace = true, features = ["sui-types", "utoipa"] }
 walrus-test-utils = { workspace = true, optional = true }
 walrus-utils = { workspace = true, features = ["backoff", "config", "metrics"] }
 
@@ -67,7 +67,7 @@ clap.workspace = true
 indoc.workspace = true
 serde_yaml.workspace = true
 tracing-subscriber.workspace = true
-walrus-core = { workspace = true, features = ["sui-types", "test-utils"] }
+walrus-core = { workspace = true, features = ["sui-types", "test-utils", "utoipa"] }
 
 [build-dependencies]
 inflections = "1.1.1"


### PR DESCRIPTION
## Description

Fix the dependency tree so that walrus_sdk crate should be usable by external tools without requiring importing transitive dependencies.

## Test plan

Local build of external tool.
