### PR TITLE
ci: ensure WFs involving Sui transactions are not concurrent

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -65,6 +65,9 @@ jobs:
       RUST_LOG: info
       EPOCHS: 10
       BUILD_DIR: docs/build/html
+    concurrency:
+      group: sui-wallet-operations
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
       - uses: ./.github/actions/build-mdbook

--- a/.github/workflows/update-ws-binaries.yaml
+++ b/.github/workflows/update-ws-binaries.yaml
@@ -9,7 +9,9 @@ on:
   # on demand
   workflow_dispatch:
 
-concurrency: ci-${{ github.ref }}
+concurrency:
+  group: sui-wallet-operations
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/update-ws-install.yaml
+++ b/.github/workflows/update-ws-install.yaml
@@ -12,7 +12,9 @@ on:
     # Update Walrus Site every first day of the month at 03:14 UTC.
     - cron: "14 3 1 * *"
 
-concurrency: ci-${{ github.ref }}
+concurrency:
+  group: sui-wallet-operations
+  cancel-in-progress: false
 
 permissions:
   contents: read


### PR DESCRIPTION
Otherwise, we could end up with conflicting transactions and locked objects.
