### PR TITLE
feat: non-blocking event processing

### DIFF
--- a/crates/walrus-service/node_config_example.yaml
+++ b/crates/walrus-service/node_config_example.yaml
@@ -175,3 +175,5 @@ checkpoint_config:
 admin_socket_path: null
 node_recovery_config:
   max_concurrent_blob_syncs_during_recovery: 1000
+node_blob_event_processor_config:
+  num_workers: 10

--- a/crates/walrus-service/node_config_example.yaml
+++ b/crates/walrus-service/node_config_example.yaml
@@ -175,5 +175,5 @@ checkpoint_config:
 admin_socket_path: null
 node_recovery_config:
   max_concurrent_blob_syncs_during_recovery: 1000
-node_blob_event_processor_config:
+blob_event_processor_config:
   num_workers: 10

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -694,7 +694,7 @@ impl StorageNode {
         let blob_event_processor = BlobEventProcessor::new(
             inner.clone(),
             blob_sync_handler.clone(),
-            config.node_blob_event_processor_config.num_workers,
+            config.blob_event_processor_config.num_workers,
         );
 
         tracing::debug!(

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -4858,8 +4858,8 @@ mod tests {
         Ok(())
     }
 
-    // TODO(WAL-872): move failure injection test to src/tests/. Currently there is no way to run seed-search
-    // on these tests since there is no test target.
+    // TODO(WAL-872): move failure injection test to src/tests/. Currently there is no way to run
+    // seed-search on these tests since there is no test target.
     #[cfg(msim)]
     mod failure_injection_tests {
         use sui_macros::{
@@ -5460,6 +5460,13 @@ mod tests {
                 .start_epoch_change_finisher
                 .wait_until_previous_task_done()
                 .await;
+
+            // There should be 4 initial events:
+            //  - EpochChangeStart
+            //  - EpochChangeDone
+            //  - BlobRegistered
+            //  - BlobCertified
+            wait_until_events_processed(&cluster.nodes[0], 4).await?;
 
             let processed_event_count_initial = &cluster.nodes[0]
                 .storage_node

--- a/crates/walrus-service/src/node/blob_event_processor.rs
+++ b/crates/walrus-service/src/node/blob_event_processor.rs
@@ -1,0 +1,235 @@
+// Copyright (c) Walrus Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use tokio::{
+    sync::mpsc::{self, UnboundedReceiver, UnboundedSender},
+    task::JoinHandle,
+};
+use walrus_sui::types::{BlobCertified, BlobDeleted, BlobEvent, InvalidBlobId};
+use walrus_utils::metrics::monitored_scope;
+
+use super::{
+    NodeStatus,
+    StorageNodeInner,
+    blob_sync::BlobSyncHandler,
+    metrics,
+    system_events::EventHandle,
+};
+use crate::node::{
+    storage::blob_info::{BlobInfoApi, CertifiedBlobInfoApi},
+    system_events::CompletableHandle,
+};
+
+#[derive(Debug)]
+struct BackgroundEventProcessor {
+    node: Arc<StorageNodeInner>,
+    blob_sync_handler: Arc<BlobSyncHandler>,
+    event_receiver: UnboundedReceiver<(EventHandle, BlobEvent)>,
+}
+
+impl BackgroundEventProcessor {
+    fn new(
+        node: Arc<StorageNodeInner>,
+        blob_sync_handler: Arc<BlobSyncHandler>,
+        event_receiver: UnboundedReceiver<(EventHandle, BlobEvent)>,
+    ) -> Self {
+        Self {
+            node,
+            blob_sync_handler,
+            event_receiver,
+        }
+    }
+
+    async fn run(&mut self) {
+        // TODO: add metrics to measure events stay in the channel (queue length).
+        while let Some((event_handle, blob_event)) = self.event_receiver.recv().await {
+            if let Err(e) = self.process_event(event_handle, blob_event).await {
+                tracing::error!("error processing blob event: {}", e);
+            }
+        }
+    }
+
+    async fn process_event(
+        &self,
+        event_handle: EventHandle,
+        blob_event: BlobEvent,
+    ) -> anyhow::Result<()> {
+        // TODO: what should happen to the processor if this returns error?
+        match blob_event {
+            BlobEvent::Certified(event) => {
+                monitored_scope::monitored_scope("ProcessEvent::BlobEvent::Certified");
+                self.process_blob_certified_event(event_handle, event)
+                    .await?;
+            }
+            BlobEvent::Deleted(event) => {
+                monitored_scope::monitored_scope("ProcessEvent::BlobEvent::Deleted");
+                self.process_blob_deleted_event(event_handle, event).await?;
+            }
+            BlobEvent::InvalidBlobID(event) => {
+                monitored_scope::monitored_scope("ProcessEvent::BlobEvent::InvalidBlobID");
+                self.process_blob_invalid_event(event_handle, event).await?;
+            }
+            BlobEvent::DenyListBlobDeleted(_) => {
+                // TODO (WAL-424): Implement DenyListBlobDeleted event handling.
+                todo!("DenyListBlobDeleted event handling is not yet implemented");
+            }
+            BlobEvent::Registered(_) => {
+                unreachable!("registered event should be processed immediately");
+            }
+        }
+
+        Ok(())
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn process_blob_certified_event(
+        &self,
+        event_handle: EventHandle,
+        event: BlobCertified,
+    ) -> anyhow::Result<()> {
+        let start = tokio::time::Instant::now();
+        let histogram_set = self.node.metrics.recover_blob_duration_seconds.clone();
+
+        if !self.node.is_blob_certified(&event.blob_id)?
+            // For blob extension events, the original blob certified event should already recover
+            // the entire blob, and we can skip the recovery.
+            || event.is_extension
+            || self.node.storage.node_status()? == NodeStatus::RecoveryCatchUp
+            || self
+                .node
+                .is_stored_at_all_shards_at_epoch(&event.blob_id, self.node.current_event_epoch())
+                .await?
+        {
+            event_handle.mark_as_complete();
+
+            walrus_utils::with_label!(histogram_set, metrics::STATUS_SKIPPED)
+                .observe(start.elapsed().as_secs_f64());
+
+            return Ok(());
+        }
+
+        // Slivers and (possibly) metadata are not stored, so initiate blob sync.
+        self.blob_sync_handler
+            .start_sync(event.blob_id, event.epoch, Some(event_handle))
+            .await?;
+
+        walrus_utils::with_label!(histogram_set, metrics::STATUS_QUEUED)
+            .observe(start.elapsed().as_secs_f64());
+
+        Ok(())
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn process_blob_deleted_event(
+        &self,
+        event_handle: EventHandle,
+        event: BlobDeleted,
+    ) -> anyhow::Result<()> {
+        let blob_id = event.blob_id;
+
+        if let Some(blob_info) = self.node.storage.get_blob_info(&blob_id)? {
+            if !blob_info.is_certified(self.node.current_epoch()) {
+                self.node
+                    .blob_retirement_notifier
+                    .notify_blob_retirement(&blob_id);
+                self.blob_sync_handler
+                    .cancel_sync_and_mark_event_complete(&blob_id)
+                    .await?;
+            }
+            // Note that this function is called *after* the blob info has already been updated with
+            // the event. So it can happen that the only registered blob was deleted and the blob is
+            // now no longer registered.
+            // We use the event's epoch for this check (as opposed to the current epoch) as
+            // subsequent certify or delete events may update the `blob_info`; so we cannot remove
+            // it even if it is no longer valid in the *current* epoch
+            if !blob_info.is_registered(event.epoch) {
+                tracing::debug!("deleting data for deleted blob");
+                // TODO (WAL-201): Actually delete blob data.
+            }
+        } else {
+            tracing::warn!(
+                walrus.blob_id = %blob_id,
+                "handling `BlobDeleted` event for an untracked blob"
+            );
+        }
+
+        event_handle.mark_as_complete();
+
+        Ok(())
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn process_blob_invalid_event(
+        &self,
+        event_handle: EventHandle,
+        event: InvalidBlobId,
+    ) -> anyhow::Result<()> {
+        self.node
+            .blob_retirement_notifier
+            .notify_blob_retirement(&event.blob_id);
+        self.blob_sync_handler
+            .cancel_sync_and_mark_event_complete(&event.blob_id)
+            .await?;
+        self.node.storage.delete_blob_data(&event.blob_id).await?;
+
+        event_handle.mark_as_complete();
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct BlobEventProcessor {
+    node: Arc<StorageNodeInner>,
+    background_processor_senders: Vec<UnboundedSender<(EventHandle, BlobEvent)>>,
+    _background_processors: Vec<Arc<JoinHandle<()>>>,
+}
+
+impl BlobEventProcessor {
+    pub fn new(node: Arc<StorageNodeInner>, blob_sync_handler: Arc<BlobSyncHandler>) -> Self {
+        let num_workers = 4;
+
+        let mut senders = Vec::with_capacity(num_workers);
+        let mut workers = Vec::with_capacity(num_workers);
+        for _ in 0..num_workers {
+            let (tx, rx) = mpsc::unbounded_channel();
+            senders.push(tx);
+            let mut background_processor =
+                BackgroundEventProcessor::new(node.clone(), blob_sync_handler.clone(), rx);
+            workers.push(Arc::new(tokio::spawn(async move {
+                background_processor.run().await;
+            })));
+        }
+
+        Self {
+            node,
+            background_processor_senders: senders,
+            _background_processors: workers,
+        }
+    }
+
+    pub async fn process_event(
+        &self,
+        event_handle: EventHandle,
+        blob_event: BlobEvent,
+    ) -> anyhow::Result<()> {
+        self.node
+            .storage
+            .update_blob_info(event_handle.index(), &blob_event)?;
+
+        if let BlobEvent::Registered(_) = &blob_event {
+            monitored_scope::monitored_scope("ProcessEvent::BlobEvent::Registered");
+            event_handle.mark_as_complete();
+        } else {
+            let processor_index = blob_event.blob_id().first_two_bytes() as usize
+                % self.background_processor_senders.len();
+            self.background_processor_senders[processor_index]
+                .send((event_handle, blob_event))
+                .map_err(|e| {
+                    anyhow::anyhow!("failed to send event to background processor: {}", e)
+                })?;
+        }
+        Ok(())
+    }
+}

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -701,6 +701,7 @@ impl Default for NodeRecoveryConfig {
 #[serde(default)]
 pub struct NodeBlobEventProcessorConfig {
     /// The number of workers to process blob events in parallel.
+    /// When set to 0, the node will process all blob events sequentially.
     pub num_workers: usize,
 }
 

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -190,7 +190,7 @@ pub struct StorageNodeConfig {
     pub node_recovery_config: NodeRecoveryConfig,
     /// Configuration for the blob event processor.
     #[serde(default, skip_serializing_if = "defaults::is_default")]
-    pub node_blob_event_processor_config: NodeBlobEventProcessorConfig,
+    pub blob_event_processor_config: BlobEventProcessorConfig,
 }
 
 impl Default for StorageNodeConfig {
@@ -233,7 +233,7 @@ impl Default for StorageNodeConfig {
             checkpoint_config: Default::default(),
             admin_socket_path: None,
             node_recovery_config: Default::default(),
-            node_blob_event_processor_config: Default::default(),
+            blob_event_processor_config: Default::default(),
         }
     }
 }
@@ -699,13 +699,13 @@ impl Default for NodeRecoveryConfig {
 #[serde_as]
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(default)]
-pub struct NodeBlobEventProcessorConfig {
+pub struct BlobEventProcessorConfig {
     /// The number of workers to process blob events in parallel.
     /// When set to 0, the node will process all blob events sequentially.
     pub num_workers: usize,
 }
 
-impl Default for NodeBlobEventProcessorConfig {
+impl Default for BlobEventProcessorConfig {
     fn default() -> Self {
         Self { num_workers: 10 }
     }

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -188,6 +188,9 @@ pub struct StorageNodeConfig {
     /// Configuration for node recovery.
     #[serde(default, skip_serializing_if = "defaults::is_default")]
     pub node_recovery_config: NodeRecoveryConfig,
+    /// Configuration for the blob event processor.
+    #[serde(default, skip_serializing_if = "defaults::is_default")]
+    pub node_blob_event_processor_config: NodeBlobEventProcessorConfig,
 }
 
 impl Default for StorageNodeConfig {
@@ -230,6 +233,7 @@ impl Default for StorageNodeConfig {
             checkpoint_config: Default::default(),
             admin_socket_path: None,
             node_recovery_config: Default::default(),
+            node_blob_event_processor_config: Default::default(),
         }
     }
 }
@@ -688,6 +692,21 @@ impl Default for NodeRecoveryConfig {
         Self {
             max_concurrent_blob_syncs_during_recovery: 1000,
         }
+    }
+}
+
+/// Configuration for the blob event processor.
+#[serde_as]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[serde(default)]
+pub struct NodeBlobEventProcessorConfig {
+    /// The number of workers to process blob events in parallel.
+    pub num_workers: usize,
+}
+
+impl Default for NodeBlobEventProcessorConfig {
+    fn default() -> Self {
+        Self { num_workers: 10 }
     }
 }
 

--- a/crates/walrus-service/src/node/metrics.rs
+++ b/crates/walrus-service/src/node/metrics.rs
@@ -169,6 +169,9 @@ walrus_utils::metrics::define_metric_set! {
 
         #[help = "The number of ongoing blob syncs during node recovery."]
         node_recovery_ongoing_blob_syncs: IntGauge[],
+
+        #[help = "The number of blob events pending processing in the queue."]
+        pending_processing_blob_event_in_queue: IntGaugeVec["worker_index"],
     }
 }
 

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -95,6 +95,7 @@ use crate::node::{
     config::{
         self,
         ConfigSynchronizerConfig,
+        NodeBlobEventProcessorConfig,
         NodeRecoveryConfig,
         ShardSyncConfig,
         StorageNodeConfig,
@@ -2802,12 +2803,14 @@ pub fn storage_node_config() -> WithTempDir<StorageNodeConfig> {
             // Turn on all consistency checks in integration tests.
             consistency_check: StorageNodeConsistencyCheckConfig {
                 enable_consistency_check: true,
-                enable_sliver_data_existence_check: true,
+                enable_sliver_data_existence_check: false,
                 sliver_data_existence_check_sample_rate_percentage: 100,
             },
             checkpoint_config: Default::default(),
             admin_socket_path: None,
             node_recovery_config: Default::default(),
+            // Uses smaller number of workers in tests to avoid overwhelming the tests.
+            node_blob_event_processor_config: NodeBlobEventProcessorConfig { num_workers: 3 },
         },
         temp_dir,
     }

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -2803,6 +2803,9 @@ pub fn storage_node_config() -> WithTempDir<StorageNodeConfig> {
             // Turn on all consistency checks in integration tests.
             consistency_check: StorageNodeConsistencyCheckConfig {
                 enable_consistency_check: true,
+                // TODO: re-enable blob data consistency check by tracking epoch in the event.
+                // Currently, the consistency check is not compatible with parallel event
+                // processing since the node does know whether a blob needs recovery or not.
                 enable_sliver_data_existence_check: false,
                 sliver_data_existence_check_sample_rate_percentage: 100,
             },

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -94,8 +94,8 @@ use crate::node::{
     },
     config::{
         self,
+        BlobEventProcessorConfig,
         ConfigSynchronizerConfig,
-        NodeBlobEventProcessorConfig,
         NodeRecoveryConfig,
         ShardSyncConfig,
         StorageNodeConfig,
@@ -2803,7 +2803,8 @@ pub fn storage_node_config() -> WithTempDir<StorageNodeConfig> {
             // Turn on all consistency checks in integration tests.
             consistency_check: StorageNodeConsistencyCheckConfig {
                 enable_consistency_check: true,
-                // TODO: re-enable blob data consistency check by tracking epoch in the event.
+                // TODO(WAL-875): re-enable blob data consistency check by tracking epoch in the
+                // event.
                 // Currently, the consistency check is not compatible with parallel event
                 // processing since the node does know whether a blob needs recovery or not.
                 enable_sliver_data_existence_check: false,
@@ -2813,7 +2814,7 @@ pub fn storage_node_config() -> WithTempDir<StorageNodeConfig> {
             admin_socket_path: None,
             node_recovery_config: Default::default(),
             // Uses smaller number of workers in tests to avoid overwhelming the tests.
-            node_blob_event_processor_config: NodeBlobEventProcessorConfig { num_workers: 3 },
+            blob_event_processor_config: BlobEventProcessorConfig { num_workers: 3 },
         },
         temp_dir,
     }

--- a/crates/walrus-service/src/testbed.rs
+++ b/crates/walrus-service/src/testbed.rs
@@ -796,12 +796,13 @@ pub async fn create_storage_node_configs(
             thread_pool: Default::default(),
             consistency_check: StorageNodeConsistencyCheckConfig {
                 enable_consistency_check: true,
-                enable_sliver_data_existence_check: true,
+                enable_sliver_data_existence_check: false,
                 sliver_data_existence_check_sample_rate_percentage: 100,
             },
             checkpoint_config: Default::default(),
             admin_socket_path: Some(working_dir.join(format!("admin-{}.sock", node_index))),
             node_recovery_config: Default::default(),
+            node_blob_event_processor_config: Default::default(),
         });
     }
 

--- a/crates/walrus-service/src/testbed.rs
+++ b/crates/walrus-service/src/testbed.rs
@@ -802,7 +802,7 @@ pub async fn create_storage_node_configs(
             checkpoint_config: Default::default(),
             admin_socket_path: Some(working_dir.join(format!("admin-{}.sock", node_index))),
             node_recovery_config: Default::default(),
-            node_blob_event_processor_config: Default::default(),
+            blob_event_processor_config: Default::default(),
         });
     }
 

--- a/crates/walrus-simtest/tests/simtest_failure.rs
+++ b/crates/walrus-simtest/tests/simtest_failure.rs
@@ -90,6 +90,7 @@ mod tests {
                 &client,
                 data_length,
                 false,
+                false,
                 &mut blobs_written,
             )
             .await
@@ -109,6 +110,7 @@ mod tests {
                 simtest_utils::write_read_and_check_random_blob(
                     &client,
                     data_length,
+                    false,
                     false,
                     &mut blobs_written,
                 )
@@ -434,6 +436,7 @@ mod tests {
                 client_clone.as_ref(),
                 data_length,
                 true,
+                false,
                 &mut blobs_written,
             )
             .await


### PR DESCRIPTION
## Description

This PR improves storage node event processing speed by moving event action execution to a set of background workers.

Currently, processing certified events is somewhat slow due to blob data existence check, and sequentially processing
events makes event catchup slow. This is particularly problematic for storage nodes with lagging highest persisted
event. After restart, such node needs to reprocess events from the highest persisted event, and may take long time
to reach to the latest event.

By moving all but blob info update to background workers, the node can bring the blob info table to the latest state
faster, and therefore, reduce the window of highest processed event catchup.

This PR also adds a fallback config as if setting NodeBlobEventProcessorConfig::num_workers to 0, it fallback
to the prior sequential event processing logic.

## Test plan

General simtest coverage
Added a simtest to test event ordering.
Added a dedicated integration test to test overlapping event processing.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
