### PR TITLE
chore: sending checkpoint to download checking if the channel is full

### DIFF
--- a/crates/checkpoint-downloader/src/config.rs
+++ b/crates/checkpoint-downloader/src/config.rs
@@ -134,11 +134,11 @@ impl Default for AdaptiveDownloaderConfig {
 
 impl AdaptiveDownloaderConfig {
     pub(crate) fn message_queue_size(&self) -> usize {
-        self.max_workers * self.channel_config.work_queue_buffer_factor
+        self.max_workers * self.channel_config.work_queue_buffer_factor * 2
     }
 
     pub(crate) fn checkpoint_queue_size(&self) -> usize {
-        self.max_workers * self.channel_config.work_queue_buffer_factor
+        self.max_workers * self.channel_config.work_queue_buffer_factor * 2
     }
 
     pub(crate) fn result_queue_size(&self) -> usize {

--- a/crates/checkpoint-downloader/src/metrics.rs
+++ b/crates/checkpoint-downloader/src/metrics.rs
@@ -3,32 +3,19 @@
 
 //! Metrics for the checkpoint downloader.
 
-use prometheus::{IntGauge, register_int_gauge_with_registry};
-use walrus_utils::metrics::Registry;
+use prometheus::IntGauge;
 
-#[derive(Clone, Debug)]
-pub(crate) struct AdaptiveDownloaderMetrics {
-    /// The number of checkpoint downloader workers.
-    pub num_workers: IntGauge,
-    /// The current checkpoint lag between the local store and the full node.
-    pub checkpoint_lag: IntGauge,
-}
-
-impl AdaptiveDownloaderMetrics {
-    pub fn new(registry: &Registry) -> Self {
-        Self {
-            num_workers: register_int_gauge_with_registry!(
-                "checkpoint_downloader_num_workers",
-                "Number of workers active in the worker pool",
-                registry,
-            )
-            .expect("this is a valid metrics registration"),
-            checkpoint_lag: register_int_gauge_with_registry!(
-                "checkpoint_downloader_checkpoint_lag",
-                "Current checkpoint lag between local store and full node",
-                registry,
-            )
-            .expect("this is a valid metrics registration"),
-        }
+walrus_utils::metrics::define_metric_set! {
+    #[namespace = "checkpoint_downloader"]
+    /// Metrics for the event processor.
+    pub struct AdaptiveDownloaderMetrics {
+        #[help = "Number of workers active in the worker pool"]
+        num_workers: IntGauge[],
+        #[help = "Current checkpoint lag between local store and full node"]
+        checkpoint_lag: IntGauge[],
+        #[help = "Number of inflight checkpoint downloads"]
+        num_inflight_downloading: IntGauge[],
+        #[help = "Number of checkpoints pending processing"]
+        num_pending_processing_checkpoints: IntGauge[],
     }
 }


### PR DESCRIPTION
## Description

When the channel is full, sending may be blocked, and at the same time, we cannot consume any checkpoints, so the loop
may be stuck forever.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
