### PR TITLE
feat: rate limit concurrent blob recovery during node recovery

### DIFF
--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -981,11 +981,8 @@ async fn test_blocklist() -> TestResult {
     let blocklist_dir = tempfile::tempdir().expect("temporary directory creation must succeed");
     let (_sui_cluster_handle, _cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
         .with_test_nodes_config(TestNodesConfig {
-            node_weights: vec![1, 2, 3, 3, 4],
-            use_legacy_event_processor: true,
-            disable_event_blob_writer: false,
             blocklist_dir: Some(blocklist_dir.path().to_path_buf()),
-            enable_node_config_synchronizer: false,
+            ..Default::default()
         })
         .build()
         .await?;
@@ -1232,10 +1229,7 @@ async fn test_repeated_shard_move() -> TestResult {
         .with_epoch_duration(Duration::from_secs(20))
         .with_test_nodes_config(TestNodesConfig {
             node_weights: vec![1, 1],
-            use_legacy_event_processor: true,
-            disable_event_blob_writer: false,
-            blocklist_dir: None,
-            enable_node_config_synchronizer: false,
+            ..Default::default()
         })
         .build()
         .await?;
@@ -2056,10 +2050,7 @@ async fn test_shard_move_out_and_back_in_immediately() -> TestResult {
         .with_epoch_duration(Duration::from_secs(20))
         .with_test_nodes_config(TestNodesConfig {
             node_weights: vec![1, 1],
-            use_legacy_event_processor: true,
-            disable_event_blob_writer: false,
-            blocklist_dir: None,
-            enable_node_config_synchronizer: false,
+            ..Default::default()
         })
         .build()
         .await?;

--- a/crates/walrus-e2e-tests/tests/test_event_blobs.rs
+++ b/crates/walrus-e2e-tests/tests/test_event_blobs.rs
@@ -18,6 +18,7 @@ async fn test_event_blobs() -> anyhow::Result<()> {
     let (_sui_cluster, _cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
         .with_test_nodes_config(TestNodesConfig {
             node_weights: vec![2, 2],
+            use_legacy_event_processor: false,
             ..Default::default()
         })
         .build()
@@ -80,8 +81,7 @@ async fn test_disabled_event_blob_writer() -> anyhow::Result<()> {
             node_weights: vec![1, 1],
             use_legacy_event_processor: false,
             disable_event_blob_writer: true,
-            blocklist_dir: None,
-            enable_node_config_synchronizer: false,
+            ..Default::default()
         })
         .build()
         .await?;

--- a/crates/walrus-service/node_config_example.yaml
+++ b/crates/walrus-service/node_config_example.yaml
@@ -173,3 +173,5 @@ checkpoint_config:
   max_background_operations: 1
   periodic_db_checkpoints: false
 admin_socket_path: null
+node_recovery_config:
+  max_concurrent_blob_syncs_during_recovery: 1000

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -684,8 +684,11 @@ impl StorageNode {
 
         let start_epoch_change_finisher = StartEpochChangeFinisher::new(inner.clone());
 
-        let node_recovery_handler =
-            NodeRecoveryHandler::new(inner.clone(), blob_sync_handler.clone());
+        let node_recovery_handler = NodeRecoveryHandler::new(
+            inner.clone(),
+            blob_sync_handler.clone(),
+            config.node_recovery_config.clone(),
+        );
         node_recovery_handler.restart_recovery().await?;
 
         tracing::debug!(

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -185,6 +185,9 @@ pub struct StorageNodeConfig {
     /// ```
     #[serde(default, skip_serializing_if = "defaults::is_none")]
     pub admin_socket_path: Option<PathBuf>,
+    /// Configuration for node recovery.
+    #[serde(default, skip_serializing_if = "defaults::is_default")]
+    pub node_recovery_config: NodeRecoveryConfig,
 }
 
 impl Default for StorageNodeConfig {
@@ -226,6 +229,7 @@ impl Default for StorageNodeConfig {
             consistency_check: Default::default(),
             checkpoint_config: Default::default(),
             admin_socket_path: None,
+            node_recovery_config: Default::default(),
         }
     }
 }
@@ -665,6 +669,25 @@ impl Default for ShardSyncConfig {
             shard_sync_concurrency: 10,
             shard_sync_retry_switch_to_recovery_interval: Duration::from_secs(12 * 60 * 60), // 12hr
             restart_shard_sync_always_retry_transfer_first: true,
+        }
+    }
+}
+
+/// Configuration for node recovery.
+#[serde_as]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[serde(default)]
+pub struct NodeRecoveryConfig {
+    /// The maximum number of blobs to recover in parallel.
+    /// Different from `BlobRecoveryConfig::max_concurrent_blob_syncs`, this is to control the
+    /// number of blob recover tasks initiated by node recovery logic.
+    pub max_concurrent_blob_syncs_during_recovery: usize,
+}
+
+impl Default for NodeRecoveryConfig {
+    fn default() -> Self {
+        Self {
+            max_concurrent_blob_syncs_during_recovery: 1000,
         }
     }
 }

--- a/crates/walrus-service/src/node/metrics.rs
+++ b/crates/walrus-service/src/node/metrics.rs
@@ -162,6 +162,13 @@ walrus_utils::metrics::define_metric_set! {
 
         #[help = "Status metric indicating the node's ID"]
         node_id: IntGaugeVec["walrus_node_id"],
+
+        #[help = "The progress of the node recovery. It is represented by the first two bytes \
+        of the blob ID since the recovery job is sequential over blob IDs."]
+        node_recovery_recover_blob_progress: IntGauge[],
+
+        #[help = "The number of ongoing blob syncs during node recovery."]
+        node_recovery_ongoing_blob_syncs: IntGauge[],
     }
 }
 

--- a/crates/walrus-service/src/testbed.rs
+++ b/crates/walrus-service/src/testbed.rs
@@ -807,6 +807,7 @@ pub async fn create_storage_node_configs(
             },
             checkpoint_config: Default::default(),
             admin_socket_path: Some(working_dir.join(format!("admin-{}.sock", node_index))),
+            node_recovery_config: Default::default(),
         });
     }
 

--- a/crates/walrus-service/tests/epoch_change.rs
+++ b/crates/walrus-service/tests/epoch_change.rs
@@ -19,10 +19,7 @@ async fn nodes_drive_epoch_change() -> walrus_test_utils::Result {
         .with_epoch_duration(epoch_duration)
         .with_test_nodes_config(TestNodesConfig {
             node_weights: vec![1, 1],
-            use_legacy_event_processor: true,
-            disable_event_blob_writer: false,
-            blocklist_dir: None,
-            enable_node_config_synchronizer: false,
+            ..Default::default()
         })
         .with_default_num_checkpoints_per_blob()
         .build()

--- a/crates/walrus-simtest/tests/simtest.rs
+++ b/crates/walrus-simtest/tests/simtest.rs
@@ -25,6 +25,7 @@ mod tests {
     use walrus_proc_macros::walrus_simtest;
     use walrus_service::{
         client::ClientCommunicationConfig,
+        node::config::NodeRecoveryConfig,
         test_utils::{SimStorageNodeHandle, TestNodesConfig, test_cluster},
     };
     use walrus_simtest::test_utils::simtest_utils::{
@@ -122,9 +123,7 @@ mod tests {
             .with_test_nodes_config(TestNodesConfig {
                 node_weights: node_weights.clone(),
                 use_legacy_event_processor: false,
-                disable_event_blob_writer: false,
-                blocklist_dir: None,
-                enable_node_config_synchronizer: false,
+                ..Default::default()
             })
             .with_num_checkpoints_per_blob(100)
             .with_communication_config(
@@ -223,11 +222,26 @@ mod tests {
             panic!("shard sync should not enter recovery mode in this test");
         });
 
+        let mut node_recovery_config = NodeRecoveryConfig::default();
+
+        // 20% of the time using a more restrictive node recovery config.
+        if rand::thread_rng().gen_bool(0.2) {
+            let max_concurrent_blob_syncs_during_recovery = rand::thread_rng().gen_range(1..=3);
+            tracing::info!(
+                "using more restrictive node recovery config, \
+                max_concurrent_blob_syncs_during_recovery: {}",
+                max_concurrent_blob_syncs_during_recovery
+            );
+            node_recovery_config.max_concurrent_blob_syncs_during_recovery =
+                max_concurrent_blob_syncs_during_recovery;
+        }
+
         let (_sui_cluster, mut walrus_cluster, client, _) =
             test_cluster::E2eTestSetupBuilder::new()
                 .with_epoch_duration(Duration::from_secs(30))
                 .with_test_nodes_config(TestNodesConfig {
                     node_weights: vec![1, 2, 3, 3, 4, 0],
+                    node_recovery_config: Some(node_recovery_config),
                     ..Default::default()
                 })
                 .with_communication_config(
@@ -391,14 +405,27 @@ mod tests {
     #[ignore = "ignore integration simtests by default"]
     #[walrus_simtest]
     async fn test_long_node_recovery() {
+        let mut node_recovery_config = NodeRecoveryConfig::default();
+
+        // 20% of the time using a more restrictive node recovery config.
+        if rand::thread_rng().gen_bool(0.2) {
+            let max_concurrent_blob_syncs_during_recovery = rand::thread_rng().gen_range(1..=3);
+            tracing::info!(
+                "using more restrictive node recovery config, \
+                max_concurrent_blob_syncs_during_recovery: {}",
+                max_concurrent_blob_syncs_during_recovery
+            );
+            node_recovery_config.max_concurrent_blob_syncs_during_recovery =
+                max_concurrent_blob_syncs_during_recovery;
+        }
+
         let (_sui_cluster, walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
             .with_epoch_duration(Duration::from_secs(30))
             .with_test_nodes_config(TestNodesConfig {
                 node_weights: vec![1, 2, 3, 3, 4],
                 use_legacy_event_processor: false,
-                disable_event_blob_writer: false,
-                blocklist_dir: None,
-                enable_node_config_synchronizer: false,
+                node_recovery_config: Some(node_recovery_config),
+                ..Default::default()
             })
             .with_communication_config(
                 ClientCommunicationConfig::default_for_test_with_reqwest_timeout(

--- a/crates/walrus-simtest/tests/simtest_failure.rs
+++ b/crates/walrus-simtest/tests/simtest_failure.rs
@@ -23,6 +23,7 @@ mod tests {
     use walrus_proc_macros::walrus_simtest;
     use walrus_service::{
         client::ClientCommunicationConfig,
+        node::config::NodeRecoveryConfig,
         test_utils::{SimStorageNodeHandle, TestNodesConfig, test_cluster},
     };
     use walrus_simtest::test_utils::simtest_utils::{
@@ -196,14 +197,27 @@ mod tests {
     #[ignore = "ignore integration simtests by default"]
     #[walrus_simtest]
     async fn test_lagging_node_recovery() {
+        let mut node_recovery_config = NodeRecoveryConfig::default();
+
+        // 20% of the time using a more restrictive node recovery config.
+        if rand::thread_rng().gen_bool(0.2) {
+            let max_concurrent_blob_syncs_during_recovery = rand::thread_rng().gen_range(1..=3);
+            tracing::info!(
+                "using more restrictive node recovery config, \
+                max_concurrent_blob_syncs_during_recovery: {}",
+                max_concurrent_blob_syncs_during_recovery
+            );
+            node_recovery_config.max_concurrent_blob_syncs_during_recovery =
+                max_concurrent_blob_syncs_during_recovery;
+        }
+
         let (_sui_cluster, walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
             .with_epoch_duration(Duration::from_secs(30))
             .with_test_nodes_config(TestNodesConfig {
                 node_weights: vec![1, 2, 3, 3, 4],
                 use_legacy_event_processor: false,
-                disable_event_blob_writer: false,
-                blocklist_dir: None,
-                enable_node_config_synchronizer: false,
+                node_recovery_config: Some(node_recovery_config),
+                ..Default::default()
             })
             .with_communication_config(
                 ClientCommunicationConfig::default_for_test_with_reqwest_timeout(
@@ -349,9 +363,7 @@ mod tests {
             .with_test_nodes_config(TestNodesConfig {
                 node_weights: vec![2, 2, 3, 3, 3],
                 use_legacy_event_processor: false,
-                disable_event_blob_writer: false,
-                blocklist_dir: None,
-                enable_node_config_synchronizer: false,
+                ..Default::default()
             })
             .with_communication_config(
                 ClientCommunicationConfig::default_for_test_with_reqwest_timeout(
@@ -506,9 +518,7 @@ mod tests {
             .with_test_nodes_config(TestNodesConfig {
                 node_weights: vec![2, 2, 3, 3, 3],
                 use_legacy_event_processor: false,
-                disable_event_blob_writer: false,
-                blocklist_dir: None,
-                enable_node_config_synchronizer: false,
+                ..Default::default()
             })
             .with_communication_config(
                 ClientCommunicationConfig::default_for_test_with_reqwest_timeout(
@@ -582,14 +592,26 @@ mod tests {
     #[ignore = "ignore integration simtests by default"]
     #[walrus_simtest]
     async fn test_node_slow_process_events_entering_recovery() {
+        let mut node_recovery_config = NodeRecoveryConfig::default();
+
+        // 20% of the time using a more restrictive node recovery config.
+        if rand::thread_rng().gen_bool(0.2) {
+            let max_concurrent_blob_syncs_during_recovery = rand::thread_rng().gen_range(1..=3);
+            tracing::info!(
+                "using more restrictive node recovery config, \
+                max_concurrent_blob_syncs_during_recovery: {}",
+                max_concurrent_blob_syncs_during_recovery
+            );
+            node_recovery_config.max_concurrent_blob_syncs_during_recovery =
+                max_concurrent_blob_syncs_during_recovery;
+        }
+
         let (_sui_cluster, walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
             .with_epoch_duration(Duration::from_secs(30))
             .with_test_nodes_config(TestNodesConfig {
                 node_weights: vec![1, 2, 3, 3, 4],
                 use_legacy_event_processor: false,
-                disable_event_blob_writer: false,
-                blocklist_dir: None,
-                enable_node_config_synchronizer: false,
+                ..Default::default()
             })
             .with_communication_config(
                 ClientCommunicationConfig::default_for_test_with_reqwest_timeout(

--- a/crates/walrus-simtest/tests/simtest_param_sync.rs
+++ b/crates/walrus-simtest/tests/simtest_param_sync.rs
@@ -221,9 +221,8 @@ mod tests {
                 .with_test_nodes_config(TestNodesConfig {
                     node_weights: vec![1, 2, 3, 3, 4, 0],
                     use_legacy_event_processor: false,
-                    disable_event_blob_writer: false,
-                    blocklist_dir: None,
                     enable_node_config_synchronizer: true,
+                    ..Default::default()
                 })
                 .with_communication_config(
                     ClientCommunicationConfig::default_for_test_with_reqwest_timeout(
@@ -410,9 +409,8 @@ mod tests {
             .with_test_nodes_config(TestNodesConfig {
                 node_weights: vec![1, 2, 3, 3, 4, 2],
                 use_legacy_event_processor: false,
-                disable_event_blob_writer: false,
-                blocklist_dir: None,
                 enable_node_config_synchronizer: true,
+                ..Default::default()
             })
             .with_communication_config(
                 ClientCommunicationConfig::default_for_test_with_reqwest_timeout(
@@ -491,9 +489,8 @@ mod tests {
                 .with_test_nodes_config(TestNodesConfig {
                     node_weights: vec![1, 2, 3, 3, 4, 0],
                     use_legacy_event_processor: false,
-                    disable_event_blob_writer: false,
-                    blocklist_dir: None,
                     enable_node_config_synchronizer: true,
+                    ..Default::default()
                 })
                 .with_communication_config(
                     ClientCommunicationConfig::default_for_test_with_reqwest_timeout(
@@ -737,9 +734,8 @@ mod tests {
             .with_test_nodes_config(TestNodesConfig {
                 node_weights: vec![1, 2, 3, 3, 4, 2],
                 use_legacy_event_processor: false,
-                disable_event_blob_writer: false,
-                blocklist_dir: None,
                 enable_node_config_synchronizer: true,
+                ..Default::default()
             })
             .with_communication_config(
                 ClientCommunicationConfig::default_for_test_with_reqwest_timeout(


### PR DESCRIPTION
## Description

For full node recovery, the memory usage grows when the number of live blobs in the system, which doesn't scale and may
cause OOM.

## Test plan

Simtest
Each modified simtest passed 100 seeds.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
