### PR TITLE
fix: use original package ID to filter events (cherry-pick)

### DIFF
--- a/crates/walrus-service/src/event/event_processor/checkpoint.rs
+++ b/crates/walrus-service/src/event/event_processor/checkpoint.rs
@@ -41,7 +41,7 @@ pub struct CheckpointProcessor {
     stores: EventProcessorStores,
     package_store: LocalDBPackageStore,
     package_resolver: Arc<Resolver<PackageCache>>,
-    system_pkg_id: ObjectID,
+    original_system_pkg_id: ObjectID,
     latest_checkpoint_seq_number: Arc<AtomicU64>,
 }
 
@@ -50,7 +50,7 @@ impl fmt::Debug for CheckpointProcessor {
         f.debug_struct("CheckpointProcessor")
             .field("stores", &self.stores)
             .field("package_store", &self.package_store)
-            .field("system_pkg_id", &self.system_pkg_id)
+            .field("original_system_pkg_id", &self.original_system_pkg_id)
             .finish()
     }
 }
@@ -60,12 +60,12 @@ impl CheckpointProcessor {
     pub fn new(
         stores: EventProcessorStores,
         package_store: LocalDBPackageStore,
-        system_pkg_id: ObjectID,
+        original_system_pkg_id: ObjectID,
     ) -> Self {
         Self {
             stores,
             package_store: package_store.clone(),
-            system_pkg_id,
+            original_system_pkg_id,
             package_resolver: Arc::new(Resolver::new(PackageCache::new(package_store.clone()))),
             latest_checkpoint_seq_number: Arc::new(AtomicU64::new(0)),
         }
@@ -156,7 +156,7 @@ impl CheckpointProcessor {
                 .into_iter()
                 .zip(original_package_ids)
                 // Filter out events that are not from the Walrus system package.
-                .filter(|(_, original_id)| *original_id == self.system_pkg_id)
+                .filter(|(_, original_id)| *original_id == self.original_system_pkg_id)
                 .map(|(event, _)| event)
                 .enumerate()
             {

--- a/crates/walrus-service/src/event/event_processor/processor.rs
+++ b/crates/walrus-service/src/event/event_processor/processor.rs
@@ -43,8 +43,8 @@ pub struct EventProcessor {
     pub stores: EventProcessorStores,
     /// Event polling interval.
     pub event_polling_interval: Duration,
-    /// The address of the Walrus system package.
-    pub system_pkg_id: ObjectID,
+    /// The original address of the Walrus system package.
+    pub original_system_pkg_id: ObjectID,
     /// Event index before which events are pruned.
     pub event_store_commit_index: Arc<Mutex<u64>>,
     /// Event store pruning interval.
@@ -62,7 +62,7 @@ pub struct EventProcessor {
 impl fmt::Debug for EventProcessor {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("EventProcessor")
-            .field("system_pkg_id", &self.system_pkg_id)
+            .field("original_system_pkg_id", &self.original_system_pkg_id)
             .field("checkpoint_store", &self.stores.checkpoint_store)
             .field("walrus_package_store", &self.stores.walrus_package_store)
             .field("committee_store", &self.stores.committee_store)
@@ -109,13 +109,13 @@ impl EventProcessor {
         let checkpoint_processor = CheckpointProcessor::new(
             stores.clone(),
             package_store.clone(),
-            system_config.system_pkg_id,
+            original_system_package_id,
         );
 
         let event_processor = EventProcessor {
             client_manager: client_manager.clone(),
             stores,
-            system_pkg_id: original_system_package_id,
+            original_system_pkg_id: original_system_package_id,
             event_polling_interval: runtime_config.event_polling_interval,
             event_store_commit_index: Arc::new(Mutex::new(0)),
             pruning_interval: config.pruning_interval,
@@ -155,7 +155,7 @@ impl EventProcessor {
             let (committee, verified_checkpoint) = get_bootstrap_committee_and_checkpoint(
                 client_manager.get_sui_client().clone(),
                 client_manager.get_client().clone(),
-                event_processor.system_pkg_id,
+                event_processor.original_system_pkg_id,
             )
             .await?;
             event_processor


### PR DESCRIPTION
## Description

Cherry-picks #2318.

## Test plan

Deploy to Testnet node.