### PR TITLE
feat: schedule call to process subsidies

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -1435,6 +1435,7 @@ impl StorageNode {
                 self.epoch_change_driver.schedule_initiate_epoch_change(
                     NonZero::new(event.next_epoch).expect("the next epoch is always non-zero"),
                 );
+                self.epoch_change_driver.schedule_process_subsidies();
                 event_handle.mark_as_complete();
             }
             EpochChangeEvent::EpochChangeStart(event) => {

--- a/crates/walrus-service/src/node/epoch_change_driver.rs
+++ b/crates/walrus-service/src/node/epoch_change_driver.rs
@@ -31,6 +31,8 @@ const MAX_SCHEDULE_JITTER: Duration = Duration::from_secs(180);
 const MIN_BACKOFF: Duration = Duration::from_secs(5);
 /// The maximum exponential backoff when performing retries.
 const MAX_BACKOFF: Duration = Duration::from_secs(300);
+/// The maximum amount of time before the epoch change that process subsidies is scheduled.
+const MAX_SUBSIDIES_TIME_BEFORE_EPOCH_CHANGE: Duration = Duration::from_secs(300);
 
 /// Function returning the current time in Utc.
 type UtcNowFn = Arc<dyn Fn() -> DateTime<Utc> + Send + Sync>;
@@ -74,6 +76,7 @@ impl EpochChangeDriver {
                 waker: None,
                 end_voting_future: None,
                 epoch_change_start_future: None,
+                subsidies_future: None,
             }))),
             system_parameters,
             contract_service,
@@ -121,7 +124,10 @@ impl EpochChangeDriver {
         match state {
             EpochState::EpochChangeSync(_) => (),
             EpochState::EpochChangeDone(_) => self.schedule_voting_end(next_epoch),
-            EpochState::NextParamsSelected(_) => self.schedule_initiate_epoch_change(next_epoch),
+            EpochState::NextParamsSelected(_) => {
+                self.schedule_initiate_epoch_change(next_epoch);
+                self.schedule_process_subsidies();
+            }
         }
 
         Ok(())
@@ -239,6 +245,45 @@ impl EpochChangeDriver {
         }
     }
 
+    /// Schedules a call to process subsidies for the next epoch that will be dispatched by
+    /// [`run()`][Self::run] if subsidies are configured in the contract service.
+    ///
+    /// Should be called after [`NextParamsSelected`] events. Subsequent calls to this
+    /// method cancel any earlier scheduled calls.
+    #[tracing::instrument(skip_all)]
+    pub fn schedule_process_subsidies(&self) {
+        if !self.contract_service.is_subsidies_object_configured() {
+            tracing::debug!("subsidies are not configured in the contract");
+            return;
+        }
+
+        let mut inner = self.inner.lock().expect("thread did not panic with lock");
+
+        if inner.subsidies_future.is_some() {
+            tracing::debug!("replacing subsidies future");
+            inner.subsidies_future = None;
+        }
+
+        let subsidies_future = ScheduledEpochOperation::new(
+            SubsidiesOperation {
+                time_before_epoch_change: (self.system_parameters.epoch_duration / 10)
+                    .min(MAX_SUBSIDIES_TIME_BEFORE_EPOCH_CHANGE),
+                system_params: self.system_parameters,
+                time_fn: self.utc_now_fn.clone(),
+            },
+            self.system_parameters.epoch_duration,
+            self.contract_service.clone(),
+            self.utc_now_fn.clone(),
+            &mut inner.rng,
+        )
+        .wait_then_call();
+
+        inner.subsidies_future = Some(subsidies_future.boxed());
+
+        tracing::debug!("scheduled process subsidies");
+        inner.wake();
+    }
+
     #[cfg(test)]
     /// Returns true if there is currently a scheduled call to end voting.
     pub fn is_voting_end_scheduled(&self) -> bool {
@@ -274,6 +319,8 @@ struct EpochChangeDriverInner<'pin> {
     end_voting_future: Option<(Epoch, BoxFuture<'pin, ()>)>,
     /// An optional future that will start epoch change for a given epoch.
     epoch_change_start_future: Option<(Epoch, BoxFuture<'pin, ()>)>,
+    /// An optional future that will process subsidies.
+    subsidies_future: Option<BoxFuture<'pin, ()>>,
 }
 
 impl EpochChangeDriverInner<'_> {
@@ -584,6 +631,71 @@ impl EpochOperation for InitiateEpochChangeOperation {
         .await
         .map_err(|e| anyhow::anyhow!("initiate epoch change panicked: {:?}", e))??;
         tracing::debug!("epoch change successfully started");
+        Ok(())
+    }
+}
+
+/// Operation that calls the walrus subsidies contract if set.
+struct SubsidiesOperation {
+    time_before_epoch_change: Duration,
+    system_params: FixedSystemParameters,
+    time_fn: UtcNowFn,
+}
+
+impl EpochOperation for SubsidiesOperation {
+    fn time_until_ready(
+        &self,
+        utc_now: DateTime<Utc>,
+        current_epoch: Epoch,
+        state: EpochState,
+    ) -> Option<Duration> {
+        let current_epoch_started_at = match state {
+            EpochState::EpochChangeDone(_) | EpochState::EpochChangeSync(_) => {
+                todo!("How should we handle this? Panic? Or return time?")
+            }
+            EpochState::NextParamsSelected(current_epoch_started_at) => current_epoch_started_at,
+        };
+        if current_epoch == GENESIS_EPOCH {
+            return None;
+        }
+
+        let subsidies_call_at = current_epoch_started_at + self.system_params.epoch_duration
+            - self.time_before_epoch_change;
+
+        let duration_until_subsidies_call = subsidies_call_at
+            .signed_duration_since(utc_now)
+            .max(TimeDelta::zero())
+            .to_std()
+            .expect("max(., 0) makes the value always positive");
+        tracing::debug!("subsidies call in {duration_until_subsidies_call:.0?}");
+
+        Some(duration_until_subsidies_call)
+    }
+
+    async fn invoke(&self, contract: Arc<dyn SystemContractService>) -> Result<(), anyhow::Error> {
+        let last_subsidies_call = contract.last_walrus_subsidies_call().await?;
+        let current_time = (self.time_fn)();
+        // If the last subsidies call was less than time_before_epoch_change ago, return without
+        // calling them again. We use the same duration here to avoid having to configure too
+        // many parameters.
+        if current_time - self.time_before_epoch_change > last_subsidies_call {
+            tracing::debug!("subsidies already called recently");
+            return Ok(());
+        }
+
+        tracing::info!("initiating subsidy distribution");
+        // Move transaction execution to a separate task so that it cannot be cancelled when
+        // invoke() is cancelled. Otherwise, cancelling inflight transaction may cause object
+        // conflicts.
+        tokio::spawn({
+            let contract = contract.clone();
+            async move { contract.process_subsidies().await }
+        })
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!("call to initiate subsidy distribution panicked: {:?}", e)
+        })??;
+        tracing::debug!("successfully initiated subsidy distribution");
         Ok(())
     }
 }

--- a/crates/walrus-service/src/node/epoch_change_driver.rs
+++ b/crates/walrus-service/src/node/epoch_change_driver.rs
@@ -374,6 +374,15 @@ impl Future for EpochChangeDriverInner<'_> {
             }
         });
 
+        tracing::info_span!("scheduled_process_subsidies").in_scope(|| {
+            if let Some(subsidies) = this.subsidies_future.as_mut() {
+                if let Poll::Ready(()) = subsidies.poll_unpin(cx) {
+                    tracing::trace!("subsidies future completed");
+                    this.subsidies_future = None;
+                }
+            }
+        });
+
         // This future never completes, as this is an infinite task.
         Poll::Pending
     }

--- a/crates/walrus-service/src/node/start_epoch_change_finisher.rs
+++ b/crates/walrus-service/src/node/start_epoch_change_finisher.rs
@@ -111,6 +111,7 @@ impl StartEpochChangeFinisher {
                 .contract_service
                 .epoch_sync_done(event.epoch, self.node.node_capability())
                 .await;
+            tracing::info!("epoch sync done signaled");
         } else {
             // Since we just refreshed the committee after receiving the event, the committees'
             // epoch must be at least the event's epoch.

--- a/crates/walrus-sui/src/client.rs
+++ b/crates/walrus-sui/src/client.rs
@@ -266,6 +266,15 @@ impl CertifyAndExtendBlobResult {
     }
 }
 
+/// The object ID of a shared object with the object ID of an associated admin cap.
+#[derive(Debug, Clone)]
+pub struct SharedObjectWithAdminCap {
+    /// The object ID of the shared object.
+    pub object_id: ObjectID,
+    /// The object ID of the admin cap.
+    pub admin_cap_id: ObjectID,
+}
+
 /// Metadata for a blob object on Sui.
 #[derive(Debug, Clone)]
 pub struct BlobObjectMetadata {
@@ -930,7 +939,7 @@ impl SuiContractClient {
         system_subsidy_rate: u32,
         base_subsidy: u64,
         subsidy_per_shard: u64,
-    ) -> SuiClientResult<(ObjectID, ObjectID)> {
+    ) -> SuiClientResult<SharedObjectWithAdminCap> {
         self.retry_on_wrong_version(|| async {
             self.inner
                 .lock()
@@ -964,7 +973,7 @@ impl SuiContractClient {
         initial_buyer_subsidy_rate: u16,
         initial_system_subsidy_rate: u16,
         amount: u64,
-    ) -> SuiClientResult<(ObjectID, ObjectID)> {
+    ) -> SuiClientResult<SharedObjectWithAdminCap> {
         self.inner
             .lock()
             .await
@@ -2107,7 +2116,7 @@ impl SuiContractClientInner {
         system_subsidy_rate: u32,
         base_subsidy: u64,
         subsidy_per_shard: u64,
-    ) -> SuiClientResult<(ObjectID, ObjectID)> {
+    ) -> SuiClientResult<SharedObjectWithAdminCap> {
         tracing::info!("creating a new walrus subsidies object");
 
         let mut pt_builder = self.transaction_builder()?;
@@ -2138,7 +2147,10 @@ impl SuiContractClientInner {
             "unexpected number of `WalrusSubsidies`s created: {}",
             subsidies_id.len()
         );
-        Ok((subsidies_id[0], admin_cap[0]))
+        Ok(SharedObjectWithAdminCap {
+            object_id: subsidies_id[0],
+            admin_cap_id: admin_cap[0],
+        })
     }
 
     /// Adds funds to the walrus subsidies object (`walrus_subsidies::WalrusSubsidies`) if it is
@@ -2191,7 +2203,7 @@ impl SuiContractClientInner {
         initial_buyer_subsidy_rate: u16,
         initial_system_subsidy_rate: u16,
         amount: u64,
-    ) -> SuiClientResult<(ObjectID, ObjectID)> {
+    ) -> SuiClientResult<SharedObjectWithAdminCap> {
         tracing::info!("creating a new credits object");
 
         let mut pt_builder = self.transaction_builder()?;
@@ -2220,7 +2232,10 @@ impl SuiContractClientInner {
             "unexpected number of `Subsidies`s created: {}",
             credits_id.len()
         );
-        Ok((credits_id[0], admin_cap[0]))
+        Ok(SharedObjectWithAdminCap {
+            object_id: credits_id[0],
+            admin_cap_id: admin_cap[0],
+        })
     }
 
     /// Exchanges the given `amount` of SUI (in MIST) for WAL using the shared exchange.

--- a/crates/walrus-sui/src/client.rs
+++ b/crates/walrus-sui/src/client.rs
@@ -1965,6 +1965,7 @@ impl SuiContractClientInner {
     ///
     /// Requires the new walrus subsidy contract to be set.
     pub async fn process_subsidies(&mut self) -> SuiClientResult<()> {
+        tracing::debug!("sending transaction to call process_subsidies");
         let mut pt_builder = self.transaction_builder()?;
         pt_builder.process_subsidies().await?;
         let transaction = pt_builder.build_transaction_data(self.gas_budget).await?;

--- a/crates/walrus-sui/src/client/contract_config.rs
+++ b/crates/walrus-sui/src/client/contract_config.rs
@@ -23,6 +23,9 @@ pub struct ContractConfig {
     /// Object ID of the credits object.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub credits_object: Option<ObjectID>,
+    /// Object ID of the walrus subsidies object.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub walrus_subsidies_object: Option<ObjectID>,
 }
 
 impl ContractConfig {
@@ -33,6 +36,7 @@ impl ContractConfig {
             staking_object,
             credits_object: None,
             subsidies_object: None,
+            walrus_subsidies_object: None,
         }
     }
 }

--- a/crates/walrus-sui/src/client/read_client.rs
+++ b/crates/walrus-sui/src/client/read_client.rs
@@ -807,7 +807,7 @@ impl SuiReadClient {
 
     /// Checks if the walrus subsidies object
     /// ([`contracts::walrus_subsidies::WalrusSubsidies`]) exist on chain and returns the object.
-    pub(crate) async fn get_walrus_subsidies_object(
+    pub async fn get_walrus_subsidies_object(
         &self,
         with_inner: bool,
     ) -> SuiClientResult<WalrusSubsidies> {

--- a/crates/walrus-sui/src/client/read_client.rs
+++ b/crates/walrus-sui/src/client/read_client.rs
@@ -805,8 +805,8 @@ impl SuiReadClient {
         })
     }
 
-    /// Checks if the walrus subsidies object (`walrus_subsidies::WalrusSubsidies` in Move) exist on
-    /// chain and returns the object.
+    /// Checks if the walrus subsidies object
+    /// ([`contracts::walrus_subsidies::WalrusSubsidies`]) exist on chain and returns the object.
     pub(crate) async fn get_walrus_subsidies_object(
         &self,
         with_inner: bool,
@@ -902,8 +902,8 @@ impl SuiReadClient {
         Ok(())
     }
 
-    /// Sets a walrus subsidies (`walrus_subsidies::WalrusSubsidies`) object to be used by the
-    /// client.
+    /// Sets a walrus subsidies ([`contracts::walrus_subsidies::WalrusSubsidies`]) object to be
+    /// used by the client.
     pub async fn set_walrus_subsidies_object(&self, object_id: ObjectID) -> SuiClientResult<()> {
         let package_id = self
             .sui_client

--- a/crates/walrus-sui/src/client/read_client.rs
+++ b/crates/walrus-sui/src/client/read_client.rs
@@ -34,7 +34,6 @@ use sui_types::{
     TypeTag,
     base_types::{ObjectRef, SequenceNumber, SuiAddress},
     event::EventID,
-    object::Owner,
     transaction::ObjectArg,
 };
 use tokio::sync::{OnceCell, mpsc};
@@ -71,10 +70,14 @@ use crate::{
             StakingInnerV1,
             StakingObjectForDeserialization,
             StakingPool,
+            SubsidiesInnerKey,
             SystemObjectForDeserialization,
             SystemStateInnerV1,
             SystemStateInnerV1Enum,
             SystemStateInnerV1Testnet,
+            WalrusSubsidies,
+            WalrusSubsidiesForDeserialization,
+            WalrusSubsidiesInner,
         },
     },
     utils::{get_sui_object_from_object_response, handle_pagination},
@@ -236,6 +239,13 @@ pub trait ReadClient: Send + Sync {
     /// Should be called after the `subsidies` contract for credits is upgraded.
     fn refresh_credits_package_id(&self) -> impl Future<Output = SuiClientResult<()>> + Send;
 
+    /// Refreshes the walrus subsidies package ID.
+    ///
+    /// Should be called after the `walrus_subsidies` contract is upgraded.
+    fn refresh_walrus_subsidies_package_id(
+        &self,
+    ) -> impl Future<Output = SuiClientResult<()>> + Send;
+
     /// Returns the version of the system object.
     fn system_object_version(&self) -> impl Future<Output = SuiClientResult<u64>> + Send;
 }
@@ -265,26 +275,18 @@ impl From<Mutability> for bool {
     }
 }
 
-/// Credits (former: Subsidies) configuration and state
+/// Configuration and state for a shared object with a package ID that is not the walrus package.
+/// E.g. for credits or walrus subsidies.
 #[derive(Clone, Debug)]
-pub struct Credits {
-    /// The package ID of the credits contract
+pub struct SharedObjectWithPkgConfig {
+    /// The package ID of the corresponding package
     pub package_id: ObjectID,
-    /// The object ID of the `subsidies::Subsidies` Move object
+    /// The object ID of the object
     pub object_id: ObjectID,
-    /// The initial version of the `subsidies::Subsidies` object when it was created
-    credits_obj_initial_version: OnceCell<SequenceNumber>,
-}
-
-impl Credits {
-    /// Creates a new instance with the given package and object IDs
-    pub fn new(package_id: ObjectID, object_id: ObjectID) -> Self {
-        Self {
-            package_id,
-            object_id,
-            credits_obj_initial_version: OnceCell::new(),
-        }
-    }
+    /// The initial version of the shared object when it was created
+    initial_version: SequenceNumber,
+    /// The type origin map for the package
+    type_origin_map: TypeOriginMap,
 }
 
 /// Client implementation for interacting with the Walrus smart contracts.
@@ -297,7 +299,8 @@ pub struct SuiReadClient {
     type_origin_map: Arc<RwLock<TypeOriginMap>>,
     sys_obj_initial_version: OnceCell<SequenceNumber>,
     staking_obj_initial_version: OnceCell<SequenceNumber>,
-    credits: Arc<RwLock<Option<Credits>>>,
+    credits: Arc<RwLock<Option<SharedObjectWithPkgConfig>>>,
+    walrus_subsidies: Arc<RwLock<Option<SharedObjectWithPkgConfig>>>,
     wal_type: String,
 }
 
@@ -317,20 +320,7 @@ impl SuiReadClient {
             .type_origin_map_for_package(walrus_package_id)
             .await?;
         let wal_type = sui_client.wal_type_from_package(walrus_package_id).await?;
-        let credits = if let Some(object_id) = contract_config
-            .credits_object
-            .or(contract_config.subsidies_object)
-        {
-            let package_id = sui_client.get_credits_object(object_id).await?.package_id;
-            Some(Credits {
-                package_id,
-                object_id,
-                credits_obj_initial_version: OnceCell::new(),
-            })
-        } else {
-            None
-        };
-        Ok(Self {
+        let client = Self {
             walrus_package_id: Arc::new(RwLock::new(walrus_package_id)),
             sui_client,
             system_object_id: contract_config.system_object,
@@ -338,9 +328,22 @@ impl SuiReadClient {
             type_origin_map: Arc::new(RwLock::new(type_origin_map)),
             sys_obj_initial_version: OnceCell::new(),
             staking_obj_initial_version: OnceCell::new(),
-            credits: Arc::new(RwLock::new(credits)),
+            credits: Arc::new(RwLock::new(None)),
+            walrus_subsidies: Arc::new(RwLock::new(None)),
             wal_type,
-        })
+        };
+        if let Some(credits_object_id) = contract_config
+            .credits_object
+            .or(contract_config.subsidies_object)
+        {
+            client.set_credits_object(credits_object_id).await?;
+        }
+        if let Some(walrus_subsidies_object_id) = contract_config.walrus_subsidies_object {
+            client
+                .set_walrus_subsidies_object(walrus_subsidies_object_id)
+                .await?;
+        }
+        Ok(client)
     }
 
     /// Constructs a new `SuiReadClient` around a [`RetriableSuiClient`] constructed for the
@@ -365,7 +368,10 @@ impl SuiReadClient {
         object_id: ObjectID,
         mutable: Mutability,
     ) -> SuiClientResult<ObjectArg> {
-        let initial_shared_version = self.get_shared_object_initial_version(object_id).await?;
+        let initial_shared_version = self
+            .sui_client
+            .get_shared_object_initial_version(object_id)
+            .await?;
         Ok(ObjectArg::SharedObject {
             id: object_id,
             initial_shared_version,
@@ -388,7 +394,10 @@ impl SuiReadClient {
     async fn system_object_initial_version(&self) -> SuiClientResult<SequenceNumber> {
         let initial_shared_version = self
             .sys_obj_initial_version
-            .get_or_try_init(|| self.get_shared_object_initial_version(self.system_object_id))
+            .get_or_try_init(|| {
+                self.sui_client
+                    .get_shared_object_initial_version(self.system_object_id)
+            })
             .await?;
         Ok(*initial_shared_version)
     }
@@ -409,22 +418,33 @@ impl SuiReadClient {
         &self,
         mutable: Mutability,
     ) -> SuiClientResult<ObjectArg> {
-        let credits = self
-            .credits
-            .read()
-            .expect("mutex should not be poisoned")
+        let credits = self.credits.read().expect("mutex should not be poisoned");
+        let credits = credits
             .as_ref()
-            .ok_or_else(|| SuiClientError::Internal(anyhow!("credits object ID not found")))?
-            .clone();
-
-        let initial_shared_version = credits
-            .credits_obj_initial_version
-            .get_or_try_init(|| self.get_shared_object_initial_version(credits.object_id))
-            .await?;
+            .ok_or_else(|| SuiClientError::Internal(anyhow!("credits object ID not found")))?;
 
         Ok(ObjectArg::SharedObject {
             id: credits.object_id,
-            initial_shared_version: *initial_shared_version,
+            initial_shared_version: credits.initial_version,
+            mutable: mutable.into(),
+        })
+    }
+
+    pub(crate) async fn object_arg_for_walrus_subsidies_obj(
+        &self,
+        mutable: Mutability,
+    ) -> SuiClientResult<ObjectArg> {
+        let walrus_subsidies = self
+            .walrus_subsidies
+            .read()
+            .expect("mutex should not be poisoned");
+        let walrus_subsidies = walrus_subsidies.as_ref().ok_or_else(|| {
+            SuiClientError::Internal(anyhow!("walrus subsidies object ID not found"))
+        })?;
+
+        Ok(ObjectArg::SharedObject {
+            id: walrus_subsidies.object_id,
+            initial_shared_version: walrus_subsidies.initial_version,
             mutable: mutable.into(),
         })
     }
@@ -432,30 +452,12 @@ impl SuiReadClient {
     async fn staking_object_initial_version(&self) -> SuiClientResult<SequenceNumber> {
         let initial_shared_version = self
             .staking_obj_initial_version
-            .get_or_try_init(|| self.get_shared_object_initial_version(self.staking_object_id))
+            .get_or_try_init(|| {
+                self.sui_client
+                    .get_shared_object_initial_version(self.staking_object_id)
+            })
             .await?;
         Ok(*initial_shared_version)
-    }
-
-    async fn get_shared_object_initial_version(
-        &self,
-        object_id: ObjectID,
-    ) -> SuiClientResult<SequenceNumber> {
-        let Some(Owner::Shared {
-            initial_shared_version,
-        }) = self
-            .sui_client
-            .get_object_with_options(object_id, SuiObjectDataOptions::new().with_owner())
-            .await?
-            .owner()
-        else {
-            return Err(anyhow!(
-                "trying to get the initial version of a non-shared object {}",
-                object_id
-            )
-            .into());
-        };
-        Ok(initial_shared_version)
     }
 
     /// Returns the system package ID.
@@ -466,6 +468,15 @@ impl SuiReadClient {
     /// Returns the credits package ID.
     pub fn get_credits_package_id(&self) -> Option<ObjectID> {
         self.credits
+            .read()
+            .expect("mutex should not be poisoned")
+            .as_ref()
+            .map(|s| s.package_id)
+    }
+
+    /// Returns the walrus subsidies package ID.
+    pub fn get_walrus_subsidies_package_id(&self) -> Option<ObjectID> {
+        self.walrus_subsidies
             .read()
             .expect("mutex should not be poisoned")
             .as_ref()
@@ -491,6 +502,15 @@ impl SuiReadClient {
             .map(|s| s.object_id)
     }
 
+    /// Returns the walrus subsidies object ID.
+    pub fn get_walrus_subsidies_object_id(&self) -> Option<ObjectID> {
+        self.walrus_subsidies
+            .read()
+            .expect("mutex should not be poisoned")
+            .as_ref()
+            .map(|s| s.object_id)
+    }
+
     /// Returns the contract config.
     pub fn contract_config(&self) -> ContractConfig {
         ContractConfig {
@@ -503,6 +523,12 @@ impl SuiReadClient {
                 .as_ref()
                 .map(|s| s.object_id),
             subsidies_object: None,
+            walrus_subsidies_object: self
+                .walrus_subsidies
+                .read()
+                .expect("mutex should not be poisoned")
+                .as_ref()
+                .map(|s| s.object_id),
         }
     }
 
@@ -524,8 +550,15 @@ impl SuiReadClient {
     }
 
     /// Returns a mutable reference to the credits object.
-    fn credits_mut(&self) -> RwLockWriteGuard<Option<Credits>> {
+    fn credits_mut(&self) -> RwLockWriteGuard<Option<SharedObjectWithPkgConfig>> {
         self.credits.write().expect("mutex should not be poisoned")
+    }
+
+    /// Returns a mutable reference to the walrus subsidies object.
+    fn walrus_subsidies_mut(&self) -> RwLockWriteGuard<Option<SharedObjectWithPkgConfig>> {
+        self.walrus_subsidies
+            .write()
+            .expect("mutex should not be poisoned")
     }
 
     pub(crate) fn type_origin_map(&self) -> RwLockReadGuard<TypeOriginMap> {
@@ -772,6 +805,50 @@ impl SuiReadClient {
         })
     }
 
+    /// Checks if the walrus subsidies object (`walrus_subsidies::WalrusSubsidies` in Move) exist on
+    /// chain and returns the object.
+    pub(crate) async fn get_walrus_subsidies_object(
+        &self,
+        with_inner: bool,
+    ) -> SuiClientResult<WalrusSubsidies> {
+        let walrus_subsidies = self
+            .walrus_subsidies
+            .read()
+            .expect("RwLock should not be poisoned")
+            .as_ref()
+            .cloned();
+
+        let Some(walrus_subsidies) = walrus_subsidies else {
+            return Err(SuiClientError::WalrusSubsidiesNotConfigured);
+        };
+
+        let deserialized_object = self
+            .sui_client
+            .get_sui_object::<WalrusSubsidiesForDeserialization>(walrus_subsidies.object_id)
+            .await?;
+        let inner = if with_inner {
+            let key_tag = contracts::walrus_subsidies::SubsidiesInnerKey
+                .to_move_struct_tag_with_type_map(&walrus_subsidies.type_origin_map, &[])?;
+            let inner = self
+                .sui_client
+                .get_dynamic_field::<SubsidiesInnerKey, WalrusSubsidiesInner>(
+                    walrus_subsidies.object_id,
+                    key_tag.into(),
+                    SubsidiesInnerKey { dummy_field: false },
+                )
+                .await?;
+            Some(inner)
+        } else {
+            None
+        };
+        Ok(WalrusSubsidies {
+            id: deserialized_object.id,
+            version: deserialized_object.version,
+            package_id: deserialized_object.package_id,
+            inner,
+        })
+    }
+
     /// Returns the staking object.
     pub async fn get_staking_object(&self) -> SuiClientResult<StakingObject> {
         let StakingObjectForDeserialization {
@@ -808,10 +885,44 @@ impl SuiReadClient {
             .get_credits_object(object_id)
             .await?
             .package_id;
-        *self.credits_mut() = Some(Credits {
+        let initial_version = self
+            .sui_client
+            .get_shared_object_initial_version(object_id)
+            .await?;
+        let type_origin_map = self
+            .sui_client
+            .type_origin_map_for_package(package_id)
+            .await?;
+        *self.credits_mut() = Some(SharedObjectWithPkgConfig {
             package_id,
             object_id,
-            credits_obj_initial_version: OnceCell::new(),
+            initial_version,
+            type_origin_map,
+        });
+        Ok(())
+    }
+
+    /// Sets a walrus subsidies (`walrus_subsidies::WalrusSubsidies`) object to be used by the
+    /// client.
+    pub async fn set_walrus_subsidies_object(&self, object_id: ObjectID) -> SuiClientResult<()> {
+        let package_id = self
+            .sui_client
+            .get_sui_object::<WalrusSubsidiesForDeserialization>(object_id)
+            .await?
+            .package_id;
+        let initial_version = self
+            .sui_client
+            .get_shared_object_initial_version(object_id)
+            .await?;
+        let type_origin_map = self
+            .sui_client
+            .type_origin_map_for_package(package_id)
+            .await?;
+        *self.walrus_subsidies_mut() = Some(SharedObjectWithPkgConfig {
+            package_id,
+            object_id,
+            initial_version,
+            type_origin_map,
         });
         Ok(())
     }
@@ -910,6 +1021,16 @@ impl SuiReadClient {
         &self,
     ) -> SuiClientResult<SystemObjectForDeserialization> {
         self.sui_client.get_sui_object(self.system_object_id).await
+    }
+
+    /// Returns the time at which process_subsidies was last called on the walrus subsidies object.
+    pub async fn last_walrus_subsidies_call(&self) -> SuiClientResult<DateTime<Utc>> {
+        Ok(self
+            .get_walrus_subsidies_object(true)
+            .await?
+            .inner
+            .ok_or_else(|| anyhow!("could not retrieve inner subsidies object"))?
+            .last_subsidized)
     }
 }
 
@@ -1164,25 +1285,16 @@ impl ReadClient for SuiReadClient {
     }
 
     async fn refresh_credits_package_id(&self) -> SuiClientResult<()> {
-        let credits = self
-            .credits
-            .read()
-            .expect("mutex should not be poisoned")
-            .clone();
-        if let Some(credits) = credits {
-            let new_package_id = self
-                .sui_client
-                .get_credits_object(credits.object_id)
-                .await?
-                .package_id;
+        if let Some(credits_object_id) = self.get_credits_object_id() {
+            self.set_credits_object(credits_object_id).await?;
+        }
+        Ok(())
+    }
 
-            // Update the package_id if it has changed
-            if new_package_id != credits.package_id {
-                let mut credits_guard = self.credits.write().expect("mutex should not be poisoned");
-                if let Some(credits) = credits_guard.as_mut() {
-                    credits.package_id = new_package_id;
-                }
-            }
+    async fn refresh_walrus_subsidies_package_id(&self) -> SuiClientResult<()> {
+        if let Some(walrus_subsidies_object_id) = self.get_walrus_subsidies_object_id() {
+            self.set_walrus_subsidies_object(walrus_subsidies_object_id)
+                .await?;
         }
         Ok(())
     }

--- a/crates/walrus-sui/src/client/transaction_builder.rs
+++ b/crates/walrus-sui/src/client/transaction_builder.rs
@@ -841,8 +841,8 @@ impl WalrusPtbBuilder {
         Ok(result_arg)
     }
 
-    /// Adds a call to create a new walrus subsidies object (`walrus_subsidies::WalrusSubsidies` in
-    /// Move), funded with `amount` WAL, to the PTB. Returns the argument for the AdminCap.
+    /// Adds a call to create a new walrus subsidies object
+    /// ([`contracts::walrus_subsidies::WalrusSubsidies`]) to the PTB.
     pub async fn create_walrus_subsidies(
         &mut self,
         package_id: ObjectID,
@@ -862,8 +862,9 @@ impl WalrusPtbBuilder {
         Ok(result_arg)
     }
 
-    /// Adds a call to fund the walrus subsidies object (`walrus_subsidies::WalrusSubsidies`)
-    /// to the PTB, if a walrus subsidies object is configured.
+    /// Adds a call to fund the walrus subsidies object
+    /// ([`contracts::walrus_subsidies::WalrusSubsidies`]) to the PTB, if a walrus subsidies object
+    /// is configured.
     pub async fn fund_walrus_subsidies(&mut self, amount: u64) -> SuiClientResult<()> {
         let Some(walrus_subsidies_pkg_id) = self.read_client.get_walrus_subsidies_package_id()
         else {

--- a/crates/walrus-sui/src/client/transaction_builder.rs
+++ b/crates/walrus-sui/src/client/transaction_builder.rs
@@ -300,7 +300,6 @@ impl WalrusPtbBuilder {
 
         let reserve_arguments = vec![
             self.credits_arg(Mutability::Mutable).await?,
-            self.credits_arg(Mutability::Mutable).await?,
             self.system_arg(Mutability::Mutable).await?,
             self.pt_builder.pure(encoded_size)?,
             self.pt_builder.pure(epochs_ahead)?,

--- a/crates/walrus-sui/src/client/transaction_builder.rs
+++ b/crates/walrus-sui/src/client/transaction_builder.rs
@@ -300,6 +300,7 @@ impl WalrusPtbBuilder {
 
         let reserve_arguments = vec![
             self.credits_arg(Mutability::Mutable).await?,
+            self.credits_arg(Mutability::Mutable).await?,
             self.system_arg(Mutability::Mutable).await?,
             self.pt_builder.pure(encoded_size)?,
             self.pt_builder.pure(epochs_ahead)?,
@@ -841,6 +842,58 @@ impl WalrusPtbBuilder {
         Ok(result_arg)
     }
 
+    /// Adds a call to create a new walrus subsidies object (`walrus_subsidies::WalrusSubsidies` in
+    /// Move), funded with `amount` WAL, to the PTB. Returns the argument for the AdminCap.
+    pub async fn create_walrus_subsidies(
+        &mut self,
+        package_id: ObjectID,
+        system_subsidy_rate: u32,
+        base_subsidy: u64,
+        subsidy_per_shard: u64,
+    ) -> SuiClientResult<Argument> {
+        let args = vec![
+            self.system_arg(Mutability::Immutable).await?,
+            self.staking_arg(Mutability::Immutable).await?,
+            self.pt_builder.pure(system_subsidy_rate)?,
+            self.pt_builder.pure(base_subsidy)?,
+            self.pt_builder.pure(subsidy_per_shard)?,
+        ];
+        let result_arg = self.move_call(package_id, contracts::walrus_subsidies::new, args)?;
+        self.add_result_to_be_consumed(result_arg);
+        Ok(result_arg)
+    }
+
+    /// Adds a call to fund the walrus subsidies object (`walrus_subsidies::WalrusSubsidies`)
+    /// to the PTB, if a walrus subsidies object is configured.
+    pub async fn fund_walrus_subsidies(&mut self, amount: u64) -> SuiClientResult<()> {
+        let Some(walrus_subsidies_pkg_id) = self.read_client.get_walrus_subsidies_package_id()
+        else {
+            return Err(SuiClientError::WalrusSubsidiesNotConfigured);
+        };
+        self.fill_wal_balance(amount).await?;
+        let split_main_coin_arg = self.wal_coin_arg()?;
+        let split_amount_arg = self.pt_builder.pure(amount)?;
+        let split_coin = self.pt_builder.command(Command::SplitCoins(
+            split_main_coin_arg,
+            vec![split_amount_arg],
+        ));
+        let args = vec![
+            self.pt_builder.obj(
+                self.read_client
+                    .object_arg_for_walrus_subsidies_obj(Mutability::Mutable)
+                    .await?,
+            )?,
+            split_coin,
+        ];
+        self.move_call(
+            walrus_subsidies_pkg_id,
+            contracts::walrus_subsidies::add_coin,
+            args,
+        )?;
+        self.reduce_wal_balance(amount)?;
+        Ok(())
+    }
+
     /// Adds a call to `invalidate_blob_id` to the PTB.
     pub async fn invalidate_blob_id(
         &mut self,
@@ -892,6 +945,26 @@ impl WalrusPtbBuilder {
             self.pt_builder.obj(CLOCK_OBJECT_ARG)?,
         ];
         self.walrus_move_call(contracts::staking::voting_end, args)?;
+        Ok(())
+    }
+
+    /// Adds a call to `walrus_subsidies::process_subsidies` to the PTB.
+    pub async fn process_subsidies(&mut self) -> SuiClientResult<()> {
+        let args = vec![
+            self.walrus_subsidies_arg(Mutability::Mutable).await?,
+            self.staking_arg(Mutability::Mutable).await?,
+            self.system_arg(Mutability::Mutable).await?,
+            self.pt_builder.obj(CLOCK_OBJECT_ARG)?,
+        ];
+        let Some(walrus_subsidies_package_id) = self.read_client.get_walrus_subsidies_package_id()
+        else {
+            return Err(SuiClientError::CreditsNotEnabled);
+        };
+        self.move_call(
+            walrus_subsidies_package_id,
+            contracts::walrus_subsidies::process_subsidies,
+            args,
+        )?;
         Ok(())
     }
 
@@ -1684,6 +1757,14 @@ impl WalrusPtbBuilder {
         Ok(self
             .pt_builder
             .obj(self.read_client.object_arg_for_credits_obj(mutable).await?)?)
+    }
+
+    async fn walrus_subsidies_arg(&mut self, mutable: Mutability) -> SuiClientResult<Argument> {
+        Ok(self.pt_builder.obj(
+            self.read_client
+                .object_arg_for_walrus_subsidies_obj(mutable)
+                .await?,
+        )?)
     }
 
     fn wal_coin_arg(&mut self) -> SuiClientResult<Argument> {

--- a/crates/walrus-sui/src/contracts.rs
+++ b/crates/walrus-sui/src/contracts.rs
@@ -429,6 +429,19 @@ pub mod credits {
     contract_ident!(fn subsidies::register_blob);
 }
 
+/// Module for tags corresponding to the Move module `walrus_subsidies`.
+pub mod walrus_subsidies {
+    use super::*;
+
+    contract_ident!(struct walrus_subsidies::WalrusSubsidies);
+    contract_ident!(struct walrus_subsidies::WalrusSubsidiesInnerV1);
+    contract_ident!(struct walrus_subsidies::SubsidiesInnerKey);
+    contract_ident!(struct walrus_subsidies::AdminCap);
+    contract_ident!(fn walrus_subsidies::new);
+    contract_ident!(fn walrus_subsidies::add_coin);
+    contract_ident!(fn walrus_subsidies::process_subsidies);
+}
+
 /// Module for tags corresponding to the Move module `dynamic_field` from the `sui` package.
 pub mod dynamic_field {
     use super::*;

--- a/crates/walrus-sui/src/test_utils/system_setup.rs
+++ b/crates/walrus-sui/src/test_utils/system_setup.rs
@@ -231,14 +231,15 @@ pub async fn create_and_init_system(
 
     // Create credits object if enabled.
     let credits_object = if let Some(pkg_id) = credits_pkg_id {
-        let (credits_object_id, _) = admin_contract_client
+        let credits_object_id = admin_contract_client
             .create_and_fund_credits(
                 pkg_id,
                 DEFAULT_BUYER_CREDITS_RATE,
                 DEFAULT_SYSTEM_CREDITS_RATE,
                 DEFAULT_CREDITS_FUNDS,
             )
-            .await?;
+            .await?
+            .object_id;
 
         admin_contract_client
             .read_client()
@@ -251,14 +252,15 @@ pub async fn create_and_init_system(
 
     // Create walrus subsidies object if enabled.
     let walrus_subsidies_object = if let Some(pkg_id) = walrus_subsidies_pkg_id {
-        let (walrus_subsidies_object_id, _) = admin_contract_client
+        let walrus_subsidies_object_id = admin_contract_client
             .create_walrus_subsidies(
                 pkg_id,
                 DEFAULT_SYSTEM_SUBSIDY_RATE,
                 DEFAULT_BASE_SUBSIDY,
                 DEFAULT_SUBSIDY_PER_SHARD,
             )
-            .await?;
+            .await?
+            .object_id;
         admin_contract_client
             .read_client()
             .set_walrus_subsidies_object(walrus_subsidies_object_id)
@@ -499,9 +501,10 @@ async fn publish_with_default_system_with_epoch_duration(
         .collect();
 
     if let Some(credits_pkg_id) = system_context.credits_pkg_id {
-        let (credits_object_id, _admin_cap_id) = contract_client
+        let credits_object_id = contract_client
             .create_and_fund_credits(credits_pkg_id, subsidy_rate, subsidy_rate, MEGA_WAL)
-            .await?;
+            .await?
+            .object_id;
 
         contract_client
             .read_client()

--- a/crates/walrus-sui/src/test_utils/system_setup.rs
+++ b/crates/walrus-sui/src/test_utils/system_setup.rs
@@ -43,6 +43,22 @@ pub const DEFAULT_MAX_EPOCHS_AHEAD: EpochCount = 53;
 const ONE_WAL: u64 = 1_000_000_000;
 const MEGA_WAL: u64 = 1_000_000 * ONE_WAL;
 
+/// Default buyer subsidy rate (5%) in credits object.
+const DEFAULT_BUYER_CREDITS_RATE: u16 = 500;
+/// Default system subsidy rate (6%) in credits object.
+const DEFAULT_SYSTEM_CREDITS_RATE: u16 = 600;
+/// Default initial credits funds amount
+const DEFAULT_CREDITS_FUNDS: u64 = MEGA_WAL;
+
+/// Default system subsidy rate (50%) in walrus subsidies object.
+const DEFAULT_SYSTEM_SUBSIDY_RATE: u32 = 5_000;
+/// Default base subsidy in walrus subsidies object.
+const DEFAULT_BASE_SUBSIDY: u64 = ONE_WAL;
+/// Default subsidy per shard in walrus subsidies object.
+const DEFAULT_SUBSIDY_PER_SHARD: u64 = ONE_WAL / 10;
+/// Default initial subsidies funds amount
+const DEFAULT_SUBSIDIES_FUNDS: u64 = MEGA_WAL;
+
 /// Provides the path of the latest development contracts directory.
 pub fn development_contract_dir() -> anyhow::Result<PathBuf> {
     Ok(project_root_dir()?.join("contracts"))
@@ -78,6 +94,10 @@ pub struct SystemContext {
     pub credits_object: Option<ObjectID>,
     /// The ID of the credits package.
     pub credits_pkg_id: Option<ObjectID>,
+    /// The ID of the walrus subsidies object.
+    pub walrus_subsidies_object: Option<ObjectID>,
+    /// The ID of the walrus subsidies package.
+    pub walrus_subsidies_pkg_id: Option<ObjectID>,
 }
 
 impl SystemContext {
@@ -107,6 +127,7 @@ impl SystemContext {
             staking_object: self.staking_object,
             credits_object: self.credits_object,
             subsidies_object: None,
+            walrus_subsidies_object: self.walrus_subsidies_object,
         }
     }
 }
@@ -117,7 +138,7 @@ impl SystemContext {
 /// Returns the package id and the object IDs of the system object and the staking object.
 #[allow(clippy::too_many_arguments)]
 pub async fn create_and_init_system_for_test(
-    admin_wallet: &mut Wallet,
+    admin_wallet: Wallet,
     n_shards: NonZeroU16,
     epoch_zero_duration: Duration,
     epoch_duration: Duration,
@@ -125,7 +146,7 @@ pub async fn create_and_init_system_for_test(
     with_credits: bool,
     deploy_directory: Option<PathBuf>,
     contract_dir: Option<PathBuf>,
-) -> Result<SystemContext> {
+) -> Result<(SystemContext, SuiContractClient)> {
     let temp_dir; // make sure the temp_dir is in scope until the end of the function
     let deploy_directory = if deploy_directory.is_none() {
         temp_dir = tempfile::tempdir()?;
@@ -150,6 +171,7 @@ pub async fn create_and_init_system_for_test(
             with_wal_exchange: true,
             use_existing_wal_token: false,
             with_credits,
+            with_walrus_subsidies: true,
         },
         None,
     )
@@ -159,15 +181,16 @@ pub async fn create_and_init_system_for_test(
 /// Publishes the contracts and initializes the system with the provided parameters.
 ///
 /// Returns a `SystemContext` containing the package ID and object IDs for the system, staking,
-/// upgrade manager, and optionally credits and WAL exchange objects.
+/// upgrade manager, and optionally credits and walrus subsidies objects, as well as an initialized
+/// walrus client with the admin wallet.
 ///
 /// If `deploy_directory` is provided, the contracts will be copied to this directory and published
 /// from there to keep the `Move.toml` in the original directory unchanged.
 pub async fn create_and_init_system(
-    admin_wallet: &mut Wallet,
+    mut admin_wallet: Wallet,
     init_system_params: InitSystemParams,
     gas_budget: Option<u64>,
-) -> Result<SystemContext> {
+) -> Result<(SystemContext, SuiContractClient)> {
     let init_system_params_cloned = init_system_params.clone();
     let PublishSystemPackageResult {
         walrus_pkg_id,
@@ -175,20 +198,17 @@ pub async fn create_and_init_system(
         upgrade_cap_id,
         wal_exchange_pkg_id,
         credits_pkg_id,
+        walrus_subsidies_pkg_id,
     } = system_setup::publish_coin_and_system_package(
-        admin_wallet,
-        init_system_params_cloned.contract_dir,
-        init_system_params_cloned.deploy_directory,
-        init_system_params_cloned.with_wal_exchange,
-        init_system_params_cloned.use_existing_wal_token,
-        init_system_params_cloned.with_credits,
+        &mut admin_wallet,
+        init_system_params_cloned,
         gas_budget,
     )
     .await?;
 
     let (system_object, staking_object, upgrade_manager_object) =
         system_setup::create_system_and_staking_objects(
-            admin_wallet,
+            &mut admin_wallet,
             walrus_pkg_id,
             init_cap_id,
             upgrade_cap_id,
@@ -197,15 +217,74 @@ pub async fn create_and_init_system(
         )
         .await?;
 
-    Ok(SystemContext {
-        walrus_pkg_id,
-        system_object,
-        staking_object,
-        upgrade_manager_object,
-        credits_object: None,
-        wal_exchange_pkg_id,
-        credits_pkg_id,
-    })
+    let contract_config = ContractConfig::new(system_object, staking_object);
+
+    let rpc_urls = &[admin_wallet.get_rpc_url()?];
+    let admin_contract_client = SuiContractClient::new(
+        admin_wallet,
+        rpc_urls,
+        &contract_config,
+        ExponentialBackoffConfig::default(),
+        gas_budget,
+    )
+    .await?;
+
+    // Create credits object if enabled.
+    let credits_object = if let Some(pkg_id) = credits_pkg_id {
+        let (credits_object_id, _) = admin_contract_client
+            .create_and_fund_credits(
+                pkg_id,
+                DEFAULT_BUYER_CREDITS_RATE,
+                DEFAULT_SYSTEM_CREDITS_RATE,
+                DEFAULT_CREDITS_FUNDS,
+            )
+            .await?;
+
+        admin_contract_client
+            .read_client()
+            .set_credits_object(credits_object_id)
+            .await?;
+        Some(credits_object_id)
+    } else {
+        None
+    };
+
+    // Create walrus subsidies object if enabled.
+    let walrus_subsidies_object = if let Some(pkg_id) = walrus_subsidies_pkg_id {
+        let (walrus_subsidies_object_id, _) = admin_contract_client
+            .create_walrus_subsidies(
+                pkg_id,
+                DEFAULT_SYSTEM_SUBSIDY_RATE,
+                DEFAULT_BASE_SUBSIDY,
+                DEFAULT_SUBSIDY_PER_SHARD,
+            )
+            .await?;
+        admin_contract_client
+            .read_client()
+            .set_walrus_subsidies_object(walrus_subsidies_object_id)
+            .await?;
+        admin_contract_client
+            .fund_walrus_subsidies(DEFAULT_SUBSIDIES_FUNDS)
+            .await?;
+        Some(walrus_subsidies_object_id)
+    } else {
+        None
+    };
+
+    Ok((
+        SystemContext {
+            walrus_pkg_id,
+            system_object,
+            staking_object,
+            upgrade_manager_object,
+            credits_object,
+            wal_exchange_pkg_id,
+            credits_pkg_id,
+            walrus_subsidies_pkg_id,
+            walrus_subsidies_object,
+        },
+        admin_contract_client,
+    ))
 }
 
 /// Registers the nodes based on the provided parameters, distributes WAL to each contract client,
@@ -353,11 +432,8 @@ pub async fn initialize_contract_and_wallet_for_testing(
     let result = admin_wallet
         .and_then_async(
             async |admin_wallet| -> anyhow::Result<(SystemContext, SuiContractClient)> {
-                let rpc_urls = &[admin_wallet.get_rpc_url()?];
-
                 publish_with_default_system_with_epoch_duration(
                     admin_wallet,
-                    rpc_urls,
                     &bls_keys,
                     epoch_duration,
                     with_credits,
@@ -389,15 +465,14 @@ pub async fn initialize_contract_and_wallet_for_testing(
 /// Returns the system context and the contract client with the admin wallet that
 /// also holds the node caps for all nodes.
 async fn publish_with_default_system_with_epoch_duration(
-    mut admin_wallet: Wallet,
-    rpc_urls: &[String],
+    admin_wallet: Wallet,
     bls_keys: &[ProtocolKeyPair],
     epoch_duration: Duration,
     with_credits: bool,
     subsidy_rate: u16,
 ) -> anyhow::Result<(SystemContext, SuiContractClient)> {
-    let system_context = create_and_init_system_for_test(
-        &mut admin_wallet,
+    let (system_context, contract_client) = create_and_init_system_for_test(
+        admin_wallet,
         NonZeroU16::new(1000).expect("1000 is not 0"),
         Duration::from_secs(0),
         epoch_duration,
@@ -422,11 +497,6 @@ async fn publish_with_default_system_with_epoch_duration(
             )
         })
         .collect();
-
-    // Create admin contract client
-    let contract_client = system_context
-        .new_contract_client(admin_wallet, rpc_urls, Default::default(), None)
-        .await?;
 
     if let Some(credits_pkg_id) = system_context.credits_pkg_id {
         let (credits_object_id, _admin_cap_id) = contract_client

--- a/crates/walrus-sui/src/types/move_structs.rs
+++ b/crates/walrus-sui/src/types/move_structs.rs
@@ -998,6 +998,7 @@ pub(crate) struct WalrusSubsidiesInner {
     pub system_subsidy_rate: u32,
     /// The balance of funds available in the subsidy pool.
     pub subsidy_pool: u64,
+    // TODO(WAL-788): Use a specific type to represent different denominations.
     /// The base subsidy (in FROST) paid directly per storage node per epoch.
     pub base_subsidy: u64,
     /// The additional subsidy (in FROST) paid to each storage node directly per shard.

--- a/crates/walrus-sui/src/types/move_structs.rs
+++ b/crates/walrus-sui/src/types/move_structs.rs
@@ -5,6 +5,7 @@
 
 use std::{fmt::Display, num::NonZeroU16};
 
+use chrono::{DateTime, Utc};
 use fastcrypto::traits::ToFromBytes;
 use serde::{
     Deserialize,
@@ -949,6 +950,76 @@ impl AssociatedContractStruct for Credits {
     const CONTRACT_STRUCT: StructTag<'static> = contracts::credits::Subsidies;
 }
 
+/// Sui type for a `WalrusSubsidies` object.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WalrusSubsidies {
+    /// The object ID of the object
+    pub id: ObjectID,
+    /// The version of the object
+    pub version: u64,
+    /// The package ID of the contract
+    pub package_id: ObjectID,
+    /// The inner state of the object
+    pub(crate) inner: Option<WalrusSubsidiesInner>,
+}
+
+/// Sui type for outer system object. Used for deserialization.
+#[derive(Debug, Deserialize)]
+pub(crate) struct WalrusSubsidiesForDeserialization {
+    pub(crate) id: ObjectID,
+    pub(crate) version: u64,
+    pub(crate) package_id: ObjectID,
+}
+
+impl AssociatedContractStruct for WalrusSubsidiesForDeserialization {
+    const CONTRACT_STRUCT: StructTag<'static> = contracts::walrus_subsidies::WalrusSubsidies;
+}
+
+/// A pair mapping an epoch to a balance. Used for deserialization of the WalrusSubsidiesInner.
+#[derive(Debug, PartialEq, Eq, Clone, Deserialize)]
+pub(crate) struct EpochBalance {
+    epoch: Epoch,
+    balance: u64,
+}
+
+/// A ring buffer holding the epoch balances for a continuous range of epochs.
+/// Used for deserialization of the WalrusSubsidiesInner.
+#[derive(Debug, PartialEq, Eq, Clone, Deserialize)]
+pub(crate) struct EpochBalanceRingBuffer {
+    current_index: u32,
+    ring_buffer: Vec<EpochBalance>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub(crate) struct WalrusSubsidiesInner {
+    /// The subsidy rate applied to the price paid to the system and added to the per-epoch rewards
+    /// pool of the system. Subsidy rates are expressed in basis points (1/100 of a percent). A
+    /// subsidy rate of 100 basis points means a 1% subsidy.
+    pub system_subsidy_rate: u32,
+    /// The balance of funds available in the subsidy pool.
+    pub subsidy_pool: u64,
+    /// The base subsidy (in FROST) paid directly per storage node per epoch.
+    pub base_subsidy: u64,
+    /// The additional subsidy (in FROST) paid to each storage node directly per shard.
+    pub subsidy_per_shard: u64,
+    /// The last epoch for which the usage-independent subsidies were paid.
+    pub latest_epoch: u32,
+    /// Ring buffer to track how much of the per-epoch balance of the walrus system object has
+    /// already had subsidies added.
+    pub already_subsidized_balances: EpochBalanceRingBuffer,
+    /// Timestamp of the last time the subsidies were processed. Enables storage nodes to
+    /// easily check if subsidies were processed recently.
+    #[serde(deserialize_with = "chrono::serde::ts_milliseconds::deserialize")]
+    pub last_subsidized: DateTime<Utc>,
+    /// Reserved for future use and migrations.
+    #[serde(deserialize_with = "deserialize_bag_or_table")]
+    pub extra_fields: ObjectID,
+}
+
+impl AssociatedContractStruct for WalrusSubsidiesInner {
+    const CONTRACT_STRUCT: StructTag<'static> = contracts::walrus_subsidies::WalrusSubsidiesInnerV1;
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 /// Sui type for a dynamic field.
 pub struct SuiDynamicField<N, V> {
@@ -992,4 +1063,15 @@ pub(crate) struct Key {
 
 impl AssociatedContractStruct for Key {
     const CONTRACT_STRUCT: StructTag<'static> = contracts::extended_field::Key;
+}
+
+/// Sui type for the key of the dynamic field of the WalrusSubsidiesInner object.
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+pub(crate) struct SubsidiesInnerKey {
+    /// To match empty struct in Move.
+    pub dummy_field: bool,
+}
+
+impl AssociatedContractStruct for SubsidiesInnerKey {
+    const CONTRACT_STRUCT: StructTag<'static> = contracts::walrus_subsidies::SubsidiesInnerKey;
 }

--- a/crates/walrus-sui/src/types/move_structs.rs
+++ b/crates/walrus-sui/src/types/move_structs.rs
@@ -963,6 +963,15 @@ pub struct WalrusSubsidies {
     pub(crate) inner: Option<WalrusSubsidiesInner>,
 }
 
+#[cfg(feature = "test-utils")]
+impl WalrusSubsidies {
+    /// Returns the subsidy pool funds for the WalrusSubsidies object if it was requested with
+    /// the inner object.
+    pub fn subsidy_pool_funds(&self) -> Option<u64> {
+        self.inner.as_ref().map(|inner| inner.subsidy_pool)
+    }
+}
+
 /// Sui type for outer system object. Used for deserialization.
 #[derive(Debug, Deserialize)]
 pub(crate) struct WalrusSubsidiesForDeserialization {


### PR DESCRIPTION
## Description

Schedules a call to process the subsidies on storage nodes, to be called shortly before epoch change.

## Test plan

Added test in e2e-tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
