### PR TITLE
docs: improve installation instructions

### DIFF
--- a/.github/workflows/update-ws-install.yaml
+++ b/.github/workflows/update-ws-install.yaml
@@ -1,0 +1,50 @@
+name: Update install.wal.app site
+
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - "setup/walrus-install.sh"
+      - ".github/workflows/update-ws-install.yaml"
+  workflow_dispatch:
+  schedule:
+    # Update Walrus Site every first day of the month at 03:14 UTC.
+    - cron: "14 3 1 * *"
+
+concurrency: ci-${{ github.ref }}
+
+permissions:
+  contents: read
+
+jobs:
+  # We store the data for the Sui wallet and the site object in GitHub variables
+  # (https://github.com/MystenLabs/walrus/settings/variables/actions) and secrets
+  # (https://github.com/MystenLabs/walrus/settings/secrets/actions).
+  update-bin-walrus-site:
+    name: Update install.wal.app
+    runs-on: ubuntu-ghcloud
+    env:
+      # Colors don't seem to work properly with the multiline commands.
+      NO_COLOR: 1
+      RUST_LOG: info
+      EPOCHS: max
+      BUILD_DIR: site
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+      - uses: ./.github/actions/set-up-walrus
+        with:
+          SUI_ADDRESS: "${{ vars.SUI_ADDRESS }}"
+          SUI_KEYSTORE: "${{ secrets.SUI_KEYSTORE }}"
+          WALRUS_CONFIG: "${{ vars.WALRUS_CONFIG }}"
+          SUI_NETWORK: mainnet
+
+      - name: Create temporary directory
+        run: "mkdir -p ${{ env.BUILD_DIR }}"
+      - name: Copy install script
+        run: "cp setup/walrus-install.sh ${{ env.BUILD_DIR }}"
+      - name: Write WS resources file
+        run: echo ${{ vars.WALRUS_SITE_INSTALL_WS_RESOURCES }} > ${{ env.BUILD_DIR }}/ws-resources.json
+
+      - name: Update Walrus Site
+        run: site-builder deploy ${{ env.BUILD_DIR }} --epochs ${{ env.EPOCHS }} --check-extend

--- a/docs/book/usage/setup.md
+++ b/docs/book/usage/setup.md
@@ -72,6 +72,7 @@ Windows. The Ubuntu version most likely works on other Linux distributions as we
 | ------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | Ubuntu  | Intel 64bit           | [`ubuntu-x86_64`](https://storage.googleapis.com/mysten-walrus-binaries/walrus-mainnet-latest-ubuntu-x86_64)                 |
 | Ubuntu  | Intel 64bit (generic) | [`ubuntu-x86_64-generic`](https://storage.googleapis.com/mysten-walrus-binaries/walrus-mainnet-latest-ubuntu-x86_64-generic) |
+| Ubuntu  | ARM 64bit             | [`ubuntu-aarch64`](https://storage.googleapis.com/mysten-walrus-binaries/walrus-mainnet-latest-ubuntu-aarch64)               |
 | MacOS   | Apple Silicon         | [`macos-arm64`](https://storage.googleapis.com/mysten-walrus-binaries/walrus-mainnet-latest-macos-arm64)                     |
 | MacOS   | Intel 64bit           | [`macos-x86_64`](https://storage.googleapis.com/mysten-walrus-binaries/walrus-mainnet-latest-macos-x86_64)                   |
 | Windows | Intel 64bit           | [`windows-x86_64.exe`](https://storage.googleapis.com/mysten-walrus-binaries/walrus-mainnet-latest-windows-x86_64.exe)       |
@@ -79,18 +80,18 @@ Windows. The Ubuntu version most likely works on other Linux distributions as we
 ### Install via script {#nix-install}
 
 To download and install `walrus` to your `"$HOME"/.local/bin` directory, run one of the following
-commands in your terminal then follow on-screen instructions. See [Windows
-instructions](#windows-install) if you are on Windows.
+commands in your terminal then follow on-screen instructions. If you are on Windows, see the
+[Windows-specific instructions](#windows-install) or the [`suiup` installation](#suiup-install) (experimental)
 
 ```sh
 # Run a first-time install using the latest Mainnet version.
-curl -sSf https://docs.wal.app/setup/walrus-install.sh | sh
+curl -sSf https://install.wal.app | sh
 
 # Install the latest Testnet version instead.
-curl -sSf https://docs.wal.app/setup/walrus-install.sh | sh -s -- -n testnet
+curl -sSf https://install.wal.app | sh -s -- -n testnet
 
 # Update an existing installation (overwrites prior version of walrus).
-curl -sSf https://docs.wal.app/setup/walrus-install.sh | sh -s -- -f
+curl -sSf https://install.wal.app | sh -s -- -f
 ```
 
 Make sure that the `"$HOME"/.local/bin` directory is in your `$PATH`.
@@ -133,6 +134,19 @@ From there, you'll need to place `walrus.exe` somewhere in your `PATH`.
 ```admonish title="Windows"
 Note that most of the remaining instructions assume a UNIX-based system for the directory structure,
 commands, etc. If you use Windows, you may need to adapt most of those.
+```
+
+### Install via suiup (experimental) {#suiup-install}
+
+`suiup` is a tool to install and manage different versions of CLI tools for working in the Sui
+ecosystem, including the `walrus` CLI. After installing `suiup` as described in the [`suiup`
+documentation](https://github.com/MystenLabs/suiup?tab=readme-ov-file#installation), you can install
+specific versions of the `walrus` CLI:
+
+```sh
+suiup install walrus@testnet # install the latest testnet release
+suiup install walrus@mainnet # install the latest mainnet release
+suiup install walrus@testnet-v1.27.1 # install a specific release
 ```
 
 ### GitHub releases


### PR DESCRIPTION
## Description

- Add missing Linux aarch64 target.
- Add installation with `suiup`.
- Use `install.wal.app` for the installation script.
- Add a CI job to keep the `install.wal.app` site up to date.

## Test plan

Inspect docs preview and check workflow run after merge.

