### PR TITLE
fix(cli): Avoid unnecessary sui_read_client initialization in blob_id command

### DIFF
--- a/crates/walrus-service/src/client/cli/runner.rs
+++ b/crates/walrus-service/src/client/cli/runner.rs
@@ -1045,23 +1045,17 @@ impl ClientCommandRunner {
         rpc_url: Option<String>,
         encoding_type: Option<EncodingType>,
     ) -> Result<()> {
-        let (n_shards, encoding_type) = if let (Some(n_shards), Some(encoding_type)) =
-            (n_shards, encoding_type)
-        {
-            (n_shards, encoding_type)
+        let n_shards = if let Some(n_shards) = n_shards {
+            n_shards
         } else {
             let config = self.config?;
             let sui_read_client =
                 get_sui_read_client_from_rpc_node_or_wallet(&config, rpc_url, self.wallet).await?;
-            let n_shards = if let Some(n_shards) = n_shards {
-                n_shards
-            } else {
-                tracing::debug!("reading `n_shards` from chain");
-                sui_read_client.current_committee().await?.n_shards()
-            };
-            let encoding_type = encoding_type.unwrap_or(DEFAULT_ENCODING);
-            (n_shards, encoding_type)
+            tracing::debug!("reading `n_shards` from chain");
+            sui_read_client.current_committee().await?.n_shards()
         };
+
+        let encoding_type = encoding_type.unwrap_or(DEFAULT_ENCODING);
 
         tracing::debug!(%n_shards, "encoding the blob");
         let spinner = styled_spinner();


### PR DESCRIPTION
## Description

This PR addresses an issue in the `ClientCommandRunner::blob_id` method, where a sui_read_client was being unnecessarily initialized, even when the `n_shards` argument was provided. This was leading to some rate-limit issues on the `walrus-sites/site-builder`, particularly when trying to deploy a site with a large number of files. 

Related [linear issue](https://linear.app/mysten-labs/issue/SEW-288/error-error-while-computing-the-blob-id-for-path) & [walrus-sites PR](https://github.com/MystenLabs/walrus-sites/pull/512). 

Initially I fixed the issue on the site-builder repo by supplying the `encoding_type` as well, when running the `blob_id` method, however, after discussing with my team, we feel it makes more sense to address this here, especially since it is a tiny change. 

On a side note, it seems weird that just the initialization of the sui_read_client was enough to cause rate limits. In the specific walrus-sites related case, the sui_read_client doesn't make any calls ([that](https://github.com/MystenLabs/walrus/blob/429d070f72d9fb20e7a8a20fc0dd757938f66bae/crates/walrus-service/src/client/cli/runner.rs#L1054C17-L1054C70) "else" statement does not get reached, since we provide the "n_shards" beforehand)

## Test plan

Ran the pre-commit tests, as well as manual testing.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
