### PR TITLE
chore: blob sync handles recover sliver cancellation

### DIFF
--- a/crates/walrus-service/src/node/blob_sync.rs
+++ b/crates/walrus-service/src/node/blob_sync.rs
@@ -631,6 +631,15 @@ impl BlobSynchronizer {
                                     );
                                     return Err(RecoverSliverError::Database(err));
                                 }
+                                // When storage node is shutting down and the runtime is turning
+                                // off, internal tasks may get cancelled and this is expected.
+                                TypedStoreError::TaskError(ref message) => {
+                                    tracing::error!(
+                                        "database error during sliver sync: task error {:?}",
+                                        message
+                                    );
+                                    return Err(RecoverSliverError::Database(err));
+                                }
                                 _ => {
                                     panic!("database operations should not fail: {:?}", err)
                                 }


### PR DESCRIPTION
## Description

Found in antithesis, when a node is shutting down, internal sliver recover tasks may get cancelled. In #2228, we make
the cancellation error wrapped in `TypedStoreError::TaskError`. We should continue propagating the error back
instead of panicing in `panic!("database operations should not fail: {:?}", err)`.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
