### PR TITLE
refactor: bump Rust version to 1.87 and reduce size of some types

### DIFF
--- a/contracts/subsidies/Move.lock
+++ b/contracts/subsidies/Move.lock
@@ -40,7 +40,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.48.1"
+compiler-version = "1.49.1"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/contracts/wal/Move.lock
+++ b/contracts/wal/Move.lock
@@ -21,7 +21,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.48.1"
+compiler-version = "1.49.1"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/contracts/wal_exchange/Move.lock
+++ b/contracts/wal_exchange/Move.lock
@@ -30,6 +30,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.48.1"
+compiler-version = "1.49.1"
 edition = "2024.beta"
 flavor = "sui"

--- a/contracts/walrus/Move.lock
+++ b/contracts/walrus/Move.lock
@@ -30,7 +30,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.48.1"
+compiler-version = "1.49.1"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/crates/walrus-sdk/src/client/client_types.rs
+++ b/crates/walrus-sdk/src/client/client_types.rs
@@ -137,7 +137,9 @@ pub trait WalrusStoreBlobApi<'a, T: Debug + Clone + Send + Sync> {
 }
 
 /// A blob that is being stored in Walrus, representing its current phase in the lifecycle.
-/// TODO(WAL-755): Use a enum to represent the result of each transition.
+// TODO(WAL-755): Use a enum to represent the result of each transition.
+// TODO(WAL-755): Remove the clippy exception during the refactoring.
+#[allow(clippy::large_enum_variant)]
 #[enum_dispatch(WalrusStoreBlobApi<T>)]
 #[derive(Clone, Debug)]
 pub enum WalrusStoreBlob<'a, T: Debug + Clone + Send + Sync> {

--- a/crates/walrus-service/src/client/multiplexer.rs
+++ b/crates/walrus-service/src/client/multiplexer.rs
@@ -268,13 +268,10 @@ impl WriteClientPool {
     pub async fn next_client(&self) -> Arc<Client<SuiContractClient>> {
         let cur_idx = self.cur_idx.fetch_add(1, Ordering::Relaxed) % self.pool.len();
 
-        let client = self
-            .pool
+        self.pool
             .get(cur_idx)
             .expect("the index is computed modulo the length and clients cannot be removed")
-            .clone();
-
-        client
+            .clone()
     }
 }
 

--- a/crates/walrus-service/src/node/committee/test_committee_service.rs
+++ b/crates/walrus-service/src/node/committee/test_committee_service.rs
@@ -604,7 +604,7 @@ async fn restarts_inconsistency_proof_collection_across_epoch_change() -> TestRe
             let attestation = node::sign_message(message, arbitrary_key_pair).await?;
 
             service_map.insert_ready(node.public_key.clone(), move |_request| {
-                Ok(Response::InvalidBlobAttestation(attestation.clone()))
+                Ok(attestation.clone().into())
             });
         }
     }
@@ -669,7 +669,7 @@ async fn collects_inconsistency_proof_despite_epoch_change() -> TestResult {
             let attestation = node::sign_message(message, arbitrary_key_pair).await?;
 
             service_map.insert_ready(node.public_key.clone(), move |_request| {
-                Ok(Response::InvalidBlobAttestation(attestation.clone()))
+                Ok(attestation.clone().into())
             });
         }
     }

--- a/crates/walrus-sui/src/config.rs
+++ b/crates/walrus-sui/src/config.rs
@@ -137,8 +137,7 @@ impl WalletConfig {
                 .config
                 .keystore
                 .addresses()
-                .iter()
-                .any(|address| *address == active_address)
+                .contains(&active_address)
             {
                 return Err(anyhow!(
                     "Address '{}' not found in wallet keystore for file '{}'.",

--- a/crates/walrus-sui/src/test_utils.rs
+++ b/crates/walrus-sui/src/test_utils.rs
@@ -96,6 +96,8 @@ pub fn object_id_for_testing() -> ObjectID {
 }
 
 /// Represents a test cluster running within this process or as a separate process.
+// Allowing a large enum variant as this is anyway just used in tests.
+#[allow(clippy::large_enum_variant)]
 pub enum LocalOrExternalTestCluster {
     /// A test cluster running within this process.
     Local {

--- a/docker/walrus-antithesis/build-walrus-image-for-antithesis/Dockerfile
+++ b/docker/walrus-antithesis/build-walrus-image-for-antithesis/Dockerfile
@@ -8,7 +8,7 @@
 
 # Stage 1: Base Build Environment + Builder
 # -------------------------------------
-FROM rust:1.86-bookworm AS builder
+FROM rust:1.87-bookworm AS builder
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION
 WORKDIR "$WORKDIR/walrus"

--- a/docker/walrus-orchestrator/Dockerfile
+++ b/docker/walrus-orchestrator/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.86-bookworm AS builder
+FROM rust:1.87-bookworm AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/docker/walrus-proxy/Dockerfile
+++ b/docker/walrus-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.86-bookworm as builder
+FROM rust:1.87-bookworm as builder
 
 ARG PROFILE=release
 WORKDIR /work

--- a/docker/walrus-service/Dockerfile
+++ b/docker/walrus-service/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.86-bookworm AS builder
+FROM rust:1.87-bookworm AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/docker/walrus-service/Dockerfile.walrus-backup
+++ b/docker/walrus-service/Dockerfile.walrus-backup
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.86-bookworm AS builder
+FROM rust:1.87-bookworm AS builder
 ARG PROFILE=release
 ARG RUST_LOG=info,walrus_service::common::event_blob_downloader=warn
 ARG GIT_REVISION

--- a/docker/walrus-stress/Dockerfile
+++ b/docker/walrus-stress/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.86-bookworm AS builder
+FROM rust:1.87-bookworm AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.86"
+channel = "1.87"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Description

Clippy emitted a few new warnings [`result_large_err`](https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err) and [`large_enum_variant`](https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant) and suggested boxing some of the large variants/types.

This commit wraps some large (and rarely used) enum variants and error fields in a `Box` to avoid the memory overhead on the stack:
- `walrus_sdk::error::ClientError::kind`
- `walrus_service::node::committee::node_service::Response::InvalidBlobAttestation`
- `walrus_sui::client::SuiClientError::SuiError`

Two other instances of this lint warning are (temporarily) ignored. The commit also changes some instances of `.iter().any()` to the more efficient `contains()`.

## Test plan

Existing test suite.