### PR TITLE
feat: guard storage db access

### DIFF
--- a/crates/typed-store/src/rocks/errors.rs
+++ b/crates/typed-store/src/rocks/errors.rs
@@ -135,6 +135,9 @@ pub enum TypedStoreError {
     /// tokio tasks errors back to the caller.
     #[error("Task error: {0}")]
     TaskError(String),
+    /// The database is being deleted
+    #[error("The database is being deleted")]
+    DatabaseBeingDeleted,
 }
 
 /// The result type for the typed store

--- a/crates/typed-store/src/rocks/errors.rs
+++ b/crates/typed-store/src/rocks/errors.rs
@@ -136,8 +136,8 @@ pub enum TypedStoreError {
     #[error("Task error: {0}")]
     TaskError(String),
     /// The database is being deleted
-    #[error("The database is being deleted")]
-    DatabaseBeingDeleted,
+    #[error("The shard storage is being deleted")]
+    ShardBeingDeleted,
 }
 
 /// The result type for the typed store

--- a/crates/walrus-service/src/node/blob_sync.rs
+++ b/crates/walrus-service/src/node/blob_sync.rs
@@ -701,7 +701,7 @@ impl BlobSynchronizer {
 
             Span::current().record("walrus.sliver.pair_index", field::display(sliver_id));
 
-            if shard_storage.is_sliver_stored::<A>(&self.blob_id)? {
+            if shard_storage.is_sliver_stored::<A>(&self.blob_id).await? {
                 tracing::debug!("not syncing sliver: already stored");
                 return Ok(false);
             }

--- a/crates/walrus-service/src/node/shard_sync.rs
+++ b/crates/walrus-service/src/node/shard_sync.rs
@@ -253,7 +253,7 @@ impl ShardSyncHandler {
                 ShardNotAssigned(shard_index, self.node.current_epoch())
             })?;
 
-        let shard_status = shard_storage.status()?;
+        let shard_status = shard_storage.status().await?;
 
         // Skip if shard is already active
         if shard_status == ShardStatus::Active {
@@ -266,7 +266,7 @@ impl ShardSyncHandler {
 
         // Update status and start sync. After this function returns, we can always restart
         // the sync upon node restart.
-        shard_storage.record_start_shard_sync()?;
+        shard_storage.record_start_shard_sync().await?;
         self.start_shard_sync_impl(shard_storage.clone()).await;
         Ok(())
     }
@@ -298,7 +298,7 @@ impl ShardSyncHandler {
             for shard_storage in self.node.storage.existing_shard_storages().await {
                 // Restart the syncing task for shards that were previously syncing (in ActiveSync
                 // status).
-                let shard_status = shard_storage.status()?;
+                let shard_status = shard_storage.status().await?;
                 match shard_status {
                     ShardStatus::ActiveSync => {
                         self.start_shard_sync_impl(shard_storage.clone()).await;
@@ -306,7 +306,7 @@ impl ShardSyncHandler {
                     ShardStatus::ActiveRecover => {
                         if self.config.restart_shard_sync_always_retry_transfer_first {
                             let shard_last_sync_status =
-                                shard_storage.resume_active_shard_sync()?;
+                                shard_storage.resume_active_shard_sync().await?;
                             tracing::info!(
                                 walrus.shard_index = %shard_storage.id(),
                                 ?shard_last_sync_status,
@@ -697,6 +697,7 @@ mod tests {
                 .await
                 .expect("Failed to get shard storage")
                 .update_status_in_test(ShardStatus::ActiveSync)
+                .await
                 .expect("Failed to update shard status");
         }
         let shard_sync_handler = ShardSyncHandler::new(
@@ -740,6 +741,7 @@ mod tests {
             .await
             .expect("Failed to get shard storage")
             .update_status_in_test(ShardStatus::None)
+            .await
             .expect("Failed to update shard status");
 
         assert_eq!(shard_sync_handler.current_sync_task_count().await, 0);

--- a/crates/walrus-service/src/node/start_epoch_change_finisher.rs
+++ b/crates/walrus-service/src/node/start_epoch_change_finisher.rs
@@ -132,6 +132,8 @@ impl StartEpochChangeFinisher {
     ) -> Result<(), TypedStoreError> {
         for shard_index in shards {
             tracing::info!(walrus.shard_index = %shard_index, "start removing shard from storage");
+            // TODO(WAL-902): we also need to cancel any ongoing shard syncs on these shards if
+            // there are any.
             self.node
                 .storage
                 .remove_storage_for_shards(&[*shard_index])


### PR DESCRIPTION
## Description

Previously, shard storage access db without any protection, meaning that for async tasks such as sliver recovery
or shard recovery, it is possible that the shard may be deleted while the task is running, and the db is
accessed after the task finishes, causing crash.

This PR gurads all accesses in a shard's storage via a RwLock, and almost all accesses requires read lock and check
if the shard is deleted, except for shard removal.

The change is made generally towards concurrent DB access in case there will be other storage change made in the
future.

## Test plan

Added a simple unit test to test access after deletion.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
