### PR TITLE
feat: continue node recovery upon restart if the recovery takes longer than 1 epoch to finish

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -1208,6 +1208,7 @@ impl StorageNode {
         element_index: u64,
         maybe_epoch_at_start: &mut Option<Epoch>,
     ) -> anyhow::Result<()> {
+        sui_macros::fail_point!("fail_point_process_event");
         let _scope = monitored_scope::monitored_scope("ProcessEvent");
 
         let node_status = self.inner.storage.node_status()?;

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -1301,12 +1301,6 @@ impl StorageNode {
             return Ok(());
         };
 
-        // Update initial latest event epoch. This is the first (non-extension) event the node
-        // processes.
-        self.inner
-            .latest_event_epoch_sender
-            .send(Some(event_epoch))?;
-
         tracing::debug!("checking the first contract event if we're severely lagging");
 
         // Clear the starting epoch, so that we won't make this check again in the current run.
@@ -1322,6 +1316,12 @@ impl StorageNode {
             );
             self.inner.set_node_status(NodeStatus::RecoveryCatchUp)?;
         }
+
+        // Update initial latest event epoch. This is the first (non-extension) event the node
+        // processes.
+        self.inner
+            .latest_event_epoch_sender
+            .send(Some(event_epoch))?;
 
         Ok(())
     }

--- a/crates/walrus-service/src/node/blob_event_processor.rs
+++ b/crates/walrus-service/src/node/blob_event_processor.rs
@@ -107,7 +107,10 @@ impl BackgroundEventProcessor {
             || self.node.storage.node_status()?.is_catching_up()
             || self
                 .node
-                .is_stored_at_all_shards_at_epoch(&event.blob_id, self.node.current_event_epoch())
+                .is_stored_at_all_shards_at_epoch(
+                    &event.blob_id,
+                    self.node.current_event_epoch().expect("current event epoch should be set"),
+                )
                 .await?
         {
             event_handle.mark_as_complete();

--- a/crates/walrus-service/src/node/blob_event_processor.rs
+++ b/crates/walrus-service/src/node/blob_event_processor.rs
@@ -109,7 +109,7 @@ impl BackgroundEventProcessor {
                 .node
                 .is_stored_at_all_shards_at_epoch(
                     &event.blob_id,
-                    self.node.current_event_epoch().expect("current event epoch should be set"),
+                    self.node.current_event_epoch().await?,
                 )
                 .await?
         {

--- a/crates/walrus-service/src/node/blob_sync.rs
+++ b/crates/walrus-service/src/node/blob_sync.rs
@@ -578,10 +578,7 @@ impl BlobSynchronizer {
                     "shard assignment must be found at the certified epoch {}",
                     latest_event_epoch
                 );
-                panic!(
-                    "shard assignment must be found at the certified epoch {}",
-                    latest_event_epoch
-                )
+                panic!("shard assignment must be found at the certified epoch {latest_event_epoch}")
             })
             .into_iter()
             .map(|shard| {

--- a/crates/walrus-service/src/node/blob_sync.rs
+++ b/crates/walrus-service/src/node/blob_sync.rs
@@ -561,15 +561,23 @@ impl BlobSynchronizer {
         // recovering all the missing blobs.
         let futures_iter = self
             .node
-            .owned_shards_at_epoch(self.node.current_event_epoch())
+            .owned_shards_at_epoch(
+                self.node
+                    .current_event_epoch()
+                    .expect("current event epoch should be set"),
+            )
             .unwrap_or_else(|_| {
                 tracing::error!(
                     "shard assignment must be found at the certified epoch {}",
-                    self.node.current_event_epoch()
+                    self.node
+                        .current_event_epoch()
+                        .expect("current event epoch should be set")
                 );
                 panic!(
                     "shard assignment must be found at the certified epoch {}",
-                    self.node.current_event_epoch()
+                    self.node
+                        .current_event_epoch()
+                        .expect("current event epoch should be set")
                 )
             })
             .into_iter()

--- a/crates/walrus-service/src/node/blob_sync.rs
+++ b/crates/walrus-service/src/node/blob_sync.rs
@@ -274,6 +274,9 @@ impl BlobSyncHandler {
             .remove(blob_id);
     }
 
+    /// Starts a blob sync for the given `blob_id` and `certified_epoch`.
+    ///
+    /// Returns a `Notify` that is notified when the sync task is finished.
     #[tracing::instrument(skip_all, fields(otel.kind = "PRODUCER"))]
     pub async fn start_sync(
         &self,
@@ -286,8 +289,7 @@ impl BlobSyncHandler {
             .lock()
             .expect("should be able to acquire lock");
 
-        let finish_notify = Arc::new(Notify::new());
-        match in_progress.entry(blob_id) {
+        let finish_notify = match in_progress.entry(blob_id) {
             Entry::Vacant(entry) => {
                 let spawned_trace = tracing::info_span!(
                     parent: &Span::current(),
@@ -307,6 +309,7 @@ impl BlobSyncHandler {
                     "error.type" = field::Empty,
                 );
                 spawned_trace.follows_from(Span::current());
+                let finish_notify = Arc::new(Notify::new());
 
                 let cancel_token = CancellationToken::new();
                 let synchronizer = BlobSynchronizer::new(
@@ -333,16 +336,19 @@ impl BlobSyncHandler {
                 entry.insert(InProgressSyncHandle {
                     cancel_token,
                     blob_sync_handle: Some(sync_handle),
+                    finish_notify: finish_notify.clone(),
                 });
+                finish_notify
             }
-            Entry::Occupied(_) => {
+            Entry::Occupied(existing_sync) => {
                 // A blob sync with a lower sequence number is already in progress. We can safely
                 // try to increase the event cursor since it will only be advanced once that sync is
                 // finished or cancelled due to an invalid blob event.
                 event_handle.mark_as_complete();
-                finish_notify.notify_one();
+
+                existing_sync.get().finish_notify.clone()
             }
-        }
+        };
         Ok(finish_notify)
     }
 
@@ -441,6 +447,7 @@ type SyncJoinHandle = JoinHandle<Option<EventHandle>>;
 struct InProgressSyncHandle {
     cancel_token: CancellationToken,
     blob_sync_handle: Option<SyncJoinHandle>,
+    finish_notify: Arc<Notify>,
 }
 
 impl InProgressSyncHandle {
@@ -448,6 +455,7 @@ impl InProgressSyncHandle {
     // `blob_syncs_in_progress`.
     fn cancel(&mut self) -> Option<SyncJoinHandle> {
         self.cancel_token.cancel();
+        self.finish_notify.notify_one();
         self.blob_sync_handle.take()
     }
 }

--- a/crates/walrus-service/src/node/node_recovery.rs
+++ b/crates/walrus-service/src/node/node_recovery.rs
@@ -242,29 +242,18 @@ impl NodeRecoveryHandler {
     }
 
     /// Restarts any in progress recovery.
-    pub async fn restart_recovery(&self) -> Result<(), TypedStoreError> {
+    pub async fn restart_recovery(&self) -> anyhow::Result<()> {
         if let NodeStatus::RecoveryInProgress(recovering_epoch) = self.node.storage.node_status()? {
-            // Wait until the latest_event_epoch watcher is set to Some(epoch)
-            let mut watcher = self.node.latest_event_epoch_watcher();
-
             tracing::info!("waiting for latest event epoch to be set to restart node recovery");
-
-            // Wait for the node.latest_event_epoch is initialized, so that the node recovery
-            // task can start.
-            while watcher.borrow().is_none() {
-                watcher
-                    .changed()
-                    .await
-                    .expect("watcher should not be closed");
-            }
-
+            self.node.current_event_epoch().await?;
             tracing::info!(
                 "restarting node recovery to recover to the epoch {}",
                 recovering_epoch
             );
 
-            return self.start_node_recovery(recovering_epoch).await;
+            self.start_node_recovery(recovering_epoch).await?;
         }
+
         Ok(())
     }
 }

--- a/crates/walrus-service/src/node/node_recovery.rs
+++ b/crates/walrus-service/src/node/node_recovery.rs
@@ -149,6 +149,7 @@ impl NodeRecoveryHandler {
 
                     tracing::debug!(
                         walrus.blob_id = %blob_id,
+                        recoverying_epoch = certified_before_epoch,
                         "start recovery sync for blob"
                     );
                     node.metrics.node_recovery_ongoing_blob_syncs.inc();
@@ -232,6 +233,8 @@ impl NodeRecoveryHandler {
             // Wait until the latest_event_epoch watcher is set to Some(epoch)
             let mut watcher = self.node.latest_event_epoch_watcher();
 
+            tracing::info!("waiting for latest event epoch to be set to restart node recovery");
+
             // Wait for the node.latest_event_epoch is initialized, so that the node recovery
             // task can start.
             while watcher.borrow().is_none() {
@@ -240,6 +243,11 @@ impl NodeRecoveryHandler {
                     .await
                     .expect("watcher should not be closed");
             }
+
+            tracing::info!(
+                "restarting node recovery to recover to the epoch {}",
+                recovering_epoch
+            );
 
             return self.start_node_recovery(recovering_epoch).await;
         }

--- a/crates/walrus-simtest/src/test_utils.rs
+++ b/crates/walrus-simtest/src/test_utils.rs
@@ -8,7 +8,7 @@ pub mod simtest_utils {
     use std::{
         collections::{HashMap, HashSet},
         sync::{Arc, Mutex, atomic::AtomicBool},
-        time::Duration,
+        time::{Duration, Instant},
     };
 
     use anyhow::Context;
@@ -615,5 +615,48 @@ pub mod simtest_utils {
                 .id(),
             );
         }
+    }
+
+    /// Simulates repeated node crash and restart with sim node id.
+    pub fn repeatedly_crash_target_node(
+        target_node_id: sui_simulator::task::NodeId,
+        next_fail_triggered_clone: Arc<Mutex<Instant>>,
+        crash_end_time: Instant,
+        min_crash_duration_secs: u64,
+        max_crash_duration_secs: u64,
+        min_live_duration_secs: u64,
+        max_live_duration_secs: u64,
+    ) {
+        let time_now = Instant::now();
+        if time_now > crash_end_time {
+            // No more crash is needed.
+            return;
+        }
+
+        if time_now < *next_fail_triggered_clone.lock().unwrap() {
+            // Not time to crash yet.
+            return;
+        }
+
+        let current_node = sui_simulator::current_simnode_id();
+        if target_node_id != current_node {
+            return;
+        }
+
+        let mut rng = rand::thread_rng();
+
+        let node_down_duration =
+            Duration::from_secs(rng.gen_range(min_crash_duration_secs..=max_crash_duration_secs));
+        let next_crash_time = Instant::now()
+            + node_down_duration
+            + Duration::from_secs(rng.gen_range(min_live_duration_secs..=max_live_duration_secs));
+
+        tracing::warn!(
+            "crashing node {current_node} for {} seconds; next crash is set to {:?}",
+            node_down_duration.as_secs(),
+            next_crash_time
+        );
+        sui_simulator::task::kill_current_node(Some(node_down_duration));
+        *next_fail_triggered_clone.lock().unwrap() = next_crash_time;
     }
 }

--- a/crates/walrus-simtest/src/test_utils.rs
+++ b/crates/walrus-simtest/src/test_utils.rs
@@ -647,14 +647,16 @@ pub mod simtest_utils {
 
         let node_down_duration =
             Duration::from_secs(rng.gen_range(min_crash_duration_secs..=max_crash_duration_secs));
-        let next_crash_time = Instant::now()
-            + node_down_duration
+        let next_crash_after = node_down_duration
             + Duration::from_secs(rng.gen_range(min_live_duration_secs..=max_live_duration_secs));
+        let next_crash_time = time_now + next_crash_after;
 
         tracing::warn!(
-            "crashing node {current_node} for {} seconds; next crash is set to {:?}",
+            "crashing node {current_node} for {} seconds; next crash is set to {:?} after {} \
+            seconds",
             node_down_duration.as_secs(),
-            next_crash_time
+            next_crash_time,
+            next_crash_after.as_secs(),
         );
         sui_simulator::task::kill_current_node(Some(node_down_duration));
         *next_fail_triggered_clone.lock().unwrap() = next_crash_time;

--- a/crates/walrus-simtest/tests/simtest.rs
+++ b/crates/walrus-simtest/tests/simtest.rs
@@ -750,8 +750,8 @@ mod tests {
         blob_info_consistency_check.check_storage_node_consistency();
     }
 
-    // The node recovery process is artificially prolonged to be longer than 1 epoch.
-    // We should expect the recovering node should eventually become Active.
+    // Tests that when a node is in RecoveryInProgress state, restarting the node repeatedly
+    // will not cause the node to be stuck/malfunction.
     #[ignore = "ignore integration simtests by default"]
     #[walrus_simtest]
     async fn test_recovery_in_progress_with_node_restart() {
@@ -832,7 +832,7 @@ mod tests {
         {
             let next_fail_triggered = Arc::new(Mutex::new(Instant::now()));
             let next_fail_triggered_clone = next_fail_triggered.clone();
-            let crash_end_time = Instant::now() + Duration::from_secs(60);
+            let crash_end_time = Instant::now() + Duration::from_secs(120);
             let target_fail_node_id = walrus_cluster.nodes[0]
                 .node_id
                 .expect("node id should be set");

--- a/crates/walrus-simtest/tests/simtest.rs
+++ b/crates/walrus-simtest/tests/simtest.rs
@@ -38,6 +38,7 @@ mod tests {
         self,
         BlobInfoConsistencyCheck,
         CRASH_NODE_FAIL_POINTS,
+        NodeCrashConfig,
         repeatedly_crash_target_node,
     };
     use walrus_storage_node_client::api::ShardStatus;
@@ -842,10 +843,12 @@ mod tests {
                     target_fail_node_id,
                     next_fail_triggered_clone.clone(),
                     crash_end_time,
-                    /* min_crash_duration_secs */ 1,
-                    /* max_crash_duration_secs */ 3,
-                    /* min_live_duration_secs */ 5,
-                    /* max_live_duration_secs */ 40,
+                    NodeCrashConfig {
+                        min_crash_duration_secs: 1,
+                        max_crash_duration_secs: 3,
+                        min_live_duration_secs: 5,
+                        max_live_duration_secs: 40,
+                    },
                 );
             });
         }

--- a/crates/walrus-simtest/tests/simtest.rs
+++ b/crates/walrus-simtest/tests/simtest.rs
@@ -10,9 +10,10 @@ mod tests {
         collections::HashSet,
         sync::{
             Arc,
+            Mutex,
             atomic::{AtomicBool, Ordering},
         },
-        time::Duration,
+        time::{Duration, Instant},
     };
 
     use rand::{Rng, SeedableRng};
@@ -37,6 +38,7 @@ mod tests {
         self,
         BlobInfoConsistencyCheck,
         CRASH_NODE_FAIL_POINTS,
+        repeatedly_crash_target_node,
     };
     use walrus_storage_node_client::api::ShardStatus;
     use walrus_sui::client::ReadClient;
@@ -746,5 +748,131 @@ mod tests {
         }
 
         blob_info_consistency_check.check_storage_node_consistency();
+    }
+
+    // The node recovery process is artificially prolonged to be longer than 1 epoch.
+    // We should expect the recovering node should eventually become Active.
+    #[ignore = "ignore integration simtests by default"]
+    #[walrus_simtest]
+    async fn test_recovery_in_progress_with_node_restart() {
+        let (_sui_cluster, walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
+            .with_epoch_duration(Duration::from_secs(30))
+            .with_test_nodes_config(TestNodesConfig {
+                node_weights: vec![1, 2, 3, 3, 4],
+                use_legacy_event_processor: false,
+                ..Default::default()
+            })
+            .with_communication_config(
+                ClientCommunicationConfig::default_for_test_with_reqwest_timeout(
+                    Duration::from_secs(2),
+                ),
+            )
+            .with_default_num_checkpoints_per_blob()
+            .build_generic::<SimStorageNodeHandle>()
+            .await
+            .unwrap();
+
+        let blob_info_consistency_check = BlobInfoConsistencyCheck::new();
+
+        let client_arc = Arc::new(client);
+
+        // Starts a background workload that a client keeps writing and retrieving data.
+        // All requests should succeed even if a node crashes.
+        let workload_handle =
+            simtest_utils::start_background_workload(client_arc.clone(), false, 0, None);
+
+        // Run the workload to get some data in the system.
+        tokio::time::sleep(Duration::from_secs(60)).await;
+
+        // Register a fail point to have a temporary pause in the first node recovery process that
+        // is longer than epoch length.
+        // Note that when a node is in RecoveryInProgress state, it will not start a new recovery
+        // everytime when a new epoch change start event is processed. So here we only delay the
+        // first recovery.
+        let delay_triggered = Arc::new(AtomicBool::new(false));
+        register_fail_point_async("start_node_recovery_entry", move || {
+            let delay_triggered_clone = delay_triggered.clone();
+            async move {
+                if !delay_triggered_clone.load(Ordering::SeqCst) {
+                    delay_triggered_clone.store(true, Ordering::SeqCst);
+                    tracing::info!("delaying node recovery for 60s");
+                    tokio::time::sleep(Duration::from_secs(60)).await;
+                }
+            }
+        });
+
+        // First, trigger a node crash with long delay to bring node into recovery mode.
+        {
+            // Tracks if a crash has been triggered.
+            let fail_triggered = Arc::new(AtomicBool::new(false));
+            let target_fail_node_id = walrus_cluster.nodes[0]
+                .node_id
+                .expect("node id should be set");
+            let fail_triggered_clone = fail_triggered.clone();
+
+            register_fail_point("fail_point_process_event", move || {
+                crash_target_node(
+                    target_fail_node_id,
+                    fail_triggered_clone.clone(),
+                    Duration::from_secs(60),
+                );
+            });
+
+            // Wait until fail_triggered is set to true with a timeout.
+            let timeout = Instant::now() + Duration::from_secs(20);
+            while !fail_triggered.load(Ordering::SeqCst) {
+                if Instant::now() > timeout {
+                    panic!("fail_triggered is not set to true within 20 seconds");
+                }
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+        }
+
+        // During recovery, repeatedly restart the node.
+        {
+            let next_fail_triggered = Arc::new(Mutex::new(Instant::now()));
+            let next_fail_triggered_clone = next_fail_triggered.clone();
+            let crash_end_time = Instant::now() + Duration::from_secs(60);
+            let target_fail_node_id = walrus_cluster.nodes[0]
+                .node_id
+                .expect("node id should be set");
+
+            sui_macros::register_fail_points(CRASH_NODE_FAIL_POINTS, move || {
+                repeatedly_crash_target_node(
+                    target_fail_node_id,
+                    next_fail_triggered_clone.clone(),
+                    crash_end_time,
+                    /* min_crash_duration_secs */ 1,
+                    /* max_crash_duration_secs */ 3,
+                    /* min_live_duration_secs */ 5,
+                    /* max_live_duration_secs */ 40,
+                );
+            });
+        }
+
+        tokio::time::sleep(Duration::from_secs(180)).await;
+
+        let node_health_info = simtest_utils::get_nodes_health_info(&walrus_cluster.nodes).await;
+
+        assert!(node_health_info[0].shard_detail.is_some());
+        for shard in &node_health_info[0].shard_detail.as_ref().unwrap().owned {
+            // For all the shards that the crashed node owns, they should be in ready state.
+            assert_eq!(shard.status, ShardStatus::Ready);
+        }
+
+        assert_eq!(
+            simtest_utils::get_nodes_health_info([&walrus_cluster.nodes[0]])
+                .await
+                .get(0)
+                .unwrap()
+                .node_status,
+            "Active"
+        );
+
+        workload_handle.abort();
+
+        blob_info_consistency_check.check_storage_node_consistency();
+
+        clear_fail_point("start_node_recovery_entry");
     }
 }

--- a/crates/walrus-simtest/tests/simtest_failure.rs
+++ b/crates/walrus-simtest/tests/simtest_failure.rs
@@ -28,6 +28,7 @@ mod tests {
         self,
         BlobInfoConsistencyCheck,
         CRASH_NODE_FAIL_POINTS,
+        repeatedly_crash_target_node,
     };
     use walrus_storage_node_client::api::ShardStatus;
     use walrus_sui::client::ReadClient;
@@ -330,42 +331,6 @@ mod tests {
         blob_info_consistency_check.check_storage_node_consistency();
     }
 
-    // Simulates repeated node crash and restart with sim node id.
-    fn repeatedly_crash_target_node(
-        target_node_id: sui_simulator::task::NodeId,
-        next_fail_triggered_clone: Arc<Mutex<Instant>>,
-        crash_end_time: Instant,
-    ) {
-        let time_now = Instant::now();
-        if time_now > crash_end_time {
-            // No more crash is needed.
-            return;
-        }
-
-        if time_now < *next_fail_triggered_clone.lock().unwrap() {
-            // Not time to crash yet.
-            return;
-        }
-
-        let current_node = sui_simulator::current_simnode_id();
-        if target_node_id != current_node {
-            return;
-        }
-
-        let mut rng = rand::thread_rng();
-        let node_down_duration = Duration::from_secs(rng.gen_range(5..=25));
-        let next_crash_time =
-            Instant::now() + node_down_duration + Duration::from_secs(rng.gen_range(5..=25));
-
-        tracing::warn!(
-            "crashing node {current_node} for {} seconds; next crash is set to {:?}",
-            node_down_duration.as_secs(),
-            next_crash_time
-        );
-        sui_simulator::task::kill_current_node(Some(node_down_duration));
-        *next_fail_triggered_clone.lock().unwrap() = next_crash_time;
-    }
-
     // This integration test simulates a scenario where a node is repeatedly crashing and
     // recovering.
     #[ignore = "ignore integration simtests by default"]
@@ -442,6 +407,10 @@ mod tests {
                 target_fail_node_id,
                 next_fail_triggered_clone.clone(),
                 crash_end_time,
+                5,
+                25,
+                5,
+                25,
             );
         });
 

--- a/crates/walrus-simtest/tests/simtest_failure.rs
+++ b/crates/walrus-simtest/tests/simtest_failure.rs
@@ -407,10 +407,10 @@ mod tests {
                 target_fail_node_id,
                 next_fail_triggered_clone.clone(),
                 crash_end_time,
-                5,
-                25,
-                5,
-                25,
+                /* min_crash_duration_secs */ 5,
+                /* max_crash_duration_secs */ 25,
+                /* min_live_duration_secs */ 5,
+                /* max_live_duration_secs */ 25,
             );
         });
 

--- a/crates/walrus-simtest/tests/simtest_failure.rs
+++ b/crates/walrus-simtest/tests/simtest_failure.rs
@@ -28,6 +28,7 @@ mod tests {
         self,
         BlobInfoConsistencyCheck,
         CRASH_NODE_FAIL_POINTS,
+        NodeCrashConfig,
         repeatedly_crash_target_node,
     };
     use walrus_storage_node_client::api::ShardStatus;
@@ -407,10 +408,12 @@ mod tests {
                 target_fail_node_id,
                 next_fail_triggered_clone.clone(),
                 crash_end_time,
-                /* min_crash_duration_secs */ 5,
-                /* max_crash_duration_secs */ 25,
-                /* min_live_duration_secs */ 5,
-                /* max_live_duration_secs */ 25,
+                NodeCrashConfig {
+                    min_crash_duration_secs: 5,
+                    max_crash_duration_secs: 25,
+                    min_live_duration_secs: 5,
+                    max_live_duration_secs: 25,
+                },
             );
         });
 


### PR DESCRIPTION
## Description

Previously, storage node assumed that a node recovery should finish within 1 epoch length, and if during node
restart, the node sees it is in RecoveryInProgress(epoch) state, and the epoch is lagging behind, it assumed that
the node is lagging again, and then directly enter RecoveryCatchUp mode.

However in practice, we have seen that it is not uncommon that the RecoveryInProgress takes more than 1 epoch.
Restarting node after epoch change would make the node goes back to RecoveryCatchup mode and therefore
not recovering any blobs until next epoch change, which can be 1 epoch length away (2 weeks on mainnet)

This PR addresses this issue by allowing in progress node recovery to continue after node restart. A list of changes
are made to achieve this goal:
- During epoch change, ongoing node recovery will be restarted to recovery to the new epoch, so that RecoveryInProgress should not lag.
- Previously, blob sync initiated during node recovery does not wait for any existing blob sync of the same blob to finish. Since now we need to restart node recovery during epoch change, we *have to* wait for any ongoing blob sync.
- Change latest event epoch using a tokio channel. Any functionality that requires it waits for it to become available and then proceed. There are mainly 2 places: (1) blob recovery, and (2) node recovery. 

Resolve WAL-917

## Test plan

Existing simtest. New simtest.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
