### PR TITLE
feat: use subsidies contract to proxy register blob call

### DIFF
--- a/crates/walrus-sdk/src/lib.rs
+++ b/crates/walrus-sdk/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! The Walrus Rust SDK.
 
+#![recursion_limit = "256"]
+
 pub mod active_committees;
 pub mod blocklist;
 pub mod client;

--- a/crates/walrus-sui/src/client.rs
+++ b/crates/walrus-sui/src/client.rs
@@ -1599,21 +1599,18 @@ impl SuiContractClientInner {
             .iter()
             .fold(0, |acc, metadata| acc + metadata.encoded_size);
 
-        let main_storage_arg = match with_subsidies {
-            true => {
-                pt_builder
-                    .reserve_space_with_subsidies(
-                        main_storage_arg_size,
-                        epochs_ahead,
-                        subsidies_package_id,
-                    )
-                    .await?
-            }
-            false => {
-                pt_builder
-                    .reserve_space_without_subsidies(main_storage_arg_size, epochs_ahead)
-                    .await?
-            }
+        let main_storage_arg = if with_subsidies {
+            pt_builder
+                .reserve_space_with_subsidies(
+                    main_storage_arg_size,
+                    epochs_ahead,
+                    subsidies_package_id,
+                )
+                .await?
+        } else {
+            pt_builder
+                .reserve_space_without_subsidies(main_storage_arg_size, epochs_ahead)
+                .await?
         };
 
         for blob_metadata in blob_metadata_list.into_iter() {
@@ -1627,26 +1624,19 @@ impl SuiContractClientInner {
                 main_storage_arg
             };
 
-            match with_subsidies {
-                true => {
-                    pt_builder
-                        .register_blob_with_subsidies(
-                            storage_arg.into(),
-                            blob_metadata,
-                            persistence,
-                            subsidies_package_id,
-                        )
-                        .await?
-                }
-                false => {
-                    pt_builder
-                        .register_blob_without_subsidies(
-                            storage_arg.into(),
-                            blob_metadata,
-                            persistence,
-                        )
-                        .await?
-                }
+            if with_subsidies {
+                pt_builder
+                    .register_blob_with_subsidies(
+                        storage_arg.into(),
+                        blob_metadata,
+                        persistence,
+                        subsidies_package_id,
+                    )
+                    .await?
+            } else {
+                pt_builder
+                    .register_blob_without_subsidies(storage_arg.into(), blob_metadata, persistence)
+                    .await?
             };
         }
 

--- a/crates/walrus-sui/src/client.rs
+++ b/crates/walrus-sui/src/client.rs
@@ -32,7 +32,7 @@ use sui_types::{
     TypeTag,
     base_types::SuiAddress,
     event::EventID,
-    transaction::{Argument, TransactionData},
+    transaction::{Argument, ProgrammableTransaction, TransactionData, TransactionKind},
 };
 use tokio::sync::Mutex;
 use tokio_stream::Stream;
@@ -1471,14 +1471,34 @@ impl SuiContractClientInner {
             return Ok(vec![]);
         }
 
+        let subsidies_package_id = self.read_client.get_subsidies_package_id();
+
         let expected_num_blobs = blob_metadata_and_storage.len();
         tracing::debug!(num_blobs = expected_num_blobs, "starting to register blobs");
         let mut pt_builder = self.transaction_builder()?;
         // Build a ptb to include all register blob commands for all blobs.
         for (blob_metadata, storage) in blob_metadata_and_storage.into_iter() {
-            pt_builder
-                .register_blob(storage.id.into(), blob_metadata, persistence)
-                .await?;
+            match subsidies_package_id {
+                Some(pkg_id) => {
+                    pt_builder
+                        .register_blob_with_subsidies(
+                            storage.id.into(),
+                            blob_metadata,
+                            persistence,
+                            pkg_id,
+                        )
+                        .await?;
+                }
+                None => {
+                    pt_builder
+                        .register_blob_without_subsidies(
+                            storage.id.into(),
+                            blob_metadata,
+                            persistence,
+                        )
+                        .await?;
+                }
+            };
         }
         let transaction = pt_builder.build_transaction_data(self.gas_budget).await?;
         let res = self
@@ -1560,61 +1580,6 @@ impl SuiContractClientInner {
         persistence: BlobPersistence,
         subsidies_package_id: ObjectID,
     ) -> SuiClientResult<Vec<Blob>> {
-        // Use helper for implementing with the subsidies approach
-        self.reserve_and_register_blobs_impl(
-            epochs_ahead,
-            blob_metadata_list,
-            persistence,
-            |builder, encoded_size, epochs| {
-                Box::pin(async move {
-                    builder
-                        .reserve_space_with_subsidies(encoded_size, epochs, subsidies_package_id)
-                        .await
-                }) as BoxFuture<'_, SuiClientResult<Argument>>
-            },
-        )
-        .await
-    }
-
-    /// reserve and register blobs without subsidies
-    pub async fn reserve_and_register_blobs_without_subsidies(
-        &mut self,
-        epochs_ahead: EpochCount,
-        blob_metadata_list: Vec<BlobObjectMetadata>,
-        persistence: BlobPersistence,
-    ) -> SuiClientResult<Vec<Blob>> {
-        // Use helper for implementing with the non-subsidies approach
-        self.reserve_and_register_blobs_impl(
-            epochs_ahead,
-            blob_metadata_list,
-            persistence,
-            |builder, encoded_size, epochs| {
-                Box::pin(async move {
-                    builder
-                        .reserve_space_without_subsidies(encoded_size, epochs)
-                        .await
-                }) as BoxFuture<'_, SuiClientResult<Argument>>
-            },
-        )
-        .await
-    }
-
-    /// Common implementation for reserving and registering blobs
-    async fn reserve_and_register_blobs_impl<F>(
-        &mut self,
-        epochs_ahead: EpochCount,
-        blob_metadata_list: Vec<BlobObjectMetadata>,
-        persistence: BlobPersistence,
-        reserve_space_fn: F,
-    ) -> SuiClientResult<Vec<Blob>>
-    where
-        F: for<'a> Fn(
-                &'a mut WalrusPtbBuilder,
-                u64,
-                EpochCount,
-            ) -> BoxFuture<'a, SuiClientResult<Argument>>
-            + Send,
-    {
         if blob_metadata_list.is_empty() {
             tracing::debug!("no blobs to register");
             return Ok(vec![]);
@@ -1632,8 +1597,10 @@ impl SuiContractClientInner {
         let mut main_storage_arg_size = blob_metadata_list
             .iter()
             .fold(0, |acc, metadata| acc + metadata.encoded_size);
-        let main_storage_arg =
-            reserve_space_fn(&mut pt_builder, main_storage_arg_size, epochs_ahead).await?;
+
+        let main_storage_arg = pt_builder
+            .reserve_space_with_subsidies(main_storage_arg_size, epochs_ahead, subsidies_package_id)
+            .await?;
 
         for blob_metadata in blob_metadata_list.into_iter() {
             // Split off a storage resource, unless the remainder is equal to the required size.
@@ -1646,13 +1613,82 @@ impl SuiContractClientInner {
                 main_storage_arg
             };
             pt_builder
-                .register_blob(storage_arg.into(), blob_metadata, persistence)
+                .register_blob_with_subsidies(
+                    storage_arg.into(),
+                    blob_metadata,
+                    persistence,
+                    subsidies_package_id,
+                )
                 .await?;
         }
 
         let transaction = pt_builder.build_transaction_data(self.gas_budget).await?;
         let res = self
-            .sign_and_send_transaction(transaction, "reserve_and_register_blobs_impl")
+            .sign_and_send_transaction(transaction, "reserve_and_register_blobs_with_subsidies")
+            .await?;
+        let blob_obj_ids = get_created_sui_object_ids_by_type(
+            &res,
+            &contracts::blob::Blob
+                .to_move_struct_tag_with_type_map(&self.read_client.type_origin_map(), &[])?,
+        )?;
+
+        ensure!(
+            blob_obj_ids.len() == expected_num_blobs,
+            "unexpected number of blob objects created: {} expected {} ",
+            blob_obj_ids.len(),
+            expected_num_blobs
+        );
+
+        self.sui_client().get_sui_objects(&blob_obj_ids).await
+    }
+
+    /// reserve and register blobs without subsidies
+    pub async fn reserve_and_register_blobs_without_subsidies(
+        &mut self,
+        epochs_ahead: EpochCount,
+        blob_metadata_list: Vec<BlobObjectMetadata>,
+        persistence: BlobPersistence,
+    ) -> SuiClientResult<Vec<Blob>> {
+        if blob_metadata_list.is_empty() {
+            tracing::debug!("no blobs to register");
+            return Ok(vec![]);
+        }
+
+        let expected_num_blobs = blob_metadata_list.len();
+        tracing::debug!(
+            num_blobs = expected_num_blobs,
+            "starting to reserve and register blobs"
+        );
+
+        let mut pt_builder = self.transaction_builder()?;
+
+        // Reserve enough space for all blobs
+        let mut main_storage_arg_size = blob_metadata_list
+            .iter()
+            .fold(0, |acc, metadata| acc + metadata.encoded_size);
+
+        let main_storage_arg = pt_builder
+            .reserve_space_without_subsidies(main_storage_arg_size, epochs_ahead)
+            .await?;
+
+        for blob_metadata in blob_metadata_list.into_iter() {
+            // Split off a storage resource, unless the remainder is equal to the required size.
+            let storage_arg = if main_storage_arg_size != blob_metadata.encoded_size {
+                main_storage_arg_size -= blob_metadata.encoded_size;
+                pt_builder
+                    .split_storage_by_size(main_storage_arg.into(), main_storage_arg_size)
+                    .await?
+            } else {
+                main_storage_arg
+            };
+            pt_builder
+                .register_blob_without_subsidies(storage_arg.into(), blob_metadata, persistence)
+                .await?;
+        }
+
+        let transaction = pt_builder.build_transaction_data(self.gas_budget).await?;
+        let res = self
+            .sign_and_send_transaction(transaction, "reserve_and_register_blobs_without_subsidies")
             .await?;
         let blob_obj_ids = get_created_sui_object_ids_by_type(
             &res,

--- a/crates/walrus-sui/src/client/read_client.rs
+++ b/crates/walrus-sui/src/client/read_client.rs
@@ -319,8 +319,9 @@ impl SuiReadClient {
         let wal_type = sui_client.wal_type_from_package(walrus_package_id).await?;
         let subsidies = if let Some(subsidies_object_id) = contract_config.subsidies_object {
             let subsidies_package_id = sui_client
-                .get_subsidies_package_id_from_subsidies_object(subsidies_object_id)
-                .await?;
+                .get_subsidies_object(subsidies_object_id)
+                .await?
+                .package_id;
             Some(Subsidies {
                 package_id: subsidies_package_id,
                 object_id: subsidies_object_id,
@@ -804,8 +805,9 @@ impl SuiReadClient {
     pub async fn set_subsidies_object(&self, subsidies_object_id: ObjectID) -> SuiClientResult<()> {
         let subsidies_package_id = self
             .sui_client
-            .get_subsidies_package_id_from_subsidies_object(subsidies_object_id)
-            .await?;
+            .get_subsidies_object(subsidies_object_id)
+            .await?
+            .package_id;
         *self.subsidies_mut() = Some(Subsidies {
             package_id: subsidies_package_id,
             object_id: subsidies_object_id,
@@ -1170,8 +1172,9 @@ impl ReadClient for SuiReadClient {
         if let Some(subsidies) = subsidies {
             let new_package_id = self
                 .sui_client
-                .get_subsidies_package_id_from_subsidies_object(subsidies.object_id)
-                .await?;
+                .get_subsidies_object(subsidies.object_id)
+                .await?
+                .package_id;
 
             // Update the package_id if it has changed
             if new_package_id != subsidies.package_id {

--- a/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
@@ -886,16 +886,11 @@ impl RetriableSuiClient {
     }
 
     /// Checks if the Walrus subsidies object exist on chain and returns the subsidies package ID.
-    pub(crate) async fn get_subsidies_package_id_from_subsidies_object(
+    pub(crate) async fn get_subsidies_object(
         &self,
         subsidies_object_id: ObjectID,
-    ) -> SuiClientResult<ObjectID> {
-        let subsidies_object = self
-            .get_sui_object::<Subsidies>(subsidies_object_id)
-            .await?;
-
-        let pkg_id = subsidies_object.package_id;
-        Ok(pkg_id)
+    ) -> SuiClientResult<Subsidies> {
+        self.get_sui_object::<Subsidies>(subsidies_object_id).await
     }
 
     /// Returns the package ID from the type of the given object.

--- a/crates/walrus-sui/src/client/transaction_builder.rs
+++ b/crates/walrus-sui/src/client/transaction_builder.rs
@@ -61,7 +61,7 @@ use crate::{
         UpdatePublicKeyParams,
         move_structs::{Authorized, BlobAttribute, EmergencyUpgradeCap, NodeMetadata, WalExchange},
     },
-    utils::{MAX_BUYER_SUBSIDY_RATE, price_for_encoded_length, write_price_for_encoded_length},
+    utils::{TEN_THOUSAND_BASIS_POINTS, price_for_encoded_length, write_price_for_encoded_length},
 };
 
 const CLOCK_OBJECT_ARG: ObjectArg = ObjectArg::SharedObject {
@@ -1596,7 +1596,7 @@ impl WalrusPtbBuilder {
                     .get_subsidies_object(subsidies_object_id)
                     .await?;
                 let subsidy = full_price * u64::from(subsidies_object.buyer_subsidy_rate)
-                    / MAX_BUYER_SUBSIDY_RATE;
+                    / TEN_THOUSAND_BASIS_POINTS;
                 full_price - subsidy
             }
             Some(_) => full_price,
@@ -1624,7 +1624,7 @@ impl WalrusPtbBuilder {
                     .await?
                     .buyer_subsidy_rate;
                 // TODO: (WAL-905) Hack until new subsidy is integrated with system contract
-                if u64::from(buyer_subsidy_rate) == MAX_BUYER_SUBSIDY_RATE {
+                if u64::from(buyer_subsidy_rate) == TEN_THOUSAND_BASIS_POINTS {
                     0
                 } else {
                     full_price

--- a/crates/walrus-sui/src/test_utils/system_setup.rs
+++ b/crates/walrus-sui/src/test_utils/system_setup.rs
@@ -329,6 +329,7 @@ pub async fn end_epoch_zero(contract_client: &SuiContractClient) -> Result<()> {
 pub async fn initialize_contract_and_wallet_for_testing(
     epoch_duration: Duration,
     with_subsidies: bool,
+    subsidy_rate: u16,
     n_nodes: usize,
 ) -> anyhow::Result<(
     Arc<tokio::sync::Mutex<TestClusterHandle>>,
@@ -357,6 +358,7 @@ pub async fn initialize_contract_and_wallet_for_testing(
                     &bls_keys,
                     epoch_duration,
                     with_subsidies,
+                    subsidy_rate,
                 )
                 .await
             },
@@ -389,6 +391,7 @@ async fn publish_with_default_system_with_epoch_duration(
     bls_keys: &[ProtocolKeyPair],
     epoch_duration: Duration,
     with_subsidies: bool,
+    subsidy_rate: u16,
 ) -> anyhow::Result<(SystemContext, SuiContractClient)> {
     let system_context = create_and_init_system_for_test(
         &mut admin_wallet,
@@ -421,9 +424,6 @@ async fn publish_with_default_system_with_epoch_duration(
     let contract_client = system_context
         .new_contract_client(admin_wallet, rpc_urls, Default::default(), None)
         .await?;
-
-    // We only care about gas cost, so the actual subsidy rate can be zero to make it cheap to fund.
-    let subsidy_rate = 0;
 
     if let Some(subsidies_pkg_id) = system_context.subsidies_pkg_id {
         let (subsidies_object_id, _admin_cap_id) = contract_client

--- a/crates/walrus-sui/src/utils.rs
+++ b/crates/walrus-sui/src/utils.rs
@@ -45,8 +45,8 @@ use crate::{
     wallet::Wallet,
 };
 
-/// Max subsidy rate is 100%.
-pub const MAX_BUYER_SUBSIDY_RATE: u64 = 10_000;
+/// 10,000 basis points is 100%.
+pub const TEN_THOUSAND_BASIS_POINTS: u64 = 10_000;
 
 // Keep in sync with the same constant in `contracts/walrus/sources/system/system_state_inner.move`.
 // The storage unit is used in doc comments for CLI arguments in the files

--- a/crates/walrus-sui/src/utils.rs
+++ b/crates/walrus-sui/src/utils.rs
@@ -46,7 +46,7 @@ use crate::{
 };
 
 /// Max subsidy rate is 100%.
-pub const MAX_SUBSIDY_RATE: u64 = 10_000;
+pub const MAX_BUYER_SUBSIDY_RATE: u64 = 10_000;
 
 // Keep in sync with the same constant in `contracts/walrus/sources/system/system_state_inner.move`.
 // The storage unit is used in doc comments for CLI arguments in the files

--- a/crates/walrus-sui/src/utils.rs
+++ b/crates/walrus-sui/src/utils.rs
@@ -45,6 +45,9 @@ use crate::{
     wallet::Wallet,
 };
 
+/// Max subsidy rate is 100%.
+pub const MAX_SUBSIDY_RATE: u64 = 10_000;
+
 // Keep in sync with the same constant in `contracts/walrus/sources/system/system_state_inner.move`.
 // The storage unit is used in doc comments for CLI arguments in the files
 // `crates/walrus-service/bin/deploy.rs` and `crates/walrus-service/bin/node.rs`.


### PR DESCRIPTION
## Description

This PR modifies the CLI to proxy `register_blob` to subsidies contract as well as `reserve_space`. By doing so, this enables Walrus partners to pay zero WAL when interacting with the network. One the new subsidies contract is deployed. The code path should still work since this feature is dependent on subsidies_object being set in the config

## Test plan

How did you test the new or updated feature?
New sim test

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [x] CLI: use subsidies contract to proxy register blob call
