### PR TITLE
feat: Add proto definitions for event streaming service

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ diesel = { version = "2.2", features = ["chrono", "postgres", "uuid"] }
 diesel-async = { version = "0.5", features = ["postgres"] }
 diesel_migrations = { version = "2.2.0", features = ["postgres"] }
 enum_dispatch = "0.3"
+event-streaming = { path = "crates/event-streaming" }
 eyre = "0.6.12"
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9" }
 fdlimit = "0.3.0"
@@ -86,6 +87,10 @@ pin-project = "1.1.10"
 prettytable = "0.10.0"
 proc-macro2 = "1.0.95"
 prometheus = "0.13.4"
+prost = "0.13"
+prost-build = "0.13"
+prost-types = "0.13"
+protox = "0.7"
 quote = "1.0"
 rand = "0.8.5"
 rayon = "1.10.0"
@@ -128,6 +133,7 @@ tokio = { version = "=1.44.2", features = ["macros", "rt-multi-thread", "signal"
 tokio-stream = "0.1.17"
 tokio-util = "0.7.13"
 tonic = { version = "0.13.1", default-features = false }
+tonic-build = "0.13"
 tower = "0.5"
 tower-http = { version = "0.5.2", features = ["cors", "timeout", "trace"] }
 tracing = "0.1.41"

--- a/crates/event-streaming/Cargo.toml
+++ b/crates/event-streaming/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "event-streaming"
+authors.workspace = true
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+prost.workspace = true
+prost-types.workspace = true
+tokio.workspace = true
+tokio-stream.workspace = true
+tonic = { workspace = true, features = ["codegen", "prost", "transport"] }
+# Example of how to use other workspace crates in the future:
+# walrus-sui.workspace = true
+
+[build-dependencies]
+prost-build.workspace = true
+protox.workspace = true

--- a/crates/event-streaming/build.rs
+++ b/crates/event-streaming/build.rs
@@ -1,0 +1,142 @@
+// Copyright (c) Walrus Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{fs, path::PathBuf, process::Command};
+
+const SUI_REPO_URL: &str = "https://github.com/MystenLabs/sui.git";
+const SUI_TAG: &str = "testnet-v1.50.1";
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let sui_proto_source = ensure_sui_proto_source()?;
+
+    // Get the manifest directory (crate root) to resolve proto files relative to it
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")?;
+    let crate_root = PathBuf::from(manifest_dir);
+
+    let proto_file_names = vec!["proto/walrus/event/v1alpha/service.proto"];
+
+    // Convert to full paths and check that our proto files exist
+    let mut proto_files = Vec::new();
+    for proto_file in &proto_file_names {
+        let full_proto_path = crate_root.join(proto_file);
+        if !full_proto_path.exists() {
+            return Err(format!(
+                "Proto file not found: {} (resolved to: {})",
+                proto_file,
+                full_proto_path.display()
+            )
+            .into());
+        }
+        proto_files.push(full_proto_path.to_string_lossy().to_string());
+    }
+
+    // Use protox to compile proto files without requiring system protoc
+    let include_paths = vec![
+        crate_root.join("proto").to_string_lossy().to_string(),
+        sui_proto_source.to_string_lossy().to_string(),
+    ];
+
+    let file_descriptor_set = protox::compile(&proto_files, &include_paths)?;
+
+    // Generate Rust code using prost-build
+    let mut prost_config = prost_build::Config::new();
+    prost_config.include_file("mod.rs");
+
+    // Compile the file descriptor set
+    prost_config.compile_fds(file_descriptor_set)?;
+
+    // Tell cargo to rerun if proto files change
+    println!(
+        "cargo:rerun-if-changed={}",
+        crate_root.join("proto").display()
+    );
+
+    Ok(())
+}
+
+fn ensure_sui_proto_source() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    // Always download Sui proto files from GitHub to ensure we have the exact version we need
+    // This eliminates potential version mismatches and simplifies the build process
+    download_sui_repo()
+}
+
+fn download_sui_repo() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let out_dir = std::env::var("OUT_DIR")?;
+    let sui_clone_dir = PathBuf::from(&out_dir).join(format!("sui_clone_{}", SUI_TAG));
+    let sui_proto_path = sui_clone_dir.join("crates/sui-rpc-api/proto");
+
+    cleanup_old_sui_caches(&out_dir)?;
+
+    // Check if already cloned and up to date
+    if sui_proto_path.exists() {
+        println!(
+            "cargo:warning=Using cached Sui proto files from: {} (tag: {})",
+            sui_proto_path.display(),
+            SUI_TAG
+        );
+        return Ok(sui_proto_path);
+    }
+
+    println!(
+        "cargo:warning=Downloading Sui repository from GitHub (tag: {})...",
+        SUI_TAG
+    );
+
+    // Remove existing clone if it exists but is incomplete
+    if sui_clone_dir.exists() {
+        fs::remove_dir_all(&sui_clone_dir)?;
+    }
+
+    // Clone the specific tag with shallow depth for faster download
+    let output = Command::new("git")
+        .args([
+            "clone",
+            "--depth=1",
+            "--branch",
+            SUI_TAG,
+            SUI_REPO_URL,
+            &sui_clone_dir.to_string_lossy(),
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "Failed to clone Sui repository: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+        .into());
+    }
+
+    // Verify the proto files exist
+    if !sui_proto_path.exists() {
+        return Err("Cloned Sui repository doesn't contain expected proto files".into());
+    }
+
+    println!(
+        "cargo:warning=Successfully downloaded Sui proto files to: {} (tag: {})",
+        sui_proto_path.display(),
+        SUI_TAG
+    );
+    Ok(sui_proto_path)
+}
+
+fn cleanup_old_sui_caches(out_dir: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let out_path = PathBuf::from(out_dir);
+    let current_cache_name = format!("sui_clone_{}", SUI_TAG);
+
+    // Read the directory and remove old sui_clone_* directories
+    if let Ok(entries) = fs::read_dir(&out_path) {
+        for entry in entries.flatten() {
+            if let Some(name) = entry.file_name().to_str() {
+                if name.starts_with("sui_clone_") && name != current_cache_name {
+                    if let Err(e) = fs::remove_dir_all(entry.path()) {
+                        println!("cargo:warning=Failed to clean up old cache {}: {}", name, e);
+                    } else {
+                        println!("cargo:warning=Cleaned up old Sui cache: {}", name);
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/event-streaming/proto/walrus/event/v1alpha/service.proto
+++ b/crates/event-streaming/proto/walrus/event/v1alpha/service.proto
@@ -1,0 +1,164 @@
+syntax = "proto3";
+
+package walrus.event.v1alpha;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
+import "sui/rpc/v2beta/checkpoint_contents.proto";
+import "sui/rpc/v2beta/checkpoint_summary.proto";
+import "sui/rpc/v2beta/event.proto";
+
+// EventStreamingService provides a verifiable stream of events from the Sui
+// blockchain for an event stream. It allows clients to receive events
+// along with cryptographic proofs that tie them to a specific checkpoint.
+// It is designed to be forward-compatible, allowing for proof mechanisms
+// to be upgraded over time without breaking clients.
+service EventStreamingService {
+    // StreamEvents opens a server-side stream that sends sets of events
+    // as they are finalized in checkpoints. Each message in the stream contains
+    // all relevant events for a single checkpoint, plus the necessary data to verify them.
+    rpc StreamEvents(StreamEventsRequest) returns (stream VerifiableEvents);
+
+    // GetNonInclusionProof allows a client to request a cryptographic proof
+    // that a specific event did NOT occur within a given range of checkpoints.
+    // This is a standard unary RPC call.
+    rpc GetNonInclusionProof(GetNonInclusionProofRequest) returns (GetNonInclusionProofResponse);
+}
+
+
+// ============== Event Streaming RPC Messages ==============
+
+// An enum defining the available proof types.
+enum ProofType {
+    // Defaults to the server's preferred/most modern proof type.
+    PROOF_TYPE_UNSPECIFIED = 0;
+
+    // The client does not require a proof.
+    PROOF_TYPE_NONE = 1;
+
+    // The V1 checkpoint contents proof.
+    PROOF_TYPE_CHECKPOINT_CONTENTS_V1 = 2;
+
+    // The V2 Merkle inclusion proof.
+    PROOF_TYPE_MERKLE_PROOF_V2 = 3;
+}
+
+message StreamEventsRequest {
+    // The checkpoint sequence number from which to start streaming.
+    // Events from checkpoints before this number will not be sent.
+    // Defaults to 0, starting from the first available checkpoint.
+    optional uint64 starting_checkpoint_sequence_number = 1;
+
+    // The method used to identify the event stream. The client MUST specify
+    // exactly one of these options. This makes the API explicit and avoids
+    // ambiguity between V1 (package-based) and V2 (object-based) streams.
+    oneof stream_selector {
+        // V1: Subscribe to all events emitted by a specific package.
+        PackageSubscription package_id = 2;
+
+        // V2: Subscribe to events managed by a dedicated stream head object.
+        StreamHead stream_head = 3;
+    }
+
+    // The desired proof types, in order of client preference.
+    // The server will attempt to provide the first type in this list that it
+    // supports for a given checkpoint. If empty, it uses its default behavior.
+    // Example: [MERKLE_PROOF_V2, CHECKPOINT_CONTENTS_V1] means client prefer V2,
+    // but will accept V1 if V2 is not available (would not accept response without
+    // a proof)
+    repeated ProofType desired_proof_types = 4;
+}
+
+// VerifiableEvents is the message type for the stream.
+// Each message represents a single checkpoint that contained Walrus events.
+message VerifiableEvents {
+    // The summary of the checkpoint containing these events. The client uses
+    // the `digest` field from this summary to verify the accompanying proof.
+    optional sui.rpc.v2beta.CheckpointSummary summary = 1;
+
+    // The list of all events found within this checkpoint.
+    repeated sui.rpc.v2beta.Event events = 2;
+
+    optional uint64 checkpoint_sequence_number = 3;
+
+    // The cryptographic proof that ties the events to the checkpoint summary.
+    // This is designed to be upgradeable.
+    optional Proof proof = 4;
+}
+
+message StreamHead {
+    // The Object ID of the dedicated stream head object.
+    optional string object_id = 1;
+}
+
+message PackageSubscription {
+    // The package object ID to subscribe to.
+    optional string package_id = 1;
+}
+
+// ============== Proof Structures ============================
+
+// Proof is an enum that allows the server to send different types of proofs.
+// This enables a future protocol upgrade from the simple V1 proof to the
+// more efficient V2 Merkle proof without breaking the API contract.
+message Proof {
+    oneof proof_type {
+        // V1 Proof: The entire raw contents of the checkpoint.
+        // The client verifies this by hashing the bcs and comparing
+        // it to the digest in the CheckpointSummary. And comparing the
+        // events against the content. Inefficient but simple.
+        sui.rpc.v2beta.CheckpointContents checkpoint_contents = 1;
+
+        // V2 Proof: A compact Merkle proof.
+        MerkleInclusionProof merkle_proof = 2;
+
+        // No-Proof Option: Sent when the client trusts the server and opts out
+        // of verification to save bandwidth and CPU.
+        google.protobuf.Empty proof_none = 3;
+    }
+}
+
+// Represents a Merkle inclusion proof for a checkpoint artifact.
+message MerkleInclusionProof {
+    // The index of the leaf in the Merkle tree.
+    optional uint64 leaf_index = 1;
+
+    // The raw bytes of the event artifact that was hashed to create the leaf.
+    optional bytes leaf_artifact = 2;
+
+    // The list of sibling hashes needed to reconstruct the path to the root.
+    repeated bytes sibling_hashes = 3;
+}
+
+// ============== Non-Inclusion Proof RPC Messages ==============
+
+message GetNonInclusionProofRequest {
+    // The starting checkpoint sequence number for the range to check (inclusive).
+    optional uint64 start_checkpoint_sequence_number = 1;
+
+    // The ending checkpoint sequence number for the range to check (inclusive).
+    optional uint64 end_checkpoint_sequence_number = 2;
+
+    // The selector for the event stream to prove non-inclusion against.
+    oneof stream_selector {
+        PackageSubscription package_id = 3;
+        StreamHead stream_head = 4;
+    }
+}
+
+// Represents a proof that a specific event was not included in a checkpoint.
+// This is only possible with a V2 (Merkle tree) proofing system.
+message NonInclusionProof {
+    // The sequence number of the checkpoint this proof applies to.
+    optional uint64 checkpoint_sequence_number = 1;
+
+    // A valid non-inclusion proof consists of proving the existence of the
+    // two artifacts that are the immediate neighbors of the item being disproven
+    // in the sorted Merkle tree.
+    repeated MerkleInclusionProof adjacent_proofs = 2;
+}
+
+message GetNonInclusionProofResponse {
+    // The non-inclusion proofs for each checkpoint in the requested range.
+    repeated NonInclusionProof proofs = 1;
+}

--- a/crates/event-streaming/src/lib.rs
+++ b/crates/event-streaming/src/lib.rs
@@ -1,0 +1,19 @@
+// Copyright (c) Walrus Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Event streaming library for Walrus.
+//!
+//! This crate provides gRPC-based event streaming functionality with external
+//! proto dependencies managed by buf, including Sui RPC types.
+
+// Allow clippy warnings for generated protobuf code
+#![allow(clippy::doc_lazy_continuation)]
+#![allow(clippy::doc_markdown)]
+#![allow(clippy::doc_overindented_list_items)]
+#![allow(clippy::too_many_arguments)]
+#![allow(clippy::large_enum_variant)]
+
+// Include the generated protobuf code
+include!(concat!(env!("OUT_DIR"), "/mod.rs"));
+
+pub use walrus::event::v1alpha::*;


### PR DESCRIPTION
## Description

This PR introduces a new event-streaming crate that provides gRPC-based event streaming functionality for Walrus with optional cryptographic proofs (of various types). It  includes automatic dependency management that downloads required protobuf definitions from GitHub when not available locally. 
Added two rpc endpoints to this service:
1. StreamEvents RPC for server-side streaming of verifiable events
2. GetNonInclusionProof RPC for cryptographic non-inclusion proofs

We chose gRPC for this service to stay consistent with Fullnode rpc as we want Walrus node (clients) to have seamless experience when switching between events from local sidecar or remote Fullnode.
## Test plan

Added basic unit tests covering all major message types and proof mechanisms
