### PR TITLE
feat(fanout): do not require tx_id and nonce for free proxies

### DIFF
--- a/crates/fan-out-proxy/src/error.rs
+++ b/crates/fan-out-proxy/src/error.rs
@@ -35,6 +35,14 @@ pub enum FanOutError {
     )]
     BlobLengthMismatch,
 
+    /// The query parameters are missing the transaction ID or the nonce, but the proxy requires
+    /// them to check the tip payment.
+    #[error(
+        "The query parameters are missing the transaction ID or the nonce, but the proxy requires \
+        them to check the tip payment."
+    )]
+    MissingTxIdOrNonce,
+
     /// BlobId was not registered in the given transaction.
     #[allow(unused)]
     #[error("blob_id {0} was not registered in the referenced transaction")]
@@ -84,6 +92,11 @@ impl IntoResponse for FanOutError {
             FanOutError::BlobIdMismatch => (
                 StatusCode::BAD_REQUEST,
                 FanOutError::BlobIdMismatch.to_string(),
+            )
+                .into_response(),
+            FanOutError::MissingTxIdOrNonce => (
+                StatusCode::BAD_REQUEST,
+                FanOutError::MissingTxIdOrNonce.to_string(),
             )
                 .into_response(),
             FanOutError::ClientError(_) | FanOutError::SuiClientError(_) => {

--- a/crates/fan-out-proxy/src/tip/config.rs
+++ b/crates/fan-out-proxy/src/tip/config.rs
@@ -64,3 +64,10 @@ pub(crate) enum TipConfig {
         kind: TipKind,
     },
 }
+
+impl TipConfig {
+    /// Checks if the tip config requires payment; returns `false` if no tip is required.
+    pub(crate) fn requires_payment(&self) -> bool {
+        matches!(self, TipConfig::SendTip { .. })
+    }
+}


### PR DESCRIPTION
## Description

Ensures the `tx_id` and the `nonce` are not needed if the fan out is being run in "free" mode (`NoTip`).

## Test plan

Manual testing.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
