### PR TITLE
chore: move Restore command out of LocalAdmin.

### DIFF
--- a/crates/walrus-service/bin/node.rs
+++ b/crates/walrus-service/bin/node.rs
@@ -1119,8 +1119,8 @@ mod commands {
 
         let target_checkpoint = checkpoint_id.map_or("latest".to_string(), |id| id.to_string());
         println!(
-            "Restore from {target_checkpoint} successfully. The node must be restarted for changes \
-            to take effect."
+            "Restored from {target_checkpoint} successfully. The node must be restarted for \
+            changes to take effect."
         );
 
         Ok(())

--- a/crates/walrus-service/src/node/db_checkpoint.rs
+++ b/crates/walrus-service/src/node/db_checkpoint.rs
@@ -284,7 +284,7 @@ impl DbCheckpointManager {
         db: Arc<RocksDB>,
         config: DbCheckpointConfig,
     ) -> Result<Self, DbCheckpointError> {
-        tracing::info!("DbCheckpointManager starting with config: {:?}", config);
+        tracing::info!(?config, "DbCheckpointManager starting...");
         if let Some(db_checkpoint_dir) = config.db_checkpoint_dir.as_ref() {
             create_dir_all(db_checkpoint_dir).map_err(|e| DbCheckpointError::Other(e.into()))?;
         }


### PR DESCRIPTION
## Description

Move `Restore` out of `LocalAdmin` since it doesn't require communication with a running storage node.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
