### PR TITLE
feat: update commands for contract upgrades

### DIFF
--- a/crates/walrus-service/bin/deploy.rs
+++ b/crates/walrus-service/bin/deploy.rs
@@ -13,7 +13,7 @@ use std::{
 
 use anyhow::Context;
 use clap::{Parser, Subcommand};
-use sui_types::base_types::ObjectID;
+use sui_types::base_types::{ObjectID, SuiAddress};
 use walrus_core::EpochCount;
 use walrus_service::{
     node::config::{
@@ -55,6 +55,8 @@ enum Commands {
     /// Upgrades the system contract with a quorum-based upgrade that has been voted for by
     /// a quorum of storage nodes by shard weight.
     Upgrade(UpgradeArgs),
+    /// Migrates the system and staking objects to a new package version.
+    Migrate(MigrateArgs),
 }
 
 #[derive(Debug, Clone, clap::Args)]
@@ -249,6 +251,34 @@ struct UpgradeArgs {
     /// The upgrade manager object ID.
     #[arg(long)]
     upgrade_manager_object_id: ObjectID,
+    /// Create and output a serialized unsigned transaction. Useful for an emergency upgrade
+    /// authorized by a multisig address.
+    #[arg(long)]
+    serialize_unsigned: bool,
+    /// The sender address to use to create the serialized unsigned transaction. If not specified,
+    /// the active address from the wallet is used.
+    #[arg(long, requires = "serialize_unsigned")]
+    sender: Option<SuiAddress>,
+    /// Also migrate the system and staking objects after upgrading the contract.
+    #[arg(long, conflicts_with = "serialize_unsigned")]
+    migrate: bool,
+}
+
+#[derive(Debug, Clone, clap::Args)]
+struct MigrateArgs {
+    /// The path to the wallet used to perform the upgrade. If not provided, the default
+    /// wallet path is used.
+    #[arg(long)]
+    wallet_path: Option<PathBuf>,
+    /// The staking object ID.
+    #[arg(long)]
+    staking_object_id: ObjectID,
+    /// The system object ID.
+    #[arg(long)]
+    system_object_id: ObjectID,
+    /// The package ID of the upgraded package.
+    #[arg(long)]
+    new_package_id: ObjectID,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -260,16 +290,18 @@ fn main() -> anyhow::Result<()> {
         Commands::GenerateDryRunConfigs(args) => commands::generate_dry_run_configs(args)?,
         Commands::EmergencyUpgrade(args) => commands::upgrade(args, UpgradeType::Emergency)?,
         Commands::Upgrade(args) => commands::upgrade(args, UpgradeType::Quorum)?,
+        Commands::Migrate(args) => commands::migrate(args)?,
     }
     Ok(())
 }
 
 mod commands {
     use config::NodeRegistrationParamsForThirdPartyRegistration;
+    use fastcrypto::encoding::Encoding;
     use itertools::Itertools as _;
     use testbed::ADMIN_CONFIG_PREFIX;
     use walrus_service::{
-        client::cli::HumanReadableFrost,
+        client::cli::{HumanReadableFrost, success},
         testbed::{
             DeployTestbedContractParameters,
             TestbedConfig,
@@ -281,8 +313,14 @@ mod commands {
         utils,
     };
     use walrus_sui::{
-        client::{SuiContractClient, UpgradeType, contract_config::ContractConfig},
+        client::{
+            SuiContractClient,
+            UpgradeType,
+            contract_config::ContractConfig,
+            transaction_builder::WalrusPtbBuilder,
+        },
         config::load_wallet_context_from_path,
+        system_setup::compile_package,
     };
     use walrus_utils::{backoff::ExponentialBackoffConfig, load_from_yaml};
 
@@ -322,7 +360,9 @@ mod commands {
             .await?;
         let node_ids = node_caps.iter().map(|cap| cap.node_id).collect::<Vec<_>>();
         println!(
-            "Successfully registered {count} storage nodes:\n{}",
+            "{} Registered {} storage nodes:\n{}",
+            success(),
+            count,
             node_ids.iter().map(|id| id.to_string()).join(", ")
         );
 
@@ -341,7 +381,8 @@ mod commands {
             .context("staking with newly registered nodes failed")?;
 
         println!(
-            "Successfully staked {} with each newly registered node (total: {}).",
+            "{} Staked {} with each newly registered node (total: {}).",
+            success(),
             HumanReadableFrost::from(stake_amount),
             HumanReadableFrost::from(
                 stake_amount * u64::try_from(count).expect("definitely fits into a u64")
@@ -562,6 +603,9 @@ mod commands {
             staking_object_id,
             system_object_id,
             upgrade_manager_object_id,
+            sender,
+            serialize_unsigned,
+            migrate,
         }: UpgradeArgs,
         upgrade_type: UpgradeType,
     ) -> anyhow::Result<()> {
@@ -576,13 +620,77 @@ mod commands {
         let contract_client =
             SuiContractClient::new(wallet, rpc_urls, &contract_config, Default::default(), None)
                 .await?;
+        if serialize_unsigned {
+            // Compile package
+            let chain_id = contract_client
+                .sui_client()
+                .get_chain_identifier()
+                .await
+                .ok();
+            let (compiled_package, _build_config) =
+                compile_package(contract_dir, Default::default(), chain_id).await?;
 
-        let new_package_id = contract_client
-            .upgrade(upgrade_manager_object_id, contract_dir, upgrade_type)
-            .await?;
+            let sender = sender.unwrap_or(contract_client.address());
+            let mut pt_builder = WalrusPtbBuilder::new(contract_client.read_client, sender);
+
+            pt_builder
+                .custom_walrus_upgrade(upgrade_manager_object_id, compiled_package, upgrade_type)
+                .await?;
+
+            let tx_data = pt_builder.build_transaction_data(None).await?;
+            println!(
+                "{}",
+                fastcrypto::encoding::Base64::encode(bcs::to_bytes(&tx_data)?)
+            );
+        } else {
+            let new_package_id = contract_client
+                .upgrade(upgrade_manager_object_id, contract_dir, upgrade_type)
+                .await?;
+            println!(
+                "{} Upgraded the system contract:\npackage_id: {}",
+                success(),
+                new_package_id
+            );
+            if migrate {
+                contract_client.migrate_contracts(new_package_id).await?;
+                println!(
+                    "{} Migrated the shared objects to package_id: {}",
+                    success(),
+                    new_package_id
+                );
+            }
+        }
+        Ok(())
+    }
+
+    #[tokio::main]
+    pub(super) async fn migrate(
+        MigrateArgs {
+            wallet_path,
+            staking_object_id,
+            system_object_id,
+            new_package_id,
+        }: MigrateArgs,
+    ) -> anyhow::Result<()> {
+        utils::init_tracing_subscriber()?;
+
+        let wallet =
+            load_wallet_context_from_path(wallet_path, None).context("unable to load wallet")?;
+        let contract_config = ContractConfig::new(system_object_id, staking_object_id);
+
+        #[allow(deprecated)]
+        let rpc_urls = &[wallet.get_rpc_url()?];
+
+        let contract_client =
+            SuiContractClient::new(wallet, rpc_urls, &contract_config, Default::default(), None)
+                .await?;
 
         contract_client.migrate_contracts(new_package_id).await?;
-        println!("Successfully upgraded the system contract:\npackage_id: {new_package_id}");
+        println!(
+            "{} Migrated the shared objects to package_id: {}",
+            success(),
+            new_package_id
+        );
         Ok(())
     }
 

--- a/crates/walrus-service/bin/deploy.rs
+++ b/crates/walrus-service/bin/deploy.rs
@@ -678,7 +678,6 @@ mod commands {
             load_wallet_context_from_path(wallet_path, None).context("unable to load wallet")?;
         let contract_config = ContractConfig::new(system_object_id, staking_object_id);
 
-        #[allow(deprecated)]
         let rpc_urls = &[wallet.get_rpc_url()?];
 
         let contract_client =

--- a/crates/walrus-service/src/client/cli/args.rs
+++ b/crates/walrus-service/src/client/cli/args.rs
@@ -617,6 +617,12 @@ pub enum NodeAdminCommands {
         /// The object or address to set as authorized entity.
         object_or_address: ObjectOrAddress,
     },
+    /// Outputs the package digest of a sui package.
+    PackageDigest {
+        /// The path to the package directory.
+        #[arg(long)]
+        package_path: PathBuf,
+    },
 }
 
 #[derive(Debug, Clone, Args, Deserialize, PartialEq, Eq)]

--- a/crates/walrus-service/src/client/cli/args.rs
+++ b/crates/walrus-service/src/client/cli/args.rs
@@ -549,9 +549,6 @@ pub enum CliCommands {
     },
     /// Administration subcommands for storage node operators.
     NodeAdmin {
-        #[arg(long, global = true, required = false)]
-        /// The ID of the node for which the operation should be performed.
-        node_id: ObjectID,
         /// The specific node admin command to run.
         #[command(subcommand)]
         command: NodeAdminCommands,
@@ -595,9 +592,16 @@ pub enum InfoCommands {
 #[serde(rename_all = "camelCase", rename_all_fields = "camelCase")]
 pub enum NodeAdminCommands {
     /// Collect the commission.
-    CollectCommission,
+    CollectCommission {
+        #[arg(long)]
+        /// The ID of the node for which the operation should be performed.
+        node_id: ObjectID,
+    },
     /// Vote for a contract upgrade.
     VoteForUpgrade {
+        #[arg(long)]
+        /// The ID of the node for which the operation should be performed.
+        node_id: ObjectID,
         /// The upgrade manager object ID.
         #[arg(long)]
         upgrade_manager_object_id: ObjectID,
@@ -607,12 +611,18 @@ pub enum NodeAdminCommands {
     },
     /// Set the authorized entity for governance operations.
     SetGovernanceAuthorized {
+        #[arg(long)]
+        /// The ID of the node for which the operation should be performed.
+        node_id: ObjectID,
         #[command(flatten)]
         /// The object or address to set as authorized entity.
         object_or_address: ObjectOrAddress,
     },
     /// Set the authorized entity for commission operations.
     SetCommissionAuthorized {
+        #[arg(long)]
+        /// The ID of the node for which the operation should be performed.
+        node_id: ObjectID,
         #[command(flatten)]
         /// The object or address to set as authorized entity.
         object_or_address: ObjectOrAddress,

--- a/crates/walrus-service/src/client/cli/runner.rs
+++ b/crates/walrus-service/src/client/cli/runner.rs
@@ -14,6 +14,7 @@ use std::{
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
+use fastcrypto::encoding::Encoding;
 use indicatif::MultiProgress;
 use itertools::Itertools as _;
 use rand::seq::SliceRandom;
@@ -1136,10 +1137,11 @@ impl ClientCommandRunner {
                     .compute_package_digest(package_path.clone())
                     .await?;
                 println!(
-                    "{} Digest for package '{}': 0x{}",
+                    "{} Digest for package '{}':\n  Hex: 0x{}\n  Base64: {}",
                     success(),
                     package_path.display(),
-                    digest.iter().map(|b| format!("{:02x}", b)).join("")
+                    digest.iter().map(|b| format!("{:02x}", b)).join(""),
+                    fastcrypto::encoding::Base64::encode(digest)
                 );
             }
         }

--- a/crates/walrus-service/src/client/cli/runner.rs
+++ b/crates/walrus-service/src/client/cli/runner.rs
@@ -418,9 +418,7 @@ impl ClientCommandRunner {
                 Ok(())
             }
 
-            CliCommands::NodeAdmin { node_id, command } => {
-                self.run_admin_command(node_id, command).await
-            }
+            CliCommands::NodeAdmin { command } => self.run_admin_command(command).await,
         }
     }
 
@@ -1079,17 +1077,14 @@ impl ClientCommandRunner {
         Ok(())
     }
 
-    pub(crate) async fn run_admin_command(
-        self,
-        node_id: ObjectID,
-        command: NodeAdminCommands,
-    ) -> Result<()> {
+    pub(crate) async fn run_admin_command(self, command: NodeAdminCommands) -> Result<()> {
         let sui_client = self
             .config?
             .new_contract_client(self.wallet?, self.gas_budget)
             .await?;
         match command {
             NodeAdminCommands::VoteForUpgrade {
+                node_id,
                 upgrade_manager_object_id,
                 package_path,
             } => {
@@ -1102,7 +1097,10 @@ impl ClientCommandRunner {
                     digest.iter().map(|b| format!("{:02x}", b)).join("")
                 );
             }
-            NodeAdminCommands::SetCommissionAuthorized { object_or_address } => {
+            NodeAdminCommands::SetCommissionAuthorized {
+                node_id,
+                object_or_address,
+            } => {
                 let authorized: Authorized = object_or_address.try_into()?;
                 sui_client
                     .set_commission_receiver(node_id, authorized.clone())
@@ -1114,7 +1112,10 @@ impl ClientCommandRunner {
                     authorized
                 );
             }
-            NodeAdminCommands::SetGovernanceAuthorized { object_or_address } => {
+            NodeAdminCommands::SetGovernanceAuthorized {
+                node_id,
+                object_or_address,
+            } => {
                 let authorized: Authorized = object_or_address.try_into()?;
                 sui_client
                     .set_governance_authorized(node_id, authorized.clone())
@@ -1126,7 +1127,7 @@ impl ClientCommandRunner {
                     authorized
                 );
             }
-            NodeAdminCommands::CollectCommission => {
+            NodeAdminCommands::CollectCommission { node_id } => {
                 let amount =
                     HumanReadableFrost::from(sui_client.collect_commission(node_id).await?);
                 println!("{} Collected {} as commission", success(), amount);

--- a/crates/walrus-service/src/client/cli/runner.rs
+++ b/crates/walrus-service/src/client/cli/runner.rs
@@ -1130,6 +1130,18 @@ impl ClientCommandRunner {
                     HumanReadableFrost::from(sui_client.collect_commission(node_id).await?);
                 println!("{} Collected {} as commission", success(), amount);
             }
+            NodeAdminCommands::PackageDigest { package_path } => {
+                let digest = sui_client
+                    .read_client()
+                    .compute_package_digest(package_path.clone())
+                    .await?;
+                println!(
+                    "{} Digest for package '{}': 0x{}",
+                    success(),
+                    package_path.display(),
+                    digest.iter().map(|b| format!("{:02x}", b)).join("")
+                );
+            }
         }
         Ok(())
     }

--- a/crates/walrus-sui/src/client/transaction_builder.rs
+++ b/crates/walrus-sui/src/client/transaction_builder.rs
@@ -12,6 +12,7 @@ use std::{
 };
 
 use fastcrypto::traits::ToFromBytes;
+use sui_move_build::CompiledPackage;
 use sui_sdk::rpc_types::SuiObjectDataOptions;
 use sui_types::{
     Identifier,
@@ -19,7 +20,14 @@ use sui_types::{
     SUI_CLOCK_OBJECT_SHARED_VERSION,
     base_types::{ObjectID, ObjectType, SuiAddress},
     programmable_transaction_builder::ProgrammableTransactionBuilder,
-    transaction::{Argument, Command, ObjectArg, ProgrammableTransaction},
+    transaction::{
+        Argument,
+        Command,
+        ObjectArg,
+        ProgrammableTransaction,
+        TransactionData,
+        TransactionKind,
+    },
 };
 use tokio::sync::OnceCell;
 use tracing::instrument;
@@ -40,6 +48,7 @@ use super::{
     SuiClientError,
     SuiClientResult,
     SuiReadClient,
+    UpgradeType,
     read_client::Mutability,
 };
 use crate::{
@@ -50,7 +59,7 @@ use crate::{
         NodeUpdateParams,
         SystemObject,
         UpdatePublicKeyParams,
-        move_structs::{Authorized, BlobAttribute, NodeMetadata, WalExchange},
+        move_structs::{Authorized, BlobAttribute, EmergencyUpgradeCap, NodeMetadata, WalExchange},
     },
     utils::{price_for_encoded_length, write_price_for_encoded_length},
 };
@@ -1345,26 +1354,8 @@ impl WalrusPtbBuilder {
         self.walrus_move_call(contracts::upgrade::authorize_emergency_upgrade, args)
     }
 
-    /// Performs a contract upgrade.
-    ///
-    /// Returns the `UpgradeReceipt` as result argument.
-    pub fn upgrade(
-        &mut self,
-        current_package_object_id: ObjectID,
-        upgrade_ticket: Argument,
-        transitive_deps: Vec<ObjectID>,
-        modules: Vec<Vec<u8>>,
-    ) -> Argument {
-        self.pt_builder.upgrade(
-            current_package_object_id,
-            upgrade_ticket,
-            transitive_deps,
-            modules,
-        )
-    }
-
     /// Commits a contract upgrade.
-    pub async fn commit_upgrade(
+    pub(crate) async fn commit_upgrade(
         &mut self,
         upgrade_manager: ObjectID,
         upgrade_receipt: Argument,
@@ -1383,6 +1374,54 @@ impl WalrusPtbBuilder {
         Ok(())
     }
 
+    /// Builds a transaction to upgrade the walrus contract using the custom upgrade policy.
+    ///
+    /// This includes the authorization, the upgrade itself, and committing the upgrade.
+    pub async fn custom_walrus_upgrade(
+        &mut self,
+        upgrade_manager: ObjectID,
+        compiled_package: CompiledPackage,
+        upgrade_type: UpgradeType,
+    ) -> SuiClientResult<()> {
+        let digest = compiled_package.get_package_digest(false);
+
+        let upgrade_ticket_arg = if upgrade_type.is_emergency_upgrade() {
+            let emergency_upgrade_cap: EmergencyUpgradeCap = self
+                .read_client
+                .get_owned_objects(self.sender_address, &[])
+                .await?
+                .next()
+                .ok_or_else(|| anyhow::anyhow!("no emergency upgrade capability found"))?;
+
+            // Authorize the upgrade.
+            self.authorize_emergency_upgrade(
+                upgrade_manager,
+                emergency_upgrade_cap.id.into(),
+                &digest,
+            )
+            .await?
+        } else {
+            self.authorize_upgrade(upgrade_manager, &digest).await?
+        };
+
+        // Execute the upgrade.
+        let modules = compiled_package.get_package_bytes(false);
+        let upgrade_receipt_arg = self.pt_builder.upgrade(
+            self.read_client.get_system_package_id(),
+            upgrade_ticket_arg,
+            compiled_package
+                .dependency_ids // TODO: do we need the dependencies as returned by `compile`?
+                .published
+                .into_values()
+                .collect(),
+            modules,
+        );
+
+        // Commit the upgrade
+        self.commit_upgrade(upgrade_manager, upgrade_receipt_arg)
+            .await
+    }
+
     /// Migrates the staking and system contracts to the new package id.
     pub async fn migrate_contracts(&mut self, new_package_id: ObjectID) -> SuiClientResult<()> {
         let args = vec![
@@ -1392,12 +1431,65 @@ impl WalrusPtbBuilder {
         self.move_call(new_package_id, contracts::init::migrate, args)?;
         Ok(())
     }
+
     /// Transfers all remaining outputs and returns the PTB and the SUI balance needed in addition
     /// to the gas cost that needs to be covered by the gas coin.
+    #[deprecated = "use [`Self::build_transaction_data`] instead"]
     pub async fn finish(mut self) -> SuiClientResult<(ProgrammableTransaction, u64)> {
         self.transfer_remaining_outputs(None).await?;
         let sui_cost = self.tx_sui_cost;
         Ok((self.pt_builder.finish(), sui_cost))
+    }
+
+    /// Transfers all remaining outputs and returns the [`TransactionData`] containing
+    /// the unsigned transaction. If no `gas_budget` is provided, the budget will be estimated.
+    pub async fn build_transaction_data(
+        self,
+        gas_budget: Option<u64>,
+    ) -> SuiClientResult<TransactionData> {
+        self.build_transaction_data_with_min_gas_balance(gas_budget, 0)
+            .await
+    }
+
+    /// Transfers all remaining outputs and returns the [`TransactionData`] containing
+    /// the unsigned transaction. If no `gas_budget` is provided, the budget will be estimated.
+    /// The used gas coins will cover a balance of at least `minimum_gas_coin_balance`. This
+    /// is useful, e.g.,  to make sure that all gas coins get merged.
+    pub(crate) async fn build_transaction_data_with_min_gas_balance(
+        mut self,
+        gas_budget: Option<u64>,
+        minimum_gas_coin_balance: u64,
+    ) -> SuiClientResult<TransactionData> {
+        self.transfer_remaining_outputs(None).await?;
+        let programmable_transaction = self.pt_builder.finish();
+
+        // Get the current gas price from the network
+        let gas_price = self.read_client.get_reference_gas_price().await?;
+
+        // Estimate the gas budget unless explicitly set.
+        let gas_budget = if let Some(budget) = gas_budget {
+            budget
+        } else {
+            let tx_kind =
+                TransactionKind::ProgrammableTransaction(programmable_transaction.clone());
+            self.read_client
+                .sui_client()
+                .estimate_gas_budget(self.sender_address, tx_kind, gas_price)
+                .await?
+        };
+
+        let min_gas_coin_balance = minimum_gas_coin_balance.max(gas_budget + self.tx_sui_cost);
+
+        // Construct the transaction with gas coins that meet the minimum balance requirement
+        Ok(TransactionData::new_programmable(
+            self.sender_address,
+            self.read_client
+                .get_compatible_gas_coins(self.sender_address, min_gas_coin_balance)
+                .await?,
+            programmable_transaction,
+            gas_budget,
+            gas_price,
+        ))
     }
 
     /// Given the node ID, checks if the sender is authorized to perform the operation (either as


### PR DESCRIPTION
## Description

- Adds a command to compute the package digest
- Separates the migrate command from the upgrade command
- Allows creating an unsigned transaction for the upgrade (to allow emergency upgrades from the multisig addr)
- Includes refactoring to build TransactionData in the WalrusPtbBuilder
- closes WAL-741

## Test plan

- Manual test of the new cli commands

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [x] CLI: Adds node-admin command to compute package digest
