### PR TITLE
refactor: bump Rust to 1.88 and fix new Clippy warnings

### DIFF
--- a/crates/walrus-core/benches/basic_encoding.rs
+++ b/crates/walrus-core/benches/basic_encoding.rs
@@ -40,8 +40,7 @@ fn basic_encoding(c: &mut Criterion) {
 
             group.bench_with_input(
                 BenchmarkId::from_parameter(format!(
-                    "symbol_count={},symbol_size={}",
-                    symbol_count, symbol_size
+                    "symbol_count={symbol_count},symbol_size={symbol_size}"
                 )),
                 &(symbol_count, data),
                 |b, (symbol_count, data)| {
@@ -90,8 +89,7 @@ fn basic_decoding(c: &mut Criterion) {
             .collect();
             group.bench_with_input(
                 BenchmarkId::from_parameter(format!(
-                    "symbol_count={},symbol_size={}",
-                    symbol_count, symbol_size
+                    "symbol_count={symbol_count},symbol_size={symbol_size}"
                 )),
                 &(symbol_count, symbol_size, symbols),
                 |b, (symbol_count, symbol_size, symbols)| {
@@ -146,7 +144,7 @@ fn flatten_symbols(c: &mut Criterion) {
             group.bench_with_input(
                 BenchmarkId::new(
                     "original",
-                    format!("symbol_count={},symbol_size={}", symbol_count, symbol_size),
+                    format!("symbol_count={symbol_count},symbol_size={symbol_size}"),
                 ),
                 &input,
                 |b, input| {
@@ -162,7 +160,7 @@ fn flatten_symbols(c: &mut Criterion) {
             group.bench_with_input(
                 BenchmarkId::new(
                     "memcpy",
-                    format!("symbol_count={},symbol_size={}", symbol_count, symbol_size),
+                    format!("symbol_count={symbol_count},symbol_size={symbol_size}"),
                 ),
                 &input,
                 |b, input| {
@@ -203,8 +201,7 @@ fn merkle_tree(c: &mut Criterion) {
 
             group.bench_with_input(
                 BenchmarkId::from_parameter(format!(
-                    "symbol_count={},symbol_size={}",
-                    symbol_count, symbol_size
+                    "symbol_count={symbol_count},symbol_size={symbol_size}"
                 )),
                 &encoded_symbols,
                 |b, encoded_symbols| {

--- a/crates/walrus-core/src/encoding/quilt_encoding.rs
+++ b/crates/walrus-core/src/encoding/quilt_encoding.rs
@@ -364,8 +364,7 @@ impl TryFrom<u8> for QuiltVersionEnum {
         match value {
             QuiltVersionV1::QUILT_VERSION_BYTE => Ok(QuiltVersionEnum::V1),
             _ => Err(QuiltError::Other(format!(
-                "Invalid quilt version byte: {}",
-                value
+                "Invalid quilt version byte: {value}"
             ))),
         }
     }
@@ -373,7 +372,7 @@ impl TryFrom<u8> for QuiltVersionEnum {
 
 impl fmt::Display for QuiltVersionEnum {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 
@@ -589,19 +588,18 @@ impl QuiltVersionV1 {
     /// Returns the total size of the serialized blob.
     pub fn serialized_blob_size(blob: &QuiltStoreBlob) -> Result<usize, QuiltError> {
         let identifier_size = bcs::serialized_size(&blob.identifier)
-            .map_err(|e| QuiltError::Other(format!("Failed to compute identifier size: {}", e)))?;
+            .map_err(|e| QuiltError::Other(format!("Failed to compute identifier size: {e}")))?;
 
         if identifier_size >= MAX_BLOB_IDENTIFIER_BYTES_LENGTH {
             return Err(QuiltError::InvalidIdentifier(format!(
-                "identifier size exceeds maximum allowed value: {}",
-                MAX_BLOB_IDENTIFIER_BYTES_LENGTH
+                "identifier size exceeds maximum allowed value: {MAX_BLOB_IDENTIFIER_BYTES_LENGTH}"
             )));
         }
         let mut prefix_size = identifier_size as usize + BLOB_IDENTIFIER_SIZE_BYTES_LENGTH;
 
         if !blob.tags.is_empty() {
             let tags_size = bcs::serialized_size(&blob.tags)
-                .map_err(|e| QuiltError::Other(format!("Failed to compute tags size: {}", e)))?;
+                .map_err(|e| QuiltError::Other(format!("Failed to compute tags size: {e}")))?;
             prefix_size += tags_size + TAGS_SIZE_BYTES_LENGTH;
         }
 
@@ -1079,7 +1077,7 @@ impl fmt::Debug for DebugRow<'_> {
                 write!(f, "    ")?;
             }
 
-            write!(f, "{:width$}", entry, width = hex_width)?;
+            write!(f, "{entry:hex_width$}")?;
 
             if i < self.entries.len() - 1 {
                 write!(f, ", ")?;
@@ -1179,28 +1177,27 @@ impl<'a> QuiltEncoderV1<'a> {
 
         let identifier_size =
             u16::try_from(bcs::serialized_size(&blob.identifier).map_err(|e| {
-                QuiltError::InvalidIdentifier(format!("Failed to serialize identifier: {}", e))
+                QuiltError::InvalidIdentifier(format!("Failed to serialize identifier: {e}"))
             })?)
             .map_err(|e| {
                 QuiltError::InvalidIdentifier(format!(
-                    "Failed to convert identifier size to u16: {}",
-                    e
+                    "Failed to convert identifier size to u16: {e}"
                 ))
             })?;
         identifier_bytes.extend_from_slice(&identifier_size.to_le_bytes());
         identifier_bytes.extend_from_slice(&bcs::to_bytes(&blob.identifier).map_err(|e| {
-            QuiltError::InvalidIdentifier(format!("Failed to serialize identifier: {}", e))
+            QuiltError::InvalidIdentifier(format!("Failed to serialize identifier: {e}"))
         })?);
         extension_bytes.push(identifier_bytes);
 
         if !blob.tags.is_empty() {
             header.set_has_tags(true);
             let serialized_tags = bcs::to_bytes(&blob.tags)
-                .map_err(|e| QuiltError::Other(format!("Failed to serialize tags: {}", e)))?;
+                .map_err(|e| QuiltError::Other(format!("Failed to serialize tags: {e}")))?;
 
             // This must be the same as TAGS_SIZE_BYTES_LENGTH.
             let tags_size = u16::try_from(serialized_tags.len()).map_err(|e| {
-                QuiltError::Other(format!("Failed to convert tags size to u16: {}", e))
+                QuiltError::Other(format!("Failed to convert tags size to u16: {e}"))
             })?;
 
             let mut result_bytes = Vec::with_capacity(tags_size as usize + serialized_tags.len());
@@ -1755,9 +1752,8 @@ mod utils {
         let max_symbol_size = usize::from(encoding_type.max_symbol_size());
         if symbol_size > max_symbol_size {
             return Err(QuiltError::QuiltOversize(format!(
-                "the resulting symbol size {} is larger than the maximum symbol size {}; \
-                remove some blobs",
-                symbol_size, max_symbol_size
+                "the resulting symbol size {symbol_size} is larger than the maximum symbol size \
+                {max_symbol_size}; remove some blobs"
             )));
         }
 
@@ -2073,11 +2069,8 @@ mod tests {
             let min_blob_size = rng.gen_range(1..100);
             let max_blob_size = rng.gen_range(min_blob_size..1000);
             std::println!(
-                "test_quilt_with_random_blobs: {}, {}, {}, {}",
-                num_blobs,
-                min_blob_size,
-                max_blob_size,
-                n_shards
+                "test_quilt_with_random_blobs: \
+                {num_blobs}, {min_blob_size}, {max_blob_size}, {n_shards}"
             );
             // test_quilt_encoder_and_decoder(num_blobs, min_blob_size, max_blob_size, n_shards);
             test_quilt_encoder_and_decoder(num_blobs, min_blob_size, max_blob_size, n_shards);

--- a/crates/walrus-core/src/utils.rs
+++ b/crates/walrus-core/src/utils.rs
@@ -155,8 +155,8 @@ pub fn data_prefix_string<T: ToString>(data: &[T], max_values_printed: usize) ->
         .collect::<Vec<_>>()
         .join(", ");
     if data.len() <= max_values_printed {
-        format!("[{}]", data_items)
+        format!("[{data_items}]")
     } else {
-        format!("[{}, ...]", data_items)
+        format!("[{data_items}, ...]")
     }
 }

--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -137,7 +137,7 @@ where
 
     // Create paths for each blob.
     for (i, data) in blob_data.iter().enumerate() {
-        let path = PathBuf::from(format!("blob_{}", i));
+        let path = PathBuf::from(format!("blob_{i}"));
         path_to_data.insert(path.clone(), data.to_vec());
         blobs_with_paths.push((path, data.to_vec()));
     }
@@ -231,10 +231,7 @@ async fn test_store_and_read_blob_with_crash_failures(
             }
             Err(err) => panic!("unexpected error {err}"),
         },
-        (act, exp) => panic!(
-            "test result mismatch; expected=({:?}); actual=({:?});",
-            exp, act
-        ),
+        (act, exp) => panic!("test result mismatch; expected=({exp:?}); actual=({act:?});"),
     }
 }
 
@@ -288,8 +285,7 @@ async fn test_inconsistency(failed_nodes: &[usize]) -> TestResult {
     let blob = walrus_test_utils::random_data(31415);
 
     // Find the shards of the failed nodes.
-    let failed_node_names: Vec<String> =
-        failed_nodes.iter().map(|i| format!("node-{}", i)).collect();
+    let failed_node_names: Vec<String> = failed_nodes.iter().map(|i| format!("node-{i}")).collect();
     let committees = client
         .as_ref()
         .get_committees()
@@ -589,7 +585,7 @@ pub async fn test_store_and_read_duplicate_blobs() -> TestResult {
 
     // Create paths for each blob.
     for (i, data) in blob_data.iter().enumerate() {
-        let path = PathBuf::from(format!("blob_{}", i));
+        let path = PathBuf::from(format!("blob_{i}"));
         blobs_with_paths.push((path, data.to_vec()));
     }
 
@@ -767,7 +763,7 @@ async fn test_store_with_existing_storage_resource(
     let unencoded_blobs = blob_data
         .iter()
         .enumerate()
-        .map(|(i, data)| WalrusStoreBlob::new_unencoded(data, format!("test-{:02}", i)))
+        .map(|(i, data)| WalrusStoreBlob::new_unencoded(data, format!("test-{i:02}")))
         .collect();
     let encoding_type = DEFAULT_ENCODING;
     let encoded_blobs = client
@@ -940,8 +936,7 @@ async fn test_storage_nodes_delete_data_for_deleted_blobs() -> TestResult {
         .await?;
     assert!(
         matches!(status_result, BlobStatus::Nonexistent),
-        "status_result: {:?}",
-        status_result
+        "status_result: {status_result:?}"
     );
 
     let read_result = client
@@ -1028,7 +1023,7 @@ async fn test_store_quilt(blobs_to_create: u32) -> TestResult {
     } = store_operation_result;
     let blob_object = match blob_store_result {
         BlobStoreResult::NewlyCreated { blob_object, .. } => blob_object,
-        _ => panic!("Expected NewlyCreated, got {:?}", blob_store_result),
+        _ => panic!("Expected NewlyCreated, got {blob_store_result:?}"),
     };
 
     // Read the blobs in the quilt.
@@ -1172,8 +1167,7 @@ async fn test_blocklist() -> TestResult {
 
     assert!(
         matches!(error.kind(), ClientErrorKind::BlobIdBlocked(_)),
-        "unexpected error {:?}",
-        error
+        "unexpected error {error:?}"
     );
 
     // Remove the blob from the blocklist
@@ -1393,10 +1387,7 @@ async fn test_multiple_stores_same_blob() -> TestResult {
             BlobStoreResult::AlreadyCertified { .. } => {
                 assert!(is_already_certified, "the blob should be already stored");
             }
-            other => panic!(
-                "we either store the blob, or find it's already created:\n{:?}",
-                other
-            ),
+            other => panic!("we either store the blob, or find it's already created:\n{other:?}"),
         }
     }
 
@@ -1756,7 +1747,7 @@ async fn test_post_store_action(
         .await?;
     assert_eq!(target_address_blobs.len(), n_target_blobs);
     for result in &results {
-        println!("test_post_store_action result: {:?}", result);
+        println!("test_post_store_action result: {result:?}");
     }
 
     if post_store == PostStoreAction::Share {

--- a/crates/walrus-e2e-tests/tests/test_event_blobs.rs
+++ b/crates/walrus-e2e-tests/tests/test_event_blobs.rs
@@ -100,7 +100,7 @@ async fn test_disabled_event_blob_writer() -> anyhow::Result<()> {
         .await
         .unwrap()
     {
-        panic!("Event blob should not be written: {:?}", blob);
+        panic!("Event blob should not be written: {blob:?}");
     };
     Ok(())
 }

--- a/crates/walrus-orchestrator/src/client/aws.rs
+++ b/crates/walrus-orchestrator/src/client/aws.rs
@@ -54,7 +54,7 @@ pub struct AwsClient {
 
 impl Display for AwsClient {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "AWS EC2 client v{}", PKG_VERSION)
+        write!(f, "AWS EC2 client v{PKG_VERSION}")
     }
 }
 

--- a/crates/walrus-orchestrator/src/settings.rs
+++ b/crates/walrus-orchestrator/src/settings.rs
@@ -213,7 +213,7 @@ impl Settings {
     {
         let mut s = s.to_string();
         for (name, value) in env::vars() {
-            s = s.replace(&format!("${{{}}}", name), &value);
+            s = s.replace(&format!("${{{name}}}"), &value);
         }
         if s.contains("${") {
             let error = SettingsError::InvalidSettings {

--- a/crates/walrus-proc-macros/src/walrus_simtest.rs
+++ b/crates/walrus-proc-macros/src/walrus_simtest.rs
@@ -19,7 +19,7 @@ pub fn attribute_macro(args: TokenStream, item: TokenStream) -> TokenStream {
     let output = if cfg!(msim) {
         let mut input = input;
         let fn_name = &input.sig.ident;
-        input.sig.ident = syn::Ident::new(&format!("simtest_{}", fn_name), fn_name.span());
+        input.sig.ident = syn::Ident::new(&format!("simtest_{fn_name}"), fn_name.span());
         quote! {
             #[sui_macros::sim_test(#(#args),*)]
             #input

--- a/crates/walrus-proxy/src/config.rs
+++ b/crates/walrus-proxy/src/config.rs
@@ -75,7 +75,7 @@ pub fn load<P: AsRef<std::path::Path>, T: DeserializeOwned + Serialize>(path: P)
     let path = path.as_ref();
     debug!("Reading config from {:?}", path);
     Ok(serde_yaml::from_reader(
-        std::fs::File::open(path).context(format!("cannot open {:?}", path))?,
+        std::fs::File::open(path).context(format!("cannot open {path:?}"))?,
     )?)
 }
 

--- a/crates/walrus-proxy/src/providers/walrus/query.rs
+++ b/crates/walrus-proxy/src/providers/walrus/query.rs
@@ -73,7 +73,7 @@ pub fn load_allowlist_from_file(allowlist_path: &Option<PathBuf>) -> Result<Vec<
         tracing::info!("loading allowlist from file: {:?}", path);
         // Read file in yaml format which stores a list of name, network_address, network_public_key
         let nodes: Vec<NodeInfo> = serde_yaml::from_reader(
-            std::fs::File::open(path).context(format!("cannot open {:?}", path))?,
+            std::fs::File::open(path).context(format!("cannot open {path:?}"))?,
         )?;
         for node in nodes.iter() {
             tracing::info!(

--- a/crates/walrus-sdk/src/client.rs
+++ b/crates/walrus-sdk/src/client.rs
@@ -989,8 +989,8 @@ impl Client<SuiContractClient> {
             if total_blob_size > max_total_blob_size {
                 return Err(ClientError::from(ClientErrorKind::Other(
                     format!(
-                        "total blob size {} exceeds the maximum limit of {}",
-                        total_blob_size, max_total_blob_size
+                        "total blob size {total_blob_size} exceeds the maximum limit of \
+                        {max_total_blob_size}"
                     )
                     .into(),
                 )));
@@ -1123,8 +1123,8 @@ impl Client<SuiContractClient> {
         debug_assert_eq!(
             num_registered_blobs, num_encoded_blobs,
             "the number of registered blobs and the number of blobs to store must be the same \
-            (num_registered_blobs = {}, num_encoded_blobs = {})",
-            num_registered_blobs, num_encoded_blobs
+            (num_registered_blobs = {num_registered_blobs}, num_encoded_blobs = \
+            {num_encoded_blobs})"
         );
         if let Some(metrics) = metrics {
             metrics.observe_store_operation(store_op_duration);
@@ -1143,8 +1143,7 @@ impl Client<SuiContractClient> {
                 to_be_certified.push(registered_blob);
             } else {
                 return Err(ClientError::store_blob_internal(format!(
-                    "unexpected blob state {:?}",
-                    registered_blob
+                    "unexpected blob state {registered_blob:?}"
                 )));
             }
         }
@@ -1232,26 +1231,26 @@ impl Client<SuiContractClient> {
         // Complete to_be_extended blobs.
         for blob in to_be_extended {
             let Some(object_id) = blob.get_object_id() else {
-                panic!("Invalid blob state {:?}", blob);
+                panic!("Invalid blob state {blob:?}");
             };
             if let Some(result) = result_map.get(&object_id) {
                 final_result
                     .push(blob.with_certify_and_extend_result(result.clone(), &price_computation)?);
             } else {
-                panic!("Invalid blob state {:?}", blob);
+                panic!("Invalid blob state {blob:?}");
             }
         }
 
         // Complete to_be_certified blobs.
         for blob in to_be_certified {
             let Some(object_id) = blob.get_object_id() else {
-                panic!("Invalid blob state {:?}", blob);
+                panic!("Invalid blob state {blob:?}");
             };
             if let Some(result) = result_map.get(&object_id) {
                 final_result
                     .push(blob.with_certify_and_extend_result(result.clone(), &price_computation)?);
             } else {
-                panic!("Invalid blob state {:?}", blob);
+                panic!("Invalid blob state {blob:?}");
             }
         }
 
@@ -1276,8 +1275,7 @@ impl Client<SuiContractClient> {
                 let blob_id = encode_blob
                     .get_blob_id()
                     .ok_or(ClientError::store_blob_internal(format!(
-                        "missing blob ID from {:?}",
-                        encode_blob
+                        "missing blob ID from {encode_blob:?}"
                     )))?;
                 if let Err(e) = self.check_blob_id(&blob_id) {
                     return encode_blob.with_error(e);
@@ -1319,8 +1317,7 @@ impl Client<SuiContractClient> {
                     let operation = registered_blob.get_operation().cloned();
                     let Some(StoreOp::RegisterNew { blob, operation }) = operation else {
                         return Err(ClientError::store_blob_internal(format!(
-                            "Expected a WalrusStoreBlob::RegisterNew, got {:?}",
-                            registered_blob
+                            "Expected a WalrusStoreBlob::RegisterNew, got {registered_blob:?}"
                         )));
                     };
                     let (Some(pairs), Some(metadata), Some(blob_status)) = (
@@ -1329,8 +1326,8 @@ impl Client<SuiContractClient> {
                         registered_blob.get_status(),
                     ) else {
                         return Err(ClientError::store_blob_internal(format!(
-                            "Missing sliver pairs, metadata, or status for blob: {:?}",
-                            registered_blob
+                            "Missing sliver pairs, metadata, or status for blob: \
+                            {registered_blob:?}"
                         )));
                     };
                     let certificate_result = self

--- a/crates/walrus-sdk/src/client/client_types.rs
+++ b/crates/walrus-sdk/src/client/client_types.rs
@@ -189,7 +189,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlob<'a, T> {
         blobs
             .iter()
             .enumerate()
-            .map(|(i, blob)| WalrusStoreBlob::new_unencoded(blob, format!("blob_{:06}", i)))
+            .map(|(i, blob)| WalrusStoreBlob::new_unencoded(blob, format!("blob_{i:06}")))
             .collect()
     }
 
@@ -342,8 +342,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for Unencoded
 
     fn get_certify_and_extend_params(&self) -> ClientResult<CertifyAndExtendBlobParams> {
         Err(ClientError::store_blob_internal(format!(
-            "Invalid operation for blob {:?}",
-            self,
+            "Invalid operation for blob {self:?}",
         )))
     }
 
@@ -387,8 +386,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for Unencoded
         status: Result<BlobStatus, ClientError>,
     ) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(ClientError::store_blob_internal(format!(
-            "Invalid operation for blob {:?}, status: {:?}",
-            self, status,
+            "Invalid operation for blob {self:?}, status: {status:?}",
         )))
     }
 
@@ -397,8 +395,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for Unencoded
         target_epoch: u32,
     ) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(ClientError::store_blob_internal(format!(
-            "Invalid operation for blob {:?}, target_epoch: {:?}",
-            self, target_epoch,
+            "Invalid operation for blob {self:?}, target_epoch: {target_epoch:?}",
         )))
     }
 
@@ -407,8 +404,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for Unencoded
         result: Result<StoreOp, ClientError>,
     ) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(ClientError::store_blob_internal(format!(
-            "Invalid operation for blob {:?}, result: {:?}",
-            self, result,
+            "Invalid operation for blob {self:?}, result: {result:?}",
         )))
     }
 
@@ -417,8 +413,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for Unencoded
         certificate_result: ClientResult<ConfirmationCertificate>,
     ) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(ClientError::store_blob_internal(format!(
-            "Invalid operation for blob {:?}, certificate_result: {:?}",
-            self, certificate_result,
+            "Invalid operation for blob {self:?}, certificate_result: {certificate_result:?}",
         )))
     }
 
@@ -429,7 +424,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for Unencoded
     ) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(invalid_operation_for_blob(
             &self,
-            format!("with_certify_and_extend_result: {:?}", result),
+            format!("with_certify_and_extend_result: {result:?}"),
         ))
     }
 
@@ -548,7 +543,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for EncodedBl
     ) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(invalid_operation_for_blob(
             &self,
-            format!("with_encode_result: {:?}", result),
+            format!("with_encode_result: {result:?}"),
         ))
     }
 
@@ -592,7 +587,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for EncodedBl
     ) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(invalid_operation_for_blob(
             &self,
-            format!("try_complete_if_certified_beyond_epoch: {:?}", target_epoch),
+            format!("try_complete_if_certified_beyond_epoch: {target_epoch:?}"),
         ))
     }
 
@@ -602,7 +597,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for EncodedBl
     ) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(invalid_operation_for_blob(
             &self,
-            format!("with_register_result: {:?}", result),
+            format!("with_register_result: {result:?}"),
         ))
     }
 
@@ -612,7 +607,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for EncodedBl
     ) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(invalid_operation_for_blob(
             &self,
-            format!("with_get_certificate_result: {:?}", certificate_result),
+            format!("with_get_certificate_result: {certificate_result:?}"),
         ))
     }
 
@@ -623,7 +618,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for EncodedBl
     ) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(invalid_operation_for_blob(
             &self,
-            format!("with_certify_and_extend_result: {:?}", result),
+            format!("with_certify_and_extend_result: {result:?}"),
         ))
     }
 
@@ -637,7 +632,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for EncodedBl
     fn with_error(self, error: ClientError) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(invalid_operation_for_blob(
             &self,
-            format!("with_error: {:?}", error),
+            format!("with_error: {error:?}"),
         ))
     }
 }
@@ -728,8 +723,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for BlobWithS
 
     fn get_certify_and_extend_params(&self) -> Result<CertifyAndExtendBlobParams, ClientError> {
         Err(ClientError::store_blob_internal(format!(
-            "Invalid operation for blob {:?}",
-            self,
+            "Invalid operation for blob {self:?}",
         )))
     }
 
@@ -739,14 +733,14 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for BlobWithS
     ) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(invalid_operation_for_blob(
             &self,
-            format!("with_encode_result: {:?}", result),
+            format!("with_encode_result: {result:?}"),
         ))
     }
 
     fn with_status(self, status: ClientResult<BlobStatus>) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(invalid_operation_for_blob(
             &self,
-            format!("with_status: {:?}", status),
+            format!("with_status: {status:?}"),
         ))
     }
 
@@ -842,7 +836,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for BlobWithS
     ) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(invalid_operation_for_blob(
             &self,
-            format!("with_get_certificate_result: {:?}", certificate_result),
+            format!("with_get_certificate_result: {certificate_result:?}"),
         ))
     }
 
@@ -853,7 +847,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for BlobWithS
     ) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(invalid_operation_for_blob(
             &self,
-            format!("with_certify_and_extend_result: {:?}", result),
+            format!("with_certify_and_extend_result: {result:?}"),
         ))
     }
 
@@ -1018,8 +1012,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for Registere
         result: Result<(Vec<SliverPair>, VerifiedBlobMetadataWithId), ClientError>,
     ) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(ClientError::store_blob_internal(format!(
-            "Invalid operation for blob {:?}, result: {:?}",
-            self, result,
+            "Invalid operation for blob {self:?}, result: {result:?}",
         )))
     }
 
@@ -1028,8 +1021,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for Registere
         status: Result<BlobStatus, ClientError>,
     ) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(ClientError::store_blob_internal(format!(
-            "Invalid operation for blob {:?}, status: {:?}",
-            self, status,
+            "Invalid operation for blob {self:?}, status: {status:?}",
         )))
     }
 
@@ -1038,8 +1030,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for Registere
         target_epoch: u32,
     ) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(ClientError::store_blob_internal(format!(
-            "Invalid operation for blob {:?}, target_epoch: {:?}",
-            self, target_epoch,
+            "Invalid operation for blob {self:?}, target_epoch: {target_epoch:?}",
         )))
     }
 
@@ -1049,7 +1040,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for Registere
     ) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(invalid_operation_for_blob(
             &self,
-            format!("with_register_result: {:?}", result),
+            format!("with_register_result: {result:?}"),
         ))
     }
 
@@ -1285,7 +1276,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for BlobWithC
     ) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(invalid_operation_for_blob(
             &self,
-            format!("with_encode_result: {:?}", result),
+            format!("with_encode_result: {result:?}"),
         ))
     }
 
@@ -1295,7 +1286,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for BlobWithC
     ) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(invalid_operation_for_blob(
             &self,
-            format!("with_status: {:?}", status),
+            format!("with_status: {status:?}"),
         ))
     }
 
@@ -1305,7 +1296,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for BlobWithC
     ) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(invalid_operation_for_blob(
             &self,
-            format!("try_complete_if_certified_beyond_epoch: {:?}", target_epoch),
+            format!("try_complete_if_certified_beyond_epoch: {target_epoch:?}"),
         ))
     }
 
@@ -1315,7 +1306,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for BlobWithC
     ) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(invalid_operation_for_blob(
             &self,
-            format!("with_register_result: {:?}", result),
+            format!("with_register_result: {result:?}"),
         ))
     }
 
@@ -1325,7 +1316,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for BlobWithC
     ) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(invalid_operation_for_blob(
             &self,
-            format!("with_get_certificate_result: {:?}", certificate_result),
+            format!("with_get_certificate_result: {certificate_result:?}"),
         ))
     }
 
@@ -1346,10 +1337,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for BlobWithC
         let StoreOp::RegisterNew { operation, blob } = &self.operation else {
             return Err(invalid_operation_for_blob(
                 &self,
-                format!(
-                    "with_certify_and_extend_result: {:?}",
-                    certify_and_extend_result
-                ),
+                format!("with_certify_and_extend_result: {certify_and_extend_result:?}"),
             ));
         };
 
@@ -1487,7 +1475,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for Completed
     ) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(invalid_operation_for_blob(
             &self,
-            format!("with_encode_result: {:?}", result),
+            format!("with_encode_result: {result:?}"),
         ))
     }
 
@@ -1497,7 +1485,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for Completed
     ) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(invalid_operation_for_blob(
             &self,
-            format!("with_status: {:?}", status),
+            format!("with_status: {status:?}"),
         ))
     }
 
@@ -1507,7 +1495,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for Completed
     ) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(invalid_operation_for_blob(
             &self,
-            format!("try_complete_if_certified_beyond_epoch: {:?}", target_epoch),
+            format!("try_complete_if_certified_beyond_epoch: {target_epoch:?}"),
         ))
     }
 
@@ -1517,7 +1505,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for Completed
     ) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(invalid_operation_for_blob(
             &self,
-            format!("with_register_result: {:?}", result),
+            format!("with_register_result: {result:?}"),
         ))
     }
 
@@ -1527,7 +1515,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for Completed
     ) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(invalid_operation_for_blob(
             &self,
-            format!("with_get_certificate_result: {:?}", certificate_result),
+            format!("with_get_certificate_result: {certificate_result:?}"),
         ))
     }
 
@@ -1538,7 +1526,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for Completed
     ) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(invalid_operation_for_blob(
             &self,
-            format!("with_certify_and_extend_result: {:?}", result),
+            format!("with_certify_and_extend_result: {result:?}"),
         ))
     }
 
@@ -1552,7 +1540,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for Completed
     fn with_error(self, error: ClientError) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(invalid_operation_for_blob(
             &self,
-            format!("with_error: {:?}", error),
+            format!("with_error: {error:?}"),
         ))
     }
 }
@@ -1644,8 +1632,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for FailedBlo
 
     fn get_certify_and_extend_params(&self) -> Result<CertifyAndExtendBlobParams, ClientError> {
         Err(ClientError::store_blob_internal(format!(
-            "Invalid operation for blob {:?}",
-            self,
+            "Invalid operation for blob {self:?}",
         )))
     }
 
@@ -1655,7 +1642,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for FailedBlo
     ) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(invalid_operation_for_blob(
             &self,
-            format!("with_encode_result: {:?}", result),
+            format!("with_encode_result: {result:?}"),
         ))
     }
 
@@ -1664,8 +1651,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for FailedBlo
         status: Result<BlobStatus, ClientError>,
     ) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(ClientError::store_blob_internal(format!(
-            "Invalid operation for blob {:?}, status: {:?}",
-            self, status,
+            "Invalid operation for blob {self:?}, status: {status:?}",
         )))
     }
 
@@ -1674,8 +1660,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for FailedBlo
         target_epoch: u32,
     ) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(ClientError::store_blob_internal(format!(
-            "Invalid operation for blob {:?}, target_epoch: {:?}",
-            self, target_epoch,
+            "Invalid operation for blob {self:?}, target_epoch: {target_epoch:?}",
         )))
     }
 
@@ -1684,8 +1669,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for FailedBlo
         result: Result<StoreOp, ClientError>,
     ) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(ClientError::store_blob_internal(format!(
-            "Invalid operation for blob {:?}, result: {:?}",
-            self, result,
+            "Invalid operation for blob {self:?}, result: {result:?}",
         )))
     }
 
@@ -1694,8 +1678,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for FailedBlo
         certificate_result: ClientResult<ConfirmationCertificate>,
     ) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(ClientError::store_blob_internal(format!(
-            "Invalid operation for blob {:?}, certificate_result: {:?}",
-            self, certificate_result,
+            "Invalid operation for blob {self:?}, certificate_result: {certificate_result:?}",
         )))
     }
 
@@ -1706,7 +1689,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for FailedBlo
     ) -> ClientResult<WalrusStoreBlob<'a, T>> {
         Err(invalid_operation_for_blob(
             &self,
-            format!("with_certify_and_extend_result: {:?}", result),
+            format!("with_certify_and_extend_result: {result:?}"),
         ))
     }
 
@@ -1751,8 +1734,7 @@ impl<T: Debug + Clone + Send + Sync> std::fmt::Debug for FailedBlob<'_, T> {
 
 fn invalid_operation_for_blob<B: Debug>(blob: &B, operation: String) -> ClientError {
     ClientError::store_blob_internal(format!(
-        "Invalid operation for blob {:?}, operation: {:?}",
-        blob, operation,
+        "Invalid operation for blob {blob:?}, operation: {operation:?}",
     ))
 }
 

--- a/crates/walrus-sdk/src/client/quilt_client.rs
+++ b/crates/walrus-sdk/src/client/quilt_client.rs
@@ -36,7 +36,7 @@ pub fn generate_identifier_from_path(path: &Path, index: usize) -> String {
     path.file_name()
         .and_then(|file_name| file_name.to_str())
         .map(String::from)
-        .unwrap_or_else(|| format!("unnamed-blob-{}", index))
+        .unwrap_or_else(|| format!("unnamed-blob-{index}"))
 }
 
 /// Converts a list of blobs with paths to a list of [`QuiltStoreBlob`]s.
@@ -840,7 +840,7 @@ mod tests {
         if current_depth < max_depth && rng.gen_bool(0.3) {
             let num_subdirs = rng.gen_range(1..=3);
             for i in 0..num_subdirs {
-                let subdir_name = format!("subdir_{}", i);
+                let subdir_name = format!("subdir_{i}");
                 let subdir_path = base_dir.join(&subdir_name);
                 fs::create_dir_all(&subdir_path)?;
 
@@ -863,7 +863,7 @@ mod tests {
         };
 
         for i in 0..files_in_dir {
-            let file_name = format!("file_{}.dat", i);
+            let file_name = format!("file_{i}.dat");
             let file_size = rng.gen_range(100..=1000);
             let content = create_random_file(base_dir, &file_name, file_size)?;
             file_contents.insert(base_dir.join(&file_name), content);
@@ -899,8 +899,7 @@ mod tests {
             let actual_content = read_files_map.get(path).expect("File should exist");
             assert_eq!(
                 actual_content, expected_content,
-                "Content mismatch for file: {:?}.",
-                path
+                "Content mismatch for file: {path:?}."
             );
         }
 

--- a/crates/walrus-sdk/src/client/resource.rs
+++ b/crates/walrus-sdk/src/client/resource.rs
@@ -429,7 +429,7 @@ impl<'a> ResourceManager<'a> {
 
                 // Get the vec of (blob, op) pairs for this blob ID
                 let Some(entries) = blob_id_map.get_mut(&blob_id) else {
-                    panic!("missing blob ID: {}", blob_id);
+                    panic!("missing blob ID: {blob_id}");
                 };
 
                 // Pop one (blob, op) pair from the vec
@@ -442,7 +442,7 @@ impl<'a> ResourceManager<'a> {
                     blob.with_register_result(Ok(StoreOp::new(operation, blob_obj)))
                         .expect("should succeed on a Ok result")
                 } else {
-                    panic!("missing blob ID: {}", blob_id);
+                    panic!("missing blob ID: {blob_id}");
                 }
             })
             .collect())

--- a/crates/walrus-sdk/src/client/responses.rs
+++ b/crates/walrus-sdk/src/client/responses.rs
@@ -37,7 +37,7 @@ impl Display for EventOrObjectId {
                 )
             }
             EventOrObjectId::Object(object_id) => {
-                write!(f, "Owned Blob registration object ID: {}", object_id)
+                write!(f, "Owned Blob registration object ID: {object_id}")
             }
         }
     }

--- a/crates/walrus-sdk/src/config.rs
+++ b/crates/walrus-sdk/src/config.rs
@@ -72,7 +72,7 @@ pub fn load_configuration(
     tracing::info!(
         "using Walrus configuration from '{}' with {} context",
         path.display(),
-        context.map_or("default".to_string(), |c| format!("'{}'", c))
+        context.map_or("default".to_string(), |c| format!("'{c}'"))
     );
     Ok(config)
 }

--- a/crates/walrus-sdk/src/utils.rs
+++ b/crates/walrus-sdk/src/utils.rs
@@ -332,7 +332,7 @@ impl From<CompletedReasonWeight> for CompletedReason {
 pub fn string_prefix<T: ToString>(s: &T) -> String {
     let mut string = s.to_string();
     string.truncate(8);
-    format!("{}...", string)
+    format!("{string}...")
 }
 
 // TODO: See WAL-763. Move these helpers back into the `walrus-service` crate once we've created an

--- a/crates/walrus-service/bin/node.rs
+++ b/crates/walrus-service/bin/node.rs
@@ -1149,10 +1149,7 @@ mod commands {
         let wallet_address =
             utils::generate_sui_wallet(sui_network, &wallet_config, use_faucet, faucet_timeout)
                 .await?;
-        println!(
-            "Successfully generated a new Sui wallet with address {}",
-            wallet_address
-        );
+        println!("Successfully generated a new Sui wallet with address {wallet_address}");
 
         let mut config = generate_config(
             PathArgs {
@@ -1489,11 +1486,11 @@ async fn handle_log_level_command(level: String, args: &AdminArgs) -> AdminComma
     match args.tracing_handle.update_log(level.as_str()) {
         Ok(_) => AdminCommandResponse {
             success: true,
-            message: format!("Log level updated successfully to: {}", level),
+            message: format!("Log level updated successfully to: {level}"),
         },
         Err(e) => AdminCommandResponse {
             success: false,
-            message: format!("Failed to update log level: {}", e),
+            message: format!("Failed to update log level: {e}"),
         },
     }
 }
@@ -1524,7 +1521,7 @@ async fn handle_checkpoint_command(
                 },
                 Err(e) => AdminCommandResponse {
                     success: false,
-                    message: format!("Failed to create checkpoint: {:?}", e),
+                    message: format!("Failed to create checkpoint: {e:?}"),
                 },
             }
         }
@@ -1537,14 +1534,14 @@ async fn handle_checkpoint_command(
                         "Backups:\n{}",
                         db_checkpoints
                             .iter()
-                            .map(|b| format!("  {}", b))
+                            .map(|b| format!("  {b}"))
                             .collect::<Vec<_>>()
                             .join("\n")
                     ),
                 },
                 Err(e) => AdminCommandResponse {
                     success: false,
-                    message: format!("Failed to list db checkpoints: {}", e),
+                    message: format!("Failed to list db checkpoints: {e}"),
                 },
             }
         }
@@ -1561,7 +1558,7 @@ async fn handle_checkpoint_command(
                 },
                 Err(e) => AdminCommandResponse {
                     success: false,
-                    message: format!("Failed to cancel checkpoint creation: {}", e),
+                    message: format!("Failed to cancel checkpoint creation: {e}"),
                 },
             }
         }
@@ -1588,7 +1585,7 @@ async fn handle_connection(stream: UnixStream, args: AdminArgs) {
             },
             Err(e) => AdminCommandResponse {
                 success: false,
-                message: format!("Failed to parse command: {}", e),
+                message: format!("Failed to parse command: {e}"),
             },
         };
 

--- a/crates/walrus-service/src/backup/service.rs
+++ b/crates/walrus-service/src/backup/service.rs
@@ -789,7 +789,7 @@ async fn upload_blob_to_storage(
                         .with_bucket_name(backup_bucket.to_string())
                         .build()?,
                 ),
-                format!("gs://{}/{}", backup_bucket, blob_id),
+                format!("gs://{backup_bucket}/{blob_id}"),
             )
         } else {
             (
@@ -878,7 +878,7 @@ where
                 db_reconnects.inc();
             }
             Err(error) => {
-                panic!("final error within retry_serializable_query: {:?}", error);
+                panic!("final error within retry_serializable_query: {error:?}");
             }
         }
     }

--- a/crates/walrus-service/src/client/cli.rs
+++ b/crates/walrus-service/src/client/cli.rs
@@ -269,7 +269,7 @@ impl std::fmt::Display for HumanReadableBytes {
         let set_precision = f.precision().unwrap_or(3).max(1);
         let precision = set_precision.saturating_sub(normalized_integer_digits);
 
-        write!(f, "{normalized_value:.*} {unit}", precision)
+        write!(f, "{normalized_value:.precision$} {unit}")
     }
 }
 

--- a/crates/walrus-service/src/client/cli/args.rs
+++ b/crates/walrus-service/src/client/cli/args.rs
@@ -1189,7 +1189,7 @@ impl std::fmt::Display for BlobIdentity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut identity = String::new();
         if let Some(blob_id) = &self.blob_id {
-            identity = format!("blob ID: {}", blob_id);
+            identity = format!("blob ID: {blob_id}");
         }
         if let Some(file) = &self.file {
             if !identity.is_empty() {
@@ -1201,9 +1201,9 @@ impl std::fmt::Display for BlobIdentity {
             if !identity.is_empty() {
                 identity.push(' ');
             }
-            identity.push_str(&format!("object ID: {}", object_id));
+            identity.push_str(&format!("object ID: {object_id}"));
         }
-        write!(f, "{}", identity)
+        write!(f, "{identity}")
     }
 }
 
@@ -1699,9 +1699,8 @@ mod tests {
         format!(
             r#"{{
                 "config": "path/to/client_config.yaml",
-                "command": {}
-            }}"#,
-            command
+                "command": {command}
+            }}"#
         )
     }
 

--- a/crates/walrus-service/src/client/cli/cli_output.rs
+++ b/crates/walrus-service/src/client/cli/cli_output.rs
@@ -124,10 +124,10 @@ impl CliOutput for Vec<BlobStoreResultWithPath> {
 
         let mut parts = Vec::new();
         if newly_certified > 0 {
-            parts.push(format!("{} newly certified", newly_certified));
+            parts.push(format!("{newly_certified} newly certified"));
         }
         if reuse_and_extend_count > 0 {
-            parts.push(format!("{} extended", reuse_and_extend_count));
+            parts.push(format!("{reuse_and_extend_count} extended"));
         }
 
         if !parts.is_empty() {
@@ -224,7 +224,7 @@ impl CliOutput for BlobStoreResultWithPath {
                     operation_str,
                     blob_object.storage.end_epoch,
                     shared_blob_object
-                        .map_or_else(String::new, |id| format!("\nShared blob object ID: {}", id)),
+                        .map_or_else(String::new, |id| format!("\nShared blob object ID: {id}")),
                     blob_object.encoding_type,
                 )
             }
@@ -375,7 +375,7 @@ impl CliOutput for BlobStatusOutput {
                     },
             } => {
                 let initial_certified_str = if let Some(epoch) = initial_certified_epoch {
-                    format!(", initially certified in epoch {}", epoch)
+                    format!(", initially certified in epoch {epoch}")
                 } else {
                     "".to_string()
                 };
@@ -405,7 +405,7 @@ impl CliOutput for BlobStatusOutput {
                 })
                 .bold();
                 let initial_certified_str = if let Some(epoch) = initial_certified_epoch {
-                    format!("\nInitially certified in epoch: {}", epoch,)
+                    format!("\nInitially certified in epoch: {epoch}",)
                 } else {
                     "".to_string()
                 };
@@ -494,7 +494,7 @@ impl CliOutput for InfoEpochOutput {
                 let end_time = *start_time
                     + chrono::Duration::from_std(*epoch_duration)
                         .expect("any practical epoch duration fits into a chrono::Duration");
-                format!("Start time: {}\nEnd time: {}", start_time, end_time)
+                format!("Start time: {start_time}\nEnd time: {end_time}")
             }
             EpochTimeOrMessage::Message(msg) => msg.clone(),
         };
@@ -1000,9 +1000,8 @@ impl NodeHealthOutput {
                                     checkpoint_seq, latest_seq - checkpoint_seq
                                 )
                             } else {
-                                format!("Latest checkpoint sequence number: {}\
-                                \nCheckpoint: up-to-date",
-                                    checkpoint_seq
+                                format!("Latest checkpoint sequence number: {checkpoint_seq}\
+                                \nCheckpoint: up-to-date"
                                 )
                             }
                         },
@@ -1011,8 +1010,8 @@ impl NodeHealthOutput {
                             \nLatest sui checkpoint: {}",
                                 health_info
                                     .latest_checkpoint_sequence_number
-                                    .map_or("N/A".to_string(), |seq| format!("{}", seq)),
-                                latest_seq.map_or("N/A".to_string(), |seq| format!("{}", seq))
+                                    .map_or("N/A".to_string(), |seq| format!("{seq}")),
+                                latest_seq.map_or("N/A".to_string(), |seq| format!("{seq}"))
                             )
                         },
                     },
@@ -1077,12 +1076,12 @@ impl CliOutput for ServiceHealthInfoOutput {
             println!("\n{}\n", "Summary".bold().walrus_purple());
             table.printstd();
             println!("\nTotal nodes: {}", self.health_info.len());
-            println!("Owned shards: {}", owned_shards);
-            println!("Read-only shards: {}", read_only_shards);
+            println!("Owned shards: {owned_shards}");
+            println!("Read-only shards: {read_only_shards}");
 
             println!("\n{}", "Node Status Breakdown".bold().walrus_purple());
             for (status, count) in &node_statuses {
-                println!("{}: {}", status, count);
+                println!("{status}: {count}");
             }
         }
     }
@@ -1107,7 +1106,7 @@ fn blob_and_file_str(blob_id: &BlobId, file: &Option<PathBuf>) -> String {
     if let Some(file) = file {
         format!("{} (file: {})", blob_id, file.display())
     } else {
-        format!("{}", blob_id)
+        format!("{blob_id}")
     }
 }
 
@@ -1194,7 +1193,7 @@ impl CliOutput for GetBlobAttributeOutput {
         if let Some(attribute) = &self.attribute {
             println!("\n{}", "Attribute".bold().walrus_purple());
             for (key, value) in attribute.iter() {
-                println!("{}: {}", key, value);
+                println!("{key}: {value}");
             }
         } else {
             println!("No attribute found");
@@ -1245,7 +1244,7 @@ impl CliOutput for ReadQuiltOutput {
                 } else {
                     println!("   Tags:");
                     for (key, value) in blob.tags() {
-                        println!("     {}: {}", key, value);
+                        println!("     {key}: {value}");
                     }
                 }
                 println!();

--- a/crates/walrus-service/src/client/cli/runner.rs
+++ b/crates/walrus-service/src/client/cli/runner.rs
@@ -1182,7 +1182,7 @@ impl ClientCommandRunner {
                 Ok(client) => client,
                 Err(e) => {
                     if !self.json {
-                        eprintln!("Error connecting to client: {}", e);
+                        eprintln!("Error connecting to client: {e}");
                     }
                     return Err(e);
                 }
@@ -1379,7 +1379,7 @@ impl ClientCommandRunner {
                 println!(
                     "{} Voted for package upgrade with digest 0x{}",
                     success(),
-                    digest.iter().map(|b| format!("{:02x}", b)).join("")
+                    digest.iter().map(|b| format!("{b:02x}")).join("")
                 );
             }
             NodeAdminCommands::SetCommissionAuthorized {
@@ -1426,7 +1426,7 @@ impl ClientCommandRunner {
                     "{} Digest for package '{}':\n  Hex: 0x{}\n  Base64: {}",
                     success(),
                     package_path.display(),
-                    digest.iter().map(|b| format!("{:02x}", b)).join(""),
+                    digest.iter().map(|b| format!("{b:02x}")).join(""),
                     fastcrypto::encoding::Base64::encode(digest)
                 );
             }
@@ -1451,9 +1451,9 @@ impl ClientCommandRunner {
                 };
 
                 let new_filename = if let Some(ext) = extension {
-                    format!("{}_{}.{}", stem, counter, ext)
+                    format!("{stem}_{counter}.{ext}")
                 } else {
-                    format!("{}_{}", stem, counter)
+                    format!("{stem}_{counter}")
                 };
 
                 out_dir.join(new_filename)
@@ -1533,7 +1533,7 @@ async fn delete_blob(
             {
                 Ok(status) => Some(status),
                 Err(e) => {
-                    result.error = Some(format!("Failed to get post-deletion status: {}", e));
+                    result.error = Some(format!("Failed to get post-deletion status: {e}"));
                     None
                 }
             };

--- a/crates/walrus-service/src/client/daemon.rs
+++ b/crates/walrus-service/src/client/daemon.rs
@@ -170,7 +170,7 @@ impl<T: ReadClient> WalrusReadClient for Client<T> {
         blobs.into_iter().next().ok_or_else(|| {
             use walrus_sdk::error::ClientErrorKind;
             ClientError::from(ClientErrorKind::Other(
-                format!("blob with identifier '{}' not found in quilt", identifier).into(),
+                format!("blob with identifier '{identifier}' not found in quilt").into(),
             ))
         })
     }

--- a/crates/walrus-service/src/client/daemon/auth.rs
+++ b/crates/walrus-service/src/client/daemon/auth.rs
@@ -503,7 +503,7 @@ mod tests {
     }
 
     fn correct_auth_header(token: String) -> Option<(String, String)> {
-        Some(("authorization".to_string(), format!("Bearer {}", token)))
+        Some(("authorization".to_string(), format!("Bearer {token}")))
     }
 
     // Test bodies.
@@ -583,7 +583,7 @@ mod tests {
             (
                 RequestHeadersAndData::new(
                     // The send_object_to field is does not match.
-                    &format!("/v1/blobs?epochs=1&send_object_to={}", OTHER_ADDRESS),
+                    &format!("/v1/blobs?epochs=1&send_object_to={OTHER_ADDRESS}"),
                     correct_auth_header(token.clone()),
                     None,
                 ),
@@ -693,7 +693,7 @@ mod tests {
             ),
             (
                 RequestHeadersAndData::new(
-                    &format!("/v1/blobs?epochs=1&send_object_to={}", OTHER_ADDRESS),
+                    &format!("/v1/blobs?epochs=1&send_object_to={OTHER_ADDRESS}"),
                     correct_auth_header(token_invalid_sig.clone()),
                     None,
                 ),

--- a/crates/walrus-service/src/client/daemon/routes.rs
+++ b/crates/walrus-service/src/client/daemon/routes.rs
@@ -877,7 +877,7 @@ mod tests {
         ]
     }
     fn test_parse_publisher_query(query_str: &str, expected: Option<PublisherQuery>) {
-        let uri_str = format!("http://localhost/test?{}", query_str);
+        let uri_str = format!("http://localhost/test?{query_str}");
         let uri: Uri = uri_str.parse().expect("the uri is valid");
 
         let result = Query::<PublisherQuery>::try_from_uri(&uri);

--- a/crates/walrus-service/src/client/multiplexer.rs
+++ b/crates/walrus-service/src/client/multiplexer.rs
@@ -354,8 +354,8 @@ impl<'a> SubClientLoader<'a> {
     fn create_or_load_sub_wallet(&self, sub_wallet_idx: usize) -> anyhow::Result<Wallet> {
         let wallet_config_path = self
             .sub_wallets_dir
-            .join(format!("sui_client_{}.yaml", sub_wallet_idx));
-        let keystore_filename = format!("sui_{}.keystore", sub_wallet_idx);
+            .join(format!("sui_client_{sub_wallet_idx}.yaml"));
+        let keystore_filename = format!("sui_{sub_wallet_idx}.keystore");
 
         if wallet_config_path.exists() {
             tracing::debug!(?wallet_config_path, "loading sub-wallet from file");

--- a/crates/walrus-service/src/common/telemetry.rs
+++ b/crates/walrus-service/src/common/telemetry.rs
@@ -347,7 +347,7 @@ impl MetricsMiddlewareState {
         self.inner
             .task_monitors
             .get_or_insert_with_task_name(&(method.clone(), http_route.to_owned()), || {
-                format!("{} {}", method, http_route)
+                format!("{method} {http_route}")
             })
     }
 

--- a/crates/walrus-service/src/common/utils.rs
+++ b/crates/walrus-service/src/common/utils.rs
@@ -204,8 +204,7 @@ where
     let name: String = Deserialize::deserialize(deserializer)?;
     if name.len() > MAX_NODE_NAME_LENGTH {
         return Err(D::Error::custom(format!(
-            "Node name must not exceed {} characters",
-            MAX_NODE_NAME_LENGTH
+            "Node name must not exceed {MAX_NODE_NAME_LENGTH} characters"
         )));
     }
     Ok(name)

--- a/crates/walrus-service/src/event/event_processor/runtime.rs
+++ b/crates/walrus-service/src/event/event_processor/runtime.rs
@@ -152,7 +152,7 @@ impl EventProcessorRuntime {
         tokio::spawn(async move {
             let result = event_processor_clone.start(cancel_token).await;
             if let Err(ref error) = result {
-                panic!("event manager exited with an error: {:?}", error);
+                panic!("event manager exited with an error: {error:?}");
             }
         });
         Ok(event_processor)

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -993,7 +993,7 @@ impl StorageNode {
         {
             let event_label: &'static str = stream_element.element.label();
             let monitor = task_monitors.get_or_insert_with_task_name(&event_label, || {
-                format!("process_event {}", event_label)
+                format!("process_event {event_label}")
             });
 
             let task = async {
@@ -4270,7 +4270,7 @@ mod tests {
                 &cluster.nodes[0].as_ref().inner.protocol_key_pair,
             )
             .await;
-        assert!(status.is_ok(), "Unexpected sync shard error: {:?}", status);
+        assert!(status.is_ok(), "Unexpected sync shard error: {status:?}");
 
         let SyncShardResponse::V1(response) = status.unwrap();
         assert_eq!(response.len(), 1);
@@ -4314,7 +4314,7 @@ mod tests {
                 &cluster.nodes[0].as_ref().inner.protocol_key_pair,
             )
             .await;
-        assert!(status.is_ok(), "Unexpected sync shard error: {:?}", status);
+        assert!(status.is_ok(), "Unexpected sync shard error: {status:?}");
 
         let SyncShardResponse::V1(response) = status.unwrap();
         assert_eq!(response.len(), 0);

--- a/crates/walrus-service/src/node/blob_sync.rs
+++ b/crates/walrus-service/src/node/blob_sync.rs
@@ -578,7 +578,7 @@ impl BlobSynchronizer {
                     .recover_slivers_for_shard(shared_metadata.clone(), shard)
             });
 
-        let mut futures_with_permits = stream::iter(futures_iter).then(move |future| {
+        let futures_with_permits = stream::iter(futures_iter).then(move |future| {
             let permits = sliver_permits.clone();
 
             // We use a future to get the permit. Only then is the future returned from the stream
@@ -632,7 +632,7 @@ impl BlobSynchronizer {
                                     return Err(RecoverSliverError::Database(err));
                                 }
                                 _ => {
-                                    panic!("database operations should not fail: {:?}", err)
+                                    panic!("database operations should not fail: {err:?}")
                                 }
                             }
                         }
@@ -743,7 +743,7 @@ impl BlobSynchronizer {
                 .storage()
                 .shard_storage(shard)
                 .await
-                .unwrap_or_else(|| panic!("shard {} is managed by this node", shard));
+                .unwrap_or_else(|| panic!("shard {shard} is managed by this node"));
             let sliver_id = shard.to_pair_index(self.encoding_config().n_shards(), &self.blob_id);
 
             Span::current().record("walrus.sliver.pair_index", field::display(sliver_id));

--- a/crates/walrus-service/src/node/committee/committee_service.rs
+++ b/crates/walrus-service/src/node/committee/committee_service.rs
@@ -265,8 +265,7 @@ where
                 .set_committee_for_next_epoch(next_committee)
                 .unwrap_or_else(|error| {
                     panic!(
-                        "committee for the next epoch cannot change after being fetched: {}",
-                        error
+                        "committee for the next epoch cannot change after being fetched: {error}"
                     );
                 });
 

--- a/crates/walrus-service/src/node/committee/request_futures.rs
+++ b/crates/walrus-service/src/node/committee/request_futures.rs
@@ -1002,7 +1002,7 @@ where
                 certificate
             }
             Err(CertificateError::SignatureAggregation(err)) => {
-                panic!("attestations must be verified beforehand: {:?}", err)
+                panic!("attestations must be verified beforehand: {err:?}")
             }
             Err(CertificateError::MessageMismatch) => {
                 panic!("messages must be verified against the same epoch and blob id")

--- a/crates/walrus-service/src/node/committee/test_committee_service.rs
+++ b/crates/walrus-service/src/node/committee/test_committee_service.rs
@@ -298,7 +298,7 @@ async fn new_committee_unavailable_for_reads_until_transition_completes() -> Tes
         .build_with_factory(committee_lookup, service_map)
         .await?;
 
-    let mut pending_request =
+    let pending_request =
         committee_service.get_and_verify_metadata(*expected_metadata.blob_id(), 0);
     let mut pending_request = std::pin::pin!(pending_request);
 
@@ -544,7 +544,7 @@ async fn recovers_slivers_across_epoch_change() -> TestResult {
         .build_with_factory(committee_lookup, service_map)
         .await?;
 
-    let mut pending_request = committee_service.recover_sliver(
+    let pending_request = committee_service.recover_sliver(
         metadata.into(),
         target_sliver_index.into(),
         SliverType::Primary,
@@ -621,7 +621,7 @@ async fn restarts_inconsistency_proof_collection_across_epoch_change() -> TestRe
         .build_with_factory(committee_lookup, service_map)
         .await?;
 
-    let mut pending_request =
+    let pending_request =
         committee_service.get_invalid_blob_certificate(blob_id, &inconsistency_proof);
     let mut pending_request = std::pin::pin!(pending_request);
 
@@ -686,7 +686,7 @@ async fn collects_inconsistency_proof_despite_epoch_change() -> TestResult {
         .build_with_factory(committee_lookup, service_map)
         .await?;
 
-    let mut pending_request =
+    let pending_request =
         committee_service.get_invalid_blob_certificate(blob_id, &inconsistency_proof);
     let mut pending_request = std::pin::pin!(pending_request);
 

--- a/crates/walrus-service/src/node/contract_service.rs
+++ b/crates/walrus-service/src/node/contract_service.rs
@@ -642,8 +642,7 @@ fn calculate_protocol_key_action(
         let error_msg = format!(
             "Local protocol key pair does not match remote protocol key pair, \
             please update the protocol key pair to match the remote protocol public key: \
-            local public key: {}, remote public key: {}",
-            local_public_key, remote_public_key
+            local public key: {local_public_key}, remote public key: {remote_public_key}"
         );
 
         let Some(local_next) = &local_next_public_key else {

--- a/crates/walrus-service/src/node/db_checkpoint.rs
+++ b/crates/walrus-service/src/node/db_checkpoint.rs
@@ -21,7 +21,7 @@ pub struct DisplayableDbCheckpointInfo {
 
 impl std::fmt::Debug for DisplayableDbCheckpointInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{self}")
     }
 }
 
@@ -192,14 +192,14 @@ impl DelayedTask {
                     }
                     Ok(Err(e)) => {
                         let mut status_guard = status.lock().expect("Failed to lock status");
-                        *status_guard = TaskStatus::Failed(format!("Task failed: {:?}", e));
+                        *status_guard = TaskStatus::Failed(format!("Task failed: {e:?}"));
                         let _ = response.send(TaskResult::Failed(e));
                     }
                     Err(e) => {
                         let mut status_guard = status.lock().expect("Failed to lock status");
-                        *status_guard = TaskStatus::TaskError(format!("Task panicked: {}", e));
+                        *status_guard = TaskStatus::TaskError(format!("Task panicked: {e}"));
                         let _ = response.send(
-                            TaskResult::TaskError(format!("Task panicked: {}", e))
+                            TaskResult::TaskError(format!("Task panicked: {e}"))
                         );
                     }
                 };
@@ -785,7 +785,7 @@ mod tests {
         let large_count = num_keys - small_count;
 
         for i in 0..small_count {
-            let key = format!("small_key_{:03}", i).into_bytes();
+            let key = format!("small_key_{i:03}").into_bytes();
 
             let small_size = rng.gen_range(1..=median_size);
             let value = vec![b's'; small_size];
@@ -794,7 +794,7 @@ mod tests {
         }
 
         for i in 0..large_count {
-            let key = format!("large_key_{:03}", i).into_bytes();
+            let key = format!("large_key_{i:03}").into_bytes();
 
             let size = rng.gen_range(median_size + 1..=median_size * 2);
             let value = vec![b'l'; size];

--- a/crates/walrus-service/src/node/dbtool.rs
+++ b/crates/walrus-service/src/node/dbtool.rs
@@ -315,7 +315,7 @@ fn repair_db(db_path: PathBuf) -> Result<()> {
 }
 
 fn scan_events(db_path: PathBuf, start_event_index: u64, count: usize) -> Result<()> {
-    println!("Scanning events from event index {}", start_event_index);
+    println!("Scanning events from event index {start_event_index}");
     let opts = RocksdbOptions::default();
     let db = DB::open_cf_for_read_only(
         &opts,
@@ -343,7 +343,7 @@ fn scan_events(db_path: PathBuf, start_event_index: u64, count: usize) -> Result
         let (key, value) = event?;
         let event_index: u64 = config.deserialize(&key)?;
         let event: PositionedStreamEvent = bcs::from_bytes(&value)?;
-        println!("Event index: {}. Event: {:?}", event_index, event);
+        println!("Event index: {event_index}. Event: {event:?}");
 
         scan_count += 1;
         if scan_count >= count {
@@ -381,10 +381,10 @@ fn read_blob_info(db_path: PathBuf, start_blob_id: Option<BlobId>, count: usize)
             Ok((key, value)) => {
                 let blob_id: BlobId = bcs::from_bytes(&key)?;
                 let blob_info: BlobInfo = bcs::from_bytes(&value)?;
-                println!("Blob ID: {}, BlobInfo: {:?}", blob_id, blob_info);
+                println!("Blob ID: {blob_id}, BlobInfo: {blob_info:?}");
             }
             Err(e) => {
-                println!("Error: {:?}", e);
+                println!("Error: {e:?}");
                 return Err(e.into());
             }
         }
@@ -424,13 +424,10 @@ fn read_object_blob_info(
             Ok((key, value)) => {
                 let object_id: ObjectID = bcs::from_bytes(&key)?;
                 let blob_info: PerObjectBlobInfo = bcs::from_bytes(&value)?;
-                println!(
-                    "Object ID: {}, PerObjectBlobInfo: {:?}",
-                    object_id, blob_info
-                );
+                println!("Object ID: {object_id}, PerObjectBlobInfo: {blob_info:?}");
             }
             Err(e) => {
-                println!("Error: {:?}", e);
+                println!("Error: {e:?}");
                 return Err(e.into());
             }
         }
@@ -466,17 +463,11 @@ fn count_certified_blobs(db_path: PathBuf, epoch: Epoch) -> Result<()> {
 
         scan_count += 1;
         if scan_count % 10000 == 0 {
-            println!(
-                "Scanned {} blobs. Found {} certified blobs",
-                scan_count, certified_count
-            );
+            println!("Scanned {scan_count} blobs. Found {certified_count} certified blobs");
         }
     }
 
-    println!(
-        "Number of certified blobs: {}. Scanned {} blobs",
-        certified_count, scan_count
-    );
+    println!("Number of certified blobs: {certified_count}. Scanned {scan_count} blobs");
     Ok(())
 }
 
@@ -485,7 +476,7 @@ fn drop_column_family(db_path: PathBuf, column_family_name: String) -> Result<()
     let db = DB::open(&RocksdbOptions::default(), db_path)?;
 
     let result = db.drop_cf(column_family_name.as_str());
-    println!("Dropped column family: {:?}", result);
+    println!("Dropped column family: {result:?}");
 
     Ok(())
 }
@@ -493,9 +484,9 @@ fn drop_column_family(db_path: PathBuf, column_family_name: String) -> Result<()
 fn list_column_families(db_path: PathBuf) -> Result<()> {
     let result = rocksdb::DB::list_cf(&RocksdbOptions::default(), db_path);
     if let Ok(column_families) = result {
-        println!("Column families: {:?}", column_families);
+        println!("Column families: {column_families:?}");
     } else {
-        println!("Failed to get column families: {:?}", result);
+        println!("Failed to get column families: {result:?}");
     }
 
     Ok(())
@@ -543,11 +534,11 @@ fn read_blob_metadata(
                         metadata.unencoded_length()
                     );
                 } else {
-                    println!("Blob ID: {}, Metadata: {:?}", blob_id, metadata);
+                    println!("Blob ID: {blob_id}, Metadata: {metadata:?}");
                 }
             }
             Err(e) => {
-                println!("Error: {:?}", e);
+                println!("Error: {e:?}");
                 return Err(e.into());
             }
         }
@@ -574,10 +565,7 @@ fn read_primary_slivers(
     )?;
 
     let Some(cf) = db.cf_handle(&primary_slivers_column_family_name(shard_index)) else {
-        println!(
-            "Primary slivers column family not found for shard {}",
-            shard_index
-        );
+        println!("Primary slivers column family not found for shard {shard_index}");
         return Ok(());
     };
 
@@ -595,10 +583,10 @@ fn read_primary_slivers(
             Ok((key, value)) => {
                 let blob_id: BlobId = bcs::from_bytes(&key)?;
                 let sliver: PrimarySliverData = bcs::from_bytes(&value)?;
-                println!("Blob ID: {}, Primary Sliver: {:?}", blob_id, sliver);
+                println!("Blob ID: {blob_id}, Primary Sliver: {sliver:?}");
             }
             Err(e) => {
-                println!("Error: {:?}", e);
+                println!("Error: {e:?}");
                 return Err(e.into());
             }
         }
@@ -625,10 +613,7 @@ fn read_secondary_slivers(
     )?;
 
     let Some(cf) = db.cf_handle(&secondary_slivers_column_family_name(shard_index)) else {
-        println!(
-            "Secondary slivers column family not found for shard {}",
-            shard_index
-        );
+        println!("Secondary slivers column family not found for shard {shard_index}");
         return Ok(());
     };
 
@@ -646,10 +631,10 @@ fn read_secondary_slivers(
             Ok((key, value)) => {
                 let blob_id: BlobId = bcs::from_bytes(&key)?;
                 let sliver: SecondarySliverData = bcs::from_bytes(&value)?;
-                println!("Blob ID: {}, Secondary Sliver: {:?}", blob_id, sliver);
+                println!("Blob ID: {blob_id}, Secondary Sliver: {sliver:?}");
             }
             Err(e) => {
-                println!("Error: {:?}", e);
+                println!("Error: {e:?}");
                 return Err(e.into());
             }
         }
@@ -679,7 +664,7 @@ fn read_event_processor_init_state(db_path: PathBuf) -> Result<()> {
         let (key, value) = result?;
         let init_state: InitState = bcs::from_bytes(&value)?;
         let key: u64 = config.deserialize(&key)?;
-        println!("Key: {}, Init state: {:?}", key, init_state);
+        println!("Key: {key}, Init state: {init_state:?}");
     }
 
     Ok(())
@@ -702,7 +687,7 @@ fn read_certified_event_blobs(db_path: PathBuf) -> Result<()> {
     match res {
         Some(data) => {
             let metadata: CertifiedEventBlobMetadata = bcs::from_bytes(&data)?;
-            println!("Certified Event Blob Metadata: {:?}", metadata);
+            println!("Certified Event Blob Metadata: {metadata:?}");
         }
         None => println!("Certified event blob not found"),
     }
@@ -728,7 +713,7 @@ fn read_attested_event_blobs(db_path: PathBuf) -> Result<()> {
     match res {
         Some(data) => {
             let metadata: AttestedEventBlobMetadata = bcs::from_bytes(&data)?;
-            println!("Attested Event Blob Metadata: {:?}", metadata);
+            println!("Attested Event Blob Metadata: {metadata:?}");
         }
         None => println!("Attested event blob not found"),
     }
@@ -763,13 +748,10 @@ fn read_pending_event_blobs(db_path: PathBuf, start_seq: Option<u64>, count: usi
             Ok((key, value)) => {
                 let seq: u64 = bcs::from_bytes(&key)?;
                 let metadata: PendingEventBlobMetadata = bcs::from_bytes(&value)?;
-                println!(
-                    "Sequence: {}, Pending Event Blob Metadata: {:?}",
-                    seq, metadata
-                );
+                println!("Sequence: {seq}, Pending Event Blob Metadata: {metadata:?}");
             }
             Err(e) => {
-                println!("Error: {:?}", e);
+                println!("Error: {e:?}");
                 return Err(e.into());
             }
         }
@@ -796,7 +778,7 @@ fn read_failed_to_attest_event_blobs(db_path: PathBuf) -> Result<()> {
     match res {
         Some(data) => {
             let metadata: FailedToAttestEventBlobMetadata = bcs::from_bytes(&data)?;
-            println!("Failed-to-attest Event Blob Metadata: {:?}", metadata);
+            println!("Failed-to-attest Event Blob Metadata: {metadata:?}");
         }
         None => println!("Failed-to-attest event blob not found"),
     }

--- a/crates/walrus-service/src/node/node_recovery.rs
+++ b/crates/walrus-service/src/node/node_recovery.rs
@@ -164,10 +164,7 @@ impl NodeRecoveryHandler {
                             // The only place where start_sync can fail is when marking the
                             // event complete, which is not applicable here since the there
                             // is no event associated with the recovery task.
-                            panic!(
-                                "failed to start recovery sync for blob {}: {}",
-                                blob_id, err,
-                            );
+                            panic!("failed to start recovery sync for blob {blob_id}: {err}",);
                         }
                     }
                 }

--- a/crates/walrus-service/src/node/storage/blob_info.rs
+++ b/crates/walrus-service/src/node/storage/blob_info.rs
@@ -605,16 +605,22 @@ impl ValidBlobInfoV1 {
     fn to_blob_status(&self, current_epoch: Epoch) -> BlobStatus {
         // TODO: The following should be adjusted/simplified when we have proper cleanup (WAL-473).
         let deletable_counts = DeletableCounts {
-            count_deletable_total: self
+            count_deletable_total: if self
                 .latest_seen_deletable_registered_epoch
                 .is_some_and(|e| e > current_epoch)
-                .then_some(self.count_deletable_total)
-                .unwrap_or_default(),
-            count_deletable_certified: self
+            {
+                self.count_deletable_total
+            } else {
+                Default::default()
+            },
+            count_deletable_certified: if self
                 .latest_seen_deletable_certified_epoch
                 .is_some_and(|e| e > current_epoch)
-                .then_some(self.count_deletable_certified)
-                .unwrap_or_default(),
+            {
+                self.count_deletable_certified
+            } else {
+                Default::default()
+            },
         };
 
         let initial_certified_epoch = self.initial_certified_epoch;

--- a/crates/walrus-service/src/node/storage/blob_info.rs
+++ b/crates/walrus-service/src/node/storage/blob_info.rs
@@ -604,23 +604,25 @@ impl From<ValidBlobInfoV1> for BlobInfoV1 {
 impl ValidBlobInfoV1 {
     fn to_blob_status(&self, current_epoch: Epoch) -> BlobStatus {
         // TODO: The following should be adjusted/simplified when we have proper cleanup (WAL-473).
+        let count_deletable_total = if self
+            .latest_seen_deletable_registered_epoch
+            .is_some_and(|e| e > current_epoch)
+        {
+            self.count_deletable_total
+        } else {
+            Default::default()
+        };
+        let count_deletable_certified = if self
+            .latest_seen_deletable_certified_epoch
+            .is_some_and(|e| e > current_epoch)
+        {
+            self.count_deletable_certified
+        } else {
+            Default::default()
+        };
         let deletable_counts = DeletableCounts {
-            count_deletable_total: if self
-                .latest_seen_deletable_registered_epoch
-                .is_some_and(|e| e > current_epoch)
-            {
-                self.count_deletable_total
-            } else {
-                Default::default()
-            },
-            count_deletable_certified: if self
-                .latest_seen_deletable_certified_epoch
-                .is_some_and(|e| e > current_epoch)
-            {
-                self.count_deletable_certified
-            } else {
-                Default::default()
-            },
+            count_deletable_total,
+            count_deletable_certified,
         };
 
         let initial_certified_epoch = self.initial_certified_epoch;

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -1958,7 +1958,7 @@ impl TestClusterBuilder {
                 .with_disabled_event_blob_writer(disable_event_blob_writer)
                 .with_enable_node_config_synchronizer(self.enable_node_config_synchronizer)
                 .with_node_recovery_config(self.node_recovery_config.clone().unwrap_or_default())
-                .with_name(format!("node-{}", idx));
+                .with_name(format!("node-{idx}"));
             tracing::info!(
                 "test cluster builder build enable_node_config_synchronizer: {}",
                 self.enable_node_config_synchronizer
@@ -2018,7 +2018,7 @@ impl TestClusterBuilder {
             .into_iter()
             .enumerate()
             .map(|(idx, result)| {
-                result.with_context(|| format!("Failed to start storage node {}", idx))
+                result.with_context(|| format!("Failed to start storage node {idx}"))
             })
             .collect::<Result<Vec<_>, _>>()?;
 

--- a/crates/walrus-service/src/testbed.rs
+++ b/crates/walrus-service/src/testbed.rs
@@ -132,7 +132,7 @@ pub fn node_config_name_prefix(node_index: u16, committee_size: NonZeroU16) -> S
             .expect("this is smaller than `u16::MAX`")
             + 1
     };
-    format!("dryrun-node-{node_index:00$}", width)
+    format!("dryrun-node-{node_index:0width$}")
 }
 
 /// Generates deterministic keypairs for the benchmark purposes.
@@ -330,7 +330,7 @@ pub async fn deploy_walrus_contract(
 
         // The first half of the nodes will have a protocol key pair path, the second half will not.
         let protocol_key_pair_path = if i < mid {
-            Some(working_dir.join(format!("node-{}.key", node_index)))
+            Some(working_dir.join(format!("node-{node_index}.key")))
         } else {
             None
         };
@@ -529,11 +529,11 @@ pub async fn create_client_config(
     fs::create_dir_all(working_dir).expect("Failed to create working directory");
 
     // Create wallet for the client
-    let sui_client_wallet_path = working_dir.join(format!("{}.yaml", wallet_name));
+    let sui_client_wallet_path = working_dir.join(format!("{wallet_name}.yaml"));
     let mut sui_client_wallet_context = create_wallet(
         &sui_client_wallet_path,
         sui_network.env(),
-        Some(&format!("{}.keystore", wallet_name)),
+        Some(&format!("{wallet_name}.keystore")),
         sui_client_request_timeout,
     )?;
 
@@ -800,7 +800,7 @@ pub async fn create_storage_node_configs(
                 sliver_data_existence_check_sample_rate_percentage: 100,
             },
             checkpoint_config: Default::default(),
-            admin_socket_path: Some(working_dir.join(format!("admin-{}.sock", node_index))),
+            admin_socket_path: Some(working_dir.join(format!("admin-{node_index}.sock"))),
             node_recovery_config: Default::default(),
             blob_event_processor_config: Default::default(),
         });
@@ -896,11 +896,11 @@ async fn create_storage_node_wallets(
     let mut storage_node_wallets = (0..n_nodes.get())
         .map(|index| {
             let name = node_config_name_prefix(index, n_nodes);
-            let wallet_path = working_dir.join(format!("{}-sui.yaml", name));
+            let wallet_path = working_dir.join(format!("{name}-sui.yaml"));
             create_wallet(
                 &wallet_path,
                 sui_network.env(),
-                Some(&format!("{}.keystore", name)),
+                Some(&format!("{name}.keystore")),
                 None,
             )
         })

--- a/crates/walrus-storage-node-client/src/client.rs
+++ b/crates/walrus-storage-node-client/src/client.rs
@@ -198,7 +198,7 @@ impl UrlEndpoints {
 
     fn recovery_symbol(&self, blob_id: &BlobId, symbol_id: SymbolId) -> (Url, &'static str) {
         (
-            self.blob_resource(blob_id, &format!("recoverySymbols/{}", symbol_id)),
+            self.blob_resource(blob_id, &format!("recoverySymbols/{symbol_id}")),
             RECOVERY_SYMBOL_URL_TEMPLATE,
         )
     }

--- a/crates/walrus-sui/build.rs
+++ b/crates/walrus-sui/build.rs
@@ -49,7 +49,7 @@ fn main() {
 
     generate_error_defs_for_contracts(contracts_dir_path, Path::new(&out_dir));
     // Tell cargo to rerun if relevant files change
-    println!("cargo::rerun-if-changed={}", contracts_dir);
+    println!("cargo::rerun-if-changed={contracts_dir}");
 }
 
 fn generate_error_defs_for_contracts(contracts_dir: &Path, out_dir: &Path) {
@@ -144,7 +144,7 @@ fn generate_error_kind_defs(module_error_defs: &[ModuleErrorDefs]) -> String {
             module_error.fully_qualified_module
         ));
         for (error_name, error_code) in module_error.error_defs.iter() {
-            code.push_str(&format!("    {}, {},\n", error_name, error_code));
+            code.push_str(&format!("    {error_name}, {error_code},\n"));
         }
         code.push_str(");\n\n");
     }

--- a/crates/walrus-sui/src/client/retry_client/retriable_rpc_client.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_rpc_client.rs
@@ -147,14 +147,12 @@ impl LazyClientBuilder<FallibleRpcClient> for LazyFallibleRpcClientBuilder {
                     .await
                     .map_err(|_| {
                         FailoverError::FailedToGetClient(format!(
-                            "Client validation timed out for {:?}",
-                            rpc_url
+                            "Client validation timed out for {rpc_url:?}"
                         ))
                     })?
                     .map_err(|e| {
                         FailoverError::FailedToGetClient(format!(
-                            "Client validation failed for {:?}: {:?}",
-                            rpc_url, e
+                            "Client validation failed for {rpc_url:?}: {e:?}"
                         ))
                     })?;
                 }

--- a/crates/walrus-sui/src/client/retry_client/retriable_rpc_client/fallback_client.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_rpc_client/fallback_client.rs
@@ -48,7 +48,7 @@ impl FallbackClient {
         &self,
         sequence_number: u64,
     ) -> Result<CheckpointData, FallbackError> {
-        let url = self.base_url.join(&format!("{}.chk", sequence_number))?;
+        let url = self.base_url.join(&format!("{sequence_number}.chk"))?;
         tracing::debug!(%url, "downloading checkpoint from fallback bucket");
         let response = self.client.get(url).send().await?.error_for_status()?;
         let bytes = response.bytes().await?;

--- a/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
@@ -844,9 +844,8 @@ impl RetriableSuiClient {
         K: DeserializeOwned + Serialize,
     {
         let key_tag = key_type.to_canonical_string(true);
-        let key_tag =
-            TypeTag::from_str(&format!("0x2::dynamic_object_field::Wrapper<{}>", key_tag))
-                .expect("valid type tag");
+        let key_tag = TypeTag::from_str(&format!("0x2::dynamic_object_field::Wrapper<{key_tag}>"))
+            .expect("valid type tag");
         let inner_object_id = self.get_dynamic_field(parent, key_tag, key).await?;
         let inner = self.get_sui_object(inner_object_id).await?;
         Ok(inner)

--- a/crates/walrus-sui/src/types.rs
+++ b/crates/walrus-sui/src/types.rs
@@ -430,20 +430,14 @@ impl Committee {
                 let comparison = compare_node_attributes(node_id, left_node, right_node, extended);
                 error_msgs.extend(comparison);
             } else {
-                error_msgs.push(format!(
-                    "Node {:?} exists in left but not in right",
-                    node_id
-                ));
+                error_msgs.push(format!("Node {node_id:?} exists in left but not in right"));
             }
         }
 
         // Check each node in right committee exists in left
         for node_id in other_nodes.keys() {
             if !self_nodes.contains_key(node_id) {
-                error_msgs.push(format!(
-                    "Node {:?} exists in right but not in left",
-                    node_id
-                ));
+                error_msgs.push(format!("Node {node_id:?} exists in right but not in left"));
             }
         }
 

--- a/crates/walrus-sui/src/types/move_structs.rs
+++ b/crates/walrus-sui/src/types/move_structs.rs
@@ -413,8 +413,8 @@ pub enum Authorized {
 impl Display for Authorized {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Address(address) => write!(f, "sui address {}", address),
-            Self::Object(object) => write!(f, "object id {}", object),
+            Self::Address(address) => write!(f, "sui address {address}"),
+            Self::Object(object) => write!(f, "object id {object}"),
         }
     }
 }
@@ -851,12 +851,11 @@ impl Display for StakedWalState {
             StakedWalState::Withdrawing(epoch, Some(amount)) => {
                 write!(
                     f,
-                    "Withdrawing: epoch={}, pool token amount={:?}",
-                    epoch, amount
+                    "Withdrawing: epoch={epoch}, pool token amount={amount:?}"
                 )
             }
             StakedWalState::Withdrawing(epoch, None) => {
-                write!(f, "Withdrawing: epoch={}, pool token amount=Unknown", epoch)
+                write!(f, "Withdrawing: epoch={epoch}, pool token amount=Unknown")
             }
         }
     }

--- a/crates/walrus-sui/src/utils.rs
+++ b/crates/walrus-sui/src/utils.rs
@@ -340,10 +340,7 @@ pub fn create_wallet(
 pub async fn send_faucet_request(address: SuiAddress, network: &SuiNetwork) -> Result<()> {
     // send the request to the faucet
     let client = reqwest::Client::new();
-    let data_raw = format!(
-        "{{\"FixedAmountRequest\": {{ \"recipient\": \"{}\" }} }} ",
-        address
-    );
+    let data_raw = format!("{{\"FixedAmountRequest\": {{ \"recipient\": \"{address}\" }} }} ");
     let Some(faucet) = network.faucet() else {
         return Err(anyhow!("faucet not available for {network}"));
     };

--- a/docker/walrus-antithesis/build-walrus-image-for-antithesis/Dockerfile
+++ b/docker/walrus-antithesis/build-walrus-image-for-antithesis/Dockerfile
@@ -8,7 +8,7 @@
 
 # Stage 1: Base Build Environment + Builder
 # -------------------------------------
-FROM rust:1.87-bookworm AS builder
+FROM rust:1.88-bookworm AS builder
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION
 WORKDIR "$WORKDIR/walrus"

--- a/docker/walrus-orchestrator/Dockerfile
+++ b/docker/walrus-orchestrator/Dockerfile
@@ -3,8 +3,8 @@
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
 
-# This is the same as rust:1.87-bookworm but we use the GCP registry to avoid rate limiting.
-FROM us-central1-docker.pkg.dev/cryptic-bolt-398315/base-images/rust:1.87-bookworm-amd64 AS builder
+# This is the same as rust:1.88-bookworm but we use the GCP registry to avoid rate limiting.
+FROM us-central1-docker.pkg.dev/cryptic-bolt-398315/base-images/rust:1.88-bookworm-amd64 AS builder
 
 ARG PROFILE=release
 ARG GIT_REVISION

--- a/docker/walrus-proxy/Dockerfile
+++ b/docker/walrus-proxy/Dockerfile
@@ -1,5 +1,5 @@
-# This is the same as rust:1.87-bookworm but we use the GCP registry to avoid rate limiting.
-FROM us-central1-docker.pkg.dev/cryptic-bolt-398315/base-images/rust:1.87-bookworm-amd64 as builder
+# This is the same as rust:1.88-bookworm but we use the GCP registry to avoid rate limiting.
+FROM us-central1-docker.pkg.dev/cryptic-bolt-398315/base-images/rust:1.88-bookworm-amd64 as builder
 
 ARG PROFILE=release
 WORKDIR /work

--- a/docker/walrus-service/Dockerfile
+++ b/docker/walrus-service/Dockerfile
@@ -3,8 +3,8 @@
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
 
-# This is the same as rust:1.87-bookworm but we use the GCP registry to avoid rate limiting.
-FROM us-central1-docker.pkg.dev/cryptic-bolt-398315/base-images/rust:1.87-bookworm-amd64 AS builder
+# This is the same as rust:1.88-bookworm but we use the GCP registry to avoid rate limiting.
+FROM us-central1-docker.pkg.dev/cryptic-bolt-398315/base-images/rust:1.88-bookworm-amd64 AS builder
 
 ARG PROFILE=release
 ARG GIT_REVISION

--- a/docker/walrus-service/Dockerfile.walrus-backup
+++ b/docker/walrus-service/Dockerfile.walrus-backup
@@ -3,8 +3,8 @@
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
 
-# This is the same as rust:1.87-bookworm but we use the GCP registry to avoid rate limiting.
-FROM us-central1-docker.pkg.dev/cryptic-bolt-398315/base-images/rust:1.87-bookworm-amd64 AS builder
+# This is the same as rust:1.88-bookworm but we use the GCP registry to avoid rate limiting.
+FROM us-central1-docker.pkg.dev/cryptic-bolt-398315/base-images/rust:1.88-bookworm-amd64 AS builder
 
 ARG PROFILE=release
 ARG RUST_LOG=info,walrus_service::common::event_blob_downloader=warn

--- a/docker/walrus-stress/Dockerfile
+++ b/docker/walrus-stress/Dockerfile
@@ -3,8 +3,8 @@
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
 
-# This is the same as rust:1.87-bookworm but we use the GCP registry to avoid rate limiting.
-FROM us-central1-docker.pkg.dev/cryptic-bolt-398315/base-images/rust:1.87-bookworm-amd64 AS builder
+# This is the same as rust:1.88-bookworm but we use the GCP registry to avoid rate limiting.
+FROM us-central1-docker.pkg.dev/cryptic-bolt-398315/base-images/rust:1.88-bookworm-amd64 AS builder
 
 ARG PROFILE=release
 ARG GIT_REVISION

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.87"
+channel = "1.88"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Description

Bump the Rust toolchain to the latest 1.88 release and fixes all new Clippy warnings with `cargo clippy --fix`. Additionally run `cargo fmt` again and fix a few too long lines manually.

## Test plan

Existing test suite.