### PR TITLE
fix: run rust tests in CI if testnet-contracts change

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -45,7 +45,7 @@ jobs:
       isTestConfig: ${{ steps.diff.outputs.isTestConfig }}
       isOpenapi: ${{ steps.diff.outputs.isOpenapi }}
       isRelevantForRustTests: ${{ steps.diff.outputs.isRust == 'true' || steps.diff.outputs.isMove == 'true' || steps.diff.outputs.isTestConfig
-        == 'true' }}
+        == 'true' || steps.diff.outputs.isTestnetContracts == 'true' }}
       isTestnetContracts: ${{ steps.diff.outputs.isTestnetContracts }}
       isMainnetContracts: ${{ steps.diff.outputs.isMainnetContracts }}
       isExampleConfig: ${{ steps.diff.outputs.isExampleConfig }}


### PR DESCRIPTION
## Description

We use the `testnet-contracts` as basis for the upgrade tests in Rust, so we should run the Rust tests if those change as well. This caused the issue in the CI yesterday, because I forgot to bump the VERSION in the `contracts/walrus/[system|staking].move` files.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
