### PR TITLE
chore(cherry-pick): set latest_event_epoch correctly when restarting recovery

### DIFF
--- a/crates/walrus-service/src/node/node_recovery.rs
+++ b/crates/walrus-service/src/node/node_recovery.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, atomic::Ordering};
 
 use futures::stream::{FuturesUnordered, StreamExt};
 use sui_macros::fail_point_async;
@@ -222,6 +222,10 @@ impl NodeRecoveryHandler {
     pub async fn restart_recovery(&self) -> Result<(), TypedStoreError> {
         if let NodeStatus::RecoveryInProgress(recovering_epoch) = self.node.storage.node_status()? {
             if recovering_epoch == self.node.current_epoch() {
+                // The `latest_event_epoch` is still set to `0` at this point.
+                self.node
+                    .latest_event_epoch
+                    .store(recovering_epoch, Ordering::SeqCst);
                 return self.start_node_recovery(self.node.current_epoch()).await;
             } else {
                 assert!(recovering_epoch < self.node.current_epoch());


### PR DESCRIPTION
## Description

Cherry-picks #2179 into the `v1.26` release.

## Test plan

Tested through #2180. Deployment to Testnet.

---

## Release notes

- [x] Storage node: Fixes an issue where recovering nodes crash after being restarted.
