### PR TITLE
chore: add `must_use` attribute to guard structs

### DIFF
--- a/crates/walrus-sui/src/client/retry_client/retry_count_guard.rs
+++ b/crates/walrus-sui/src/client/retry_client/retry_count_guard.rs
@@ -8,6 +8,8 @@ use super::ToErrorType;
 use crate::client::SuiClientMetricSet;
 
 /// A guard that records the number of retries and the result of an RPC call.
+#[derive(Debug)]
+#[must_use]
 pub(crate) struct RetryCountGuard {
     pub(crate) method: String,
     pub(crate) count: u64,

--- a/crates/walrus-utils/src/metrics.rs
+++ b/crates/walrus-utils/src/metrics.rs
@@ -325,6 +325,8 @@ pub fn concat_labels<'a>(first: &[&'a str], second: &[&'a str]) -> Vec<&'a str> 
 }
 
 /// Increments gauge when acquired, decrements when guard drops
+#[derive(Debug)]
+#[must_use]
 pub struct OwnedGaugeGuard(IntGauge);
 
 impl OwnedGaugeGuard {

--- a/crates/walrus-utils/src/metrics/monitored_scope.rs
+++ b/crates/walrus-utils/src/metrics/monitored_scope.rs
@@ -55,6 +55,8 @@ pub fn get_monitored_scope_metrics() -> Option<&'static MonitoredScopeMetrics> {
     MONITORED_SCOPE_METRICS.get()
 }
 
+#[derive(Debug)]
+#[must_use]
 pub struct MonitoredScopeGuard {
     metrics: &'static MonitoredScopeMetrics,
     name: &'static str,


### PR DESCRIPTION

## Description

Adding this annotation avoids accidentally dropping the guards immediately after creating them (such as those fixed in #2295).

## Test plan

Not needed.