### PR TITLE
feat: limit max recovery symbol requests

### DIFF
--- a/crates/walrus-service/node_config_example.yaml
+++ b/crates/walrus-service/node_config_example.yaml
@@ -79,6 +79,7 @@ rest_server:
   http2_initial_connection_window_size: null
   http2_max_pending_accept_reset_streams: 4294967295
   http2_adaptive_window: true
+  experimental_max_active_recovery_symbols_requests: null
 rest_graceful_shutdown_period_secs: 60
 sui:
   rpc: https://fullnode.testnet.sui.io:443

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -1014,6 +1014,12 @@ pub struct RestServerConfig {
     /// Configuration for incoming HTTP/2 connections.
     #[serde(flatten, skip_serializing_if = "defaults::is_default")]
     pub http2_config: Http2Config,
+
+    /// The maximum number of active requests that will be served on the recovery symbols endpoint.
+    ///
+    /// An unset value means it is unlimited.
+    #[serde(skip_serializing_if = "defaults::is_none")]
+    pub experimental_max_active_recovery_symbols_requests: Option<usize>,
 }
 
 /// Configuration of the HTTP/2 connections established by the REST API.


### PR DESCRIPTION
## Description

This adds the config parameter `rest_server.experimental_max_active_recovery_symbols_requests` which allows limiting the maximum number of active requests for symbols. A value of zero completely disables all recovery symbol endpoints (both individual and batch).

Depends on #2214 

## Test plan

Add a unit test which checks setting to zero.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
