### PR TITLE
docs(walrus-sites): add staking object references to installation documentation

### DIFF
--- a/docs/book/walrus-sites/tutorial-install.md
+++ b/docs/book/walrus-sites/tutorial-install.md
@@ -99,6 +99,7 @@ contexts:
     # module: site
     # portal: wal.app
     package: 0xf99aee9f21493e1590e7e5a9aea6f343a1f381031a04a732724871fc294be799
+    staking_object: 0xbe46180321c30aab2f8b3501e24048377287fa708018a5b7c2792b35fe339ee3
     # general:
     #   rpc_url: https://fullnode.testnet.sui.io:443
     #   wallet: /path/to/.sui/sui_config/client.yaml
@@ -109,6 +110,7 @@ contexts:
     # module: site
     # portal: wal.app
     package: 0x26eb7ee8688da02c5f671679524e379f0b837a12f1d1d799f255b7eea260ad27
+    staking_object: 0x10b9d30c28448939ce6c4d6c6e0ffce4a7f8a4ada8248bdad09ef8b70e4a3904
     # general:
     #   rpc_url: https://fullnode.mainnet.sui.io:443
     #   wallet: /path/to/.sui/sui_config/client.yaml


### PR DESCRIPTION
## Description

* Added `staking_object: 0xbe46180321c30aab2f8b3501e24048377287fa708018a5b7c2792b35fe339ee3` under the testnet context.
* Added `staking_object: 0x10b9d30c28448939ce6c4d6c6e0ffce4a7f8a4ada8248bdad09ef8b70e4a3904` under the mainnet context.
