### PR TITLE
fix: handling accessing shard db after shard removal

### DIFF
--- a/crates/typed-store/src/rocks.rs
+++ b/crates/typed-store/src/rocks.rs
@@ -586,22 +586,7 @@ impl<K, V> DBMap<K, V> {
         let from_buf = be_fix_int_ser(start)?;
         let to_buf = be_fix_int_ser(end)?;
         self.rocksdb
-            .compact_range_cf(&self.cf(), Some(from_buf), Some(to_buf));
-        Ok(())
-    }
-
-    /// Compact a range of keys in a specific column family
-    pub fn compact_range_raw(
-        &self,
-        cf_name: &str,
-        start: Vec<u8>,
-        end: Vec<u8>,
-    ) -> Result<(), TypedStoreError> {
-        let cf = self
-            .rocksdb
-            .cf_handle(cf_name)
-            .expect("compact range: column family does not exist");
-        self.rocksdb.compact_range_cf(&cf, Some(start), Some(end));
+            .compact_range_cf(&self.cf()?, Some(from_buf), Some(to_buf));
         Ok(())
     }
 
@@ -614,35 +599,22 @@ impl<K, V> DBMap<K, V> {
         let from_buf = be_fix_int_ser(start)?;
         let to_buf = be_fix_int_ser(end)?;
         self.rocksdb
-            .compact_range_to_bottom(&self.cf(), Some(from_buf), Some(to_buf));
+            .compact_range_to_bottom(&self.cf()?, Some(from_buf), Some(to_buf));
         Ok(())
     }
 
     /// Get the column family
-    pub fn cf(&self) -> Arc<rocksdb::BoundColumnFamily<'_>> {
-        self.rocksdb.cf_handle(&self.cf).unwrap_or_else(|| {
-            // Force capture backtrace regardless of RUST_BACKTRACE env var
-            let backtrace = std::backtrace::Backtrace::force_capture();
-            eprintln!("PANIC: Column family '{}' not found!", &self.cf);
-            eprintln!("Database path: {:?}", &self.rocksdb.db_path);
-            eprintln!("Full backtrace:\n{}", backtrace);
-            panic!(
-                "Map-keying column family {} should have been checked at DB creation",
-                &self.cf
-            )
-        })
+    pub fn cf(&self) -> Result<Arc<rocksdb::BoundColumnFamily<'_>>, TypedStoreError> {
+        self.rocksdb
+            .cf_handle(&self.cf)
+            .ok_or_else(|| TypedStoreError::UnregisteredColumn(self.cf.clone()))
     }
 
     /// Flush the column family
     pub fn flush(&self) -> Result<(), TypedStoreError> {
         self.rocksdb
-            .flush_cf(&self.cf())
+            .flush_cf(&self.cf()?)
             .map_err(|e| TypedStoreError::RocksDBError(e.into_string()))
-    }
-
-    /// Set the options for the column family
-    pub fn set_options(&self, opts: &[(&str, &str)]) -> Result<(), rocksdb::Error> {
-        self.rocksdb.set_options_cf(&self.cf(), opts)
     }
 
     fn get_int_property(
@@ -686,7 +658,7 @@ impl<K, V> DBMap<K, V> {
         let results: Result<Vec<_>, TypedStoreError> = self
             .rocksdb
             .batched_multi_get_cf_opt(
-                &self.cf(),
+                &self.cf()?,
                 keys_refs,
                 /*sorted_keys=*/ false,
                 &self.opts.readopts(),
@@ -940,7 +912,7 @@ impl<K, V> DBMap<K, V> {
             .expect("the function parameters are valid");
         let mut value_hist = hdrhistogram::Histogram::<u64>::new_with_max(100000, 2)
             .expect("the function parameters are valid");
-        for item in self.safe_iter() {
+        for item in self.safe_iter()? {
             let (key, value) = item?;
             num_keys += 1;
             let key_len = be_fix_int_ser(key.borrow())?.len();
@@ -1043,7 +1015,7 @@ impl<K, V> DBMap<K, V> {
                 .unwrap_or(Bound::Unbounded),
         ));
 
-        let db_iter = self.rocksdb.raw_iterator_cf(&self.cf(), readopts);
+        let db_iter = self.rocksdb.raw_iterator_cf(&self.cf()?, readopts);
         let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
         let iter = SafeIter::new(
             self.cf.clone(),
@@ -1270,7 +1242,7 @@ impl DBBatch {
             .into_iter()
             .try_for_each::<_, Result<_, TypedStoreError>>(|k| {
                 let k_buf = be_fix_int_ser(k.borrow())?;
-                self.batch.delete_cf(&db.cf(), k_buf);
+                self.batch.delete_cf(&db.cf()?, k_buf);
 
                 Ok(())
             })?;
@@ -1299,7 +1271,7 @@ impl DBBatch {
         let from_buf = be_fix_int_ser(from)?;
         let to_buf = be_fix_int_ser(to)?;
 
-        self.batch.delete_range_cf(&db.cf(), from_buf, to_buf);
+        self.batch.delete_range_cf(&db.cf()?, from_buf, to_buf);
         Ok(())
     }
 
@@ -1319,7 +1291,7 @@ impl DBBatch {
                 let k_buf = be_fix_int_ser(k.borrow())?;
                 let v_buf = bcs::to_bytes(v.borrow()).map_err(typed_store_err_from_bcs_err)?;
                 total += k_buf.len() + v_buf.len();
-                self.batch.put_cf(&db.cf(), k_buf, v_buf);
+                self.batch.put_cf(&db.cf()?, k_buf, v_buf);
                 Ok(())
             })?;
         self.db_metrics
@@ -1343,7 +1315,7 @@ impl DBBatch {
             .into_iter()
             .try_for_each::<_, Result<_, TypedStoreError>>(|(k, v)| {
                 let k_buf = be_fix_int_ser(k.borrow())?;
-                self.batch.merge_cf(&db.cf(), k_buf, v);
+                self.batch.merge_cf(&db.cf()?, k_buf, v);
                 Ok(())
             })?;
         Ok(self)
@@ -1370,10 +1342,10 @@ where
         let readopts = self.opts.readopts();
         Ok(self
             .rocksdb
-            .key_may_exist_cf(&self.cf(), &key_buf, &readopts)
+            .key_may_exist_cf(&self.cf()?, &key_buf, &readopts)
             && self
                 .rocksdb
-                .get_pinned_cf_opt(&self.cf(), &key_buf, &readopts)
+                .get_pinned_cf_opt(&self.cf()?, &key_buf, &readopts)
                 .map_err(typed_store_err_from_rocks_err)?
                 .is_some())
     }
@@ -1406,7 +1378,7 @@ where
         let key_buf = be_fix_int_ser(key)?;
         let res = self
             .rocksdb
-            .get_pinned_cf_opt(&self.cf(), &key_buf, &self.opts.readopts())
+            .get_pinned_cf_opt(&self.cf()?, &key_buf, &self.opts.readopts())
             .map_err(typed_store_err_from_rocks_err)?;
         self.db_metrics
             .op_metrics
@@ -1452,7 +1424,7 @@ where
                 .report_metrics(&self.cf);
         }
         self.rocksdb
-            .put_cf(&self.cf(), &key_buf, &value_buf, &self.opts.writeopts())
+            .put_cf(&self.cf()?, &key_buf, &value_buf, &self.opts.writeopts())
             .map_err(typed_store_err_from_rocks_err)?;
 
         let elapsed = timer.stop_and_record();
@@ -1488,7 +1460,7 @@ where
         };
         let key_buf = be_fix_int_ser(key)?;
         self.rocksdb
-            .delete_cf(&self.cf(), key_buf, &self.opts.writeopts())
+            .delete_cf(&self.cf()?, key_buf, &self.opts.writeopts())
             .map_err(typed_store_err_from_rocks_err)?;
         self.db_metrics
             .op_metrics
@@ -1526,7 +1498,7 @@ where
     /// overridden in the config), so please use this function with caution
     #[tracing::instrument(level = "trace", skip_all, err)]
     fn schedule_delete_all(&self) -> Result<(), TypedStoreError> {
-        let first_key = self.safe_iter().next().transpose()?.map(|(k, _v)| k);
+        let first_key = self.safe_iter()?.next().transpose()?.map(|(k, _v)| k);
         let last_key = self
             .reversed_safe_iter_with_bounds(None, None)?
             .next()
@@ -1541,15 +1513,18 @@ where
     }
 
     fn is_empty(&self) -> bool {
-        self.safe_iter().next().is_none()
+        self.safe_iter()
+            .expect("safe_iter should not fail")
+            .next()
+            .is_none()
     }
 
-    fn safe_iter(&'a self) -> Self::SafeIterator {
+    fn safe_iter(&'a self) -> Result<Self::SafeIterator, TypedStoreError> {
         let db_iter = self
             .rocksdb
-            .raw_iterator_cf(&self.cf(), self.opts.readopts());
+            .raw_iterator_cf(&self.cf()?, self.opts.readopts());
         let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
-        SafeIter::new(
+        Ok(SafeIter::new(
             self.cf.clone(),
             db_iter,
             _timer,
@@ -1557,18 +1532,18 @@ where
             bytes_scanned,
             keys_scanned,
             Some(self.db_metrics.clone()),
-        )
+        ))
     }
 
     fn safe_iter_with_bounds(
         &'a self,
         lower_bound: Option<K>,
         upper_bound: Option<K>,
-    ) -> Self::SafeIterator {
+    ) -> Result<Self::SafeIterator, TypedStoreError> {
         let readopts = self.create_read_options_with_bounds(lower_bound, upper_bound);
-        let db_iter = self.rocksdb.raw_iterator_cf(&self.cf(), readopts);
+        let db_iter = self.rocksdb.raw_iterator_cf(&self.cf()?, readopts);
         let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
-        SafeIter::new(
+        Ok(SafeIter::new(
             self.cf.clone(),
             db_iter,
             _timer,
@@ -1576,14 +1551,17 @@ where
             bytes_scanned,
             keys_scanned,
             Some(self.db_metrics.clone()),
-        )
+        ))
     }
 
-    fn safe_range_iter(&'a self, range: impl RangeBounds<K>) -> Self::SafeIterator {
+    fn safe_range_iter(
+        &'a self,
+        range: impl RangeBounds<K>,
+    ) -> Result<Self::SafeIterator, TypedStoreError> {
         let readopts = self.create_read_options_with_range(range);
-        let db_iter = self.rocksdb.raw_iterator_cf(&self.cf(), readopts);
+        let db_iter = self.rocksdb.raw_iterator_cf(&self.cf()?, readopts);
         let (_timer, bytes_scanned, keys_scanned, _perf_ctx) = self.create_iter_context();
-        SafeIter::new(
+        Ok(SafeIter::new(
             self.cf.clone(),
             db_iter,
             _timer,
@@ -1591,7 +1569,7 @@ where
             bytes_scanned,
             keys_scanned,
             Some(self.db_metrics.clone()),
-        )
+        ))
     }
 
     /// Returns a vector of values corresponding to the keys provided.

--- a/crates/typed-store/src/traits.rs
+++ b/crates/typed-store/src/traits.rs
@@ -53,17 +53,20 @@ where
     fn is_empty(&self) -> bool;
 
     /// Same as `iter` but performs status check.
-    fn safe_iter(&'a self) -> Self::SafeIterator;
+    fn safe_iter(&'a self) -> Result<Self::SafeIterator, Self::Error>;
 
     /// Same as `iter_with_bounds` but performs status check.
     fn safe_iter_with_bounds(
         &'a self,
         lower_bound: Option<K>,
         upper_bound: Option<K>,
-    ) -> Self::SafeIterator;
+    ) -> Result<Self::SafeIterator, Self::Error>;
 
     /// Same as `range_iter` but performs status check.
-    fn safe_range_iter(&'a self, range: impl RangeBounds<K>) -> Self::SafeIterator;
+    fn safe_range_iter(
+        &'a self,
+        range: impl RangeBounds<K>,
+    ) -> Result<Self::SafeIterator, Self::Error>;
 
     /// Returns a vector of values corresponding to the keys provided, non-atomically.
     fn multi_get<J>(&self, keys: impl IntoIterator<Item = J>) -> Result<Vec<Option<V>>, Self::Error>

--- a/crates/walrus-service/src/event/event_processor/processor.rs
+++ b/crates/walrus-service/src/event/event_processor/processor.rs
@@ -210,7 +210,7 @@ impl EventProcessor {
     pub fn poll(&self, from: u64) -> Result<Vec<PositionedStreamEvent>, TypedStoreError> {
         self.stores
             .event_store
-            .safe_iter_with_bounds(Some(from), None)
+            .safe_iter_with_bounds(Some(from), None)?
             .take(MAX_EVENTS_PER_POLL)
             .map(|result| result.map(|(_, event)| event))
             .collect()
@@ -222,7 +222,7 @@ impl EventProcessor {
         let mut iter = self
             .stores
             .event_store
-            .safe_iter_with_bounds(Some(from), None);
+            .safe_iter_with_bounds(Some(from), None)?;
         let Some(result) = iter.next() else {
             return Ok(None);
         };
@@ -330,7 +330,7 @@ impl EventProcessor {
                         .with_fixint_encoding()
                         .serialize(&commit_index)?;
                     self.stores.event_store.rocksdb.delete_file_in_range(
-                        &self.stores.event_store.cf(),
+                        &self.stores.event_store.cf()?,
                         &start,
                         &end,
                     )?;

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -3869,24 +3869,12 @@ mod tests {
                 .await
                 .unwrap();
 
-        // Delete shard data to force a panic in the blob sync task.
-        // Note that this only deletes the storage for the shard. Storage still has an entry for the
-        // shard, so it thinks it still owns the shard.
-        cluster.nodes[0]
-            .storage_node
-            .inner
-            .storage
-            .shard_storage(test_shard)
-            .await
-            .unwrap()
-            .delete_shard_storage()
-            .unwrap();
-
         // Start a sync to trigger the blob sync task.
+        // Use a epoch number in the future will trigger a panic in reading the committee.
         cluster.nodes[0]
             .storage_node
             .blob_sync_handler
-            .start_sync(*blob.blob_id(), 1, None)
+            .start_sync(*blob.blob_id(), 100, None)
             .await
             .unwrap();
 

--- a/crates/walrus-service/src/node/blob_sync.rs
+++ b/crates/walrus-service/src/node/blob_sync.rs
@@ -517,20 +517,164 @@ impl BlobSynchronizer {
             .await
             .expect("database operations should not fail");
 
-        while let Err(error) = recover_blob_slivers(
-            this.clone(),
-            sliver_permits.clone(),
-            shared_metadata.clone(),
-        )
-        .await
+        while let Err(error) = this
+            .clone()
+            .recover_blob_slivers(sliver_permits.clone(), shared_metadata.clone())
+            .await
         {
+            let backoff_duration = if cfg!(msim) {
+                // Doing fast retry in simtest to save some time.
+                Duration::from_secs(0)
+            } else {
+                Duration::from_secs(30)
+            };
             tracing::warn!(
                 ?error,
-                "recovering sliver failed with error {:?}, retrying after 30 seconds",
-                error
+                "recovering sliver failed with error {:?}, retrying after {} seconds",
+                error,
+                backoff_duration.as_secs()
             );
-            tokio::time::sleep(Duration::from_secs(30)).await;
+            tokio::time::sleep(backoff_duration).await;
         }
+    }
+
+    /// Starts the task that syncs all the missing slivers for a blob.
+    async fn recover_blob_slivers(
+        self: Arc<Self>,
+        sliver_permits: Arc<Semaphore>,
+        shared_metadata: Arc<VerifiedBlobMetadataWithId>,
+    ) -> Result<(), RecoverSliverError> {
+        let histograms = &self.metrics().recover_blob_part_duration_seconds;
+
+        // Note that we only need to recover the slivers in the shards that are assigned to the
+        // node at the time of the start of blob sync. Due to slow event processing, the contract
+        // might have entered the new epoch with new shard assignment. Upon discovery of the new
+        // shard assignment, the node only needs to recover the slivers assigned in the epoch
+        // of the current event due to that:
+        //   - The node may not have created the new shards yet.
+        //   - Since the blob is certified in an earlier epoch, it is this node's responsibility to
+        //     hold, recover, and transfer the shard to the new owner.
+        //
+        // If the node is severally lagging behind and the certified_epoch is 2 epochs older,
+        // this function panics since no shard assignment info is found. Upon restarting the node,
+        // the node will enter recovery mode until catching up with all the events and start
+        // recovering all the missing blobs.
+        let futures_iter = self
+            .node
+            .owned_shards_at_epoch(self.node.current_event_epoch())
+            .unwrap_or_else(|_| {
+                tracing::error!(
+                    "shard assignment must be found at the certified epoch {}",
+                    self.node.current_event_epoch()
+                );
+                panic!(
+                    "shard assignment must be found at the certified epoch {}",
+                    self.node.current_event_epoch()
+                )
+            })
+            .into_iter()
+            .map(|shard| {
+                self.clone()
+                    .recover_slivers_for_shard(shared_metadata.clone(), shard)
+            });
+
+        let mut futures_with_permits = stream::iter(futures_iter).then(move |future| {
+            let permits = sliver_permits.clone();
+
+            // We use a future to get the permit. Only then is the future returned from the stream
+            // to be awaited.
+            #[allow(clippy::async_yields_async)]
+            async move {
+                let claimed_permit = permits
+                    .acquire_owned()
+                    .await
+                    .expect("semaphore should not been dropped");
+                // Attach the permit to the future, so that it is held until the future completes.
+                future.map(|result| (result, claimed_permit))
+            }
+        });
+        let mut futures_with_permits = std::pin::pin!(futures_with_permits);
+        // When stored in a JoinSet, tasks are aborted on drop.
+        let mut pending_tasks = JoinSet::new();
+
+        loop {
+            tokio::select! {
+                biased;
+
+                Some(future) = futures_with_permits.next() => {
+                    // Add the permit and the future to the list of pending futures
+                    pending_tasks.spawn(future);
+                }
+                Some(join_result) = pending_tasks.join_next() => {
+                    match join_result {
+                        Ok((Err(RecoverSliverError::Inconsistent(inconsistency_proof)), _permit)) =>
+                        {
+                            tracing::warn!("received an inconsistency proof");
+                            // No need to recover other slivers, sync the proof and return
+                            self.sync_inconsistency_proof(&inconsistency_proof)
+                                .observe_future(histograms.clone(),
+                                                labels_from_inconsistency_sync_result)
+                                .await;
+                            break;
+                        }
+                        Ok((Err(RecoverSliverError::Database(err)), _)) => {
+                            match err {
+                                TypedStoreError::UnregisteredColumn(ref column) => {
+                                    // It is possible that when the blob recovery is running, a
+                                    // shard is removed from the storage, and therefore encounter
+                                    // UnregisteredColumn error. In this case, we should not panic
+                                    // and instead return an error to retry the blob sync.
+                                    tracing::error!(
+                                        "database error during sliver sync: unregistered column \
+                                        {:?}",
+                                        column
+                                    );
+                                    return Err(RecoverSliverError::Database(err));
+                                }
+                                _ => {
+                                    panic!("database operations should not fail: {:?}", err)
+                                }
+                            }
+                        }
+                        Ok(_) => (),
+                        Err(join_err) => match join_err.try_into_panic() {
+                            Ok(reason) => {
+                                // Cancel other tasks (as a precaution) and resume the panic on
+                                // the main task, which was the prior behaviour when we were
+                                // using futures instead of tasks.
+                                pending_tasks.abort_all();
+                                std::panic::resume_unwind(reason);
+                            }
+                            Err(join_err) => {
+                                assert!(join_err.is_cancelled());
+                                // We do not poll after cancelling the tasks, and as we have the
+                                // join handle in our JoinSet, no one else should be able to
+                                // abort the task, therefore should never happen.
+                                //
+                                // Returning from this function as if the task was cancelled
+                                // would leave a sliver unrecovered and block progress, since the
+                                // recovery was not cancelled.
+                                //
+                                // Treating it as success would be worse as we would progress
+                                // but not have the sliver stored. We therefore panic.
+                                tracing::error!(
+                                    error = ?join_err,
+                                    "a sliver recovery task cancelled unexpectedly"
+                                );
+                                panic!("a sliver recovery task cancelled unexpectedly");
+                            }
+                        }
+                    }
+                }
+                else => {
+                    // Both the pending futures and the waiting futures streams have completed,
+                    // we are therefore complete.
+                    break;
+                }
+            }
+        }
+
+        Ok(())
     }
 
     /// Drives the recovery and storage of the slivers associated with this blob, for one shard.
@@ -646,147 +790,6 @@ impl BlobSynchronizer {
             .invalidate_blob_id(&invalid_blob_certificate)
             .await
     }
-}
-
-/// Starts the task that syncs all the missing slivers for a blob.
-async fn recover_blob_slivers(
-    blob_synchronizer: Arc<BlobSynchronizer>,
-    sliver_permits: Arc<Semaphore>,
-    shared_metadata: Arc<VerifiedBlobMetadataWithId>,
-) -> Result<(), RecoverSliverError> {
-    let histograms = &blob_synchronizer
-        .metrics()
-        .recover_blob_part_duration_seconds;
-
-    // Note that we only need to recover the slivers in the shards that are assigned to the
-    // node at the time of the start of blob sync. Due to slow event processing, the contract
-    // might have entered the new epoch with new shard assignment. Upon discovery of the new
-    // shard assignment, the node only needs to recover the slivers assigned in the epoch
-    // of the current event due to that:
-    //   - The node may not have created the new shards yet.
-    //   - Since the blob is certified in an earlier epoch, it is this node's responsibility to
-    //     hold, recover, and transfer the shard to the new owner.
-    //
-    // If the node is severally lagging behind and the certified_epoch is 2 epochs older,
-    // this function panics since no shard assignment info is found. Upon restarting the node,
-    // the node will enter recovery mode until catching up with all the events and start
-    // recovering all the missing blobs.
-    let futures_iter = blob_synchronizer
-        .node
-        .owned_shards_at_epoch(blob_synchronizer.node.current_event_epoch())
-        .unwrap_or_else(|_| {
-            tracing::error!(
-                "shard assignment must be found at the certified epoch {}",
-                blob_synchronizer.node.current_event_epoch()
-            );
-            panic!(
-                "shard assignment must be found at the certified epoch {}",
-                blob_synchronizer.node.current_event_epoch()
-            )
-        })
-        .into_iter()
-        .map(|shard| {
-            blob_synchronizer
-                .clone()
-                .recover_slivers_for_shard(shared_metadata.clone(), shard)
-        });
-
-    let mut futures_with_permits = stream::iter(futures_iter).then(move |future| {
-        let permits = sliver_permits.clone();
-
-        // We use a future to get the permit. Only then is the future returned from the stream
-        // to be awaited.
-        #[allow(clippy::async_yields_async)]
-        async move {
-            let claimed_permit = permits
-                .acquire_owned()
-                .await
-                .expect("semaphore should not been dropped");
-            // Attach the permit to the future, so that it is held until the future completes.
-            future.map(|result| (result, claimed_permit))
-        }
-    });
-    let mut futures_with_permits = std::pin::pin!(futures_with_permits);
-    // When stored in a JoinSet, tasks are aborted on drop.
-    let mut pending_tasks = JoinSet::new();
-
-    loop {
-        tokio::select! {
-            biased;
-
-            Some(future) = futures_with_permits.next() => {
-                // Add the permit and the future to the list of pending futures
-                pending_tasks.spawn(future);
-            }
-            Some(join_result) = pending_tasks.join_next() => {
-                match join_result {
-                    Ok((Err(RecoverSliverError::Inconsistent(inconsistency_proof)), _permit)) =>
-                    {
-                        tracing::warn!("received an inconsistency proof");
-                        // No need to recover other slivers, sync the proof and return
-                        blob_synchronizer.sync_inconsistency_proof(&inconsistency_proof)
-                            .observe_future(histograms.clone(),
-                                            labels_from_inconsistency_sync_result)
-                            .await;
-                        break;
-                    }
-                    Ok((Err(RecoverSliverError::Database(err)), _)) => {
-                        match err {
-                            TypedStoreError::UnregisteredColumn(ref column) => {
-                                // It is possible that when the blob recovery is running, a shard
-                                // is removed from the storage, and therefore encounter
-                                // UnregisteredColumn error. In this case, we should not panic
-                                // and instead return an error to retry the blob sync.
-                                tracing::error!(
-                                    "database error during sliver sync: unregistered column {:?}",
-                                    column
-                                );
-                                return Err(RecoverSliverError::Database(err));
-                            }
-                            _ => {
-                                panic!("database operations should not fail: {:?}", err)
-                            }
-                        }
-                    }
-                    Ok(_) => (),
-                    Err(join_err) => match join_err.try_into_panic() {
-                        Ok(reason) => {
-                            // Cancel other tasks (as a precaution) and resume the panic on
-                            // the main task, which was the prior behaviour when we were
-                            // using futures instead of tasks.
-                            pending_tasks.abort_all();
-                            std::panic::resume_unwind(reason);
-                        }
-                        Err(join_err) => {
-                            assert!(join_err.is_cancelled());
-                            // We do not poll after cancelling the tasks, and as we have the
-                            // join handle in our JoinSet, no one else should be able to
-                            // abort the task, therefore should never happen.
-                            //
-                            // Returning from this function as if the task was cancelled
-                            // would leave a sliver unrecovered and block progress, since the
-                            // recovery was not cancelled.
-                            //
-                            // Treating it as success would be worse as we would progress
-                            // but not have the sliver stored. We therefore panic.
-                            tracing::error!(
-                                error = ?join_err,
-                                "a sliver recovery task cancelled unexpectedly"
-                            );
-                            panic!("a sliver recovery task cancelled unexpectedly");
-                        }
-                    }
-                }
-            }
-            else => {
-                // Both the pending futures and the waiting futures streams have completed,
-                // we are therefore complete.
-                break;
-            }
-        }
-    }
-
-    Ok(())
 }
 
 fn labels_from_metadata_result(

--- a/crates/walrus-service/src/node/storage/blob_info.rs
+++ b/crates/walrus-service/src/node/storage/blob_info.rs
@@ -183,7 +183,8 @@ impl BlobInfoTable {
         BlobInfoIter::new(
             Box::new(
                 self.aggregate_blob_info
-                    .safe_range_iter((starting_blob_id_bound, Unbounded)),
+                    .safe_range_iter((starting_blob_id_bound, Unbounded))
+                    .expect("aggregate_blob_info cf must always exist in storage node"),
             ),
             before_epoch,
         )
@@ -200,7 +201,8 @@ impl BlobInfoTable {
         BlobInfoIter::new(
             Box::new(
                 self.per_object_blob_info
-                    .safe_range_iter((starting_object_id_bound, Unbounded)),
+                    .safe_range_iter((starting_object_id_bound, Unbounded))
+                    .expect("per_object_blob_info cf must always exist in storage node"),
             ),
             before_epoch,
         )
@@ -248,6 +250,7 @@ impl BlobInfoTable {
     pub fn keys(&self) -> Result<Vec<BlobId>, TypedStoreError> {
         self.aggregate_blob_info
             .safe_iter()
+            .expect("aggregate_blob_info cf must always exist in storage node")
             .map(|r| r.map(|(k, _)| k))
             .collect()
     }

--- a/crates/walrus-service/src/node/storage/shard.rs
+++ b/crates/walrus-service/src/node/storage/shard.rs
@@ -1050,10 +1050,10 @@ impl ShardStorage {
 
         // Update the metric for the total number of blobs pending recovery, so that we know how
         // many blobs are pending recovery.
-        let mut total_blobs_pending_recovery = self.pending_recover_slivers.safe_iter().count();
+        let mut total_blobs_pending_recovery = self.pending_recover_slivers.safe_iter()?.count();
         self.record_pending_recovery_metrics(&node, total_blobs_pending_recovery);
 
-        for recover_blob in self.pending_recover_slivers.safe_iter() {
+        for recover_blob in self.pending_recover_slivers.safe_iter()? {
             let ((sliver_type, blob_id), _) = recover_blob?;
 
             #[allow(unused_mut)]
@@ -1305,11 +1305,11 @@ impl ShardStorage {
         match sliver_type {
             SliverType::Primary => self
                 .primary_slivers
-                .safe_iter()
+                .safe_iter()?
                 .try_fold(0, |count, e| e.map(|_| count + 1)),
             SliverType::Secondary => self
                 .secondary_slivers
-                .safe_iter()
+                .safe_iter()?
                 .try_fold(0, |count, e| e.map(|_| count + 1)),
         }
     }
@@ -1344,7 +1344,7 @@ impl ShardStorage {
         &self,
     ) -> Result<Vec<(SliverType, BlobId)>, TypedStoreError> {
         self.pending_recover_slivers
-            .safe_iter()
+            .safe_iter()?
             .map(|r| r.map(|(k, _)| k))
             .collect()
     }

--- a/crates/walrus-simtest/tests/simtest.rs
+++ b/crates/walrus-simtest/tests/simtest.rs
@@ -82,6 +82,7 @@ mod tests {
             false,
             false,
             &mut blobs_written,
+            0,
         )
         .await
         .expect("workload should not fail");
@@ -142,7 +143,7 @@ mod tests {
             .unwrap();
 
         let client_arc = Arc::new(client);
-        let workload_handle = simtest_utils::start_background_workload(client_arc.clone(), true);
+        let workload_handle = simtest_utils::start_background_workload(client_arc.clone(), true, 0);
 
         // Run the workload for 60 seconds to get some data in the system.
         tokio::time::sleep(Duration::from_secs(60)).await;
@@ -267,7 +268,8 @@ mod tests {
 
         // Starts a background workload that a client keeps writing and retrieving data.
         // All requests should succeed even if a node crashes.
-        let workload_handle = simtest_utils::start_background_workload(client_arc.clone(), false);
+        let workload_handle =
+            simtest_utils::start_background_workload(client_arc.clone(), false, 0);
 
         // Running the workload for 60 seconds to get some data in the system.
         tokio::time::sleep(Duration::from_secs(90)).await;
@@ -449,7 +451,8 @@ mod tests {
 
         // Starts a background workload that a client keeps writing and retrieving data.
         // All requests should succeed even if a node crashes.
-        let workload_handle = simtest_utils::start_background_workload(client_arc.clone(), false);
+        let workload_handle =
+            simtest_utils::start_background_workload(client_arc.clone(), false, 0);
 
         // Running the workload for 60 seconds to get some data in the system.
         tokio::time::sleep(Duration::from_secs(60)).await;
@@ -523,7 +526,7 @@ mod tests {
             .await
             .unwrap();
 
-        let workload_handle = simtest_utils::start_background_workload(Arc::new(client), true);
+        let workload_handle = simtest_utils::start_background_workload(Arc::new(client), true, 0);
 
         // Run the workload for 120 seconds to get some data in the system.
         tokio::time::sleep(Duration::from_secs(120)).await;

--- a/crates/walrus-simtest/tests/simtest_event_blob.rs
+++ b/crates/walrus-simtest/tests/simtest_event_blob.rs
@@ -458,7 +458,8 @@ mod tests {
         restart_nodes_with_checkpoints(&mut walrus_cluster, |_| checkpoints_per_event_blob).await;
 
         // Wait for the cluster to process some events.
-        let workload_handle = simtest_utils::start_background_workload(client_arc.clone(), false);
+        let workload_handle =
+            simtest_utils::start_background_workload(client_arc.clone(), false, 0);
         tokio::time::sleep(Duration::from_secs(30)).await;
 
         // Get the latest checkpoint from Sui.

--- a/crates/walrus-simtest/tests/simtest_failure.rs
+++ b/crates/walrus-simtest/tests/simtest_failure.rs
@@ -18,7 +18,6 @@ mod tests {
     };
 
     use rand::{Rng, SeedableRng, thread_rng};
-    use sui_macros::{clear_fail_point, register_fail_point_async, register_fail_point_if};
     use sui_protocol_config::ProtocolConfig;
     use walrus_proc_macros::walrus_simtest;
     use walrus_service::{
@@ -92,6 +91,7 @@ mod tests {
                 false,
                 false,
                 &mut blobs_written,
+                0,
             )
             .await
             .expect("workload should not fail");
@@ -113,6 +113,7 @@ mod tests {
                     false,
                     false,
                     &mut blobs_written,
+                    0,
                 )
                 .await
                 .expect("workload should not fail");
@@ -237,7 +238,8 @@ mod tests {
 
         // Starts a background workload that a client keeps writing and retrieving data.
         // All requests should succeed even if a node crashes.
-        let workload_handle = simtest_utils::start_background_workload(client_arc.clone(), false);
+        let workload_handle =
+            simtest_utils::start_background_workload(client_arc.clone(), false, 0);
 
         // Running the workload for 60 seconds to get some data in the system.
         tokio::time::sleep(Duration::from_secs(60)).await;
@@ -373,7 +375,6 @@ mod tests {
 
     // This integration test simulates a scenario where a node is repeatedly crashing and
     // recovering.
-    #[ignore = "ignore integration simtests by default"]
     #[walrus_simtest]
     async fn test_repeated_node_crash() {
         // We use a very short epoch duration of 10 seconds so that we can exercise more epoch
@@ -406,7 +407,7 @@ mod tests {
         // certified blob events require blob recovery, and mix with epoch change.
         let cause_target_shard_slow_processing_event = thread_rng().gen_bool(0.5);
         if cause_target_shard_slow_processing_event {
-            register_fail_point_async("epoch_change_start_entry", move || async move {
+            sui_macros::register_fail_point_async("epoch_change_start_entry", move || async move {
                 if sui_simulator::current_simnode_id() == target_fail_node_id {
                     tokio::time::sleep(Duration::from_secs(
                         rand::rngs::StdRng::from_entropy().gen_range(2..=7),
@@ -416,36 +417,26 @@ mod tests {
             });
         }
 
-        let client_arc = Arc::new(client);
-        let client_clone = client_arc.clone();
-
-        // First, we inject some data into the cluster. Note that to control the test duration, we
-        // stopped the workload once started crashing the node.
-        let mut data_length = 64;
-        let workload_start_time = Instant::now();
-        let mut blobs_written = HashSet::new();
-        loop {
-            if workload_start_time.elapsed() > Duration::from_secs(20) {
-                tracing::info!("generated 60s of data; stopping workload");
-                break;
-            }
-            tracing::info!("writing data with size {data_length}");
-
-            // TODO(#995): use stress client for better coverage of the workload.
-            simtest_utils::write_read_and_check_random_blob(
-                client_clone.as_ref(),
-                data_length,
-                true,
-                false,
-                &mut blobs_written,
-            )
-            .await
-            .expect("workload should not fail");
-
-            tracing::info!("finished writing data with size {data_length}");
-
-            data_length += 1;
+        // 20% of the test cases, we trigger a fail point to make blob recovery slower.
+        if rand::thread_rng().gen_bool(0.2) {
+            tracing::info!(
+                "triggering fail point fail_point_recover_sliver_before_put_sliver, make \
+                blob recovery slower"
+            );
+            sui_macros::register_fail_point_async(
+                "fail_point_recover_sliver_before_put_sliver",
+                move || async move {
+                    if sui_simulator::current_simnode_id() == target_fail_node_id {
+                        tokio::time::sleep(Duration::from_secs(30)).await;
+                    }
+                },
+            );
         }
+
+        let client_arc = Arc::new(client);
+
+        // Use a higher write retry limit given that the epoch duration is short.
+        let workload_handle = simtest_utils::start_background_workload(client_arc.clone(), true, 5);
 
         let next_fail_triggered = Arc::new(Mutex::new(Instant::now()));
         let next_fail_triggered_clone = next_fail_triggered.clone();
@@ -460,19 +451,27 @@ mod tests {
         });
 
         // We probabilistically trigger a shard move to the crashed node to test the recovery.
-        // The additional stake assigned are randomly chosen between 2 and 5 times of the original
+        // The additional stake assigned are randomly chosen between 2 and 10 times of the original
         // stake the per-node.
-        let shard_move_weight = rand::thread_rng().gen_range(2..=5);
+        let shard_move_weight = rand::thread_rng().gen_range(2..=10);
         tracing::info!(
             "triggering shard move with stake weight {}",
             shard_move_weight
         );
 
+        // 30% of the time, we move shards to the crashed node. The other 70% of the time, we move
+        // shards to a different node.
+        let node_index_to_move = if thread_rng().gen_bool(0.3) {
+            node_index_to_crash
+        } else {
+            thread_rng().gen_range(0..walrus_cluster.nodes.len())
+        };
+
         client_arc
             .as_ref()
             .as_ref()
             .stake_with_node_pool(
-                walrus_cluster.nodes[node_index_to_crash]
+                walrus_cluster.nodes[node_index_to_move]
                     .storage_node_capability
                     .as_ref()
                     .unwrap()
@@ -483,6 +482,8 @@ mod tests {
             .expect("stake with node pool should not fail");
 
         tokio::time::sleep(Duration::from_secs(3 * 60)).await;
+
+        workload_handle.abort();
 
         // Check the final state of storage node after a few crash and recovery.
         let mut last_persist_event_index = 0;
@@ -523,7 +524,7 @@ mod tests {
         blob_info_consistency_check.check_storage_node_consistency();
 
         if cause_target_shard_slow_processing_event {
-            clear_fail_point("epoch_change_start_entry");
+            sui_macros::clear_fail_point("epoch_change_start_entry");
         }
     }
 
@@ -553,7 +554,7 @@ mod tests {
 
         tokio::time::sleep(Duration::from_secs(20)).await;
 
-        register_fail_point_if("fail_point_current_checkpoint_lag_error", move || true);
+        sui_macros::register_fail_point_if("fail_point_current_checkpoint_lag_error", move || true);
 
         // Make sure that checkpoint downloader is continuing making progress.
         let mut last_checkpoint_seq_number = 0;
@@ -650,7 +651,8 @@ mod tests {
 
         // Starts a background workload that a client keeps writing and retrieving data.
         // All requests should succeed even if a node is lagging behind.
-        let workload_handle = simtest_utils::start_background_workload(client_arc.clone(), false);
+        let workload_handle =
+            simtest_utils::start_background_workload(client_arc.clone(), false, 0);
 
         // Running the workload for 60 seconds to get some data in the system.
         tokio::time::sleep(Duration::from_secs(60)).await;
@@ -744,7 +746,7 @@ mod tests {
         );
 
         blob_info_consistency_check.check_storage_node_consistency();
-        clear_fail_point("before-process-event-impl");
-        clear_fail_point("fail-point-enter-recovery-mode");
+        sui_macros::clear_fail_point("before-process-event-impl");
+        sui_macros::clear_fail_point("fail-point-enter-recovery-mode");
     }
 }

--- a/crates/walrus-simtest/tests/simtest_failure.rs
+++ b/crates/walrus-simtest/tests/simtest_failure.rs
@@ -375,6 +375,7 @@ mod tests {
 
     // This integration test simulates a scenario where a node is repeatedly crashing and
     // recovering.
+    #[ignore = "ignore integration simtests by default"]
     #[walrus_simtest]
     async fn test_repeated_node_crash() {
         // We use a very short epoch duration of 10 seconds so that we can exercise more epoch
@@ -454,10 +455,6 @@ mod tests {
         // The additional stake assigned are randomly chosen between 2 and 10 times of the original
         // stake the per-node.
         let shard_move_weight = rand::thread_rng().gen_range(2..=10);
-        tracing::info!(
-            "triggering shard move with stake weight {}",
-            shard_move_weight
-        );
 
         // 30% of the time, we move shards to the crashed node. The other 70% of the time, we move
         // shards to a different node.
@@ -466,6 +463,12 @@ mod tests {
         } else {
             thread_rng().gen_range(0..walrus_cluster.nodes.len())
         };
+
+        tracing::info!(
+            "triggering shard move with stake weight {}, target node {}",
+            shard_move_weight,
+            node_index_to_move
+        );
 
         client_arc
             .as_ref()
@@ -503,7 +506,7 @@ mod tests {
             );
             if last_persist_event_index == node_health_info[0].event_progress.persisted {
                 // We expect that there shouldn't be any stuck event progress.
-                assert!(last_persisted_event_time.elapsed() < Duration::from_secs(15));
+                assert!(last_persisted_event_time.elapsed() < Duration::from_secs(30));
             } else {
                 last_persist_event_index = node_health_info[0].event_progress.persisted;
                 last_persisted_event_time = Instant::now();


### PR DESCRIPTION
## Description

Fount in antithesis test. ShardStorage currently is held as Arc<ShardStorage>, meaning that after epoch change that removes a shard and deletes all the column families in the shard, there may still be background process that may access the shard db. This can cause node crash.

To fix the issue, we make DBMap.cf() call return optional column family handle so that if a shard is removed, an error will be returned instead of crashing the node. DBMap.cf() is called in all DB operations.

## Test plan

Enhanced simtest to manifest this crash, and verified the fix.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
