### PR TITLE
ci: fix release generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,12 +1474,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bimap"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
-
-[[package]]
 name = "bin-version"
 version = "1.49.1"
 source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.49.1#3b1d6b3bd63f175b774da557f89af3619b74d783"
@@ -1937,7 +1931,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "checkpoint-downloader"
-version = "1.27.0"
+version = "1.26.3"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1955,7 +1949,7 @@ dependencies = [
  "tokio",
  "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
- "typed-store 1.27.0",
+ "typed-store 1.26.3",
  "walrus-sui",
  "walrus-utils",
 ]
@@ -2025,9 +2019,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.39"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
+checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2035,9 +2029,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.39"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
+checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2048,9 +2042,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.52"
+version = "4.5.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a554639e42d0c838336fc4fbedb9e2df3ad1fa4acda149f9126b4ccfcd7900f"
+checksum = "c91d3baa3bcd889d60e6ef28874126a0b384fd225ab83aa6d8a801c519194ce1"
 dependencies = [
  "clap",
 ]
@@ -2117,9 +2111,9 @@ checksum = "08abddbaad209601e53c7dd4308d8c04c06f17bb7df006434e586a22b83be45a"
 
 [[package]]
 name = "color-eyre"
-version = "0.6.5"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
+checksum = "e6e1761c0e16f8883bbbb8ce5990867f4f06bf11a0253da6495a04ce4b6ef0ec"
 dependencies = [
  "backtrace",
  "color-spantrace",
@@ -2132,9 +2126,9 @@ dependencies = [
 
 [[package]]
 name = "color-spantrace"
-version = "0.3.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
+checksum = "2ddd8d5bfda1e11a501d0a7303f3bfed9aa632ebdb859be40d0fd70478ed70d5"
 dependencies = [
  "once_cell",
  "owo-colors",
@@ -7896,6 +7890,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "raptorq"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90b1b1fad69672f0b901b5004863ea4307f03d168a3db5f2bcba4d3dfed88e97"
+
+[[package]]
 name = "raw-cpuid"
 version = "11.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12126,7 +12126,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store"
-version = "1.27.0"
+version = "1.26.3"
 dependencies = [
  "async-trait",
  "bcs",
@@ -12426,22 +12426,20 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.17.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
  "getrandom 0.3.1",
- "js-sys",
  "rand 0.9.0",
  "uuid-macro-internal",
- "wasm-bindgen",
 ]
 
 [[package]]
 name = "uuid-macro-internal"
-version = "1.17.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b682e8c381995ea03130e381928e0e005b7c9eb483c6c8682f50e07b33c2b7"
+checksum = "72dcd78c4f979627a754f5522cea6e6a25e55139056535fe6e69c506cd64a862"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12519,7 +12517,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-core"
-version = "1.27.0"
+version = "1.26.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -12530,6 +12528,7 @@ dependencies = [
  "hex",
  "p256",
  "rand 0.8.5",
+ "raptorq",
  "reed-solomon-simd",
  "serde",
  "serde_test",
@@ -12544,7 +12543,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-e2e-tests"
-version = "1.27.0"
+version = "1.26.3"
 dependencies = [
  "anyhow",
  "futures",
@@ -12575,7 +12574,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-orchestrator"
-version = "1.27.0"
+version = "1.26.3"
 dependencies = [
  "aws-config",
  "aws-runtime",
@@ -12605,7 +12604,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-proc-macros"
-version = "1.27.0"
+version = "1.26.3"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
@@ -12616,7 +12615,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-proxy"
-version = "1.27.0"
+version = "1.26.3"
 dependencies = [
  "anyhow",
  "axum 0.8.1",
@@ -12655,16 +12654,14 @@ dependencies = [
 
 [[package]]
 name = "walrus-sdk"
-version = "1.27.0"
+version = "1.26.3"
 dependencies = [
  "anyhow",
- "bimap",
  "chrono",
  "enum_dispatch",
  "fastcrypto",
  "futures",
  "home",
- "humantime",
  "indexmap 2.9.0",
  "indicatif",
  "indoc",
@@ -12697,7 +12694,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-service"
-version = "1.27.0"
+version = "1.26.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12785,7 +12782,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "twox-hash 2.1.0",
- "typed-store 1.27.0",
+ "typed-store 1.26.3",
  "utoipa",
  "utoipa-redoc",
  "uuid",
@@ -12800,7 +12797,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-simtest"
-version = "1.27.0"
+version = "1.26.3"
 dependencies = [
  "anyhow",
  "futures",
@@ -12825,7 +12822,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-storage-node-client"
-version = "1.27.0"
+version = "1.26.3"
 dependencies = [
  "axum 0.8.1",
  "axum-server 0.7.2",
@@ -12863,7 +12860,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-stress"
-version = "1.27.0"
+version = "1.26.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -12888,7 +12885,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-sui"
-version = "1.27.0"
+version = "1.26.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12941,7 +12938,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-test-utils"
-version = "1.27.0"
+version = "1.26.3"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -12951,7 +12948,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-utils"
-version = "1.27.0"
+version = "1.26.3"
 dependencies = [
  "anyhow",
  "bytes",

--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -199,7 +199,7 @@ def extract_notes_for_commit(commit):
     # Execute the curl command
     result = subprocess.run(curl_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
     json_data = json.loads(result.stdout)
-    message = json_data[0].get("body")
+    message = json_data[0].get("body") if json_data else ""
 
     # Get PR number
     url = f"https://api.github.com/repos/MystenLabs/walrus/commits/{commit}/pulls"
@@ -213,7 +213,7 @@ def extract_notes_for_commit(commit):
     # Execute the curl command
     result = subprocess.run(curl_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
     json_data = json.loads(result.stdout)
-    pr = json_data[0].get("number")
+    pr = json_data[0].get("number") if json_data else ""
     return parse_notes(pr, message)
 
 def print_changelog(pr, log):


### PR DESCRIPTION
## Description
fix release generation when some commits don't have a body or a PR attached to it. This happens when there is a version bump that we force push to release branches sometimes.

## Test plan
Before:
```
python3 ./scripts/release_notes.py generate releases/walrus-v1.25.0-release releases/walrus-v1.26.0-release
Traceback (most recent call last):
  File "/home/eugene/code/walrus/./scripts/release_notes.py", line 309, in <module>
    do_generate(args["from"], args["to"])
  File "/home/eugene/code/walrus/./scripts/release_notes.py", line 282, in do_generate
    pr, notes = extract_notes_for_commit(commit)
  File "/home/eugene/code/walrus/./scripts/release_notes.py", line 216, in extract_notes_for_commit
    pr = json_data[0].get("number")
IndexError: list index out of range
```
After:
```
python3 ./scripts/release_notes.py generate releases/walrus-v1.25.0-release releases/walrus-v1.26.0-release
## Storage node

https://github.com/MystenLabs/walrus/pull/1630:
Use the metrics and REST API address from the configuration file instead of always binding to `0.0.0.0`. Note that this bugfix may break some setups that relied on the previous incorrect behavior. To get the old behavior, set the `metrics_address` and `rest_api_address` to `0.0.0.0:<port>` explicitly.

https://github.com/MystenLabs/walrus/pull/2072:
Increase default value of `http2_max_pending_accept_reset_streams` parameter to disable warnings from the `h2` crate.

https://github.com/MystenLabs/walrus/pull/2067:
Reduce verbosity levels of problems with metrics and config sync from ERROR to WARN.

## Aggregator

https://github.com/MystenLabs/walrus/pull/2066:
Allow specifying Sui RPC URL in the configuration file in addition to the CLI option.

https://github.com/MystenLabs/walrus/pull/1630:
Use the metrics address specified through the CLI options file instead of always binding to `0.0.0.0`. Note that this bugfix may break some setups that relied on the previous incorrect behavior. To get the old behavior, use `--metrics-address 0.0.0.0:<port>` when starting the aggregator.

## Publisher

https://github.com/MystenLabs/walrus/pull/1630:
Use the metrics address specified through the CLI options file instead of always binding to `0.0.0.0`. Note that this bugfix may break some setups that relied on the previous incorrect behavior. To get the old behavior, use `--metrics-address 0.0.0.0:<port>` when starting the aggregator.

## CLI

https://github.com/MystenLabs/walrus/pull/2066:
Add a new `rpc_urls` field to the client config, which allows setting multiple Sui RPC URLs. The Sui RPC URL(s) used for reads are now selected in the following order: (1) CLI argument, (2) client configuration file, (3) wallet config. If none of these are set, the client will **no longer fall back to the `fullnode.testnet.sui.io`** but instead exit with an error.
```
