### PR TITLE
fix(node): fix continuing event stream from init state (cherry-pick)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1943,7 +1943,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "checkpoint-downloader"
-version = "1.28.1"
+version = "1.28.2"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1961,7 +1961,7 @@ dependencies = [
  "tokio",
  "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
- "typed-store 1.28.1",
+ "typed-store 1.28.2",
  "walrus-sui",
  "walrus-utils",
 ]
@@ -12273,7 +12273,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store"
-version = "1.28.1"
+version = "1.28.2"
 dependencies = [
  "async-trait",
  "bcs",
@@ -12666,7 +12666,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-core"
-version = "1.28.1"
+version = "1.28.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -12691,7 +12691,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-e2e-tests"
-version = "1.28.1"
+version = "1.28.2"
 dependencies = [
  "anyhow",
  "futures",
@@ -12722,7 +12722,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-orchestrator"
-version = "1.28.1"
+version = "1.28.2"
 dependencies = [
  "aws-config",
  "aws-runtime",
@@ -12752,7 +12752,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-proc-macros"
-version = "1.28.1"
+version = "1.28.2"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
@@ -12763,7 +12763,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-proxy"
-version = "1.28.1"
+version = "1.28.2"
 dependencies = [
  "anyhow",
  "axum 0.8.1",
@@ -12802,7 +12802,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-sdk"
-version = "1.28.1"
+version = "1.28.2"
 dependencies = [
  "anyhow",
  "bimap",
@@ -12844,7 +12844,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-service"
-version = "1.28.1"
+version = "1.28.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12933,7 +12933,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "twox-hash 2.1.1",
- "typed-store 1.28.1",
+ "typed-store 1.28.2",
  "utoipa",
  "utoipa-redoc",
  "uuid",
@@ -12948,7 +12948,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-simtest"
-version = "1.28.1"
+version = "1.28.2"
 dependencies = [
  "anyhow",
  "bcs",
@@ -12964,7 +12964,7 @@ dependencies = [
  "sui-types",
  "tokio",
  "tracing",
- "typed-store 1.28.1",
+ "typed-store 1.28.2",
  "walrus-core",
  "walrus-proc-macros",
  "walrus-sdk",
@@ -12976,7 +12976,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-storage-node-client"
-version = "1.28.1"
+version = "1.28.2"
 dependencies = [
  "axum 0.8.1",
  "axum-server 0.7.2",
@@ -13014,7 +13014,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-stress"
-version = "1.28.1"
+version = "1.28.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -13039,7 +13039,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-sui"
-version = "1.28.1"
+version = "1.28.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13092,7 +13092,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-test-utils"
-version = "1.28.1"
+version = "1.28.2"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -13102,7 +13102,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-utils"
-version = "1.28.1"
+version = "1.28.2"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ resolver = "2"
 authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024"
 license = "Apache-2.0"
-version = "1.28.1"
+version = "1.28.2"
 
 [workspace.dependencies]
 anyhow = "1.0.98"

--- a/crates/walrus-service/src/event/event_processor/processor.rs
+++ b/crates/walrus-service/src/event/event_processor/processor.rs
@@ -28,7 +28,7 @@ use crate::event::{
         config::{EventProcessorConfig, EventProcessorRuntimeConfig, SystemConfig},
         db::EventProcessorStores,
     },
-    events::{InitState, PositionedStreamEvent, StreamEventWithInitState},
+    events::{IndexedStreamEvent, InitState, StreamEventWithInitState},
 };
 
 /// The maximum number of events to poll per poll.
@@ -207,12 +207,12 @@ impl EventProcessor {
     }
 
     /// Polls the event store for new events starting from the given sequence number.
-    pub fn poll(&self, from: u64) -> Result<Vec<PositionedStreamEvent>, TypedStoreError> {
+    pub fn poll(&self, from: u64) -> Result<Vec<IndexedStreamEvent>, TypedStoreError> {
         self.stores
             .event_store
             .safe_iter_with_bounds(Some(from), None)
             .take(MAX_EVENTS_PER_POLL)
-            .map(|result| result.map(|(_, event)| event))
+            .map(|result| result.map(IndexedStreamEvent::from_index_and_element))
             .collect()
     }
 

--- a/crates/walrus-service/src/event/events.rs
+++ b/crates/walrus-service/src/event/events.rs
@@ -141,6 +141,11 @@ impl IndexedStreamEvent {
     pub fn new(element: PositionedStreamEvent, index: u64) -> Self {
         Self { element, index }
     }
+
+    /// Creates a new indexed stream element from an index and an element.
+    pub fn from_index_and_element((index, element): (u64, PositionedStreamEvent)) -> Self {
+        Self { element, index }
+    }
 }
 
 /// An indexed element in the event stream with an initialization state.

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -849,6 +849,8 @@ impl StorageNode {
     }
 
     /// Continues the event stream from the last committed event.
+    ///
+    /// Returns the event stream and the event cursor from which the event stream is resumed.
     async fn continue_event_stream(
         &self,
         event_blob_writer_cursor: EventStreamCursor,
@@ -856,24 +858,36 @@ impl StorageNode {
         event_blob_writer: &mut Option<EventBlobWriter>,
     ) -> anyhow::Result<(
         Pin<Box<dyn Stream<Item = PositionedStreamEvent> + Send + Sync + '_>>,
-        u64,
+        EventStreamCursor,
     )> {
         let event_cursor = std::cmp::min(storage_node_cursor, event_blob_writer_cursor);
-        let event_stream = self.inner.event_manager.events(event_cursor).await?;
-        let event_index = event_cursor.element_index;
 
         let init_state = self.inner.event_manager.init_state(event_cursor).await?;
         let Some(init_state) = init_state else {
-            return Ok((Pin::from(event_stream), event_index));
+            tracing::info!(
+                ?event_cursor,
+                "no init state found, resuming from event cursor"
+            );
+            return self.continue_event_stream_from_cursor(event_cursor).await;
         };
 
-        let actual_event_index = init_state.event_cursor.element_index;
+        if init_state.event_cursor == event_cursor {
+            tracing::info!(
+                ?event_cursor,
+                "event cursor is the same as the init state, no repositioning needed"
+            );
+            return self.continue_event_stream_from_cursor(event_cursor).await;
+        }
+
+        tracing::info!(?init_state, "continuing event stream from init_state");
+        let actual_event_cursor = init_state.event_cursor;
+        let actual_event_index = actual_event_cursor.element_index;
 
         let storage_index = storage_node_cursor.element_index;
         let mut storage_node_cursor_repositioned = false;
         if should_reposition_cursor(storage_index, actual_event_index) {
             tracing::info!(
-                "Repositioning storage node cursor from {} to {}",
+                "repositioning storage node cursor from {} to {}",
                 storage_index,
                 actual_event_index
             );
@@ -892,7 +906,7 @@ impl StorageNode {
             let event_blob_writer_index = event_blob_writer_cursor.element_index;
             if should_reposition_cursor(event_blob_writer_index, actual_event_index) {
                 tracing::info!(
-                    "Repositioning event blob writer cursor from {} to {}",
+                    "repositioning event blob writer cursor from {} to {}",
                     event_blob_writer_index,
                     actual_event_index
                 );
@@ -901,14 +915,31 @@ impl StorageNode {
             }
         }
 
-        if !storage_node_cursor_repositioned && !event_blob_writer_repositioned {
-            ensure!(
-                event_index == actual_event_index,
-                "event stream out of sync"
-            );
-        }
+        ensure!(
+            storage_node_cursor_repositioned || event_blob_writer_repositioned,
+            "event stream out of sync"
+        );
 
-        Ok((Pin::from(event_stream), actual_event_index))
+        self.continue_event_stream_from_cursor(actual_event_cursor)
+            .await
+    }
+
+    /// Continues the event stream from the provided event cursor.
+    ///
+    /// Returns the event stream and the provided event cursor.
+    // NB: This is to emphasize that the used event cursor should be the same as the one used to
+    // continue the event stream.
+    async fn continue_event_stream_from_cursor(
+        &self,
+        event_cursor: EventStreamCursor,
+    ) -> anyhow::Result<(
+        Pin<Box<dyn Stream<Item = PositionedStreamEvent> + Send + Sync + '_>>,
+        EventStreamCursor,
+    )> {
+        Ok((
+            Pin::from(self.inner.event_manager.events(event_cursor).await?),
+            event_cursor,
+        ))
     }
 
     async fn get_event_blob_downloader_from_config(
@@ -969,11 +1000,11 @@ impl StorageNode {
             Some(factory) => Some(factory.create().await?),
             None => None,
         };
-        let (event_stream, next_event_index) = self
+        let (event_stream, event_cursor) = self
             .continue_event_stream(writer_cursor, storage_node_cursor, &mut event_blob_writer)
             .await?;
 
-        let index_stream = stream::iter(next_event_index..);
+        let index_stream = stream::iter(event_cursor.element_index..);
         let mut maybe_epoch_at_start = Some(self.inner.committee_service.get_epoch());
 
         let mut indexed_element_stream = index_stream.zip(event_stream);


### PR DESCRIPTION
## Description

Cherry-picks #2273 into the `v1.28` release branch and bumps the version to `v1.28.2`.

## Test plan

See #2273.

---

## Release notes

- [x] Storage node: Fixes an issue that can occur when a node starts with deleted `events` and `event_blob_writer` DBs.
