### PR TITLE
feat(node): configurable sampled tracing interval with increased default

### DIFF
--- a/crates/walrus-service/node_config_example.yaml
+++ b/crates/walrus-service/node_config_example.yaml
@@ -140,6 +140,7 @@ event_processor_config:
       result_queue_buffer_factor: 3
     max_consecutive_pool_monitor_failures: 10
   event_stream_catchup_min_checkpoint_lag: 20000
+  sampled_tracing_interval_secs: 3600
 use_legacy_event_provider: false
 disable_event_blob_writer: false
 commission_rate: 6000

--- a/crates/walrus-service/src/event/event_processor/client.rs
+++ b/crates/walrus-service/src/event/event_processor/client.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Client module for managing Sui RPC and client connections with retry capabilities.
+
 use std::{sync::Arc, time::Duration};
 
 use anyhow::Result;
@@ -58,6 +59,7 @@ impl ClientManager {
         request_timeout: Duration,
         rpc_fallback_config: Option<&RpcFallbackConfig>,
         registry: &Registry,
+        sampled_tracing_interval: Duration,
     ) -> Result<Self, anyhow::Error> {
         let metrics = Arc::new(SuiClientMetricSet::new(registry));
         let lazy_client_builders = rest_urls
@@ -74,6 +76,7 @@ impl ClientManager {
             ExponentialBackoffConfig::default(),
             rpc_fallback_config.cloned(),
             Some(metrics.clone()),
+            sampled_tracing_interval,
         )
         .await?;
 

--- a/crates/walrus-service/src/event/event_processor/config.rs
+++ b/crates/walrus-service/src/event/event_processor/config.rs
@@ -102,6 +102,10 @@ pub struct EventProcessorConfig {
     /// This helps balance between catchup for small lags using checkpoints vs
     /// using event streams for longer checkpoint lags.
     pub event_stream_catchup_min_checkpoint_lag: u64,
+    /// The interval at which to sample high-frequency tracing logs.
+    #[serde_as(as = "DurationSeconds")]
+    #[serde(rename = "sampled_tracing_interval_secs")]
+    pub sampled_tracing_interval: Duration,
 }
 
 impl Default for EventProcessorConfig {
@@ -111,6 +115,7 @@ impl Default for EventProcessorConfig {
             checkpoint_request_timeout: Duration::from_secs(60),
             adaptive_downloader_config: Default::default(),
             event_stream_catchup_min_checkpoint_lag: 20_000,
+            sampled_tracing_interval: Duration::from_secs(3600),
         }
     }
 }

--- a/crates/walrus-utils/Cargo.toml
+++ b/crates/walrus-utils/Cargo.toml
@@ -6,17 +6,17 @@ edition.workspace = true
 license.workspace = true
 
 [features]
-backoff = ["dep:anyhow", "dep:rand", "dep:serde", "dep:serde_with", "dep:tracing", "tokio/time"]
-config = ["dep:anyhow", "dep:home", "dep:serde", "dep:tracing"]
+backoff = ["dep:rand", "dep:serde_with", "tokio/time"]
+config = ["dep:home"]
 default = []
 http = ["dep:bytes", "dep:http-body", "dep:pin-project"]
-log = ["dep:humantime", "dep:once_cell", "dep:tracing"]
+log = ["dep:humantime", "dep:once_cell"]
 metrics = ["dep:once_cell", "dep:prometheus", "dep:tap", "dep:thiserror"]
 test-utils = ["dep:tempfile", "tokio/sync"]
 tokio-metrics = ["dep:tokio-metrics"]
 
 [dependencies]
-anyhow = { workspace = true, optional = true }
+anyhow.workspace = true
 bytes = { workspace = true, optional = true }
 const-str.workspace = true
 git-version.workspace = true
@@ -27,7 +27,7 @@ once_cell = { workspace = true, optional = true }
 pin-project = { workspace = true, optional = true }
 prometheus = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
-serde = { workspace = true, features = ["derive"], optional = true }
+serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, optional = true }
 serde_with = { workspace = true, optional = true }
 serde_yaml = { workspace = true }
@@ -37,12 +37,15 @@ thiserror = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"], optional = true }
 tokio-metrics = { version = "0.4.2", optional = true, default-features = false }
 tokio-util = { workspace = true, optional = true }
-tracing = { workspace = true, optional = true }
+tracing.workspace = true
 tracing-subscriber = { workspace = true, optional = true }
+
+[lints]
+workspace = true
 
 [dev-dependencies]
 http-body-util.workspace = true
 tempfile.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
 tracing-subscriber.workspace = true
 walrus-test-utils.workspace = true

--- a/crates/walrus-utils/src/lib.rs
+++ b/crates/walrus-utils/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(missing_docs)]
+
 use std::{fs, path::Path};
 
 use anyhow::Context;

--- a/crates/walrus-utils/src/metrics.rs
+++ b/crates/walrus-utils/src/metrics.rs
@@ -324,8 +324,8 @@ pub fn concat_labels<'a>(first: &[&'a str], second: &[&'a str]) -> Vec<&'a str> 
     output
 }
 
-/// Increments gauge when acquired, decrements when guard drops
-#[derive(Debug)]
+/// Increments gauge when acquired, decrements when guard drops.
+#[derive(Debug, Clone)]
 #[must_use]
 pub struct OwnedGaugeGuard(IntGauge);
 

--- a/crates/walrus-utils/src/metrics/monitored_scope.rs
+++ b/crates/walrus-utils/src/metrics/monitored_scope.rs
@@ -55,7 +55,7 @@ pub fn get_monitored_scope_metrics() -> Option<&'static MonitoredScopeMetrics> {
     MONITORED_SCOPE_METRICS.get()
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[must_use]
 pub struct MonitoredScopeGuard {
     metrics: &'static MonitoredScopeMetrics,
@@ -68,7 +68,13 @@ impl Drop for MonitoredScopeGuard {
         self.metrics
             .scope_duration_ns
             .with_label_values(&[self.name])
-            .add(self.timer.elapsed().as_nanos() as i64);
+            .add(
+                self.timer
+                    .elapsed()
+                    .as_nanos()
+                    .try_into()
+                    .unwrap_or(i64::MAX),
+            );
         self.metrics
             .scope_entrance
             .with_label_values(&[self.name])

--- a/crates/walrus-utils/src/tracing_sampled.rs
+++ b/crates/walrus-utils/src/tracing_sampled.rs
@@ -3,6 +3,7 @@
 
 pub use humantime::parse_duration;
 pub use once_cell::sync::Lazy;
+
 /// Logs the given statement at most once per specified interval for each call site.
 /// Relies on a static variable per invocation location to track the last emission time.
 /// Includes count of skipped events in the log message when an event is finally emitted.
@@ -21,22 +22,29 @@ pub use once_cell::sync::Lazy;
 /// # Example
 ///
 /// ```rust
-/// use std::time::Duration;
-/// use tracing;
-/// use walrus_utils::tracing_sampled;
-/// use std::thread;
-///
+/// # use std::time::Duration;
+/// # use tracing;
+/// # use walrus_utils::tracing_sampled;
+/// # use std::thread;
+/// #
 /// fn process_item(item_id: u32) {
 ///     // Log processing start max once every 5 seconds for this function call site.
 ///     tracing_sampled::info!("5s", item_id, "starting processing");
 ///     // Simulate work
 ///     thread::sleep(Duration::from_millis(100));
 ///     // Log completion max once every 30 seconds, including skipped count.
-///     tracing_sampled::debug!("30s", item_id, "finished processing item");
+///     tracing_sampled::debug!(Duration::from_secs(30), item_id, "finished processing item");
 /// }
 /// ```
 #[macro_export]
 macro_rules! log {
+    ($interval:literal, $level:ident, $($fields_and_message:tt)*) => {
+        $crate::tracing_sampled::log!(
+            $crate::tracing_sampled::parse_duration($interval).unwrap(),
+            $level,
+            $($fields_and_message)*
+        )
+    };
     ($interval:expr, $level:ident, $($fields_and_message:tt)*) => {
         {
             use std::sync::atomic::{AtomicU64, Ordering};
@@ -47,20 +55,18 @@ macro_rules! log {
             static SKIPPED_COUNT: $crate::tracing_sampled::Lazy<AtomicU64> =
                 $crate::tracing_sampled::Lazy::new(|| AtomicU64::new(0));
 
-            let now_ms = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap_or(Duration::from_secs(0))
-                .as_millis() as u64;
-
             let last_ms = LAST_LOGGED_MS.load(Ordering::Relaxed);
-            let interval_ms =
-                $crate::tracing_sampled::parse_duration($interval).unwrap().as_millis() as u64;
-
-            let should_log = last_ms == 0 || now_ms.saturating_sub(last_ms) >= interval_ms;
+            let last_time = SystemTime::UNIX_EPOCH + Duration::from_millis(last_ms);
+            let now = SystemTime::now();
 
             let mut did_log = false;
-
-            if should_log {
+            if last_time + $interval <= now {
+                let now_ms = now
+                    .duration_since(UNIX_EPOCH)
+                    .expect("we are after the UNIX epoch")
+                    .as_millis()
+                    .try_into()
+                    .expect("the current timestamp should fit in a u64");
                 match LAST_LOGGED_MS.compare_exchange(
                     last_ms,
                     now_ms,
@@ -93,6 +99,7 @@ macro_rules! log {
     };
 }
 
+/// Shorthand for [`log`] with `info` level.
 #[macro_export]
 macro_rules! info {
     ($interval:expr, $($fields_and_message:tt)*) => {
@@ -100,6 +107,7 @@ macro_rules! info {
     };
 }
 
+/// Shorthand for [`log`] with `debug` level.
 #[macro_export]
 macro_rules! debug {
     ($interval:expr, $($fields_and_message:tt)*) => {
@@ -107,6 +115,7 @@ macro_rules! debug {
     };
 }
 
+/// Shorthand for [`log`] with `warn` level.
 #[macro_export]
 macro_rules! warning {
     ($interval:expr, $($fields_and_message:tt)*) => {
@@ -114,6 +123,7 @@ macro_rules! warning {
     };
 }
 
+/// Shorthand for [`log`] with `error` level.
 #[macro_export]
 macro_rules! error {
     ($interval:expr, $($fields_and_message:tt)*) => {
@@ -121,6 +131,7 @@ macro_rules! error {
     };
 }
 
+/// Shorthand for [`log`] with `trace` level.
 #[macro_export]
 macro_rules! trace {
     ($interval:expr, $($fields_and_message:tt)*) => {
@@ -138,9 +149,9 @@ mod tests {
 
     use crate::tracing_sampled;
 
-    #[tokio::test]
-    #[ignore = "ignore long-running test by default"]
+    #[tokio::test(start_paused = true)]
     async fn test_sampled_logging_new_macro() {
+        #![allow(clippy::cast_possible_truncation)]
         let _ = tracing_subscriber::fmt::try_init();
 
         let start = Instant::now();
@@ -148,18 +159,18 @@ mod tests {
         let mut total_calls = 0;
 
         tracing::info!("starting new macro test loop");
-        let test_duration = Duration::from_secs(3);
+        let test_duration = Duration::from_millis(500);
 
         while start.elapsed() < test_duration {
             total_calls += 1;
 
-            if tracing_sampled::info!("1s", iteration = total_calls, "new macro info log") {
+            if tracing_sampled::info!("100ms", iteration = total_calls, "new macro info log") {
                 actual_log_count += 1;
             }
 
-            tracing_sampled::debug!("500ms", "debug check: {}", total_calls);
+            tracing_sampled::debug!(Duration::from_millis(50), "debug check: {}", total_calls);
 
-            tokio::time::sleep(Duration::from_millis(100)).await;
+            tokio::time::sleep(Duration::from_millis(10)).await;
         }
 
         tracing::info!(
@@ -168,16 +179,14 @@ mod tests {
             actual_log_count
         );
 
-        let expected_min_logs = (test_duration.as_millis() as f64 / 1000.0).floor() as usize;
-        let expected_max_logs = (test_duration.as_millis() as f64 / 1000.0).ceil() as usize;
+        let expected_logs = 10.0 * test_duration.as_secs_f64();
+        let expected_min_logs = expected_logs.floor() as usize;
+        let expected_max_logs = expected_logs.ceil() as usize + 1;
 
         assert!(
-            actual_log_count >= expected_min_logs && actual_log_count <= expected_max_logs + 1,
-            "Expected roughly {} logs (between {} and {}), got {}",
-            expected_min_logs,
-            expected_min_logs,
-            expected_max_logs + 1,
-            actual_log_count
+            actual_log_count >= expected_min_logs && actual_log_count <= expected_max_logs,
+            "expected roughly {expected_logs} logs (between {expected_min_logs} and \
+            {expected_max_logs}), got {actual_log_count}"
         );
     }
 }


### PR DESCRIPTION
## Description

Previously, all the interval for all sampled tracing logs was hardcoded to 30 seconds. This caused a lot of emitted logs that were not useful during normal operation.

This adds a new configuration parameter for the event processor config to control this interval. The default is increased to 1 hour.

Some additional changes:
- Allow providing `Duration` values directly in the `tracing_sampled` macro (in addition to literal humantime values).
- Enable lints in the `walrus-utils` crate.
- Fix some dependencies in the `walrus-utils` crate.
- Fix some log messages.
- Some other minor refactoring.

## Test plan

Existing tests.

---

## Release notes

- [x] Storage node: Add a new configuration parameter for the event processor config to control the interval at which sampled logs are emitted with a default of 1 hour (previously 30s).
