### PR TITLE
chore: add github action to create transactions for multisig

### DIFF
--- a/.github/workflows/create-tx-for-multisig.yml
+++ b/.github/workflows/create-tx-for-multisig.yml
@@ -61,7 +61,7 @@ jobs:
           cat artifacts/tx-data.txt
 
       - name: Upload Transaction Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # pin@v4
         with:
           name: transaction-data
           path: artifacts/tx-data.txt

--- a/.github/workflows/create-tx-for-multisig.yml
+++ b/.github/workflows/create-tx-for-multisig.yml
@@ -1,0 +1,67 @@
+name: Build TX for Multisig Operation
+
+on:
+  workflow_dispatch:
+    inputs:
+      transaction_type:
+        description: "select transaction type to create"
+        type: choice
+        options:
+          - upgrade-subsidies
+          - migrate-subsidies
+      rpc:
+        description: "RPC url"
+        required: true
+        default: "https://fullnode.mainnet.sui.io:443"
+        type: string
+      gas_object_id:
+        description: "object id to get gas from for multisig transaction"
+        required: false
+        type: string
+      commit:
+        description: "commit hash of the walrus repo to create the transaction"
+        required: true
+        type: string
+
+jobs:
+  create-tx:
+    name: Create TX for multisig
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Selected transaction type
+        run: |
+          echo ${{ inputs.transaction_type }}
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          ref: ${{ inputs.commit }}
+
+      - name: Install Homebrew
+        run: |
+          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+          echo "/home/linuxbrew/.linuxbrew/bin" >> $GITHUB_PATH
+
+      - name: Install Sui using Homebrew
+        run: brew install sui
+
+      - name: Setup sui client config
+        run: |
+          sui client --yes new-env --rpc ${{ inputs.rpc }} --alias mainnet
+          sui client switch --env mainnet
+
+      - name: Create unsigned transaction for multisig
+        run: |
+          mkdir -p artifacts
+          ./scripts/create_multisig_tx.sh -t '${{ inputs.transaction_type }}' -g '${{ inputs.gas_object_id }}' >artifacts/tx-data.txt
+
+      - name: Show Transaction Data (To sign)
+        run: |
+          cat artifacts/tx-data.txt
+
+      - name: Upload Transaction Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: transaction-data
+          path: artifacts/tx-data.txt

--- a/.github/workflows/create-tx-for-multisig.yml
+++ b/.github/workflows/create-tx-for-multisig.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           echo ${{ inputs.transaction_type }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
         with:
           fetch-depth: 1
           ref: ${{ inputs.commit }}

--- a/scripts/create_multisig_tx.sh
+++ b/scripts/create_multisig_tx.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # Copyright (c) Walrus Foundation
 # SPDX-License-Identifier: Apache-2.0
+# This script allows creating unsigned transactions for operations that need to be signed
+# by a Walrus multisig address.
+# Intended to be used using the github workflow defined in
+# `../.github/workflows/create-tx-for-multisig.yml`
 
 GAS_OBJECT_ID=""
 TX_TYPE=""
@@ -83,7 +87,11 @@ case "$TX_TYPE" in
   migrate-subsidies)
     migrate_subsidies
     ;;
+  "")
+    echo "Error: The transaction type must be specified" >&2
+    exit 1
+    ;;
   *)
-    echo "Invalid transaction type \"$TX_TYPE\"" >&2
+    echo "Error: Invalid transaction type \"$TX_TYPE\"" >&2
     exit 1
 esac

--- a/scripts/create_multisig_tx.sh
+++ b/scripts/create_multisig_tx.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Copyright (c) Walrus Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+GAS_OBJECT_ID=""
+TX_TYPE=""
+
+# Addresses
+WALRUS_ADMIN="0x62a69ba94e191634841cc4d196e70ec3e4667fc78013ae6d7405a0c593b39f1e"
+WALRUS_OPS="0x23eb7ccbbb4a21afea8b1256475e255b3cd84083ca79fa1f1a9435ab93d2b71b"
+
+# Object IDs
+SUBSIDIES_ADMIN_CAP="0x7cd09be8545e524217e6f35e5c306b64e3545594879dc2590e024f42bce439c6"
+SUBSIDIES_UPGRADE_CAP="0x632e10712d32b0851a1109d5a7f09680d11c74ffa5ba50eef7f14d85385cb615"
+
+
+usage() {
+  echo "Usage: $0 [OPTIONS]"
+  echo "OPTIONS:"
+  echo "  -t <tx_type> Transaction type, mandatory ('upgrade-subsidies', 'migrate-subsidies')"
+  echo "  -g <obj_id>  Gas object ID, defaults to gas object with highest balance"
+}
+
+gas_obj_for_addr() {
+  ADDRESS=$1
+  if [[ -z $GAS_OBJECT_ID ]]
+  then
+    sui client gas $ADDRESS  --json | jq -r 'max_by(.mistBalance) | .gasCoinId'
+  else
+    echo $GAS_OBJECT_ID
+  fi
+}
+
+upgrade_subsidies() {
+  GAS=$(gas_obj_for_addr $WALRUS_ADMIN)
+  GAS_BUDGET=$(sui client object $GAS --json | jq -r '.content.fields.balance')
+  CONTRACT_DIR=mainnet-contracts/subsidies
+  sui client \
+    upgrade \
+    --gas $GAS \
+    --gas-budget $GAS_BUDGET \
+    --upgrade-capability $SUBSIDIES_UPGRADE_CAP \
+    $CONTRACT_DIR \
+    --serialize-unsigned-transaction
+}
+
+migrate_subsidies() {
+  GAS=$(gas_obj_for_addr $WALRUS_OPS)
+  GAS_BUDGET=$(sui client object $GAS --json | jq -r '.content.fields.balance')
+  SUBSIDIES_PACKAGE=$(sui client object $SUBSIDIES_UPGRADE_CAP --json | jq -r '.content.fields.package')
+  SUBSIDIES_OBJECT=$(sui client object $SUBSIDIES_ADMIN_CAP --json | jq -r '.content.fields.subsidies_id' )
+  sui client \
+    ptb \
+    --gas-coin @$GAS \
+    --gas-budget $GAS_BUDGET \
+    --move-call $SUBSIDIES_PACKAGE::subsidies::migrate \
+    @$SUBSIDIES_OBJECT @$SUBSIDIES_ADMIN_CAP @$SUBSIDIES_PACKAGE \
+    --serialize-unsigned-transaction
+}
+
+while getopts "t:g:h" arg; do
+  case "${arg}" in
+    t)
+      TX_TYPE=${OPTARG}
+      ;;
+    g)
+      GAS_OBJECT_ID=${OPTARG}
+      ;;
+    h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+  esac
+done
+
+case "$TX_TYPE" in
+  upgrade-subsidies)
+    upgrade_subsidies
+    ;;
+  migrate-subsidies)
+    migrate_subsidies
+    ;;
+  *)
+    echo "Invalid transaction type \"$TX_TYPE\"" >&2
+    exit 1
+esac


### PR DESCRIPTION
## Description

Adds a github action to create unsigned transactions for the walrus multisigs to upgrade/migrate the subsidies contract/object.

Contributes to WAL-675

## Test plan

- Manually ran script
- tested action locally with `act` (except for the uploading of the artifact)

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
