### PR TITLE
feat: export the tls certificate expiration time as a metric

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12944,6 +12944,7 @@ dependencies = [
  "walrus-sui",
  "walrus-test-utils",
  "walrus-utils",
+ "x509-cert",
 ]
 
 [[package]]

--- a/crates/walrus-service/Cargo.toml
+++ b/crates/walrus-service/Cargo.toml
@@ -53,6 +53,7 @@ node = [
   "dep:tokio-stream",
   "dep:tokio-util",
   "dep:typed-store",
+  "dep:x509-cert",
 ]
 test-utils = [
   "client",
@@ -166,6 +167,7 @@ walrus-storage-node-client.workspace = true
 walrus-sui = { workspace = true, features = ["utoipa"] }
 walrus-test-utils = { workspace = true, optional = true }
 walrus-utils = { workspace = true, features = ["backoff", "config", "http", "log", "metrics", "tokio-metrics"] }
+x509-cert = { workspace = true, optional = true }
 
 [dev-dependencies]
 hex.workspace = true

--- a/crates/walrus-service/src/common/telemetry.rs
+++ b/crates/walrus-service/src/common/telemetry.rs
@@ -30,6 +30,7 @@ use axum::{
 };
 use opentelemetry::propagation::Extractor;
 use prometheus::{
+    Gauge,
     Histogram,
     HistogramVec,
     IntGaugeVec,
@@ -111,7 +112,10 @@ walrus_utils::metrics::define_metric_set! {
                 "http_response_status_code",
             ],
             buckets: walrus_utils::metrics::default_buckets_for_bytes()
-        }
+        },
+
+        #[help = "The seconds since UNIX epoch after which the TLS certificate is not valid."]
+        tls_not_after_seconds: Gauge[],
     }
 }
 
@@ -339,6 +343,14 @@ impl MetricsMiddlewareState {
                 task_monitors: TaskMonitorFamily::new(registry.clone()),
             }),
         }
+    }
+
+    /// Exports the expiration time of the TLS certificate as a duration since UNIX epoch.
+    pub fn set_tls_expiration_time(&self, duration_since_unix_epoch: Duration) {
+        self.inner
+            .metrics
+            .tls_not_after_seconds
+            .set(duration_since_unix_epoch.as_secs_f64());
     }
 
     /// Returns the task monitor for the route and request, where `http_route` should be a

--- a/crates/walrus-service/src/common/telemetry.rs
+++ b/crates/walrus-service/src/common/telemetry.rs
@@ -115,7 +115,7 @@ walrus_utils::metrics::define_metric_set! {
         },
 
         #[help = "The seconds since UNIX epoch after which the TLS certificate is not valid."]
-        tls_not_after_seconds: Gauge[],
+        tls_certificate_not_after_seconds: Gauge[],
     }
 }
 
@@ -346,10 +346,10 @@ impl MetricsMiddlewareState {
     }
 
     /// Exports the expiration time of the TLS certificate as a duration since UNIX epoch.
-    pub fn set_tls_expiration_time(&self, duration_since_unix_epoch: Duration) {
+    pub fn set_tls_certificate_expiration_time(&self, duration_since_unix_epoch: Duration) {
         self.inner
             .metrics
-            .tls_not_after_seconds
+            .tls_certificate_not_after_seconds
             .set(duration_since_unix_epoch.as_secs_f64());
     }
 

--- a/crates/walrus-service/src/node/server.rs
+++ b/crates/walrus-service/src/node/server.rs
@@ -30,6 +30,7 @@ use utoipa::OpenApi as _;
 use utoipa_redoc::{Redoc, Servable as _};
 use walrus_core::{encoding, keys::NetworkKeyPair};
 use walrus_utils::metrics::Registry;
+use x509_cert::{Certificate, der::Decode};
 
 use self::telemetry::MetricsMiddlewareState;
 use super::config::{Http2Config, PathOrInPlace, StorageNodeConfig, TlsConfig, defaults};
@@ -311,38 +312,26 @@ where
             return Ok(None);
         };
 
-        match tls_certificate {
+        let (tls_config, certificate) = match tls_certificate {
             TlsCertificateSource::Pem { certificate, key } => {
-                if let Some((certificate_path, key_path)) = certificate.path().zip(key.path()) {
-                    RustlsConfig::from_pem_file(certificate_path, key_path)
-                        .await
-                        .context("failed to load certificate and key from provided paths")
-                } else {
-                    RustlsConfig::from_pem(
-                        certificate.load_transient()?.clone(),
-                        key.load_transient()?.clone(),
-                    )
-                    .await
-                    .context("failed to load certificate and key from in-memory contents")
-                }
-                .map(Some)
+                configure_tls_from_pem(certificate, key).await?
             }
 
             TlsCertificateSource::GenerateSelfSigned {
                 server_name,
                 network_key_pair,
-            } => {
-                let certified_key_pair =
-                    create_self_signed_certificate(network_key_pair, server_name.to_string());
-                let tls_config = RustlsConfig::from_der(
-                    vec![Vec::from(certified_key_pair.cert.der().deref())],
-                    certified_key_pair.key_pair.serialize_der(),
-                )
-                .await
-                .expect("self signed certificate to result in valid config");
-                Ok(Some(tls_config))
-            }
-        }
+            } => configure_self_signed_tls(server_name, network_key_pair).await?,
+        };
+
+        self.metrics.set_tls_expiration_time(
+            certificate
+                .tbs_certificate
+                .validity
+                .not_after
+                .to_unix_duration(),
+        );
+
+        Ok(Some(tls_config))
     }
 
     #[cfg(test)]
@@ -437,6 +426,60 @@ where
     fn config(&self) -> &RestApiConfig {
         &self.state.config
     }
+}
+
+async fn configure_self_signed_tls(
+    server_name: &str,
+    network_key_pair: &NetworkKeyPair,
+) -> Result<(RustlsConfig, Certificate), anyhow::Error> {
+    let certified_key_pair =
+        create_self_signed_certificate(network_key_pair, server_name.to_string());
+    let certificate_der = Vec::from(certified_key_pair.cert.der().deref());
+
+    let tls_config = RustlsConfig::from_der(
+        vec![certificate_der.clone()],
+        certified_key_pair.key_pair.serialize_der(),
+    )
+    .await
+    .expect("self signed certificate to result in valid config");
+
+    let certificate = x509_cert::Certificate::from_der(&certificate_der)
+        .expect("self-signed certificate should be valid DER");
+
+    Ok((tls_config, certificate))
+}
+
+async fn configure_tls_from_pem(
+    certificate: &PathOrInPlace<Vec<u8>>,
+    key: &PathOrInPlace<Vec<u8>>,
+) -> Result<(RustlsConfig, Certificate), anyhow::Error> {
+    let (tls_config, certificate_pem) =
+        if let Some((certificate_path, key_path)) = certificate.path().zip(key.path()) {
+            let tls_config = RustlsConfig::from_pem_file(certificate_path, key_path)
+                .await
+                .context("failed to load certificate and key from provided paths")?;
+
+            let certificate_pem =
+                std::fs::read(certificate_path).context("failed to load certificate")?;
+
+            (tls_config, certificate_pem)
+        } else {
+            let certificate_pem = certificate.load_transient()?.clone();
+
+            let tls_config =
+                RustlsConfig::from_pem(certificate_pem.clone(), key.load_transient()?.clone())
+                    .await
+                    .context("failed to load certificate and key from in-memory contents")?;
+
+            (tls_config, certificate_pem)
+        };
+
+    let certificate = x509_cert::Certificate::load_pem_chain(&certificate_pem)?
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow!("there must be at least one certificate present"))?;
+
+    Ok((tls_config, certificate))
 }
 
 fn create_self_signed_certificate(


### PR DESCRIPTION
## Description

Report TLS expiration time in seconds since unix epoch.

Contributes to WAL-886.

## Test plan

Ran a local cluster and checked the expiration time exported.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
