### PR TITLE
fix: [1] epoch sync done should check latest epoch [2] bypassing consistency check if node is reprocessing events

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -1521,7 +1521,15 @@ impl StorageNode {
             .wait_until_previous_task_done()
             .await;
 
-        if self.inner.consistency_check_config.enable_consistency_check {
+        // Start storage node consistency check if
+        // - consistency check is enabled
+        // - node is not reprocessing events (blob info table should not be affected by future
+        //   events)
+        let node_is_reprocessing_events =
+            self.inner.storage.get_latest_handled_event_index()? >= event_handle.index();
+        if self.inner.consistency_check_config.enable_consistency_check
+            && !node_is_reprocessing_events
+        {
             if let Err(err) = consistency_check::schedule_background_consistency_check(
                 self.inner.clone(),
                 self.blob_sync_handler.clone(),

--- a/crates/walrus-service/src/node/contract_service.rs
+++ b/crates/walrus-service/src/node/contract_service.rs
@@ -22,7 +22,7 @@ use walrus_sui::{
         BlobObjectMetadata,
         CoinType,
         FixedSystemParameters,
-        ReadClient as _,
+        ReadClient,
         SuiClientError,
         SuiClientMetricSet,
         SuiContractClient,
@@ -31,6 +31,7 @@ use walrus_sui::{
     types::{
         StorageNodeCap,
         UpdatePublicKeyParams,
+        move_errors::{MoveExecutionError, StakingInnerError},
         move_structs::{EpochState, EventBlob},
     },
 };
@@ -513,6 +514,27 @@ impl SystemContractService for SuiSystemContractService {
                     tracing::debug!(walrus.epoch = epoch, "repeatedly submitted epoch_sync_done");
                     Some(())
                 }
+                Err(SuiClientError::TransactionExecutionError(
+                    MoveExecutionError::StakingInner(StakingInnerError::EInvalidSyncEpoch(error)),
+                )) => match self.read_client.current_epoch().await {
+                    Ok(latest_epoch_on_chain) => {
+                        if latest_epoch_on_chain > epoch {
+                            tracing::info!(
+                                ?error,
+                                "walrus epoch has advanced, skipping epoch sync done"
+                            );
+                            Some(())
+                        } else if latest_epoch_on_chain < epoch {
+                            panic!("walrus epoch onchain cannot be less than event epoch");
+                        } else {
+                            None
+                        }
+                    }
+                    Err(error) => {
+                        tracing::info!(?error, "reading onchain epoch failed");
+                        None
+                    }
+                },
                 Err(error) => {
                     tracing::warn!(?error, "submitting epoch sync done to contract failed");
                     None

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -782,6 +782,11 @@ impl Storage {
         self.event_cursor.get_event_cursor_progress()
     }
 
+    /// Returns the latest event index that has been handled by the node.
+    pub(crate) fn get_latest_handled_event_index(&self) -> Result<u64, TypedStoreError> {
+        self.blob_info.get_latest_handled_event_index()
+    }
+
     /// Clears the metadata in the storage for testing purposes.
     #[cfg(test)]
     pub fn clear_metadata_in_test(&self) -> Result<(), TypedStoreError> {

--- a/crates/walrus-service/src/node/storage/blob_info.rs
+++ b/crates/walrus-service/src/node/storage/blob_info.rs
@@ -348,6 +348,16 @@ impl BlobInfoTable {
     ) -> Result<Option<PerObjectBlobInfo>, TypedStoreError> {
         self.per_object_blob_info.get(object_id)
     }
+
+    /// Returns the latest event index that has been handled by the node.
+    pub(crate) fn get_latest_handled_event_index(&self) -> Result<u64, TypedStoreError> {
+        Ok(self
+            .latest_handled_event_index
+            .lock()
+            .expect("acquire latest_handled_event_index lock should not fail")
+            .get(&())?
+            .unwrap_or(0))
+    }
 }
 
 // TODO(#900): Rewrite other tests without relying on blob-info internals.

--- a/crates/walrus-simtest/tests/simtest_failure.rs
+++ b/crates/walrus-simtest/tests/simtest_failure.rs
@@ -472,7 +472,7 @@ mod tests {
             );
             if last_persist_event_index == node_health_info[0].event_progress.persisted {
                 // We expect that there shouldn't be any stuck event progress.
-                assert!(last_persisted_event_time.elapsed() < Duration::from_secs(60));
+                assert!(last_persisted_event_time.elapsed() < Duration::from_secs(30));
             } else {
                 last_persist_event_index = node_health_info[0].event_progress.persisted;
                 last_persisted_event_time = Instant::now();


### PR DESCRIPTION
## Description

This PR fixes two issues exposed by `simtest_test_repeated_node_crash`.

- When sending epoch_sync_done, it's possible that the epoch change has advanced. In this case, epoch sync done will retry indefinitely, blocking the process_epoch_change_start event from finishing, and therefore blocking the next epoch change event. The fix is that 
- When reprocessing events, the blob info table might have been affected by "future" events. Therefore, we should bypass consistency check if the node is reprocessing events. The first time processing events should always produce consistent blob info digest.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
