### PR TITLE
refactor: enable additional lints and refactor code accordingly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,17 @@ x509-cert = "0.2.5"
 [workspace.lints.rust]
 missing_debug_implementations = "warn"
 missing_docs = "warn"
-unexpected_cfgs = { level = "allow", check-cfg = ['cfg(msim)'] }
+future_incompatible = "warn"
+nonstandard_style = "warn"
+unexpected_cfgs = { level = "allow", check-cfg = ['cfg(msim)'], priority = 1 }
+unused = "warn"
+
+[workspace.lints.clippy]
+cast_lossless = "warn"
+cast_possible_truncation = "warn"
+cast_possible_wrap = "warn"
+empty_structs_with_brackets = "warn"
+unwrap_used = "warn"
 
 [profile.release]
 panic = 'abort'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,9 +151,9 @@ walrus-utils = { path = "crates/walrus-utils" }
 x509-cert = "0.2.5"
 
 [workspace.lints.rust]
+future_incompatible = "warn"
 missing_debug_implementations = "warn"
 missing_docs = "warn"
-future_incompatible = "warn"
 nonstandard_style = "warn"
 unexpected_cfgs = { level = "allow", check-cfg = ['cfg(msim)'], priority = 1 }
 unused = "warn"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+allow-unwrap-in-tests = true

--- a/crates/checkpoint-downloader/src/downloader.rs
+++ b/crates/checkpoint-downloader/src/downloader.rs
@@ -230,7 +230,11 @@ impl ParallelCheckpointDownloaderInner {
                         .send(WorkerMessage::Shutdown)
                         .await?;
                     let new_count = worker_count.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
-                    config.metrics.num_workers.set(new_count as i64);
+                    config.metrics.num_workers.set(
+                        new_count
+                            .try_into()
+                            .expect("new_count should always fit into a i64"),
+                    );
                 }
             }
             std::cmp::Ordering::Less => {
@@ -249,7 +253,11 @@ impl ParallelCheckpointDownloaderInner {
                     );
                     *next_worker_id += 1;
                     let new_count = worker_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                    config.metrics.num_workers.set(new_count as i64);
+                    config.metrics.num_workers.set(
+                        new_count
+                            .try_into()
+                            .expect("new_count should always fit into a i64"),
+                    );
                 }
             }
             std::cmp::Ordering::Equal => {}
@@ -318,7 +326,9 @@ impl ParallelCheckpointDownloaderInner {
                     };
 
                     consecutive_failures = 0;
-                    config.metrics.checkpoint_lag.set(lag as i64);
+                    config.metrics.checkpoint_lag.set(lag.try_into().expect(
+                        "lag should always fit into a i64"
+                    ));
 
                     let current = worker_count.load(std::sync::atomic::Ordering::Relaxed);
                     if lag > downloader_config.scale_up_lag_threshold &&
@@ -456,22 +466,20 @@ impl ParallelCheckpointDownloaderInner {
         };
 
         loop {
-            let result = client.get_full_checkpoint(sequence_number).await;
-            let Ok(checkpoint) = result else {
-                let err = result.unwrap_err();
-                handle_checkpoint_error(&err, sequence_number);
+            match client.get_full_checkpoint(sequence_number).await {
+                Ok(checkpoint) => return CheckpointEntry::new(sequence_number, Ok(checkpoint)),
+                Err(err) => {
+                    handle_checkpoint_error(&err, sequence_number);
+                    if let Some(delay) = backoff.next() {
+                        tokio::time::sleep(delay).await;
+                        continue;
+                    }
 
-                if let Some(delay) = backoff.next() {
-                    tokio::time::sleep(delay).await;
-                    continue;
+                    // Note that we only return error in test mode.
+                    assert!(cfg!(test));
+                    return CheckpointEntry::new(sequence_number, Err(err.into()));
                 }
-
-                // Note that we only return error in test mode.
-                assert!(cfg!(test));
-                return CheckpointEntry::new(sequence_number, Err(err.into()));
-            };
-
-            return CheckpointEntry::new(sequence_number, Ok(checkpoint));
+            }
         }
     }
 }

--- a/crates/typed-store/src/lib.rs
+++ b/crates/typed-store/src/lib.rs
@@ -5,14 +5,13 @@
 //! This crate provides functionality for storing and retrieving typed data in RocksDB,
 //! with support for column families, batch operations, and metrics.
 
-#![warn(
-    future_incompatible,
-    nonstandard_style,
-    rust_2018_idioms,
-    rust_2021_compatibility,
-    unused,
-    missing_docs
+// TODO(WAL-869): Remove this attribute and fix corresponding warnings.
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::unwrap_used
 )]
+#![warn(rust_2018_idioms)]
 
 /// Re-export rocksdb so that consumers can use the version of rocksdb via typed-store
 pub use rocksdb;

--- a/crates/typed-store/src/rocks.rs
+++ b/crates/typed-store/src/rocks.rs
@@ -928,8 +928,10 @@ impl<K, V> DBMap<K, V> {
         let mut num_keys = 0;
         let mut key_bytes_total = 0;
         let mut value_bytes_total = 0;
-        let mut key_hist = hdrhistogram::Histogram::<u64>::new_with_max(100000, 2).unwrap();
-        let mut value_hist = hdrhistogram::Histogram::<u64>::new_with_max(100000, 2).unwrap();
+        let mut key_hist = hdrhistogram::Histogram::<u64>::new_with_max(100000, 2)
+            .expect("the function parameters are valid");
+        let mut value_hist = hdrhistogram::Histogram::<u64>::new_with_max(100000, 2)
+            .expect("the function parameters are valid");
         for item in self.safe_iter() {
             let (key, value) = item?;
             num_keys += 1;
@@ -987,7 +989,8 @@ impl<K, V> DBMap<K, V> {
         )
     }
 
-    // Creates a RocksDB read option with specified lower and upper bounds.
+    /// Creates a RocksDB read option with specified lower and upper bounds.
+    ///
     /// Lower bound is inclusive, and upper bound is exclusive.
     fn create_read_options_with_bounds(
         &self,

--- a/crates/walrus-core/benches/basic_encoding.rs
+++ b/crates/walrus-core/benches/basic_encoding.rs
@@ -91,7 +91,7 @@ fn basic_decoding(c: &mut Criterion) {
                 encoder
                     .encode_all()
                     .enumerate()
-                    .map(|(i, s)| DecodingSymbol::<Primary>::new(i as u16, s)),
+                    .map(|(i, s)| DecodingSymbol::<Primary>::new(i.try_into().unwrap(), s)),
                 usize::from(symbol_count) + 1,
             )
             .collect();

--- a/crates/walrus-core/benches/basic_encoding.rs
+++ b/crates/walrus-core/benches/basic_encoding.rs
@@ -1,6 +1,9 @@
 // Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+// Allowing `unwrap`s in benchmarks.
+#![allow(clippy::unwrap_used)]
+
 //! Benchmarks for the basic encoding and decoding.
 
 use core::time::Duration;

--- a/crates/walrus-core/benches/blob_encoding.rs
+++ b/crates/walrus-core/benches/blob_encoding.rs
@@ -1,6 +1,9 @@
 // Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+// Allowing `unwrap`s in benchmarks.
+#![allow(clippy::unwrap_used)]
+
 //! Benchmarks for the blob encoding and decoding with and without authentication.
 
 use core::{num::NonZeroU16, time::Duration};

--- a/crates/walrus-core/src/encoding/basic_encoding/raptorq.rs
+++ b/crates/walrus-core/src/encoding/basic_encoding/raptorq.rs
@@ -254,11 +254,19 @@ mod tests {
         let n_shards = end.try_into().unwrap();
 
         let encoder = RaptorQEncoder::new_with_new_encoding_plan(data, n_source_symbols, n_shards)?;
-        let encoded_symbols = encoder
-            .encode_all()
-            .skip(start.into())
-            .enumerate()
-            .map(|(i, symbol)| DecodingSymbol::<Primary>::new(i as u16 + start, symbol));
+        let encoded_symbols =
+            encoder
+                .encode_all()
+                .skip(start.into())
+                .enumerate()
+                .map(|(i, symbol)| {
+                    DecodingSymbol::<Primary>::new(
+                        u16::try_from(i)
+                            .expect("we encode `n_shards` symbols and `n_shards` is a u16")
+                            + start,
+                        symbol,
+                    )
+                });
         let mut decoder = RaptorQDecoder::new(n_source_symbols, n_shards, encoder.symbol_size());
         let decoding_result = decoder.decode(encoded_symbols);
 
@@ -284,7 +292,7 @@ mod tests {
                 .enumerate()
                 .map(|(i, symbol)| {
                     vec![DecodingSymbol::<Primary>::new(
-                        i as u16 + n_source_symbols.get(),
+                        u16::try_from(i).unwrap() + n_source_symbols.get(),
                         symbol,
                     )]
                 });

--- a/crates/walrus-core/src/encoding/basic_encoding/reed_solomon.rs
+++ b/crates/walrus-core/src/encoding/basic_encoding/reed_solomon.rs
@@ -270,7 +270,9 @@ mod tests {
             .skip(start.into())
             .take((end - start).into())
             .enumerate()
-            .map(|(i, symbol)| DecodingSymbol::<Primary>::new(i as u16 + start, symbol));
+            .map(|(i, symbol)| {
+                DecodingSymbol::<Primary>::new(u16::try_from(i).unwrap() + start, symbol)
+            });
         let mut decoder =
             ReedSolomonDecoder::new(n_source_symbols, n_shards, encoder.symbol_size());
         let decoding_result = decoder.decode(encoded_symbols);
@@ -296,7 +298,7 @@ mod tests {
             .enumerate()
             .map(|(i, symbol)| {
                 vec![DecodingSymbol::<Primary>::new(
-                    i as u16 + n_source_symbols.get(),
+                    u16::try_from(i).unwrap() + n_source_symbols.get(),
                     symbol,
                 )]
             });

--- a/crates/walrus-core/src/encoding/mapping.rs
+++ b/crates/walrus-core/src/encoding/mapping.rs
@@ -188,7 +188,8 @@ mod tests {
         rotate_pairs(&mut pairs, &blob_id).unwrap();
         // Check that all the pairs are is in the correct spot
         assert!(pairs.iter().enumerate().all(|(index, pair)| {
-            ShardIndex(index as u16).to_pair_index(7.try_into().unwrap(), &blob_id) == pair.index()
+            ShardIndex(index.try_into().unwrap()).to_pair_index(7.try_into().unwrap(), &blob_id)
+                == pair.index()
         }));
     }
 
@@ -200,7 +201,8 @@ mod tests {
         // Check that all the pairs are is in the correct spot
         for (index, pair) in pairs.iter().enumerate() {
             assert_eq!(
-                ShardIndex(index as u16).to_pair_index(7.try_into().unwrap(), &blob_id),
+                ShardIndex(index.try_into().unwrap())
+                    .to_pair_index(7.try_into().unwrap(), &blob_id),
                 pair.index()
             );
         }
@@ -209,7 +211,8 @@ mod tests {
         let combined_blob_id = test_utils::blob_id_from_u64(18); // 17 % 7 + 15 % 7 = 18 % 7
         rotate_pairs_unchecked(&mut pairs, &blob_id_2);
         assert!(pairs.iter().enumerate().all(|(index, pair)| {
-            ShardIndex(index as u16).to_pair_index(7.try_into().unwrap(), &combined_blob_id)
+            ShardIndex(index.try_into().unwrap())
+                .to_pair_index(7.try_into().unwrap(), &combined_blob_id)
                 == pair.index()
         }));
     }

--- a/crates/walrus-core/src/encoding/quilt_encoding.rs
+++ b/crates/walrus-core/src/encoding/quilt_encoding.rs
@@ -6,7 +6,10 @@
 // Please use with caution as it is subject to change without prior notice.
 // *******************************************************************************
 
-#![allow(dead_code)] // TODO: remove this once follow up PRs are merged.
+// TODO: remove this once follow up PRs are merged.
+#![allow(dead_code)]
+// TODO(WAL-869): Remove this attribute and fix corresponding warnings.
+#![allow(clippy::cast_possible_truncation)]
 
 use alloc::{
     format,

--- a/crates/walrus-core/src/messages/sync_shard.rs
+++ b/crates/walrus-core/src/messages/sync_shard.rs
@@ -84,9 +84,12 @@ impl SyncShardRequest {
     }
 
     /// Returns the number of slivers to sync starting from the starting blob ID.
-    pub fn sliver_count(&self) -> u64 {
+    pub fn sliver_count(&self) -> usize {
         match self {
-            Self::V1(request) => request.sliver_count,
+            Self::V1(request) => request
+                .sliver_count
+                .try_into()
+                .expect("nodes are expected to run on 64-bit architectures"),
         }
     }
 

--- a/crates/walrus-core/src/metadata.rs
+++ b/crates/walrus-core/src/metadata.rs
@@ -283,7 +283,10 @@ impl VerifiedBlobMetadataWithId {
     /// of shards in the encoding config with which this was verified.
     pub fn n_shards(&self) -> NonZeroU16 {
         let n_hashes = self.metadata.hashes().len();
-        NonZeroU16::new(n_hashes as u16).expect("verified metadata has a valid number of shards")
+        u16::try_from(n_hashes)
+            .ok()
+            .and_then(NonZeroU16::new)
+            .expect("verified metadata has a valid number of shards")
     }
 }
 

--- a/crates/walrus-core/src/test_utils.rs
+++ b/crates/walrus-core/src/test_utils.rs
@@ -148,9 +148,12 @@ pub const fn blob_id_from_u64(num: u64) -> BlobId {
 pub fn blob_metadata() -> BlobMetadata {
     let config = encoding_config();
     let hashes: Vec<_> = (0..config.n_shards.into())
-        .map(|i| SliverPairMetadata {
-            primary_hash: Node::Digest([(i % 256) as u8; 32]),
-            secondary_hash: Node::Digest([(i % 256) as u8; 32]),
+        .map(|i| {
+            let byte = u8::try_from(i % 256).expect("this is guaranteed to fit into a u8");
+            SliverPairMetadata {
+                primary_hash: Node::Digest([byte; 32]),
+                secondary_hash: Node::Digest([byte; 32]),
+            }
         })
         .collect();
     BlobMetadata::new(DEFAULT_ENCODING, 62_831, hashes)

--- a/crates/walrus-core/src/test_utils.rs
+++ b/crates/walrus-core/src/test_utils.rs
@@ -1,5 +1,9 @@
 // Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
+
+// Allowing `unwrap`s in test utils.
+#![allow(clippy::unwrap_used)]
+
 //! Utility functions for tests.
 
 use alloc::{vec, vec::Vec};

--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -1,6 +1,9 @@
 // Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+// Allowing `unwrap`s in tests.
+#![allow(clippy::unwrap_used)]
+
 //! Contains end-to-end tests for the Walrus client interacting with a Walrus test cluster.
 
 #[cfg(msim)]

--- a/crates/walrus-e2e-tests/tests/test_event_blobs.rs
+++ b/crates/walrus-e2e-tests/tests/test_event_blobs.rs
@@ -1,7 +1,11 @@
 // Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+// Allowing `unwrap`s in tests.
+#![allow(clippy::unwrap_used)]
+
 //! End-to-end tests for event blobs.
+
 use std::time::Duration;
 
 use anyhow::Context;

--- a/crates/walrus-orchestrator/src/main.rs
+++ b/crates/walrus-orchestrator/src/main.rs
@@ -1,6 +1,9 @@
 // Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+// TODO(WAL-869): Remove this attribute and fix corresponding warnings.
+#![allow(clippy::cast_possible_truncation, clippy::unwrap_used)]
+
 //! Orchestrator entry point.
 
 use std::path::PathBuf;

--- a/crates/walrus-proc-macros/src/walrus_simtest.rs
+++ b/crates/walrus-proc-macros/src/walrus_simtest.rs
@@ -10,7 +10,10 @@ pub fn attribute_macro(args: TokenStream, item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as ItemFn);
 
     let arg_parser = Punctuated::<syn::Meta, Token![,]>::parse_terminated;
-    let args = arg_parser.parse(args).unwrap().into_iter();
+    let args = arg_parser
+        .parse(args)
+        .expect("should be able to parse arguments")
+        .into_iter();
 
     // If running simtests, add a "simtest_" prefix to the function name.
     let output = if cfg!(msim) {

--- a/crates/walrus-proxy/src/consumer.rs
+++ b/crates/walrus-proxy/src/consumer.rs
@@ -375,7 +375,7 @@ pub async fn convert_to_remote_write(
             }
         }
     }
-    CONSUMER_OPS_SUBMITTED.inc_by(mf_cnt as f64);
+    CONSUMER_OPS_SUBMITTED.inc_by(f64::from(mf_cnt));
     timer.observe_duration();
     (StatusCode::CREATED, "created")
 }

--- a/crates/walrus-proxy/src/histogram_relay.rs
+++ b/crates/walrus-proxy/src/histogram_relay.rs
@@ -127,7 +127,9 @@ impl HistogramRelay {
         let timestamp_secs = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
-            .as_secs() as i64;
+            .as_secs()
+            .try_into()
+            .unwrap();
         let mut queue = self
             .0
             .lock()

--- a/crates/walrus-proxy/src/lib.rs
+++ b/crates/walrus-proxy/src/lib.rs
@@ -1,6 +1,9 @@
 // Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+// TODO(WAL-869): Remove this attribute and fix corresponding warnings.
+#![allow(clippy::unwrap_used)]
+
 //! # Walrus Proxy
 //!
 //! This crate provides a proxy layer for the Walrus system.

--- a/crates/walrus-proxy/src/main.rs
+++ b/crates/walrus-proxy/src/main.rs
@@ -1,8 +1,10 @@
 // Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
-//! - walrus-proxy service
-//!
-//! the walrus-proxy service acts as a relay for nodes to push metrics to and we
+
+// TODO(WAL-869): Remove this attribute and fix corresponding warnings.
+#![allow(clippy::unwrap_used)]
+
+//! The walrus-proxy service acts as a relay for nodes to push metrics to and we
 //! in turn push them to a mimir cluster.
 
 use std::env;

--- a/crates/walrus-sdk/src/blocklist.rs
+++ b/crates/walrus-sdk/src/blocklist.rs
@@ -77,7 +77,10 @@ impl Blocklist {
     /// Checks if a blob ID is blocked.
     #[inline]
     pub fn is_blocked(&self, blob_id: &BlobId) -> bool {
-        let guard = self.blocked_blobs.read().expect("mutex poisoned");
+        let guard = self
+            .blocked_blobs
+            .read()
+            .expect("mutex should not be poisoned");
         guard.contains(blob_id)
     }
 
@@ -86,8 +89,10 @@ impl Blocklist {
     /// Returns whether the ID was newly inserted.
     #[inline]
     pub fn insert(&mut self, blob_id: BlobId) -> Result<bool> {
-        let mut guard: std::sync::RwLockWriteGuard<'_, HashSet<BlobId>> =
-            self.blocked_blobs.write().expect("mutex poisoned");
+        let mut guard: std::sync::RwLockWriteGuard<'_, HashSet<BlobId>> = self
+            .blocked_blobs
+            .write()
+            .expect("mutex should not be poisoned");
         guard.insert(blob_id);
         // Update yaml file to add this blob id
         let blobs = BlocklistInner(guard.iter().cloned().collect::<Vec<_>>());
@@ -105,8 +110,10 @@ impl Blocklist {
     /// Returns whether the ID was previously blocked.
     #[inline]
     pub fn remove(&mut self, blob_id: &BlobId) -> Result<bool> {
-        let mut guard: std::sync::RwLockWriteGuard<'_, HashSet<BlobId>> =
-            self.blocked_blobs.write().expect("mutex poisoned");
+        let mut guard: std::sync::RwLockWriteGuard<'_, HashSet<BlobId>> = self
+            .blocked_blobs
+            .write()
+            .expect("mutex should not be poisoned");
         guard.remove(blob_id);
         let blobs = BlocklistInner(guard.iter().cloned().collect::<Vec<_>>());
 
@@ -142,7 +149,10 @@ impl Blocklist {
             self.deny_list_path.display()
         ))?;
 
-        let mut guard = self.blocked_blobs.write().expect("mutex poisoned");
+        let mut guard = self
+            .blocked_blobs
+            .write()
+            .expect("mutex should not be poisoned");
         let old_blobs = guard.iter().cloned().collect::<HashSet<_>>();
         let new_blobs = blocklist.0.iter().cloned().collect::<HashSet<_>>();
         let added_blobs = new_blobs.difference(&old_blobs).collect::<Vec<_>>();

--- a/crates/walrus-sdk/src/client.rs
+++ b/crates/walrus-sdk/src/client.rs
@@ -645,8 +645,14 @@ impl Client<SuiContractClient> {
                     None
                 } else {
                     Some((
-                        encoded_blob.get_sliver_pairs().unwrap().clone(),
-                        encoded_blob.get_metadata().unwrap().clone(),
+                        encoded_blob
+                            .get_sliver_pairs()
+                            .expect("sliver pairs are present on an encoded blob")
+                            .clone(),
+                        encoded_blob
+                            .get_metadata()
+                            .expect("metadata is present on an encoded blob")
+                            .clone(),
                     ))
                 }
             })

--- a/crates/walrus-sdk/src/config/sliver_write_extra_time.rs
+++ b/crates/walrus-sdk/src/config/sliver_write_extra_time.rs
@@ -24,6 +24,7 @@ impl SliverWriteExtraTime {
     ///
     /// The extra time is computed as `store_time * factor + base`.
     pub fn extra_time(&self, store_time: Duration) -> Duration {
+        #[allow(clippy::cast_possible_truncation)]
         let extra_time = Duration::from_nanos((store_time.as_nanos() as f64 * self.factor) as u64);
         self.base + extra_time
     }

--- a/crates/walrus-service/bin/node.rs
+++ b/crates/walrus-service/bin/node.rs
@@ -596,7 +596,7 @@ mod commands {
                         VERSION,
                         "walrus",
                     ))
-                    .unwrap();
+                    .expect("metrics defined at compile time must be valid");
             });
 
         tracing::info!(version = VERSION, "Walrus binary version");
@@ -1048,7 +1048,10 @@ mod commands {
         let cancel_token = CancellationToken::new();
         let cancel_token_clone = cancel_token.clone();
         tokio::spawn(async move {
-            event_processor.start(cancel_token_clone).await.unwrap();
+            event_processor
+                .start(cancel_token_clone)
+                .await
+                .expect("event processor should not fail");
         });
 
         tokio::time::sleep(runtime_duration).await;

--- a/crates/walrus-service/src/backup/config.rs
+++ b/crates/walrus-service/src/backup/config.rs
@@ -171,7 +171,7 @@ pub mod defaults {
     /// The reason we multiply by the chunk size is to ensure that the fetchers don't race to fetch
     /// blobs that are already in another fetcher's in-memory queue.
     pub fn retry_fetch_after_interval() -> Duration {
-        Duration::from_secs(45 * 60 * blob_job_chunk_size() as u64)
+        Duration::from_secs(45 * 60 * u64::from(blob_job_chunk_size()))
     }
 
     /// The default interval between the fetcher polling the database when there is no work to do.

--- a/crates/walrus-service/src/backup/garbage_collector.rs
+++ b/crates/walrus-service/src/backup/garbage_collector.rs
@@ -32,7 +32,7 @@ pub async fn start_backup_garbage_collector(
                 VERSION,
                 "walrus",
             ))
-            .unwrap();
+            .expect("metrics defined at compile time must be valid");
     });
 
     tracing::info!(version = VERSION, "Walrus backup binary version");

--- a/crates/walrus-service/src/backup/metrics.rs
+++ b/crates/walrus-service/src/backup/metrics.rs
@@ -47,7 +47,7 @@ walrus_utils::metrics::define_metric_set! {
 }
 
 fn buckets_for_blob_durations() -> Vec<f64> {
-    prometheus::exponential_buckets(0.02, 2.7, 12).unwrap()
+    prometheus::exponential_buckets(0.02, 2.7, 12).expect("this is a valid buckets config")
 }
 
 walrus_utils::metrics::define_metric_set! {

--- a/crates/walrus-service/src/backup/service.rs
+++ b/crates/walrus-service/src/backup/service.rs
@@ -643,7 +643,7 @@ async fn backup_fetcher(
                 }
                 backup_metric_set
                     .consecutive_blob_fetch_errors
-                    .set(consecutive_fetch_errors as f64);
+                    .set(f64::from(consecutive_fetch_errors));
             }
         } else {
             // Nothing to fetch. We are idle. Let's rest a bit.

--- a/crates/walrus-service/src/backup/service.rs
+++ b/crates/walrus-service/src/backup/service.rs
@@ -127,7 +127,7 @@ async fn record_event(
     retry_counter: &GenericCounter<AtomicU64>,
     db_reconnects: &GenericCounter<AtomicU64>,
 ) -> Result<(), Error> {
-    let event_id: EventID = element.event_id().unwrap();
+    let event_id: EventID = contract_event.event_id();
     retry_serializable_query(
         pg_connection,
         Location::caller(),
@@ -274,27 +274,30 @@ pub async fn establish_connection_async(
 
 /// Run the database migrations for the backup node.
 pub fn run_backup_database_migrations(config: &BackupConfig) {
-    let mut connection = establish_connection(
+    let mut connection = match establish_connection(
         &config.db_config.database_url,
         "run_backup_database_migrations",
-    )
-    .inspect_err(|error| {
-        tracing::error!(
-            ?error,
-            "failed to connect to postgres for database migration"
-        );
-        std::process::exit(1);
-    })
-    .unwrap();
+    ) {
+        Ok(connection) => connection,
+        Err(error) => {
+            tracing::error!(
+                ?error,
+                "failed to connect to postgres for database migration"
+            );
+            std::process::exit(1);
+        }
+    };
+
     tracing::info!("running pending migrations");
-    let versions = connection
-        .run_pending_migrations(MIGRATIONS)
-        .inspect_err(|error| {
+    match connection.run_pending_migrations(MIGRATIONS) {
+        Ok(versions) => {
+            tracing::info!(?versions, "migrations ran successfully");
+        }
+        Err(error) => {
             tracing::error!(?error, "failed to run pending migrations");
             std::process::exit(1);
-        })
-        .unwrap();
-    tracing::info!(?versions, "migrations ran successfully");
+        }
+    }
 }
 
 /// Starts a new backup node runtime.
@@ -312,7 +315,7 @@ pub async fn start_backup_orchestrator(
                 VERSION,
                 "walrus",
             ))
-            .unwrap();
+            .expect("metrics defined at compile time must be valid");
     });
 
     tracing::info!(version = VERSION, "Walrus backup binary version");
@@ -467,7 +470,7 @@ pub async fn start_backup_fetcher(
                 VERSION,
                 "walrus",
             ))
-            .unwrap();
+            .expect("metrics defined at compile time must be valid");
     });
 
     tracing::info!(version = VERSION, "Walrus backup binary version");
@@ -695,9 +698,11 @@ async fn backup_fetch_inner_core(
     let sha256 = sha2::Sha256::digest(&blob).to_vec();
     match upload_blob_to_storage(blob_id, blob, backup_config).await {
         Ok(backup_url) => {
-            backup_metric_set
-                .blob_bytes_uploaded
-                .inc_by(blob_len as u64);
+            backup_metric_set.blob_bytes_uploaded.inc_by(
+                blob_len
+                    .try_into()
+                    .expect("blob_len is guaranteed tofit into a u64"),
+            );
             let upload_time = Duration::from_secs_f64(timer_guard.stop_and_record());
             let affected_rows: usize = retry_serializable_query(
                 conn,
@@ -726,7 +731,10 @@ async fn backup_fetch_inner_core(
                                     AND state = 'waiting'",
                         )
                         .bind::<Text, _>(&backup_url)
-                        .bind::<Int8, _>(blob_len as i64)
+                        .bind::<Int8, _>(
+                            i64::try_from(blob_len)
+                                .expect("blob_len is guaranteed to fit into a i64"),
+                        )
                         .bind::<Bytea, _>(md5)
                         .bind::<Bytea, _>(&sha256)
                         .bind::<Text, _>(VERSION)

--- a/crates/walrus-service/src/client/cli.rs
+++ b/crates/walrus-service/src/client/cli.rs
@@ -282,7 +282,7 @@ trait CurrencyForDisplay {
     }
 
     fn units_in_superunit() -> u64 {
-        10u64.pow(Self::DECIMALS as u32)
+        10u64.pow(u32::from(Self::DECIMALS))
     }
 
     /// Gets the value of the current coin.

--- a/crates/walrus-service/src/client/cli.rs
+++ b/crates/walrus-service/src/client/cli.rs
@@ -260,7 +260,8 @@ impl std::fmt::Display for HumanReadableBytes {
             UNITS[usize::try_from(exponent - 1).expect("we assume at least a 32-bit architecture")];
 
         // Get correct number of significant digits (not rounding integer part).
-        let normalized_integer_digits = normalized_value.log10() as usize + 1;
+        #[allow(clippy::cast_possible_truncation)] // the truncation is intentional here
+        let normalized_integer_digits = normalized_value.log10().floor() as usize + 1;
         let set_precision = f.precision().unwrap_or(3).max(1);
         let precision = set_precision.saturating_sub(normalized_integer_digits);
 
@@ -382,6 +383,7 @@ fn thousands_separator(num: u64) -> String {
         .join(",")
 }
 
+#[allow(clippy::cast_possible_truncation)] // the truncation is intentional here
 fn thousands_separator_float(num: f64, digits: u32) -> String {
     let integer = num.floor() as u64;
     let decimal = (num.fract() * 10u64.pow(digits) as f64).round() as u64;

--- a/crates/walrus-service/src/client/cli/cli_output.rs
+++ b/crates/walrus-service/src/client/cli/cli_output.rs
@@ -637,7 +637,7 @@ fn print_storage_node_table(n_shards: &NonZeroU16, storage_nodes: &[StorageNodeI
     ]);
     for (i, node) in storage_nodes.iter().enumerate() {
         let n_owned = node.n_shards;
-        let n_owned_percent = (n_owned as f64) / (n_shards.get() as f64) * 100.0;
+        let n_owned_percent = (n_owned as f64) / f64::from(n_shards.get()) * 100.0;
         table.add_row(row![
             bFc->format!("{i}"),
             node.name,
@@ -1044,7 +1044,7 @@ fn blob_and_file_str(blob_id: &BlobId, file: &Option<PathBuf>) -> String {
 /// Print the full information of the storage node to stdoud.
 fn print_storage_node_info(node: &StorageNodeInfo, node_idx: usize, n_shards: &NonZeroU16) {
     let n_owned = node.n_shards;
-    let n_owned_percent = (n_owned as f64) / (n_shards.get() as f64) * 100.0;
+    let n_owned_percent = (n_owned as f64) / f64::from(n_shards.get()) * 100.0;
     printdoc!(
         "
 

--- a/crates/walrus-service/src/client/cli/cli_output.rs
+++ b/crates/walrus-service/src/client/cli/cli_output.rs
@@ -424,7 +424,9 @@ impl CliOutput for InfoEpochOutput {
 
         let time_output = match start_of_current_epoch {
             EpochTimeOrMessage::DateTime(start_time) => {
-                let end_time = *start_time + chrono::Duration::from_std(*epoch_duration).unwrap();
+                let end_time = *start_time
+                    + chrono::Duration::from_std(*epoch_duration)
+                        .expect("any practical epoch duration fits into a chrono::Duration");
                 format!("Start time: {}\nEnd time: {}", start_time, end_time)
             }
             EpochTimeOrMessage::Message(msg) => msg.clone(),

--- a/crates/walrus-service/src/client/cli/runner.rs
+++ b/crates/walrus-service/src/client/cli/runner.rs
@@ -1276,12 +1276,14 @@ async fn get_epochs_ahead(
             ensure!(
                 earliest_expiry_ts > estimated_start_of_current_epoch
                     && earliest_expiry_ts > Utc::now(),
-                "earliest_expiry_time must be greater than the current epoch start time
+                "earliest_expiry_time must be greater than the current epoch start time \
                 and the current time"
             );
             let delta =
                 (earliest_expiry_ts - estimated_start_of_current_epoch).num_milliseconds() as u64;
-            (delta / staking_object.epoch_duration() + 1) as u32
+            (delta / staking_object.epoch_duration() + 1)
+                .try_into()
+                .map_err(|_| anyhow::anyhow!("expiry time is too far in the future"))?
         }
         EpochArg {
             end_epoch: Some(end_epoch),

--- a/crates/walrus-service/src/client/refill.rs
+++ b/crates/walrus-service/src/client/refill.rs
@@ -215,7 +215,7 @@ pub async fn should_refill(
     sui_client
         .get_balance(address, coin_type)
         .await
-        .map(|balance| balance.total_balance < min_balance as u128)
+        .map(|balance| balance.total_balance < u128::from(min_balance))
         .inspect_err(|error| {
             tracing::debug!(
                 ?error,

--- a/crates/walrus-service/src/client/responses.rs
+++ b/crates/walrus-service/src/client/responses.rs
@@ -309,7 +309,7 @@ impl EncodingDependentPriceInfo {
         }
 
         let metadata_storage_size =
-            (n_shards.get() as u64) * metadata_length_for_n_shards(n_shards);
+            u64::from(n_shards.get()) * metadata_length_for_n_shards(n_shards);
         let metadata_price =
             storage_units_from_size(metadata_storage_size) * storage_price_per_unit_size;
 
@@ -437,7 +437,7 @@ impl InfoCommitteeOutput {
         }
 
         let metadata_storage_size =
-            (n_shards.get() as u64) * metadata_length_for_n_shards(n_shards);
+            u64::from(n_shards.get()) * metadata_length_for_n_shards(n_shards);
 
         Ok(Self {
             n_shards,

--- a/crates/walrus-service/src/common/config.rs
+++ b/crates/walrus-service/src/common/config.rs
@@ -167,7 +167,7 @@ impl SuiReaderConfig {
 
 /// Shared configuration defaults.
 pub mod defaults {
-    use super::*;
+    use std::time::Duration;
 
     /// Default polling interval in milliseconds.
     pub const POLLING_INTERVAL_MS: u64 = 400;

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -1029,7 +1029,7 @@ impl StorageNode {
         if let Err(error) =
             self.maybe_record_event_source(element_index, &stream_element.checkpoint_event_position)
         {
-            tracing::warn!(?error, "Failed to record event source");
+            tracing::warn!(?error, "failed to record event source");
         }
 
         let event_handle = EventHandle::new(
@@ -1905,6 +1905,7 @@ impl StorageNode {
             .unwrap_or(0)
             + event_source.counter;
 
+        #[allow(clippy::cast_possible_wrap)] // wrapping is fine here
         walrus_utils::with_label!(
             self.inner
                 .metrics

--- a/crates/walrus-service/src/node/committee/node_service.rs
+++ b/crates/walrus-service/src/node/committee/node_service.rs
@@ -381,6 +381,7 @@ impl DefaultNodeServiceFactory {
 
     /// Skips the use of proxies or the loading of native certificates, as these require interacting
     /// with the operating system and can significantly slow down the construction of new instances.
+    #[cfg(feature = "test-utils")]
     pub fn avoid_system_services() -> Self {
         Self {
             disable_use_proxy: true,

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -375,11 +375,11 @@ impl StorageNodeConfig {
         let projected_commission_rate = commission_rate_data
             .pending_commission_rate
             .last()
-            .map_or(commission_rate_data.commission_rate as u64, |&(_, rate)| {
+            .map_or(u64::from(commission_rate_data.commission_rate), |&(_, rate)| {
                 rate
             });
-        assert!(projected_commission_rate < u16::MAX as u64);
-        (projected_commission_rate != local_commission_rate as u64).then_some(local_commission_rate)
+        assert!(projected_commission_rate < u64::from(u16::MAX));
+        (projected_commission_rate != u64::from(local_commission_rate)).then_some(local_commission_rate)
     }
 
     /// Compares the current node parameters with the passed-in parameters and generates the
@@ -1437,7 +1437,7 @@ mod tests {
                 voting_params: old_voting_params.clone(),
                 metadata: old_metadata.clone(),
                 commission_rate_data: CommissionRateData {
-                    pending_commission_rate: vec![(32, config.commission_rate as u64)],
+                    pending_commission_rate: vec![(32, u64::from(config.commission_rate))],
                     commission_rate: 20,
                 },
             },
@@ -1501,7 +1501,7 @@ mod tests {
                 voting_params: config.voting_params.clone(),
                 metadata: config.metadata.clone(),
                 commission_rate_data: CommissionRateData {
-                    pending_commission_rate: vec![(32, config.commission_rate as u64), (33, 110)],
+                    pending_commission_rate: vec![(32, u64::from(config.commission_rate)), (33, 110)],
                     commission_rate: config.commission_rate,
                 },
             },

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -164,7 +164,7 @@ pub struct StorageNodeConfig {
     /// The number of uncertified blobs before the node will reset the local
     /// state in event blob writer.
     #[serde(default, skip_serializing_if = "defaults::is_none")]
-    pub num_uncertified_blob_threshold: Option<u32>,
+    pub num_uncertified_blob_threshold: Option<usize>,
     /// Configuration for background SUI balance checks and alerting.
     #[serde(default, skip_serializing_if = "defaults::is_default")]
     pub balance_check: BalanceCheckConfig,
@@ -372,14 +372,13 @@ impl StorageNodeConfig {
         commission_rate_data: &CommissionRateData,
         local_commission_rate: u16,
     ) -> Option<u16> {
-        let projected_commission_rate = commission_rate_data
-            .pending_commission_rate
-            .last()
-            .map_or(u64::from(commission_rate_data.commission_rate), |&(_, rate)| {
-                rate
-            });
+        let projected_commission_rate = commission_rate_data.pending_commission_rate.last().map_or(
+            u64::from(commission_rate_data.commission_rate),
+            |&(_, rate)| rate,
+        );
         assert!(projected_commission_rate < u64::from(u16::MAX));
-        (projected_commission_rate != u64::from(local_commission_rate)).then_some(local_commission_rate)
+        (projected_commission_rate != u64::from(local_commission_rate))
+            .then_some(local_commission_rate)
     }
 
     /// Compares the current node parameters with the passed-in parameters and generates the
@@ -614,7 +613,7 @@ impl Default for CommitteeServiceConfig {
             metadata_request_timeout: Duration::from_secs(5),
             sliver_request_timeout: Duration::from_secs(300),
             invalidity_sync_timeout: Duration::from_secs(300),
-            max_concurrent_metadata_requests: NonZeroUsize::new(1).unwrap(),
+            max_concurrent_metadata_requests: NonZeroUsize::new(1).expect("1 is non-zero"),
             node_connect_timeout: Duration::from_secs(1),
             experimental_sliver_recovery_additional_symbols: 0,
         }
@@ -1501,7 +1500,10 @@ mod tests {
                 voting_params: config.voting_params.clone(),
                 metadata: config.metadata.clone(),
                 commission_rate_data: CommissionRateData {
-                    pending_commission_rate: vec![(32, u64::from(config.commission_rate)), (33, 110)],
+                    pending_commission_rate: vec![
+                        (32, u64::from(config.commission_rate)),
+                        (33, 110),
+                    ],
                     commission_rate: config.commission_rate,
                 },
             },

--- a/crates/walrus-service/src/node/consistency_check.rs
+++ b/crates/walrus-service/src/node/consistency_check.rs
@@ -297,6 +297,7 @@ fn certified_blob_consistency_check(
                 ?existence_check_error,
             "background blob info consistency check finished");
 
+            #[allow(clippy::cast_possible_wrap)] // wrapping is fine here
             walrus_utils::with_label!(node.metrics.blob_info_consistency_check, epoch_bucket)
                 .set(blob_list_digest as i64);
 
@@ -406,6 +407,7 @@ fn compose_certified_object_blob_list_digest(
 
     tracing::info!(?epoch, certified_blob_hash = ?blob_object_list_digest,
             "background per-object blob info consistency check finished");
+    #[allow(clippy::cast_possible_wrap)] // wrapping is fine here
     walrus_utils::with_label!(
         node.metrics.per_object_blob_info_consistency_check,
         epoch_bucket

--- a/crates/walrus-service/src/node/consistency_check.rs
+++ b/crates/walrus-service/src/node/consistency_check.rs
@@ -180,7 +180,7 @@ fn compose_blob_list_digest_and_check_sliver_data_existence(
 
     // Using Epoch as the seed for the RNG to make the sampled blob selection deterministic for the
     // same epoch.
-    let mut rng = StdRng::seed_from_u64(epoch as u64);
+    let mut rng = StdRng::seed_from_u64(u64::from(epoch));
 
     // For data existence check, we should only check it if the node is in Active state. Otherwise,
     // the node may not be fully synced with the latest epoch.
@@ -191,7 +191,7 @@ fn compose_blob_list_digest_and_check_sliver_data_existence(
 
     // xxhash is not a cryptographic hash function, but it is fast, has good collision
     // resistance, and is consistent across all platforms.
-    let mut hasher = twox_hash::XxHash64::with_seed(epoch as u64);
+    let mut hasher = twox_hash::XxHash64::with_seed(u64::from(epoch));
     let mut total_synced_scanned = 0;
     let mut total_fully_stored = 0;
     let mut existence_check_error = 0;
@@ -358,7 +358,7 @@ fn compose_blob_object_list_digest(
 
     // xxhash is not a cryptographic hash function, but it is fast, has good collision
     // resistance, and is consistent across all platforms.
-    let mut hasher = twox_hash::XxHash64::with_seed(epoch as u64);
+    let mut hasher = twox_hash::XxHash64::with_seed(u64::from(epoch));
     for item in blob_info_iter {
         match item {
             Ok(blob_info) => {

--- a/crates/walrus-service/src/node/contract_service.rs
+++ b/crates/walrus-service/src/node/contract_service.rs
@@ -402,7 +402,9 @@ impl SystemContractService for SuiSystemContractService {
                     next_public_key,
                     proof_of_possession:
                         walrus_sui::utils::generate_proof_of_possession_for_address(
-                            config.next_protocol_key_pair().unwrap(),
+                            config.next_protocol_key_pair().expect(
+                                "next key pair must be set when updating remote next public key",
+                            ),
                             contract_client.address(),
                             contract_client.read_client.current_epoch().await?,
                         ),
@@ -456,7 +458,10 @@ impl SystemContractService for SuiSystemContractService {
             MIN_BACKOFF,
             MAX_BACKOFF,
             None,
-            self.rng.lock().unwrap().r#gen(),
+            self.rng
+                .lock()
+                .expect("mutex should not be poisoned")
+                .r#gen(),
         );
         backoff::retry(backoff, || async {
             self.contract_tx_client
@@ -480,7 +485,10 @@ impl SystemContractService for SuiSystemContractService {
             MIN_BACKOFF,
             MAX_BACKOFF,
             None,
-            self.rng.lock().unwrap().r#gen(),
+            self.rng
+                .lock()
+                .expect("mutex should not be poisoned")
+                .r#gen(),
         );
 
         backoff::retry(backoff, || async {

--- a/crates/walrus-service/src/node/db_checkpoint.rs
+++ b/crates/walrus-service/src/node/db_checkpoint.rs
@@ -183,8 +183,10 @@ impl DelayedTask {
 
     /// Get the status of the task.
     pub fn get_status(&self) -> TaskStatus {
-        let state = self.status.lock().unwrap();
-        state.clone()
+        self.status
+            .lock()
+            .expect("mutex should not be poisoned")
+            .clone()
     }
 }
 
@@ -687,7 +689,7 @@ mod tests {
 
     use super::*;
 
-    const MIN_BLOB_SIZE: u64 = 10;
+    const MIN_BLOB_SIZE: u16 = 10;
     const BLOB_FILE_SIZE: u64 = 1024 * 1024;
 
     /// Generates key/value pairs with random sizes:
@@ -725,7 +727,7 @@ mod tests {
     fn cf_options_with_blobs() -> Options {
         let mut opts = Options::default();
         opts.set_enable_blob_files(true);
-        opts.set_min_blob_size(MIN_BLOB_SIZE);
+        opts.set_min_blob_size(MIN_BLOB_SIZE.into());
         opts.set_blob_file_size(BLOB_FILE_SIZE);
         opts
     }
@@ -736,7 +738,7 @@ mod tests {
         let db_checkpoint_dir = tempdir()?;
         let restore_dir = tempdir()?;
 
-        let test_data = generate_test_data(100, MIN_BLOB_SIZE as usize);
+        let test_data = generate_test_data(100, MIN_BLOB_SIZE.into());
 
         {
             let mut db_opts = Options::default();

--- a/crates/walrus-service/src/node/epoch_change_driver.rs
+++ b/crates/walrus-service/src/node/epoch_change_driver.rs
@@ -94,7 +94,7 @@ impl EpochChangeDriver {
     pub async fn run(&self) {
         let inner = self.inner.clone();
         std::future::poll_fn(move |cx| {
-            let mut inner_guard = inner.lock().expect("mutex is not poisoned");
+            let mut inner_guard = inner.lock().expect("mutex should not be poisoned");
             inner_guard.poll_unpin(cx)
         })
         .await

--- a/crates/walrus-service/src/node/events/event_blob_writer.rs
+++ b/crates/walrus-service/src/node/events/event_blob_writer.rs
@@ -74,7 +74,7 @@ const MAX_BLOB_SIZE: usize = 100 * 1024 * 1024;
 /// The number of checkpoints per blob.
 pub(crate) const NUM_CHECKPOINTS_PER_BLOB: u32 = 216_000;
 /// The default number of unattested blobs threshold.
-const DEFAULT_NUM_UNATTESTED_BLOBS_THRESHOLD: u32 = 3;
+const DEFAULT_NUM_UNATTESTED_BLOBS_THRESHOLD: usize = 3;
 
 pub(crate) fn certified_cf_name() -> &'static str {
     CERTIFIED
@@ -349,7 +349,7 @@ impl EventBlobWriterFactory {
         registry: &Registry,
         num_checkpoints_per_blob: Option<u32>,
         last_certified_event_blob: Option<SuiEventBlob>,
-        num_uncertified_blob_threshold: Option<u32>,
+        num_uncertified_blob_threshold: Option<usize>,
     ) -> Result<EventBlobWriterFactory> {
         let db_path = Self::db_path(root_dir_path);
         fs::create_dir_all(db_path.as_path())?;
@@ -573,7 +573,7 @@ impl EventBlobWriterFactory {
         pending_db: &DBMap<u64, PendingEventBlobMetadata>,
         attested_db: &DBMap<(), AttestedEventBlobMetadata>,
         failed_to_attest_db: &DBMap<(), FailedToAttestEventBlobMetadata>,
-        num_uncertified_blob_threshold: Option<u32>,
+        num_uncertified_blob_threshold: Option<usize>,
         last_certified_event_blob: Option<SuiEventBlob>,
         blobs_path: &Path,
     ) -> Result<()> {
@@ -613,10 +613,7 @@ impl EventBlobWriterFactory {
         let total_uncertified_blobs = pending_db.safe_iter().count()
             + failed_to_attest_db.safe_iter().count()
             + attested_db.safe_iter().count();
-        let uncertified_blobs_after_last_certified =
-            pending.len() + failed_to_attest.len() + attested.len();
-
-        let consecutive_uncertified = uncertified_blobs_after_last_certified as u32;
+        let consecutive_uncertified = pending.len() + failed_to_attest.len() + attested.len();
 
         // We reset the node pending blobs if the local node has already certified the last
         // certified blob on chain, and have pending blob greater than
@@ -626,8 +623,8 @@ impl EventBlobWriterFactory {
         // last certified blob, to account for the situation where node is crashed after sending
         // out the last certified blob and before receiving the certification event.
         let should_reset = consecutive_uncertified >= num_uncertified_blob_threshold
-            && (total_uncertified_blobs == consecutive_uncertified as usize
-                || total_uncertified_blobs == consecutive_uncertified as usize + 1);
+            && (total_uncertified_blobs == consecutive_uncertified
+                || total_uncertified_blobs == consecutive_uncertified + 1);
 
         if !should_reset {
             tracing::info!(
@@ -827,14 +824,13 @@ pub struct EventBlobWriterConfig {
 /// Struct to manage event-based backoff logic.
 #[derive(Debug)]
 struct EventBackoff {
-    /// Base number of events to wait before retry
+    /// Base number of events to wait before retry.
     base_events: u64,
-    /// Current number of events to wait
+    /// Current number of events to wait.
     current_wait: u64,
-    /// Number of events processed since last attempt
+    /// Number of events processed since last attempt.
     events_since_attempt: u64,
-    /// Maximum number of retry attempts after which
-    /// the backoff will stop increasing
+    /// Maximum number of retry attempts after which the backoff will stop increasing.
     max_increase_backoff_for_attempts: u32,
     /// Current number of attempts
     attempts: u32,
@@ -854,6 +850,7 @@ impl EventBackoff {
 
     /// Returns the next wait count. Once max attempts is reached,
     /// keeps returning the current wait count without doubling.
+    #[allow(clippy::cast_possible_truncation)] // the truncation is intentional here
     fn update_next_attempt(&mut self) {
         if self.attempts < self.max_increase_backoff_for_attempts {
             self.current_wait *= 2
@@ -1163,7 +1160,7 @@ impl EventBlobWriter {
 
         self.metrics
             .latest_attested_checkpoint_sequence_number
-            .set(checkpoint_sequence_number as i64);
+            .set(checkpoint_sequence_number.try_into()?);
 
         match self
             .node
@@ -1362,9 +1359,10 @@ impl EventBlobWriter {
         );
         self.metrics
             .latest_in_progress_event_index
-            .set(element_index as i64);
+            .set(element_index.try_into()?);
         self.event_cursor = EventStreamCursor::new(element.element.event_id(), element_index + 1);
         self.update_sequence_range(&element);
+        assert!(self.start.is_some() && self.end.is_some());
         self.write_event_to_buffer(element.clone(), element_index)?;
 
         let mut batch = self.pending.batch();
@@ -1380,7 +1378,7 @@ impl EventBlobWriter {
 
         self.metrics
             .latest_processed_event_index
-            .set(element_index as i64);
+            .set(element_index.try_into()?);
 
         self.try_attest_next_blob().await;
 
@@ -1409,20 +1407,22 @@ impl EventBlobWriter {
 
     /// Cuts the current blob and resets for a new one.
     ///
-    /// This method finalizes the current blob, stores its metadata, and prepares
-    /// for writing a new blob.
+    /// This method finalizes the current blob, stores its metadata, and prepares for writing a new
+    /// blob.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if either `self.start.is_none()` or `self.end.is_none()` or the DB
+    /// operation fails.
     async fn cut_and_reset_blob(&mut self, batch: &mut DBBatch, element_index: u64) -> Result<()> {
         self.cut().await?;
         let blob_metadata = PendingEventBlobMetadata::new(
-            self.start.unwrap(),
-            self.end.unwrap(),
+            self.start.context("start is not set")?,
+            self.end.context("end is not set")?,
             self.event_cursor,
             self.current_epoch,
         );
-        batch.insert_batch(
-            &self.pending,
-            std::iter::once((element_index, blob_metadata)),
-        )?;
+        batch.insert_batch(&self.pending, [(element_index, blob_metadata)])?;
         self.reset()
     }
 
@@ -1465,7 +1465,7 @@ impl EventBlobWriter {
 
         self.metrics
             .latest_certified_event_index
-            .set(element_index as i64);
+            .set(element_index.try_into()?);
 
         batch.insert_batch(&self.certified, std::iter::once(((), metadata.clone())))?;
 

--- a/crates/walrus-service/src/node/events/event_blob_writer.rs
+++ b/crates/walrus-service/src/node/events/event_blob_writer.rs
@@ -1404,7 +1404,7 @@ impl EventBlobWriter {
         element.is_end_of_checkpoint_marker()
             && (self.current_blob_size() > MAX_BLOB_SIZE
                 || (element.checkpoint_event_position.checkpoint_sequence_number + 1
-                    >= self.start.unwrap_or(0) + self.num_checkpoints_per_blob() as u64))
+                    >= self.start.unwrap_or(0) + u64::from(self.num_checkpoints_per_blob())))
     }
 
     /// Cuts the current blob and resets for a new one.
@@ -1660,7 +1660,7 @@ mod tests {
             None,
         )?;
         let mut blob_writer = blob_writer_factory.create().await?;
-        let num_checkpoints: u64 = NUM_BLOBS * blob_writer.num_checkpoints_per_blob() as u64;
+        let num_checkpoints: u64 = NUM_BLOBS * u64::from(blob_writer.num_checkpoints_per_blob());
 
         generate_and_write_events(&mut blob_writer, num_checkpoints, NUM_EVENTS_PER_CHECKPOINT)
             .await?;
@@ -1713,7 +1713,7 @@ mod tests {
             None,
         )?;
         let mut blob_writer = blob_writer_factory.create().await?;
-        let num_checkpoints: u64 = NUM_BLOBS * blob_writer.num_checkpoints_per_blob() as u64;
+        let num_checkpoints: u64 = NUM_BLOBS * u64::from(blob_writer.num_checkpoints_per_blob());
 
         // Verify attestations are not paused
         assert!(!blob_writer.attestations_paused());
@@ -1796,7 +1796,7 @@ mod tests {
             None,
         )?;
         let mut blob_writer = blob_writer_factory.create().await?;
-        let num_checkpoints: u64 = NUM_BLOBS * blob_writer.num_checkpoints_per_blob() as u64;
+        let num_checkpoints: u64 = NUM_BLOBS * u64::from(blob_writer.num_checkpoints_per_blob());
 
         generate_and_write_events(&mut blob_writer, num_checkpoints, NUM_EVENTS_PER_CHECKPOINT)
             .await?;

--- a/crates/walrus-service/src/node/events/event_processor.rs
+++ b/crates/walrus-service/src/node/events/event_processor.rs
@@ -476,7 +476,7 @@ impl EventProcessor {
             tracing_sampled::info!("30s", "Processing checkpoint {}", next_checkpoint);
             self.metrics
                 .event_processor_latest_downloaded_checkpoint
-                .set(next_checkpoint as i64);
+                .set(next_checkpoint.try_into()?);
             self.metrics
                 .event_processor_total_downloaded_checkpoints
                 .inc();

--- a/crates/walrus-service/src/node/node_recovery.rs
+++ b/crates/walrus-service/src/node/node_recovery.rs
@@ -84,7 +84,7 @@ impl NodeRecoveryHandler {
                 {
                     node.metrics
                         .node_recovery_recover_blob_progress
-                        .set(blob_id.first_two_bytes() as i64);
+                        .set(i64::from(blob_id.first_two_bytes()));
 
                     // Note that here we need to use the current epoch to check if the blob is
                     // still certified. If the blob is retired, we don't need to recover it anymore.

--- a/crates/walrus-service/src/node/node_recovery.rs
+++ b/crates/walrus-service/src/node/node_recovery.rs
@@ -45,7 +45,10 @@ impl NodeRecoveryHandler {
         &self,
         certified_before_epoch: Epoch,
     ) -> Result<(), TypedStoreError> {
-        let mut locked_task_handle = self.task_handle.lock().unwrap();
+        let mut locked_task_handle = self
+            .task_handle
+            .lock()
+            .expect("mutex should not be poisoned");
         assert!(locked_task_handle.is_none());
 
         let node = self.node.clone();

--- a/crates/walrus-service/src/node/shard_sync.rs
+++ b/crates/walrus-service/src/node/shard_sync.rs
@@ -192,7 +192,7 @@ impl ShardSyncHandler {
     ) -> Result<(), SyncShardClientError> {
         node.metrics
             .sync_blob_metadata_progress
-            .set(blob_id.first_two_bytes() as i64);
+            .set(i64::from(blob_id.first_two_bytes()));
 
         let result = node
             .blob_retirement_notifier
@@ -353,7 +353,7 @@ impl ShardSyncHandler {
                 shard_sync_handler_clone.config.shard_sync_retry_min_backoff,
                 shard_sync_handler_clone.config.shard_sync_retry_max_backoff,
                 None,
-                shard_index.0 as u64, // Seed the backoff with the shard index.
+                u64::from(shard_index.0), // Seed the backoff with the shard index.
             );
 
             // Whether to directly recover the shard instead of using shard sync.

--- a/crates/walrus-service/src/node/start_epoch_change_finisher.rs
+++ b/crates/walrus-service/src/node/start_epoch_change_finisher.rs
@@ -49,7 +49,10 @@ impl StartEpochChangeFinisher {
         let self_clone = self.clone();
         let event_clone = event.clone();
 
-        let mut locked_task_handle = self.task_handle.lock().unwrap();
+        let mut locked_task_handle = self
+            .task_handle
+            .lock()
+            .expect("mutex should not be poisoned");
         assert!(locked_task_handle.is_none());
 
         let handle = tokio::spawn(async move {

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -311,6 +311,7 @@ impl Storage {
     }
 
     /// Creates the storage for the specified shards, if it does not exist yet.
+    #[cfg(any(test, feature = "test-utils"))]
     pub(crate) async fn create_storage_for_shards(
         &self,
         new_shards: &[ShardIndex],
@@ -676,10 +677,11 @@ impl Storage {
             return Err(ShardNotAssigned(request.shard_index(), current_epoch).into());
         };
 
-        let mut fetched_blobs = Vec::with_capacity(request.sliver_count() as usize);
+        let sliver_count = request.sliver_count();
+        let mut fetched_blobs = Vec::with_capacity(sliver_count);
         let mut last_fetched_blob_id = None;
-        while fetched_blobs.len() < request.sliver_count() as usize {
-            let remaining_count = request.sliver_count() as usize - fetched_blobs.len();
+        while fetched_blobs.len() < sliver_count {
+            let remaining_count = sliver_count - fetched_blobs.len();
 
             // Set starting point - either the initial request start or after last fetched blob
             let starting_blob_id_bound =

--- a/crates/walrus-service/src/node/storage/database_config.rs
+++ b/crates/walrus-service/src/node/storage/database_config.rs
@@ -54,7 +54,7 @@ pub struct DatabaseTableOptions {
     max_bytes_for_level_base: Option<u64>,
     /// Block cache size in bytes.
     #[serde(skip_serializing_if = "Option::is_none")]
-    block_cache_size: Option<u64>,
+    block_cache_size: Option<usize>,
     /// Pin l0 filter and index blocks in block cache.
     #[serde(skip_serializing_if = "Option::is_none")]
     pin_l0_filter_and_index_blocks_in_block_cache: Option<bool>,
@@ -235,7 +235,7 @@ impl DatabaseTableOptions {
         }
         if let Some(block_cache_size) = self.block_cache_size {
             let mut block_based_options = BlockBasedOptions::default();
-            block_based_options.set_block_cache(&Cache::new_lru_cache(block_cache_size as usize));
+            block_based_options.set_block_cache(&Cache::new_lru_cache(block_cache_size));
             if let Some(pin_l0_filter_and_index_blocks_in_block_cache) =
                 self.pin_l0_filter_and_index_blocks_in_block_cache
             {

--- a/crates/walrus-service/src/node/storage/event_cursor_table.rs
+++ b/crates/walrus-service/src/node/storage/event_cursor_table.rs
@@ -100,7 +100,10 @@ impl EventCursorTable {
         let next_index = this.get_sequentially_processed_event_count()?;
         this.persisted_event_count
             .store(next_index, Ordering::SeqCst);
-        *this.event_queue.lock().unwrap() = EventSequencer::continue_from(next_index);
+        *this
+            .event_queue
+            .lock()
+            .expect("mutex should not be poisoned") = EventSequencer::continue_from(next_index);
 
         Ok(this)
     }
@@ -129,7 +132,10 @@ impl EventCursorTable {
         )?;
         self.persisted_event_count
             .store(next_index, Ordering::SeqCst);
-        *self.event_queue.lock().unwrap() = EventSequencer::continue_from(next_index);
+        *self
+            .event_queue
+            .lock()
+            .expect("mutex should not be poisoned") = EventSequencer::continue_from(next_index);
 
         Ok(())
     }
@@ -151,7 +157,10 @@ impl EventCursorTable {
         event_index: u64,
         cursor: &EventID,
     ) -> Result<EventProgress, TypedStoreError> {
-        let mut event_queue = self.event_queue.lock().unwrap();
+        let mut event_queue = self
+            .event_queue
+            .lock()
+            .expect("mutex should not be poisoned");
         event_queue.add(event_index, *cursor);
         let mut count = 0u64;
         let most_recent_cursor = event_queue

--- a/crates/walrus-service/src/node/storage/shard.rs
+++ b/crates/walrus-service/src/node/storage/shard.rs
@@ -820,7 +820,7 @@ impl ShardStorage {
                     &self.id.to_string(),
                     &sliver_type.to_string()
                 )
-                .set(next_starting_blob_id.first_two_bytes() as i64);
+                .set(i64::from(next_starting_blob_id.first_two_bytes()));
 
                 let fetched_slivers = node
                     .committee_service

--- a/crates/walrus-service/src/node/storage/shard.rs
+++ b/crates/walrus-service/src/node/storage/shard.rs
@@ -1115,7 +1115,11 @@ impl ShardStorage {
             node.metrics.sync_shard_recover_sliver_pending_total,
             &self.id.to_string()
         )
-        .set(total_blobs_pending_recovery as i64);
+        .set(
+            total_blobs_pending_recovery
+                .try_into()
+                .expect("number of pending recoveries should fit into an i64"),
+        );
     }
 
     /// Skips recovering a blob that is no longer certified.

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -1,6 +1,9 @@
 // Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+// Allowing casts and `unwrap`s in test utils.
+#![allow(clippy::cast_possible_truncation, clippy::unwrap_used)]
+
 //! Test utilities for using storage nodes in tests.
 //!
 //! For creating an instance of a single storage node in a test, see [`StorageNodeHandleBuilder`] .

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -2500,7 +2500,7 @@ pub mod test_cluster {
             let amounts_to_stake = test_nodes_config
                 .node_weights
                 .iter()
-                .map(|&weight| FROST_PER_NODE_WEIGHT * weight as u64)
+                .map(|&weight| FROST_PER_NODE_WEIGHT * u64::from(weight))
                 .collect::<Vec<_>>();
             let storage_capabilities = register_committee_and_stake(
                 admin_contract_client.as_ref(),

--- a/crates/walrus-storage-node-client/src/client/middleware.rs
+++ b/crates/walrus-storage-node-client/src/client/middleware.rs
@@ -20,8 +20,6 @@ use reqwest::{
     Request,
     Response,
     StatusCode,
-    Url,
-    Version,
     header::{HeaderMap, HeaderName, HeaderValue},
 };
 use tokio::time::Instant;
@@ -579,7 +577,9 @@ impl Injector for HeaderInjector<'_> {
 }
 
 mod helpers {
-    use super::*;
+    use std::borrow::Cow;
+
+    use reqwest::{StatusCode, Url, Version};
 
     /// Enum of client HTTP error types that may be attached to metrics/traces.
     #[derive(Debug, Clone)]

--- a/crates/walrus-stress/src/generator.rs
+++ b/crates/walrus-stress/src/generator.rs
@@ -31,8 +31,10 @@ use walrus_sui::{
     utils::SuiNetwork,
 };
 
+/// Minimum burst duration in milliseconds.
+const MIN_BURST_DURATION_MS: u64 = 100;
 /// Minimum burst duration.
-const MIN_BURST_DURATION: Duration = Duration::from_millis(100);
+const MIN_BURST_DURATION: Duration = Duration::from_millis(MIN_BURST_DURATION_MS);
 /// Number of seconds per load period.
 const SECS_PER_LOAD_PERIOD: u64 = 60;
 
@@ -388,7 +390,7 @@ fn burst_load(load: u64) -> (u64, Interval) {
     let duration_per_op = Duration::from_secs_f64(SECS_PER_LOAD_PERIOD as f64 / (load as f64));
     let (load_per_burst, burst_duration) = if duration_per_op < MIN_BURST_DURATION {
         (
-            load / (SECS_PER_LOAD_PERIOD * 1_000 / MIN_BURST_DURATION.as_millis() as u64),
+            load / (SECS_PER_LOAD_PERIOD * 1_000 / MIN_BURST_DURATION_MS),
             MIN_BURST_DURATION,
         )
     } else {

--- a/crates/walrus-stress/src/generator/blob.rs
+++ b/crates/walrus-stress/src/generator/blob.rs
@@ -48,7 +48,7 @@ impl BlobData {
     /// Create a random blob of a given size.
     pub async fn random(mut rng: StdRng, config: WriteBlobConfig) -> Self {
         let mut new_rng = StdRng::from_seed(rng.r#gen());
-        let size = 2_usize.pow(config.max_size_log2 as u32);
+        let size = 2_usize.pow(u32::from(config.max_size_log2));
         let n_additional_bytes = size - TAG.len();
         let bytes = tokio::spawn(async move {
             TAG.iter()
@@ -85,8 +85,8 @@ impl BlobData {
     /// Returns a slice of the blob with a size `2^x`, where `x` is chosen uniformly at random
     /// between `min_size_log2` and `max_size_log2`.
     pub fn random_size_slice(&self) -> &[u8] {
-        let blob_size_min = 2_usize.pow(self.config.min_size_log2 as u32);
-        let blob_size_max = 2_usize.pow(self.config.max_size_log2 as u32);
+        let blob_size_min = 2_usize.pow(u32::from(self.config.min_size_log2));
+        let blob_size_max = 2_usize.pow(u32::from(self.config.max_size_log2));
         let blob_size = thread_rng().gen_range(blob_size_min..=blob_size_max);
         &self.bytes[..blob_size]
     }

--- a/crates/walrus-stress/src/main.rs
+++ b/crates/walrus-stress/src/main.rs
@@ -246,13 +246,16 @@ async fn run_staking(config: ClientConfig, _metrics: Arc<ClientMetrics>) -> anyh
                     // Allocate half the WAL to various nodes. This is a linear walk over all of the
                     // WAL which we're going to stake, just to simplify the algorithm. Each "stake"
                     // below is one unit of MIN_STAKING_THRESHOLD.
-                    let available_stakes = (wal_balance / MIN_STAKING_THRESHOLD) / 2;
+                    let available_stakes = usize::try_from(
+                        (wal_balance / MIN_STAKING_THRESHOLD) / 2,
+                    )
+                    .expect("this is at most 2.5B, which fits into a usize on 32-bit platforms");
                     let mut node_allocations = HashMap::<ObjectID, u64>::new();
                     for i in 0..available_stakes {
                         // Loop through the nodes in shuffled order until we've allocated all our
                         // stake.
                         node_allocations
-                            .entry(nodes[i as usize % nodes.len()].node_id)
+                            .entry(nodes[i % nodes.len()].node_id)
                             .and_modify(|x| *x += MIN_STAKING_THRESHOLD)
                             .or_insert(MIN_STAKING_THRESHOLD);
                     }

--- a/crates/walrus-sui/benches/gas_cost_bench.rs
+++ b/crates/walrus-sui/benches/gas_cost_bench.rs
@@ -1,6 +1,9 @@
 // Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+// Allowing `unwrap`s in benchmarks.
+#![allow(clippy::unwrap_used)]
+
 //! Gas cost benchmark for `walrus-sui`.
 
 use std::{io::Write, num::NonZeroU16, ops::Range, path::PathBuf, str::FromStr, time::Duration};

--- a/crates/walrus-sui/benches/gas_cost_bench.rs
+++ b/crates/walrus-sui/benches/gas_cost_bench.rs
@@ -69,7 +69,7 @@ impl FromStr for InputRange {
 }
 
 impl InputRange {
-    fn iter<'a>(&'a self) -> impl Iterator<Item = u32> + 'a {
+    fn iter(&self) -> impl Iterator<Item = u32> + '_ {
         self.range
             .clone()
             .step_by(self.step)

--- a/crates/walrus-sui/benches/gas_cost_bench.rs
+++ b/crates/walrus-sui/benches/gas_cost_bench.rs
@@ -72,7 +72,7 @@ impl InputRange {
     fn iter<'a>(&'a self) -> impl Iterator<Item = u32> + 'a {
         self.range
             .clone()
-            .step_by(self.step.clone())
+            .step_by(self.step)
             .map(|val| if self.exp { 2u32.pow(val) } else { val })
     }
 }

--- a/crates/walrus-sui/build.rs
+++ b/crates/walrus-sui/build.rs
@@ -92,7 +92,8 @@ fn collect_error_definitions(contracts_dir: &Path) -> Vec<ModuleErrorDefs> {
                 && !components.contains("build")
         })
     {
-        let content = fs::read_to_string(entry.path()).unwrap();
+        let content = fs::read_to_string(entry.path())
+            .expect("should be able to read file in contracts directory");
 
         let Some(module_captures) = module_pattern.captures(&content) else {
             continue;

--- a/crates/walrus-sui/src/client.rs
+++ b/crates/walrus-sui/src/client.rs
@@ -209,7 +209,7 @@ impl SuiClientError {
             ExecutionCancelledDueToSharedObjectCongestion\x20\{\x20congested_objects:
             \x20CongestedObjects\(\[(0x[a-f0-9]+)\]\)\x20\}",
         )
-        .unwrap();
+        .expect("this regex is valid");
         re.captures(error)
             .and_then(|caps| caps.get(1))
             .map(|objects_match| {
@@ -2197,7 +2197,12 @@ impl SuiContractClientInner {
 
         if wal_balance.coin_object_count > 1 {
             tx_builder
-                .fill_wal_balance(wal_balance.total_balance as u64)
+                .fill_wal_balance(
+                    wal_balance
+                        .total_balance
+                        .try_into()
+                        .expect("this is always smaller than u64::MAX"),
+                )
                 .await?;
         }
 
@@ -2206,7 +2211,10 @@ impl SuiContractClientInner {
                 tx_builder
                     .build_transaction_data_with_min_gas_balance(
                         self.gas_budget,
-                        sui_balance.total_balance as u64,
+                        sui_balance
+                            .total_balance
+                            .try_into()
+                            .expect("this is always smaller than u64::MAX"),
                     )
                     .await?,
                 "merge_coins",

--- a/crates/walrus-sui/src/client/retry_client/retriable_rpc_client.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_rpc_client.rs
@@ -383,13 +383,14 @@ impl RetriableRpcClient {
 
             let last_success = self.last_success.load(Ordering::Relaxed);
             let num_failures = self.num_failures.load(Ordering::Relaxed);
-            if self.fallback_client.is_none()
-                || !self
-                    .fallback_client
-                    .as_ref()
-                    .unwrap()
-                    .is_eligible_for_fallback(sequence_number, &error, last_success, num_failures)
-            {
+            if self.fallback_client.as_ref().is_none_or(|fallback_client| {
+                fallback_client.is_eligible_for_fallback(
+                    sequence_number,
+                    &error,
+                    last_success,
+                    num_failures,
+                )
+            }) {
                 tracing::debug!(
                     fallback_client_set = ?self.fallback_client.is_some(),
                     "primary client error while fetching checkpoint is not eligible for fallback, \

--- a/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
@@ -1028,8 +1028,14 @@ impl RetriableSuiClient {
 
         let safe_overhead = GAS_SAFE_OVERHEAD * gas_price;
         let computation_cost_with_overhead = gas_cost_summary.computation_cost + safe_overhead;
-        let gas_usage_with_overhead = gas_cost_summary.net_gas_usage() + safe_overhead as i64;
-        Ok(computation_cost_with_overhead.max(gas_usage_with_overhead.max(0) as u64))
+        let gas_usage_with_overhead = gas_cost_summary.net_gas_usage()
+            + i64::try_from(safe_overhead).expect("this should always be smaller than i64::MAX");
+        Ok(computation_cost_with_overhead.max(
+            gas_usage_with_overhead
+                .max(0)
+                .try_into()
+                .expect("we just set any negative value to 0"),
+        ))
     }
 
     /// Executes a transaction.

--- a/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
@@ -321,7 +321,7 @@ impl RetriableSuiClient {
                     .balance();
                 if min_coin_balance < coin.balance {
                     selected_coins.pop();
-                    total_selected -= min_coin_balance as u128;
+                    total_selected -= u128::from(min_coin_balance);
                 } else {
                     continue;
                 }

--- a/crates/walrus-sui/src/system_setup.rs
+++ b/crates/walrus-sui/src/system_setup.rs
@@ -201,7 +201,7 @@ pub(crate) async fn publish_package(
     };
 
     let gas_coins = retry_client
-        .select_coins(sender, None, gas_budget as u128, vec![])
+        .select_coins(sender, None, u128::from(gas_budget), vec![])
         .await?
         .into_iter()
         .map(|coin| coin.coin_object_id)
@@ -485,7 +485,7 @@ pub async fn create_system_and_staking_objects(
     };
 
     let gas_coins = retry_client
-        .select_coins(address, None, gas_budget as u128, vec![])
+        .select_coins(address, None, u128::from(gas_budget), vec![])
         .await?
         .into_iter()
         .map(|coin| coin.object_ref())

--- a/crates/walrus-sui/src/test_utils.rs
+++ b/crates/walrus-sui/src/test_utils.rs
@@ -378,7 +378,7 @@ pub mod using_tokio {
         CLUSTER
             .get_or_init(|| std::sync::Mutex::new(GlobalTestClusterHandler::new()))
             .lock()
-            .unwrap()
+            .expect("mutex should not be poisoned")
             .get_test_cluster_handle()
     }
 }

--- a/crates/walrus-sui/src/test_utils/system_setup.rs
+++ b/crates/walrus-sui/src/test_utils/system_setup.rs
@@ -6,7 +6,7 @@
 use std::{
     collections::HashMap,
     num::NonZeroU16,
-    path::PathBuf,
+    path::{Path, PathBuf},
     str::FromStr,
     sync::Arc,
     time::Duration,
@@ -43,22 +43,20 @@ const MEGA_WAL: u64 = 1_000_000 * ONE_WAL;
 
 /// Provides the path of the latest development contracts directory.
 pub fn development_contract_dir() -> anyhow::Result<PathBuf> {
-    Ok(PathBuf::from_str(env!("CARGO_MANIFEST_DIR"))?
-        .parent()
-        .unwrap()
-        .parent()
-        .unwrap()
-        .join("contracts"))
+    Ok(project_root_dir()?.join("contracts"))
 }
 
 /// Provides the path of the testnet contracts directory.
 pub fn testnet_contract_dir() -> anyhow::Result<PathBuf> {
+    Ok(project_root_dir()?.join("testnet-contracts"))
+}
+
+fn project_root_dir() -> anyhow::Result<PathBuf> {
     Ok(PathBuf::from_str(env!("CARGO_MANIFEST_DIR"))?
         .parent()
-        .unwrap()
-        .parent()
-        .unwrap()
-        .join("testnet-contracts"))
+        .and_then(Path::parent)
+        .expect("the directory structure guarantees this exists")
+        .to_owned())
 }
 
 /// Helper struct to pass around all needed object IDs when setting up the system.

--- a/crates/walrus-sui/src/types/move_errors.rs
+++ b/crates/walrus-sui/src/types/move_errors.rs
@@ -107,7 +107,7 @@ impl FromStr for RawMoveError {
         let re = Regex::new(
             r#"MoveAbort.*address:\s*(.*?),.* name:.*Identifier\((.*?)\).*instruction:\s+(\d+),.*function_name:.*Some\((.*?)\).*},\s*(\d+).*in command\s*(\d+)"#, // editorconfig-checker-disable
         )
-        .unwrap();
+        .expect("this is a valid regex");
         let Some(captures) = re.captures(s) else {
             anyhow::bail!(
                 "Cannot parse abort status string: {} as a move abort string",

--- a/crates/walrus-sui/src/types/move_structs.rs
+++ b/crates/walrus-sui/src/types/move_structs.rs
@@ -549,7 +549,7 @@ impl StakingObject {
         &self.inner.epoch_state
     }
 
-    /// Returns the epoch duration.
+    /// Returns the epoch duration in milliseconds.
     pub fn epoch_duration(&self) -> u64 {
         self.inner.epoch_duration
     }
@@ -701,9 +701,13 @@ impl SystemObject {
     /// Returns the number of members in the committee.
     pub(crate) fn committee_size(&self) -> u16 {
         match &self.inner {
-            SystemStateInnerV1Enum::V1(inner) => inner.committee.members.len() as u16,
-            SystemStateInnerV1Enum::V1Testnet(inner) => inner.committee.members.len() as u16,
+            SystemStateInnerV1Enum::V1(inner) => &inner.committee,
+            SystemStateInnerV1Enum::V1Testnet(inner) => &inner.committee,
         }
+        .members
+        .len()
+        .try_into()
+        .expect("committee size always fits in a u16")
     }
 
     /// Returns the number of epochs ahead that can be used to extend a blob.
@@ -771,6 +775,7 @@ pub(crate) enum SystemStateInnerV1Enum {
     V1Testnet(SystemStateInnerV1Testnet),
 }
 
+// TODO(WAL-867): Remove the no longer needed `SystemStateInnerV1Testnet` and all associated code.
 /// Sui type for inner system object.
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize)]
 pub(crate) struct SystemStateInnerV1Testnet {

--- a/crates/walrus-sui/src/utils.rs
+++ b/crates/walrus-sui/src/utils.rs
@@ -77,7 +77,7 @@ pub fn price_for_encoded_length(
     price_per_unit_size: u64,
     epochs: EpochCount,
 ) -> u64 {
-    storage_units_from_size(encoded_length) * price_per_unit_size * (epochs as u64)
+    storage_units_from_size(encoded_length) * price_per_unit_size * u64::from(epochs)
 }
 
 /// Computes the price given the encoded blob size.
@@ -425,7 +425,7 @@ pub async fn get_sui_from_wallet_or_faucet(
         let ptb = ptb.finish();
         let gas_budget = one_sui / 2;
         let gas_coins = client
-            .select_coins(sender, None, (gas_budget + one_sui) as u128, vec![])
+            .select_coins(sender, None, u128::from(gas_budget + one_sui), vec![])
             .await?
             .iter()
             .map(|coin| coin.object_ref())

--- a/crates/walrus-sui/tests/test_walrus_sui.rs
+++ b/crates/walrus-sui/tests/test_walrus_sui.rs
@@ -531,7 +531,7 @@ async fn test_automatic_wal_coin_squashing(
             )
             .await?
             .len(),
-        n_source_coins as usize
+        usize::try_from(n_source_coins).unwrap()
     );
 
     // Now send the full amount back in `n_target_coins` coins payments, which should trigger the
@@ -561,7 +561,7 @@ async fn test_automatic_wal_coin_squashing(
             )
             .await?
             .coin_object_count,
-        n_coins + n_target_coins as usize
+        n_coins + usize::try_from(n_target_coins).unwrap()
     );
     Ok(())
 }

--- a/crates/walrus-sui/tests/test_walrus_sui.rs
+++ b/crates/walrus-sui/tests/test_walrus_sui.rs
@@ -1,6 +1,9 @@
 // Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+// Allowing `unwrap`s in tests.
+#![allow(clippy::unwrap_used)]
+
 //! Contains integration tests for the Sui bindings.
 
 use std::{num::NonZeroU16, sync::Arc, time::Duration};

--- a/crates/walrus-utils/Cargo.toml
+++ b/crates/walrus-utils/Cargo.toml
@@ -11,7 +11,7 @@ config = ["dep:anyhow", "dep:home", "dep:serde", "dep:tracing"]
 default = []
 http = ["dep:bytes", "dep:http-body", "dep:pin-project"]
 log = ["dep:humantime", "dep:once_cell", "dep:tracing"]
-metrics = ["dep:prometheus", "dep:tap", "dep:thiserror"]
+metrics = ["dep:once_cell", "dep:prometheus", "dep:tap", "dep:thiserror"]
 test-utils = ["dep:tempfile", "tokio/sync"]
 tokio-metrics = ["dep:tokio-metrics"]
 

--- a/crates/walrus-utils/src/metrics/tokio.rs
+++ b/crates/walrus-utils/src/metrics/tokio.rs
@@ -68,7 +68,7 @@ where
         if let Some(task_monitor) = self
             .task_monitors
             .read()
-            .expect("mutex is not poisoned")
+            .expect("mutex should not be poisoned")
             .get(key)
             .cloned()
         {
@@ -80,7 +80,7 @@ where
         // to any existing monitor.
         self.task_monitors
             .write()
-            .expect("mutex is not poisoned")
+            .expect("mutex should not be poisoned")
             .entry(key.clone())
             .or_insert_with(move || {
                 let collector = TaskMonitorCollector::new(task_name());


### PR DESCRIPTION
## Description

This enables the following lints for the whole workspace (with some exceptions):
- `future_incompatible`
- `nonstandard_style`
- `unused`
- `clippy::cast_lossless`
- `clippy::cast_possible_truncation`
- `clippy::cast_possible_wrap`
- `clippy::empty_structs_with_brackets`
- `clippy::unwrap_used`

These are related to the coding conventions added in #2167.

Some warnings are automatically fixed in fc58be99518f5cb1d395111bfce92933e7d45b54. The remaining ones are fixed manually (with some accompanying refactoring) in 37c9bf91c5e719169c908b3792e13f4385bec405.

## Test plan

Existing test suite.