### PR TITLE
test: ignore some long-running tests by default

### DIFF
--- a/crates/walrus-core/src/encoding/quilt_encoding.rs
+++ b/crates/walrus-core/src/encoding/quilt_encoding.rs
@@ -1639,6 +1639,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "ignore long-running test by default"]
     fn test_quilt_with_random_blobs() {
         for _ in 0..1000 {
             let mut rng = rand::thread_rng();

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -3908,6 +3908,7 @@ mod tests {
 
     // Tests that a panic thrown by a blob sync task is propagated to the node runtime.
     #[tokio::test]
+    #[ignore = "ignore long-running test by default"]
     async fn blob_sync_panic_thrown() {
         let shards: &[&[u16]] = &[&[1], &[0, 2, 3, 4, 5, 6]];
         let test_shard = ShardIndex(1);
@@ -4076,6 +4077,7 @@ mod tests {
     }
 
     #[tokio::test(start_paused = false)]
+    #[ignore = "ignore long-running test by default"]
     async fn recovers_sliver_from_a_small_set() -> TestResult {
         let shards: &[&[u16]] = &[&[0], &(1..=6).collect::<Vec<_>>()];
         let store_secondary_at: Vec<_> = ShardIndex::range(0..5).collect();

--- a/crates/walrus-utils/src/tracing_sampled.rs
+++ b/crates/walrus-utils/src/tracing_sampled.rs
@@ -139,6 +139,7 @@ mod tests {
     use crate::tracing_sampled;
 
     #[tokio::test]
+    #[ignore = "ignore long-running test by default"]
     async fn test_sampled_logging_new_macro() {
         let _ = tracing_subscriber::fmt::try_init();
 


### PR DESCRIPTION
## Description

Most of our unit tests take less than 1s to run (or slightly above 1s). There were 4 tests that took over 2s each. Ignoring them by default speeds up the standard `cargo nextest run` significantly.

Before:
```
...
        PASS [   2.506s] walrus-service node::tests::recovers_sliver_from_a_small_set
        PASS [   5.501s] walrus-service node::tests::blob_sync_panic_thrown
        PASS [   3.078s] walrus-utils tracing_sampled::tests::test_sampled_logging_new_macro
        PASS [  15.702s] walrus-core encoding::quilt_encoding::tests::test_quilt_with_random_blobs
------------
     Summary [  16.140s] 735 tests run: 735 passed, 61 skipped
```

After:
```
...
------------
     Summary [   4.673s] 731 tests run: 731 passed, 65 skipped
```

## Test plan

Tests are still executed in CI.