### PR TITLE
ci: replace base image to internal one to avoid rate limits

### DIFF
--- a/docker/walrus-orchestrator/Dockerfile
+++ b/docker/walrus-orchestrator/Dockerfile
@@ -2,7 +2,8 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.87-bookworm AS builder
+# the base image is the same as rust:1.87-bookworm but we use the GCP registry to avoid rate limiting
+FROM us-central1-docker.pkg.dev/cryptic-bolt-398315/base-images/rust:1.87-bookworm-amd64 AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/docker/walrus-orchestrator/Dockerfile
+++ b/docker/walrus-orchestrator/Dockerfile
@@ -2,8 +2,10 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-# the base image is the same as rust:1.87-bookworm but we use the GCP registry to avoid rate limiting
+
+# This is the same as rust:1.87-bookworm but we use the GCP registry to avoid rate limiting.
 FROM us-central1-docker.pkg.dev/cryptic-bolt-398315/base-images/rust:1.87-bookworm-amd64 AS builder
+
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/docker/walrus-proxy/Dockerfile
+++ b/docker/walrus-proxy/Dockerfile
@@ -1,4 +1,5 @@
-FROM rust:1.87-bookworm as builder
+# the base image is the same as rust:1.87-bookworm but we use the GCP registry to avoid rate limiting
+FROM us-central1-docker.pkg.dev/cryptic-bolt-398315/base-images/rust:1.87-bookworm-amd64 as builder
 
 ARG PROFILE=release
 WORKDIR /work

--- a/docker/walrus-proxy/Dockerfile
+++ b/docker/walrus-proxy/Dockerfile
@@ -1,4 +1,4 @@
-# the base image is the same as rust:1.87-bookworm but we use the GCP registry to avoid rate limiting
+# This is the same as rust:1.87-bookworm but we use the GCP registry to avoid rate limiting.
 FROM us-central1-docker.pkg.dev/cryptic-bolt-398315/base-images/rust:1.87-bookworm-amd64 as builder
 
 ARG PROFILE=release

--- a/docker/walrus-service/Dockerfile
+++ b/docker/walrus-service/Dockerfile
@@ -2,7 +2,8 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.87-bookworm AS builder
+# the base image is the same as rust:1.87-bookworm but we use the GCP registry to avoid rate limiting
+FROM us-central1-docker.pkg.dev/cryptic-bolt-398315/base-images/rust:1.87-bookworm-amd64 AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/docker/walrus-service/Dockerfile
+++ b/docker/walrus-service/Dockerfile
@@ -2,8 +2,10 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-# the base image is the same as rust:1.87-bookworm but we use the GCP registry to avoid rate limiting
+
+# This is the same as rust:1.87-bookworm but we use the GCP registry to avoid rate limiting.
 FROM us-central1-docker.pkg.dev/cryptic-bolt-398315/base-images/rust:1.87-bookworm-amd64 AS builder
+
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/docker/walrus-service/Dockerfile.walrus-backup
+++ b/docker/walrus-service/Dockerfile.walrus-backup
@@ -2,8 +2,10 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-# the base image is the same as rust:1.87-bookworm but we use the GCP registry to avoid rate limiting
+
+# This is the same as rust:1.87-bookworm but we use the GCP registry to avoid rate limiting.
 FROM us-central1-docker.pkg.dev/cryptic-bolt-398315/base-images/rust:1.87-bookworm-amd64 AS builder
+
 ARG PROFILE=release
 ARG RUST_LOG=info,walrus_service::common::event_blob_downloader=warn
 ARG GIT_REVISION

--- a/docker/walrus-service/Dockerfile.walrus-backup
+++ b/docker/walrus-service/Dockerfile.walrus-backup
@@ -2,7 +2,8 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.87-bookworm AS builder
+# the base image is the same as rust:1.87-bookworm but we use the GCP registry to avoid rate limiting
+FROM us-central1-docker.pkg.dev/cryptic-bolt-398315/base-images/rust:1.87-bookworm-amd64 AS builder
 ARG PROFILE=release
 ARG RUST_LOG=info,walrus_service::common::event_blob_downloader=warn
 ARG GIT_REVISION

--- a/docker/walrus-stress/Dockerfile
+++ b/docker/walrus-stress/Dockerfile
@@ -2,7 +2,8 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.87-bookworm AS builder
+# the base image is the same as rust:1.87-bookworm but we use the GCP registry to avoid rate limiting
+FROM us-central1-docker.pkg.dev/cryptic-bolt-398315/base-images/rust:1.87-bookworm-amd64 AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/docker/walrus-stress/Dockerfile
+++ b/docker/walrus-stress/Dockerfile
@@ -2,8 +2,10 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-# the base image is the same as rust:1.87-bookworm but we use the GCP registry to avoid rate limiting
+
+# This is the same as rust:1.87-bookworm but we use the GCP registry to avoid rate limiting.
 FROM us-central1-docker.pkg.dev/cryptic-bolt-398315/base-images/rust:1.87-bookworm-amd64 AS builder
+
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION


### PR DESCRIPTION
## Description

we're seeing rate limits from dockerhub, so let's use an internal repo to host the same image.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
