### PR TITLE
test: ignore long-running-test by default

### DIFF
--- a/crates/walrus-sui/src/client/retry_client/download_handler.rs
+++ b/crates/walrus-sui/src/client/retry_client/download_handler.rs
@@ -415,6 +415,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "ignore long-running test by default"]
     async fn assess_overall_window_exceeded_triggers_fallback_and_sets_skip() {
         let skip_duration = Duration::from_secs(60);
         let config = test_config(3, Duration::from_secs(10), 5, skip_duration);


### PR DESCRIPTION
## Description

The test `assess_overall_window_exceeded_triggers_fallback_and_sets_skip` takes more than 10s to run and thus increases the time for a standard `cargo nextest run` (which is part of the pre-commit hooks) significantly.

## Test plan

The test is still run as part of our CI.