### PR TITLE
fix: do not unwind non-panic error

### DIFF
--- a/crates/walrus-service/src/node/storage/metrics.rs
+++ b/crates/walrus-service/src/node/storage/metrics.rs
@@ -171,6 +171,8 @@ pub(super) fn typed_store_error_type<T>(result: Result<&T, &TypedStoreError>) ->
         TypedStoreError::CrossDBBatch => "TypedStoreError::CrossDBBatch",
         TypedStoreError::MetricsReporting => "TypedStoreError::MetricsReporting",
         TypedStoreError::RetryableTransactionError => "TypedStoreError::RetryableTransactionError",
+        TypedStoreError::IteratorNotInitialized => "TypedStoreError::IteratorNotInitialized",
+        TypedStoreError::TaskError(_) => "TypedStoreError::TaskError",
         _ => "unrecognized",
     }
 }


### PR DESCRIPTION
## Description

Cancel can happen during node shutdown, which may stop the node non-cleanly.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
