### PR TITLE
chore: antithesis image should use public image

### DIFF
--- a/docker/walrus-antithesis/build-test-config-image/Dockerfile
+++ b/docker/walrus-antithesis/build-test-config-image/Dockerfile
@@ -1,5 +1,5 @@
 # This is the same as debian:bookworm-slim but we use the GCP registry to avoid rate limiting.
-FROM us-central1-docker.pkg.dev/cryptic-bolt-398315/base-images/debian:bookworm-slim-amd64 AS setup
+FROM debian:bookworm-slim AS setup
 
 RUN apt update
 RUN apt install python3 python3-pip -y


### PR DESCRIPTION
## Description

this one should use public image as it's not built on our internal image building system

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
