### PR TITLE
fix: flaky sync_shard_recovery_metadata_restart

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -4452,7 +4452,7 @@ mod tests {
 
     // The common setup for shard sync tests.
     // By default:
-    //   - Initial cluster with 2 nodes. Shard 0 in node 0 and shard 1 in node 1.
+    //   - Initial cluster with 2 nodes. Shard 0 in node 0 and shard 1,2,3 in node 1.
     //   - 23 blobs created and certified in node 0.
     //   - Create a new shard in node 1 with shard index 0 to test sync.
     // If assignment is provided, it will be used to create the cluster, then all
@@ -5405,9 +5405,6 @@ mod tests {
                 );
             }
 
-            storage_dst
-                .remove_storage_for_shards(&[ShardIndex(1)])
-                .await?;
             storage_dst.clear_metadata_in_test()?;
             storage_dst.set_node_status(NodeStatus::RecoverMetadata)?;
 


### PR DESCRIPTION
## Description

I don't remember why we need to remove Shard 1 in storage node 1 in the test. Probably because restarting checks
existing shards and we don't want that shard to be checked. But this shard removal is unnecessary.

After removal, blob sync will fail since now we use the shard assignment on chain to sync blob, and removing
shard 1 cause panic in shard existence check.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
