### PR TITLE
feat: [cherry-pick] continue node recovery upon restart if the recovery takes longer than 1 epoch to finish (#2291)

### DIFF
--- a/crates/walrus-service/src/node/blob_event_processor.rs
+++ b/crates/walrus-service/src/node/blob_event_processor.rs
@@ -113,7 +113,10 @@ impl BackgroundEventProcessor {
             || self.node.storage.node_status()? == NodeStatus::RecoveryCatchUp
             || self
                 .node
-                .is_stored_at_all_shards_at_epoch(&event.blob_id, self.node.current_event_epoch())
+                .is_stored_at_all_shards_at_epoch(
+                    &event.blob_id,
+                    self.node.current_event_epoch().await?,
+                )
                 .await?
         {
             event_handle.mark_as_complete();

--- a/crates/walrus-service/src/node/blob_sync.rs
+++ b/crates/walrus-service/src/node/blob_sync.rs
@@ -18,7 +18,7 @@ use futures::{
 use mysten_metrics::{GaugeGuard, GaugeGuardFutureExt};
 use rayon::prelude::*;
 use tokio::{
-    sync::{Notify, Semaphore},
+    sync::{Notify, Semaphore, watch},
     task::{JoinHandle, JoinSet},
 };
 use tokio_metrics::TaskMonitor;
@@ -274,6 +274,9 @@ impl BlobSyncHandler {
             .remove(blob_id);
     }
 
+    /// Starts a blob sync for the given `blob_id` and `certified_epoch`.
+    ///
+    /// Returns a `Notify` that is notified when the sync task is finished.
     #[tracing::instrument(skip_all, fields(otel.kind = "PRODUCER"))]
     pub async fn start_sync(
         &self,
@@ -286,8 +289,7 @@ impl BlobSyncHandler {
             .lock()
             .expect("should be able to acquire lock");
 
-        let finish_notify = Arc::new(Notify::new());
-        match in_progress.entry(blob_id) {
+        let finish_notify = match in_progress.entry(blob_id) {
             Entry::Vacant(entry) => {
                 let spawned_trace = tracing::info_span!(
                     parent: &Span::current(),
@@ -307,6 +309,7 @@ impl BlobSyncHandler {
                     "error.type" = field::Empty,
                 );
                 spawned_trace.follows_from(Span::current());
+                let finish_notify = Arc::new(Notify::new());
 
                 let cancel_token = CancellationToken::new();
                 let synchronizer = BlobSynchronizer::new(
@@ -333,16 +336,19 @@ impl BlobSyncHandler {
                 entry.insert(InProgressSyncHandle {
                     cancel_token,
                     blob_sync_handle: Some(sync_handle),
+                    finish_notify: finish_notify.clone(),
                 });
+                finish_notify
             }
-            Entry::Occupied(_) => {
+            Entry::Occupied(existing_sync) => {
                 // A blob sync with a lower sequence number is already in progress. We can safely
                 // try to increase the event cursor since it will only be advanced once that sync is
                 // finished or cancelled due to an invalid blob event.
                 event_handle.mark_as_complete();
-                finish_notify.notify_one();
+
+                existing_sync.get().finish_notify.clone()
             }
-        }
+        };
         Ok(finish_notify)
     }
 
@@ -441,6 +447,7 @@ type SyncJoinHandle = JoinHandle<Option<EventHandle>>;
 struct InProgressSyncHandle {
     cancel_token: CancellationToken,
     blob_sync_handle: Option<SyncJoinHandle>,
+    finish_notify: Arc<Notify>,
 }
 
 impl InProgressSyncHandle {
@@ -448,6 +455,7 @@ impl InProgressSyncHandle {
     // `blob_syncs_in_progress`.
     fn cancel(&mut self) -> Option<SyncJoinHandle> {
         self.cancel_token.cancel();
+        self.finish_notify.notify_one();
         self.blob_sync_handle.take()
     }
 }
@@ -458,6 +466,8 @@ enum RecoverSliverError {
     Inconsistent(InconsistencyProof),
     #[error(transparent)]
     Database(#[from] TypedStoreError),
+    #[error(transparent)]
+    WatchRecvError(#[from] watch::error::RecvError),
 }
 
 #[derive(Debug)]
@@ -530,18 +540,20 @@ impl BlobSynchronizer {
         // this function panics since no shard assignment info is found. Upon restarting the node,
         // the node will enter recovery mode until catching up with all the events and start
         // recovering all the missing blobs.
+        let latest_event_epoch = this
+            .node
+            .current_event_epoch()
+            .await
+            .expect("current event epoch should be set");
         let futures_iter = this
             .node
-            .owned_shards_at_epoch(this.node.current_event_epoch())
+            .owned_shards_at_epoch(latest_event_epoch)
             .unwrap_or_else(|_| {
                 tracing::error!(
                     "shard assignment must be found at the certified epoch {}",
-                    this.node.current_event_epoch()
+                    latest_event_epoch
                 );
-                panic!(
-                    "shard assignment must be found at the certified epoch {}",
-                    this.node.current_event_epoch()
-                )
+                panic!("shard assignment must be found at the certified epoch {latest_event_epoch}")
             })
             .into_iter()
             .map(|shard| {
@@ -729,6 +741,9 @@ impl BlobSynchronizer {
             RecoverSliverError::Database(_) => {
                 tracing::error!(?error, "database error during sliver sync")
             }
+            RecoverSliverError::WatchRecvError(_) => {
+                tracing::error!(?error, "watch recv error during sliver sync")
+            }
         })
     }
 
@@ -769,6 +784,7 @@ const fn labels_from_sliver_result<A: EncodingAxis>(
         Some(Ok(false)) => metrics::STATUS_SKIPPED,
         Some(Err(RecoverSliverError::Database(_))) => metrics::STATUS_FAILURE,
         Some(Err(RecoverSliverError::Inconsistent(_))) => metrics::STATUS_INCONSISTENT,
+        Some(Err(RecoverSliverError::WatchRecvError(_))) => metrics::STATUS_FAILURE,
     };
 
     [part, status]

--- a/crates/walrus-service/src/node/node_recovery.rs
+++ b/crates/walrus-service/src/node/node_recovery.rs
@@ -1,10 +1,11 @@
 // Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::{Arc, Mutex, atomic::Ordering};
+use std::sync::Arc;
 
 use futures::stream::{FuturesUnordered, StreamExt};
 use sui_macros::fail_point_async;
+use tokio::sync::Mutex;
 use typed_store::TypedStoreError;
 use walrus_core::Epoch;
 
@@ -40,25 +41,59 @@ impl NodeRecoveryHandler {
     /// Starts the node recovery process to recover blobs that are certified before the given epoch.
     /// For blobs that are certified after `certified_before_epoch`, the event processing is in
     /// charge of making sure the blob is stored at all shards.
+    ///
+    /// Any existing recovery task will be canceled.
     // TODO(WAL-864): Refactor this function to make it readable.
     pub async fn start_node_recovery(
         &self,
         certified_before_epoch: Epoch,
     ) -> Result<(), TypedStoreError> {
-        let mut locked_task_handle = self
-            .task_handle
-            .lock()
-            .expect("mutex should not be poisoned");
-        assert!(locked_task_handle.is_none());
+        let mut locked_task_handle = self.task_handle.lock().await;
+
+        // Cancel any existing recovery task
+        if let Some(old_task) = locked_task_handle.take() {
+            tracing::info!("canceling existing node recovery task");
+            old_task.abort();
+            // Wait for the old task to complete (it will return a JoinError due to cancellation)
+            let _ = old_task.await;
+        }
 
         let node = self.node.clone();
         let blob_sync_handler = self.blob_sync_handler.clone();
         let max_concurrent_blob_syncs_during_recovery =
             self.config.max_concurrent_blob_syncs_during_recovery;
         let task_handle = tokio::spawn(async move {
+            tracing::info!("waiting for latest event epoch to be set to restart node recovery");
+            // When current_event_epoch() returns during node start up, if the node is lagging
+            // behind, the node status will also be set to RecoveryCatchUp. So the recovery
+            // task does not need to run in this case.
+            node.current_event_epoch()
+                .await
+                .expect("current event epoch watch channel should not be dropped");
+
+            tracing::info!(
+                "starting node recovery task to recover blobs certified before epoch {}",
+                certified_before_epoch
+            );
+
             fail_point_async!("start_node_recovery_entry");
 
             loop {
+                // Node can enter recovery catch up mode while recovery is in progress. In this
+                // case, we should skip recovery. Once the node is caught up to the latest epoch,
+                // the recovery task will be restarted.
+                if node
+                    .storage
+                    .node_status()
+                    .expect("reading node status should not fail")
+                    == NodeStatus::RecoveryCatchUp
+                {
+                    tracing::info!(
+                        "node recovery encountered node is in catching up; skip recovery"
+                    );
+                    return;
+                }
+
                 // Keep track of ongoing blob syncs. Note that the memory usage of this list
                 // is capped by `max_concurrent_blob_syncs_during_recovery`.
                 let mut ongoing_syncs = FuturesUnordered::new();
@@ -133,10 +168,25 @@ impl NodeRecoveryHandler {
                         while ongoing_syncs.len() >= max_concurrent_blob_syncs_during_recovery {
                             ongoing_syncs.next().await;
                         }
+
+                        // Since there is a wait, the blob might not be certified anymore. Check
+                        // again before starting the sync.
+                        if !blob_info.is_certified(node.current_epoch()) {
+                            // Skip blobs that are not certified in the given epoch. This
+                            // includes blobs that are invalid or expired.
+                            tracing::debug!(
+                                walrus.blob_id = %blob_id,
+                                walrus.blob_certified_before_epoch = certified_before_epoch,
+                                walrus.current_epoch = node.current_epoch(),
+                                "skip non-certified blob, post concurrency limit wait"
+                            );
+                            continue;
+                        }
                     }
 
                     tracing::debug!(
                         walrus.blob_id = %blob_id,
+                        recoverying_epoch = certified_before_epoch,
                         "start recovery sync for blob"
                     );
                     node.metrics.node_recovery_ongoing_blob_syncs.inc();
@@ -218,25 +268,16 @@ impl NodeRecoveryHandler {
     }
 
     /// Restarts any in progress recovery.
-    pub async fn restart_recovery(&self) -> Result<(), TypedStoreError> {
+    pub async fn restart_recovery(&self) -> anyhow::Result<()> {
         if let NodeStatus::RecoveryInProgress(recovering_epoch) = self.node.storage.node_status()? {
-            if recovering_epoch == self.node.current_epoch() {
-                // The `latest_event_epoch` is still set to `0` at this point.
-                self.node
-                    .latest_event_epoch
-                    .store(recovering_epoch, Ordering::SeqCst);
-                return self.start_node_recovery(self.node.current_epoch()).await;
-            } else {
-                assert!(recovering_epoch < self.node.current_epoch());
-                tracing::warn!(
-                    recovering_epoch,
-                    current_epoch = self.node.current_epoch(),
-                    "recovery epoch mismatch; skip recovery restart; next epoch change start event \
-                    will bring node to the latest state"
-                );
-                self.node.set_node_status(NodeStatus::RecoveryCatchUp)?;
-            }
+            tracing::info!(
+                "restarting node recovery to recover to the epoch {}",
+                recovering_epoch
+            );
+
+            self.start_node_recovery(recovering_epoch).await?;
         }
+
         Ok(())
     }
 }

--- a/crates/walrus-simtest/src/test_utils.rs
+++ b/crates/walrus-simtest/src/test_utils.rs
@@ -8,7 +8,7 @@ pub mod simtest_utils {
     use std::{
         collections::{HashMap, HashSet},
         sync::{Arc, Mutex, atomic::AtomicBool},
-        time::Duration,
+        time::{Duration, Instant},
     };
 
     use anyhow::Context;
@@ -412,5 +412,62 @@ pub mod simtest_utils {
                 .collect::<Vec<_>>(),
         )
         .await
+    }
+    /// Configuration for node crash and restart.
+    #[derive(Debug, Clone)]
+    pub struct NodeCrashConfig {
+        /// The minimum duration of the node crash.
+        pub min_crash_duration_secs: u64,
+        /// The maximum duration of the node crash.
+        pub max_crash_duration_secs: u64,
+        /// The minimum duration of the node live after crash.
+        pub min_live_duration_secs: u64,
+        /// The maximum duration of the node live after crash.
+        pub max_live_duration_secs: u64,
+    }
+
+    /// Simulates repeated node crash and restart with sim node id.
+    pub fn repeatedly_crash_target_node(
+        target_node_id: sui_simulator::task::NodeId,
+        next_fail_triggered_clone: Arc<Mutex<Instant>>,
+        crash_end_time: Instant,
+        config: NodeCrashConfig,
+    ) {
+        let time_now = Instant::now();
+        if time_now > crash_end_time {
+            // No more crash is needed.
+            return;
+        }
+
+        if time_now < *next_fail_triggered_clone.lock().unwrap() {
+            // Not time to crash yet.
+            return;
+        }
+
+        let current_node = sui_simulator::current_simnode_id();
+        if target_node_id != current_node {
+            return;
+        }
+
+        let mut rng = rand::thread_rng();
+
+        let node_down_duration = Duration::from_secs(
+            rng.gen_range(config.min_crash_duration_secs..=config.max_crash_duration_secs),
+        );
+        let next_crash_after = node_down_duration
+            + Duration::from_secs(
+                rng.gen_range(config.min_live_duration_secs..=config.max_live_duration_secs),
+            );
+        let next_crash_time = time_now + next_crash_after;
+
+        tracing::warn!(
+            "crashing node {current_node} for {} seconds; next crash is set to {:?} after {} \
+            seconds",
+            node_down_duration.as_secs(),
+            next_crash_time,
+            next_crash_after.as_secs(),
+        );
+        *next_fail_triggered_clone.lock().unwrap() = next_crash_time;
+        sui_simulator::task::kill_current_node(Some(node_down_duration));
     }
 }

--- a/crates/walrus-simtest/tests/simtest.rs
+++ b/crates/walrus-simtest/tests/simtest.rs
@@ -8,8 +8,12 @@
 mod tests {
     use std::{
         collections::HashSet,
-        sync::{Arc, atomic::AtomicBool},
-        time::Duration,
+        sync::{
+            Arc,
+            Mutex,
+            atomic::{AtomicBool, Ordering},
+        },
+        time::{Duration, Instant},
     };
 
     use rand::{Rng, SeedableRng};
@@ -32,6 +36,8 @@ mod tests {
         self,
         BlobInfoConsistencyCheck,
         CRASH_NODE_FAIL_POINTS,
+        NodeCrashConfig,
+        repeatedly_crash_target_node,
     };
     use walrus_storage_node_client::api::ShardStatus;
     use walrus_sui::client::ReadClient;
@@ -454,10 +460,21 @@ mod tests {
         // Running the workload for 60 seconds to get some data in the system.
         tokio::time::sleep(Duration::from_secs(60)).await;
 
-        // Register a fail point to have a temporary pause in the node recovery process that is
-        // longer than epoch length.
-        register_fail_point_async("start_node_recovery_entry", || async move {
-            tokio::time::sleep(Duration::from_secs(60)).await;
+        // Register a fail point to have a temporary pause in the first node recovery process that
+        // is longer than epoch length.
+        // Note that when a node is in RecoveryInProgress state, it will not start a new recovery
+        // everytime when a new epoch change start event is processed. So here we only delay the
+        // first recovery.
+        let delay_triggered = Arc::new(AtomicBool::new(false));
+        register_fail_point_async("start_node_recovery_entry", move || {
+            let delay_triggered_clone = delay_triggered.clone();
+            async move {
+                if !delay_triggered_clone.load(Ordering::SeqCst) {
+                    delay_triggered_clone.store(true, Ordering::SeqCst);
+                    tracing::info!("delaying node recovery for 60s");
+                    tokio::time::sleep(Duration::from_secs(60)).await;
+                }
+            }
         });
 
         // Tracks if a crash has been triggered.
@@ -540,5 +557,133 @@ mod tests {
         }
 
         blob_info_consistency_check.check_storage_node_consistency();
+    }
+
+    // Tests that when a node is in RecoveryInProgress state, restarting the node repeatedly
+    // will not cause the node to be stuck/malfunction.
+    #[ignore = "ignore integration simtests by default"]
+    #[walrus_simtest]
+    async fn test_recovery_in_progress_with_node_restart() {
+        let (_sui_cluster, walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
+            .with_epoch_duration(Duration::from_secs(30))
+            .with_test_nodes_config(TestNodesConfig {
+                node_weights: vec![1, 2, 3, 3, 4],
+                use_legacy_event_processor: false,
+                ..Default::default()
+            })
+            .with_communication_config(
+                ClientCommunicationConfig::default_for_test_with_reqwest_timeout(
+                    Duration::from_secs(2),
+                ),
+            )
+            .with_default_num_checkpoints_per_blob()
+            .build_generic::<SimStorageNodeHandle>()
+            .await
+            .unwrap();
+
+        let blob_info_consistency_check = BlobInfoConsistencyCheck::new();
+
+        let client_arc = Arc::new(client);
+
+        // Starts a background workload that a client keeps writing and retrieving data.
+        // All requests should succeed even if a node crashes.
+        let workload_handle =
+            simtest_utils::start_background_workload(client_arc.clone(), false, 0, None);
+
+        // Run the workload to get some data in the system.
+        tokio::time::sleep(Duration::from_secs(60)).await;
+
+        // Register a fail point to have a temporary pause in the first node recovery process that
+        // is longer than epoch length.
+        // Note that when a node is in RecoveryInProgress state, it will not start a new recovery
+        // everytime when a new epoch change start event is processed. So here we only delay the
+        // first recovery.
+        let delay_triggered = Arc::new(AtomicBool::new(false));
+        register_fail_point_async("start_node_recovery_entry", move || {
+            let delay_triggered_clone = delay_triggered.clone();
+            async move {
+                if !delay_triggered_clone.load(Ordering::SeqCst) {
+                    delay_triggered_clone.store(true, Ordering::SeqCst);
+                    tracing::info!("delaying node recovery for 60s");
+                    tokio::time::sleep(Duration::from_secs(60)).await;
+                }
+            }
+        });
+
+        // First, trigger a node crash with long delay to bring node into recovery mode.
+        {
+            // Tracks if a crash has been triggered.
+            let fail_triggered = Arc::new(AtomicBool::new(false));
+            let target_fail_node_id = walrus_cluster.nodes[0]
+                .node_id
+                .expect("node id should be set");
+            let fail_triggered_clone = fail_triggered.clone();
+
+            register_fail_point("fail_point_process_event", move || {
+                crash_target_node(
+                    target_fail_node_id,
+                    fail_triggered_clone.clone(),
+                    Duration::from_secs(60),
+                );
+            });
+
+            // Wait until fail_triggered is set to true with a timeout.
+            let timeout = Instant::now() + Duration::from_secs(20);
+            while !fail_triggered.load(Ordering::SeqCst) {
+                if Instant::now() > timeout {
+                    panic!("fail_triggered is not set to true within 20 seconds");
+                }
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+        }
+
+        // During recovery, repeatedly restart the node.
+        {
+            let next_fail_triggered = Arc::new(Mutex::new(Instant::now()));
+            let next_fail_triggered_clone = next_fail_triggered.clone();
+            let crash_end_time = Instant::now() + Duration::from_secs(120);
+            let target_fail_node_id = walrus_cluster.nodes[0]
+                .node_id
+                .expect("node id should be set");
+
+            sui_macros::register_fail_points(CRASH_NODE_FAIL_POINTS, move || {
+                repeatedly_crash_target_node(
+                    target_fail_node_id,
+                    next_fail_triggered_clone.clone(),
+                    crash_end_time,
+                    NodeCrashConfig {
+                        min_crash_duration_secs: 1,
+                        max_crash_duration_secs: 3,
+                        min_live_duration_secs: 5,
+                        max_live_duration_secs: 40,
+                    },
+                );
+            });
+        }
+
+        tokio::time::sleep(Duration::from_secs(180)).await;
+
+        let node_health_info = simtest_utils::get_nodes_health_info(&walrus_cluster.nodes).await;
+
+        assert!(node_health_info[0].shard_detail.is_some());
+        for shard in &node_health_info[0].shard_detail.as_ref().unwrap().owned {
+            // For all the shards that the crashed node owns, they should be in ready state.
+            assert_eq!(shard.status, ShardStatus::Ready);
+        }
+
+        assert_eq!(
+            simtest_utils::get_nodes_health_info([&walrus_cluster.nodes[0]])
+                .await
+                .get(0)
+                .unwrap()
+                .node_status,
+            "Active"
+        );
+
+        workload_handle.abort();
+
+        blob_info_consistency_check.check_storage_node_consistency();
+
+        clear_fail_point("start_node_recovery_entry");
     }
 }

--- a/crates/walrus-simtest/tests/simtest.rs
+++ b/crates/walrus-simtest/tests/simtest.rs
@@ -587,8 +587,7 @@ mod tests {
 
         // Starts a background workload that a client keeps writing and retrieving data.
         // All requests should succeed even if a node crashes.
-        let workload_handle =
-            simtest_utils::start_background_workload(client_arc.clone(), false, 0, None);
+        let workload_handle = simtest_utils::start_background_workload(client_arc.clone(), false);
 
         // Run the workload to get some data in the system.
         tokio::time::sleep(Duration::from_secs(60)).await;
@@ -663,7 +662,8 @@ mod tests {
 
         tokio::time::sleep(Duration::from_secs(180)).await;
 
-        let node_health_info = simtest_utils::get_nodes_health_info(&walrus_cluster.nodes).await;
+        let node_refs: Vec<&SimStorageNodeHandle> = walrus_cluster.nodes.iter().collect();
+        let node_health_info = simtest_utils::get_nodes_health_info(&node_refs).await;
 
         assert!(node_health_info[0].shard_detail.is_some());
         for shard in &node_health_info[0].shard_detail.as_ref().unwrap().owned {
@@ -672,7 +672,7 @@ mod tests {
         }
 
         assert_eq!(
-            simtest_utils::get_nodes_health_info([&walrus_cluster.nodes[0]])
+            simtest_utils::get_nodes_health_info(&[&walrus_cluster.nodes[0]])
                 .await
                 .get(0)
                 .unwrap()

--- a/crates/walrus-simtest/tests/simtest_failure.rs
+++ b/crates/walrus-simtest/tests/simtest_failure.rs
@@ -30,6 +30,8 @@ mod tests {
         self,
         BlobInfoConsistencyCheck,
         CRASH_NODE_FAIL_POINTS,
+        NodeCrashConfig,
+        repeatedly_crash_target_node,
     };
     use walrus_storage_node_client::api::ShardStatus;
     use walrus_sui::client::ReadClient;
@@ -335,42 +337,6 @@ mod tests {
         blob_info_consistency_check.check_storage_node_consistency();
     }
 
-    // Simulates repeated node crash and restart with sim node id.
-    fn repeatedly_crash_target_node(
-        target_node_id: sui_simulator::task::NodeId,
-        next_fail_triggered_clone: Arc<Mutex<Instant>>,
-        crash_end_time: Instant,
-    ) {
-        let time_now = Instant::now();
-        if time_now > crash_end_time {
-            // No more crash is needed.
-            return;
-        }
-
-        if time_now < *next_fail_triggered_clone.lock().unwrap() {
-            // Not time to crash yet.
-            return;
-        }
-
-        let current_node = sui_simulator::current_simnode_id();
-        if target_node_id != current_node {
-            return;
-        }
-
-        let mut rng = rand::thread_rng();
-        let node_down_duration = Duration::from_secs(rng.gen_range(5..=25));
-        let next_crash_time =
-            Instant::now() + node_down_duration + Duration::from_secs(rng.gen_range(5..=25));
-
-        tracing::warn!(
-            "crashing node {current_node} for {} seconds; next crash is set to {:?}",
-            node_down_duration.as_secs(),
-            next_crash_time
-        );
-        sui_simulator::task::kill_current_node(Some(node_down_duration));
-        *next_fail_triggered_clone.lock().unwrap() = next_crash_time;
-    }
-
     // This integration test simulates a scenario where a node is repeatedly crashing and
     // recovering.
     #[ignore = "ignore integration simtests by default"]
@@ -456,6 +422,12 @@ mod tests {
                 target_fail_node_id,
                 next_fail_triggered_clone.clone(),
                 crash_end_time,
+                NodeCrashConfig {
+                    min_crash_duration_secs: 5,
+                    max_crash_duration_secs: 25,
+                    min_live_duration_secs: 5,
+                    max_live_duration_secs: 25,
+                },
             );
         });
 


### PR DESCRIPTION


* Continue node recovery upon restart if the recovery takes longer than 1 epoch to finish

* use a watch channel to set latest_event_epoch

* fix simtest_test_long_node_recovery

* allow current_event_epoch to be optional, and skip events before the first epoch change when recovering from an incomplete history

* start_node_recovery hooks to previous blob sync notify handle

* seperate current_event_epoch implementation to wait for it to be populated

* Add test

* cleanup

* address comments

* stop node recovery if the node enters RecoverCatchUp

## Description

Describe the changes or additions included in this PR.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
