### PR TITLE
chore: add walrus CLI binary to stress docker image (#2130)

### DIFF
--- a/docker/walrus-stress/Dockerfile
+++ b/docker/walrus-stress/Dockerfile
@@ -13,7 +13,7 @@ COPY Cargo.toml Cargo.lock ./
 COPY crates crates
 COPY contracts contracts
 
-RUN cargo build --profile $PROFILE --bin walrus-stress
+RUN cargo build --profile $PROFILE --bin walrus-stress --bin walrus
 
 # Production Image for walrus stress
 FROM debian:bookworm-slim AS walrus-stress
@@ -22,6 +22,7 @@ ARG PROFILE=release
 WORKDIR "$WORKDIR/walrus"
 # Both bench and release profiles copy from release dir
 COPY --from=builder /walrus/target/release/walrus-stress /opt/walrus/bin/walrus-stress
+COPY --from=builder /walrus/target/release/walrus /opt/walrus/bin/walrus
 
 ARG BUILD_DATE
 ARG GIT_REVISION


### PR DESCRIPTION
[docker] add walrus CLI binary to stress image

we need the walrus CLI binary for the `health` subcommand, so it's best to just bake the CLI binary into the stress image

## Description

Describe the changes or additions included in this PR.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
