### PR TITLE
fix: Pass ending blob checkpoint instead of event index (#2258)

### DIFF
--- a/crates/walrus-service/src/event/event_processor/catchup.rs
+++ b/crates/walrus-service/src/event/event_processor/catchup.rs
@@ -314,7 +314,7 @@ impl EventBlobCatchupManager {
             }
 
             tracing::info!(
-                "Processed event blob {} with {} events, last event index: {}, \
+                "processed event blob {} with {} events, last event index: {}, \
                 start checkpoint: {}, end checkpoint: {}",
                 blob_id,
                 downloaded_blob.events.len(),
@@ -322,7 +322,7 @@ impl EventBlobCatchupManager {
                     .events
                     .last()
                     .expect("Event list is not empty")
-                    .index
+                    .index,
                 downloaded_blob.start_checkpoint,
                 downloaded_blob.end_checkpoint
             );


### PR DESCRIPTION
* fix: Pass ending blob checkpoint instead of event index

* Update crates/walrus-service/src/event/event_processor/catchup.rs



---------

## Description

Describe the changes or additions included in this PR.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
