### PR TITLE
chore: remove deprecated status for get_rpc_url

### DIFF
--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -2223,7 +2223,6 @@ pub async fn test_select_coins_max_objects() -> TestResult {
     walrus_sui::test_utils::fund_addresses(&mut cluster_wallet, vec![address; 4], Some(sui(1)))
         .await?;
 
-    #[allow(deprecated)]
     let rpc_urls = &[wallet.as_ref().get_rpc_url().unwrap()];
 
     // Create a new client with the funded wallet.

--- a/crates/walrus-sdk/src/config.rs
+++ b/crates/walrus-sdk/src/config.rs
@@ -168,7 +168,6 @@ impl ClientConfig {
         wallet: Wallet,
         gas_budget: Option<u64>,
     ) -> Result<SuiContractClient, SuiClientError> {
-        #[allow(deprecated)]
         let wallet_rpc_url = wallet.get_rpc_url()?;
 
         SuiContractClient::new(

--- a/crates/walrus-service/bin/deploy.rs
+++ b/crates/walrus-service/bin/deploy.rs
@@ -477,7 +477,6 @@ mod commands {
             load_wallet_context_from_path(admin_wallet_path, sui_client_request_timeout)
                 .context("unable to load admin wallet")?;
 
-        #[allow(deprecated)]
         let rpc_urls = &[admin_wallet.get_rpc_url()?];
 
         let mut admin_contract_client = testbed_config
@@ -572,7 +571,6 @@ mod commands {
             load_wallet_context_from_path(wallet_path, None).context("unable to load wallet")?;
         let contract_config = ContractConfig::new(system_object_id, staking_object_id);
 
-        #[allow(deprecated)]
         let rpc_urls = &[wallet.get_rpc_url()?];
 
         let contract_client =

--- a/crates/walrus-service/bin/node.rs
+++ b/crates/walrus-service/bin/node.rs
@@ -844,7 +844,6 @@ mod commands {
             );
             let wallet = load_wallet_context_from_path(Some(&wallet_config), None)
                 .context("Reading Sui wallet failed")?;
-            #[allow(deprecated)]
             wallet
                 .get_rpc_url()
                 .context("Unable to get the wallet's active environment")?

--- a/crates/walrus-service/src/client/cli/runner.rs
+++ b/crates/walrus-service/src/client/cli/runner.rs
@@ -1312,7 +1312,6 @@ async fn get_latest_checkpoint_sequence_number(
     let url = if let Some(url) = rpc_url {
         url.clone()
     } else if let Ok(wallet) = wallet {
-        #[allow(deprecated)]
         match wallet.get_rpc_url() {
             Ok(rpc) => rpc,
             Err(error) => {

--- a/crates/walrus-service/src/client/multiplexer.rs
+++ b/crates/walrus-service/src/client/multiplexer.rs
@@ -384,7 +384,6 @@ impl<'a> SubClientLoader<'a> {
         let address = wallet.active_address()?;
         tracing::debug!(%address, "refilling sub-wallet with SUI and WAL");
 
-        #[allow(deprecated)]
         let rpc_urls = &[wallet.get_rpc_url()?];
 
         let sui_client = RetriableSuiClient::new_for_rpc_urls(

--- a/crates/walrus-service/src/common/config.rs
+++ b/crates/walrus-service/src/common/config.rs
@@ -79,7 +79,6 @@ impl SuiConfig {
     ) -> Result<SuiContractClient, SuiClientError> {
         let wallet = WalletConfig::load_wallet(Some(&self.wallet_config), self.request_timeout)?;
 
-        #[allow(deprecated)]
         let rpc_urls = combine_rpc_urls(
             wallet.get_rpc_url()?,
             &combine_rpc_urls(&self.rpc, &self.additional_rpc_endpoints),

--- a/crates/walrus-service/src/common/utils.rs
+++ b/crates/walrus-service/src/common/utils.rs
@@ -526,7 +526,6 @@ pub async fn generate_sui_wallet(
         path.display()
     );
     let mut wallet = walrus_sui::utils::create_wallet(path, sui_network.env(), None, None)?;
-    #[allow(deprecated)]
     let rpc_urls = &[wallet.get_rpc_url()?];
     let client = RetriableSuiClient::new_for_rpc_urls(rpc_urls, Default::default(), None).await?;
 

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -2406,7 +2406,6 @@ pub mod test_cluster {
             {
                 let client = wallet
                     .and_then_async(async |wallet| {
-                        #[allow(deprecated)]
                         let rpc_urls = &[wallet.get_rpc_url()?];
                         system_ctx
                             .new_contract_client(wallet, rpc_urls, Default::default(), None)
@@ -2430,7 +2429,6 @@ pub mod test_cluster {
 
             let admin_contract_client = admin_wallet
                 .and_then_async(async |wallet| {
-                    #[allow(deprecated)]
                     let rpc_urls = &[wallet.get_rpc_url()?];
 
                     SuiContractClient::new(

--- a/crates/walrus-service/src/testbed.rs
+++ b/crates/walrus-service/src/testbed.rs
@@ -388,7 +388,6 @@ pub async fn deploy_walrus_contract(
         // Try to flush output
         let _ = std::io::stdout().flush();
 
-        #[allow(deprecated)]
         let rpc_url = admin_wallet.get_rpc_url()?;
 
         // Get coins from faucet for the wallet.
@@ -433,7 +432,6 @@ pub async fn deploy_walrus_contract(
 
     tracing::debug!("Retrieved contract configuration from system context");
 
-    #[allow(deprecated)]
     let rpc_urls = &[admin_wallet.get_rpc_url()?];
 
     let contract_client = SuiContractClient::new(
@@ -811,7 +809,6 @@ pub async fn create_storage_node_configs(
     }
 
     let contract_clients = join_all(wallets.into_iter().map(|wallet| async {
-        #[allow(deprecated)]
         let rpc_urls = &[wallet
             .get_rpc_url()
             .expect("wallet environment should contain an rpc url")];

--- a/crates/walrus-stress/src/generator/write_client.rs
+++ b/crates/walrus-stress/src/generator/write_client.rs
@@ -246,7 +246,6 @@ async fn new_client(
 ) -> anyhow::Result<WithTempDir<Client<SuiContractClient>>> {
     // Create the client with a separate wallet
     let wallet = wallet_for_testing_from_refill(config, network, refiller).await?;
-    #[allow(deprecated)]
     let rpc_urls = &[wallet.as_ref().get_rpc_url()?];
     let sui_client = RetriableSuiClient::new(
         rpc_urls

--- a/crates/walrus-sui/src/system_setup.rs
+++ b/crates/walrus-sui/src/system_setup.rs
@@ -161,7 +161,6 @@ pub(crate) async fn publish_package(
     gas_budget: Option<u64>,
 ) -> Result<SuiTransactionBlockResponse> {
     let sender = wallet.active_address()?;
-    #[allow(deprecated)]
     let retry_client = RetriableSuiClient::new(
         vec![LazySuiClientBuilder::new(wallet.get_rpc_url()?, None)],
         Default::default(),
@@ -463,7 +462,6 @@ pub async fn create_system_and_staking_objects(
     let ptb = pt_builder.finish();
     let address = wallet.active_address()?;
 
-    #[allow(deprecated)]
     let retry_client = RetriableSuiClient::new(
         vec![LazySuiClientBuilder::new(wallet.get_rpc_url()?, None)],
         Default::default(),

--- a/crates/walrus-sui/src/test_utils.rs
+++ b/crates/walrus-sui/src/test_utils.rs
@@ -490,7 +490,6 @@ pub async fn new_contract_client_on_sui_test_cluster(
     let walrus_client = new_wallet_on_sui_test_cluster(sui_cluster_handle)
         .await?
         .and_then_async(async |wallet| {
-            #[allow(deprecated)]
             let rpc_urls = &[wallet.get_rpc_url()?];
             SuiContractClient::new(
                 wallet,

--- a/crates/walrus-sui/src/test_utils/system_setup.rs
+++ b/crates/walrus-sui/src/test_utils/system_setup.rs
@@ -351,7 +351,6 @@ pub async fn initialize_contract_and_wallet_for_testing(
     let result = admin_wallet
         .and_then_async(
             async |admin_wallet| -> anyhow::Result<(SystemContext, SuiContractClient)> {
-                #[allow(deprecated)]
                 let rpc_urls = &[admin_wallet.get_rpc_url()?];
 
                 publish_with_default_system_with_epoch_duration(

--- a/crates/walrus-sui/src/utils.rs
+++ b/crates/walrus-sui/src/utils.rs
@@ -416,7 +416,6 @@ pub async fn get_sui_from_wallet_or_faucet(
     let one_sui = 1_000_000_000;
     let min_balance = sui_amount + 2 * one_sui;
     let sender = wallet.active_address()?;
-    #[allow(deprecated)]
     let rpc_urls = &[wallet.get_rpc_url()?];
     let client = RetriableSuiClient::new_for_rpc_urls(rpc_urls, Default::default(), None).await?;
     let balance = client.get_balance(sender, None).await?;

--- a/crates/walrus-sui/src/wallet.rs
+++ b/crates/walrus-sui/src/wallet.rs
@@ -115,11 +115,6 @@ impl Wallet {
     }
 
     /// Get the rpc_url for the active environment.
-    #[deprecated(
-        note = "Avoid calling this method as it relies on the Wallet configuration for rpc urls. \
-        It's better to pass rpc urls directly to the location where they are needed, from Walrus \
-        configuration."
-    )]
     pub fn get_rpc_url(&self) -> Result<String, WalletError> {
         Ok(self.wallet_context.config.get_active_env()?.rpc.clone())
     }


### PR DESCRIPTION
## Description

Avoid deprecating `get_rpc_url` because in many cases it is the only rpc url we have and we do not have urgency around changing that.

## Test plan

CI Pipeline.