### PR TITLE
chore: prepare mainnet contracts for upgrade

### DIFF
--- a/mainnet-contracts/subsidies/Move.toml
+++ b/mainnet-contracts/subsidies/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.44.3" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.51.1" }
 WAL = { local = "../wal" }
 Walrus = { local = "../walrus" }
 

--- a/mainnet-contracts/wal/Move.toml
+++ b/mainnet-contracts/wal/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.44.3" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.51.1" }
 
 [addresses]
 wal = "0x0"

--- a/mainnet-contracts/walrus/Move.lock
+++ b/mainnet-contracts/walrus/Move.lock
@@ -39,5 +39,5 @@ flavor = "sui"
 [env.mainnet]
 chain-id = "35834a8a"
 original-published-id = "0x0000000000000000000000000000000000000000000000000000000000000000"
-latest-published-id = "0xfdc88f7d7cf30afab2f82e8380d11ee8f70efb90e863d1de8616fae1bb09ea77"
-published-version = "1"
+latest-published-id = "0xfa65cb2d62f4d39e60346fb7d501c12538ca2bbc646eaa37ece2aec5f897814e"
+published-version = "2"

--- a/mainnet-contracts/walrus/Move.lock
+++ b/mainnet-contracts/walrus/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "4BC589454DF8DC51D8FEC230BFFDCA8B2013DD09197792A169A73B22DDF64907"
+manifest_digest = "E8C01B2EAE30C7ECFFACB5957026E3B57C31D8A855A96FFAA4E5DDA440483AE6"
 deps_digest = "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -11,11 +11,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.44.3", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.51.1", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.44.3", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.51.1", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -30,7 +30,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.49.2"
+compiler-version = "1.51.2"
 edition = "2024.beta"
 flavor = "sui"
 
@@ -38,6 +38,6 @@ flavor = "sui"
 
 [env.mainnet]
 chain-id = "35834a8a"
-original-published-id = "0xfdc88f7d7cf30afab2f82e8380d11ee8f70efb90e863d1de8616fae1bb09ea77"
-latest-published-id = "0x5bb4a7183558164440dbd04a0501efb50467b504005337a5bd0686ad5b0420e4"
-published-version = "2"
+original-published-id = "0x0000000000000000000000000000000000000000000000000000000000000000"
+latest-published-id = "0xfdc88f7d7cf30afab2f82e8380d11ee8f70efb90e863d1de8616fae1bb09ea77"
+published-version = "1"

--- a/mainnet-contracts/walrus/Move.toml
+++ b/mainnet-contracts/walrus/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.44.3" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.51.1" }
 WAL = { local = "../wal" }
 
 [addresses]

--- a/mainnet-contracts/walrus/docs/msg_formats.txt
+++ b/mainnet-contracts/walrus/docs/msg_formats.txt
@@ -30,8 +30,10 @@ Intent types (add here):
 const PROOF_OF_POSSESSION_MSG_TYPE: u8 = 0;
 const BLOB_CERT_MSG_TYPE: u8 = 1;
 const INVALID_BLOB_ID_MSG_TYPE: u8 = 2;
-const DENY_LIST_UPDATE_MSG_TYPE: u8 = 3;
-const DENY_LIST_BLOB_DELETED_MSG_TYPE: u8 = 4;
+const SYNC_SHARD_MSG_TYPE: u8 = 3; // not used in Move
+const DENY_LIST_UPDATE_MSG_TYPE: u8 = 4;
+const DENY_LIST_BLOB_DELETED_MSG_TYPE: u8 = 5;
+const PROTOCOL_VERSION_MSG_TYPE: u8 = 6;
 
 PROOF_OF_POSSESSION message
 -----------------
@@ -75,3 +77,8 @@ DENY_LIST_BLOB_DELETED_MSG_TYPE
 
 The body is the blob_id : u256 (32 bytes) of a blob. f+1 nodes have added the blob id to
 their deny lists, and the blob should be deleted.
+
+PROTOCOL_VERSION_MSG_TYPE
+---------------
+
+The body is the start_epoch : u32 (4 bytes) and protocol_version : u64 (8 bytes).

--- a/mainnet-contracts/walrus/sources/display.move
+++ b/mainnet-contracts/walrus/sources/display.move
@@ -25,7 +25,7 @@ public struct ObjectDisplay has key {
     inner: ObjectBag,
 }
 
-/// The dynamic field key to use
+/// The dynamic field key to use.
 public struct PublisherKey() has copy, drop, store;
 
 /// Creates the `ObjectDisplay` instance with default objects in it.

--- a/mainnet-contracts/walrus/sources/init.move
+++ b/mainnet-contracts/walrus/sources/init.move
@@ -23,7 +23,8 @@ public struct InitCap has key, store {
     publisher: Publisher,
 }
 
-/// Init function, creates an init cap and transfers it to the sender.
+/// Initializes the system by creating an init cap and transferring it to the sender.
+///
 /// This allows the sender to call the function to actually initialize the system
 /// with the corresponding parameters. Once that function is called, the cap is destroyed.
 fun init(otw: INIT, ctx: &mut TxContext) {
@@ -33,7 +34,8 @@ fun init(otw: INIT, ctx: &mut TxContext) {
     transfer::transfer(init_cap, ctx.sender());
 }
 
-/// Function to initialize walrus and share the system and staking objects.
+/// Initializes Walrus and shares the system and staking objects.
+///
 /// This can only be called once, after which the `InitCap` is destroyed.
 public fun initialize_walrus(
     init_cap: InitCap,
@@ -59,11 +61,14 @@ public fun initialize_walrus(
     emergency_upgrade_cap
 }
 
-/// Migrate the staking and system objects to the new package id.
+/// Migrates the staking and system objects to the new package ID.
 ///
 /// This must be called in the new package after an upgrade is committed
 /// to emit an event that informs all storage nodes and prevent previous package
 /// versions from being used.
+///
+/// Requires the migration epoch to be set first on the staking object, which then
+/// enables the migration at the start of the next epoch.
 public fun migrate(staking: &mut Staking, system: &mut System) {
     staking.migrate();
     system.migrate();

--- a/mainnet-contracts/walrus/sources/staking/active_set.move
+++ b/mainnet-contracts/walrus/sources/staking/active_set.move
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// Contains an active set of storage nodes. The active set is a smart collection
-/// that only stores up to a 1000 nodes. The active set tracks the total amount of staked
+/// that only stores up to 1000 nodes. The active set tracks the total amount of staked
 /// WAL to make the calculation of the rewards and voting power distribution easier.
 module walrus::active_set;
 

--- a/mainnet-contracts/walrus/sources/staking/apportionment_queue.move
+++ b/mainnet-contracts/walrus/sources/staking/apportionment_queue.move
@@ -22,8 +22,8 @@ public struct ApportionmentQueue<T> has drop {
 }
 
 public struct Entry<T> has drop {
-    priority: UQ64_64, // higher value means higher priority and will be popped first
-    tie_breaker: u64, // used to break ties when priorities are equal
+    priority: UQ64_64, // Higher value means higher priority and will be popped first
+    tie_breaker: u64, // Used to break ties when priorities are equal
     value: T,
 }
 
@@ -62,7 +62,7 @@ fun bubble_down<T>(elements: &mut vector<Entry<T>>) {
         let left = i * 2 + 1;
         let right = left + 1;
         let mut max = i;
-        // Find the node with the highest priority betweenthe node and its children.
+        // Find the node with the highest priority between the node and its children.
         if (left < len && elements[left].higher_priority_than(&elements[max])) {
             max = left;
         };

--- a/mainnet-contracts/walrus/sources/staking/committee.move
+++ b/mainnet-contracts/walrus/sources/staking/committee.move
@@ -132,22 +132,22 @@ public(package) fun transition(cmt: &Committee, mut new_assignments: VecMap<ID, 
 
 #[syntax(index)]
 /// Get the shards assigned to the given `node_id`.
-public(package) fun shards(cmt: &Committee, node_id: &ID): &vector<u16> {
+public fun shards(cmt: &Committee, node_id: &ID): &vector<u16> {
     cmt.0.get(node_id)
 }
 
 /// Get the number of nodes in the committee.
-public(package) fun size(cmt: &Committee): u64 {
+public fun size(cmt: &Committee): u64 {
     cmt.0.size()
 }
 
 /// Get the inner representation of the committee.
-public(package) fun inner(cmt: &Committee): &VecMap<ID, vector<u16>> {
+public fun inner(cmt: &Committee): &VecMap<ID, vector<u16>> {
     &cmt.0
 }
 
 /// Copy the inner representation of the committee.
-public(package) fun to_inner(cmt: &Committee): VecMap<ID, vector<u16>> {
+public fun to_inner(cmt: &Committee): VecMap<ID, vector<u16>> {
     cmt.0
 }
 

--- a/mainnet-contracts/walrus/sources/staking/staking_inner.move
+++ b/mainnet-contracts/walrus/sources/staking/staking_inner.move
@@ -34,6 +34,7 @@ use walrus::{
 const MIN_STAKE: u64 = 0;
 
 // TODO: Remove once solutions are in place to prevent hitting move execution limits (#935).
+//
 /// Temporary upper limit for the number of storage nodes.
 const TEMP_ACTIVE_SET_SIZE_LIMIT: u16 = 111;
 
@@ -702,6 +703,17 @@ public(package) fun epoch_sync_done(
     events::emit_shards_received(self.epoch, *node_shards);
 }
 
+/// Adds `commissions[i]` to the commission of pool `node_ids[i]`.
+public(package) fun add_commission_to_pools(
+    self: &mut StakingInnerV1,
+    node_ids: vector<ID>,
+    commissions: vector<Balance<WAL>>,
+) {
+    node_ids.zip_do!(commissions, |node_id, commission| {
+        self.pools[node_id].add_commission(commission)
+    });
+}
+
 // === Accessors ===
 
 /// Returns the metadata of the node with the given `ID`.
@@ -836,6 +848,11 @@ public(package) fun borrow(self: &StakingInnerV1, node_id: ID): &StakingPool {
 /// Get mutable reference to the pool with the given `ID`.
 public(package) fun borrow_mut(self: &mut StakingInnerV1, node_id: ID): &mut StakingPool {
     &mut self.pools[node_id]
+}
+
+#[test_only]
+public(package) fun pool_commission(self: &StakingInnerV1, node_id: ID): u64 {
+    self.pools[node_id].commission_amount()
 }
 
 #[test_only]

--- a/mainnet-contracts/walrus/sources/staking/staking_pool.move
+++ b/mainnet-contracts/walrus/sources/staking/staking_pool.move
@@ -443,6 +443,12 @@ public(package) fun advance_epoch(
     pool.process_pending_stake(wctx);
 }
 
+/// Add `commission` directly to the pools commission. Returns the total value of the pool's
+/// commission after the operation.
+public(package) fun add_commission(pool: &mut StakingPool, commission: Balance<WAL>): u64 {
+    pool.commission.join(commission)
+}
+
 /// Process the pending stake and withdrawal requests for the pool. Called in the
 /// `advance_epoch` function in case the pool is in the committee and receives the
 /// rewards. And may be called in user-facing functions to update the pool state,
@@ -462,7 +468,7 @@ public(package) fun process_pending_stake(pool: &mut StakingPool, wctx: &WalrusC
 
     // Process withdrawals.
 
-    // each value in pending withdrawals contains the principal which became
+    // Each value in pending withdrawals contains the principal which became
     // active in the previous epoch. so unlike other pending values, we need to
     // flush it one by one, recalculating the exchange rate and pool share amount
     // for each early withdrawal epoch.

--- a/mainnet-contracts/walrus/sources/staking/storage_node.move
+++ b/mainnet-contracts/walrus/sources/staking/storage_node.move
@@ -107,7 +107,7 @@ public fun last_epoch_sync_done(cap: &StorageNodeCap): u32 {
     cap.last_epoch_sync_done
 }
 
-/// Return the latest event blob attestion.
+/// Return the latest event blob attestation.
 public fun last_event_blob_attestation(cap: &mut StorageNodeCap): Option<EventBlobAttestation> {
     cap.last_event_blob_attestation
 }
@@ -191,7 +191,7 @@ public(package) fun set_deny_list_properties(
 // === Testing ===
 
 #[test_only]
-/// Create a storage node with dummy name & address
+/// Create a storage node with dummy name & address.
 public fun new_for_testing(public_key: vector<u8>): StorageNodeInfo {
     let ctx = &mut tx_context::dummy();
     let node_id = ctx.fresh_object_address().to_id();

--- a/mainnet-contracts/walrus/sources/system/bls_aggregate.move
+++ b/mainnet-contracts/walrus/sources/system/bls_aggregate.move
@@ -107,7 +107,7 @@ public(package) fun n_members(self: &BlsCommittee): u64 {
     self.members.length()
 }
 
-/// Returns the member at given index
+/// Returns the member at given index.
 public(package) fun get_idx(self: &BlsCommittee, idx: u64): &BlsCommitteeMember {
     &self.members[idx]
 }

--- a/mainnet-contracts/walrus/sources/system/event_blob.move
+++ b/mainnet-contracts/walrus/sources/system/event_blob.move
@@ -85,7 +85,7 @@ public(package) fun create_with_empty_state(): EventBlobCertificationState {
     }
 }
 
-/// Returns the blob id of the latest certified event blob
+/// Returns the blob id of the latest certified event blob.
 public(package) fun get_latest_certified_blob_id(self: &EventBlobCertificationState): Option<u256> {
     self.latest_certified_blob.map!(|state| state.blob_id())
 }

--- a/mainnet-contracts/walrus/sources/system/events.move
+++ b/mainnet-contracts/walrus/sources/system/events.move
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// Module to emit events. Used to allow filtering all events in the
-/// rust client (as work-around for the lack of composable event filters).
+/// Rust client (as work-around for the lack of composable event filters).
 module walrus::events;
 
 use sui::event;
@@ -120,6 +120,13 @@ public struct ContractUpgradeQuorumReached has copy, drop {
     package_digest: vector<u8>,
 }
 
+/// Signals that the protocol version has been updated.
+public struct ProtocolVersionUpdated has copy, drop {
+    epoch: u32,
+    start_epoch: u32,
+    protocol_version: u64,
+}
+
 // === Functions to emit the events from other modules ===
 
 public(package) fun emit_blob_registered(
@@ -189,6 +196,10 @@ public(package) fun emit_shard_recovery_start(epoch: u32, shards: vector<u16>) {
 
 public(package) fun emit_contract_upgraded(epoch: u32, package_id: ID, version: u64) {
     event::emit(ContractUpgraded { epoch, package_id, version })
+}
+
+public(package) fun emit_protocol_version(epoch: u32, start_epoch: u32, protocol_version: u64) {
+    event::emit(ProtocolVersionUpdated { epoch, start_epoch, protocol_version })
 }
 
 public(package) fun emit_register_deny_list_update(

--- a/mainnet-contracts/walrus/sources/system/shared_blob.move
+++ b/mainnet-contracts/walrus/sources/system/shared_blob.move
@@ -50,3 +50,13 @@ public fun extend(
     system.extend_blob(&mut self.blob, extended_epochs, &mut coin);
     self.funds.join(coin.into_balance());
 }
+
+/// Returns a reference to the wrapped `Blob`.
+public fun blob(self: &SharedBlob): &Blob {
+    &self.blob
+}
+
+/// Returns the balance of funds stored in the `SharedBlob`.
+public fun funds(self: &SharedBlob): &Balance<WAL> {
+    &self.funds
+}

--- a/mainnet-contracts/walrus/sources/system/storage_resource.move
+++ b/mainnet-contracts/walrus/sources/system/storage_resource.move
@@ -54,7 +54,7 @@ public(package) fun extend_end_epoch(self: &mut Storage, extension_epochs: u32) 
     self.end_epoch = self.end_epoch + extension_epochs;
 }
 
-/// Split the storage object into two based on `split_epoch`
+/// Splits the storage object into two based on `split_epoch`.
 ///
 /// `storage` is modified to cover the period from `start_epoch` to `split_epoch`
 /// and a new storage object covering `split_epoch` to `end_epoch` is returned.
@@ -70,7 +70,7 @@ public fun split_by_epoch(storage: &mut Storage, split_epoch: u32, ctx: &mut TxC
     }
 }
 
-/// Split the storage object into two based on `split_size`
+/// Splits the storage object into two based on `split_size`.
 ///
 /// `storage` is modified to cover `split_size` and a new object covering
 /// `storage.storage_size - split_size` is created.
@@ -104,7 +104,7 @@ public fun fuse_periods(first: &mut Storage, second: Storage) {
     }
 }
 
-/// Fuse two storage objects that cover the same period
+/// Fuse two storage objects that cover the same period.
 public fun fuse_amount(first: &mut Storage, second: Storage) {
     let Storage {
         id,
@@ -133,7 +133,7 @@ public fun fuse(first: &mut Storage, second: Storage) {
 }
 
 #[test_only]
-/// Constructor for [Storage] objects for tests
+/// Constructor for [Storage] objects for tests.
 public fun create_for_test(
     start_epoch: u32,
     end_epoch: u32,
@@ -143,7 +143,7 @@ public fun create_for_test(
     Storage { id: object::new(ctx), start_epoch, end_epoch, storage_size }
 }
 
-/// Destructor for [Storage] objects
+/// Destructor for [Storage] objects.
 public fun destroy(storage: Storage) {
     let Storage { id, .. } = storage;
     id.delete();

--- a/mainnet-contracts/walrus/sources/system/system_state_inner.move
+++ b/mainnet-contracts/walrus/sources/system/system_state_inner.move
@@ -53,6 +53,8 @@ const EIncorrectDenyListSequence: u64 = 9;
 const EIncorrectDenyListNode: u64 = 10;
 /// Trying to obtain a resource with an invalid size.
 const EInvalidResourceSize: u64 = 11;
+/// Trying to update the protocol version for an invalid start epoch.
+const EInvalidStartEpoch: u64 = 12;
 
 /// The inner object that is not present in signatures and can be versioned.
 #[allow(unused_field)]
@@ -197,30 +199,63 @@ public(package) fun reserve_space(
     assert!(epochs_ahead > 0, EInvalidEpochsAhead);
     assert!(epochs_ahead <= self.future_accounting.max_epochs_ahead(), EInvalidEpochsAhead);
 
-    // Pay rewards for each future epoch into the future accounting.
-    self.process_storage_payments(storage_amount, 0, epochs_ahead, payment);
-
-    self.reserve_space_without_payment(storage_amount, epochs_ahead, true, ctx)
+    let start_epoch = self.epoch();
+    let end_epoch = start_epoch + epochs_ahead;
+    self.reserve_space_for_epochs(storage_amount, start_epoch, end_epoch, payment, ctx)
 }
 
-/// Allow buying a storage reservation for a given period of epochs without
-/// payment.
+/// Allows buying a storage reservation for a given period of epochs.
+///
+/// Returns a storage resource for the period between `start_epoch` (inclusive) and
+/// `end_epoch` (exclusive). If `start_epoch` has already passed, reserves space starting
+/// from the current epoch.
+public(package) fun reserve_space_for_epochs(
+    self: &mut SystemStateInnerV1,
+    storage_amount: u64,
+    start_epoch: u32,
+    end_epoch: u32,
+    payment: &mut Coin<WAL>,
+    ctx: &mut TxContext,
+): Storage {
+    let current_epoch = self.epoch();
+    // If the start epoch has already passed, reserve space starting at the current epoch.
+    let start_epoch = start_epoch.max(current_epoch);
+    let start_offset = start_epoch - current_epoch;
+
+    // Check that the interval is non-empty.
+    assert!(end_epoch > start_epoch, EInvalidEpochsAhead);
+
+    let end_offset = end_epoch - current_epoch;
+
+    // Check the period is within the allowed range.
+    assert!(end_offset <= self.future_accounting.max_epochs_ahead(), EInvalidEpochsAhead);
+
+    // Pay rewards for each future epoch into the future accounting.
+    self.process_storage_payments(storage_amount, start_offset, end_offset, payment);
+
+    // Reserve the space
+    self.reserve_space_without_payment(storage_amount, start_offset, end_offset, true, ctx)
+}
+
+/// Allow obtaining a storage reservation for a given period of epochs without
+/// payment. The epochs are provided as offsets from the current epoch.
 fun reserve_space_without_payment(
     self: &mut SystemStateInnerV1,
     storage_amount: u64,
-    epochs_ahead: u32,
+    start_epoch_offset: u32,
+    end_epoch_offset: u32,
     check_capacity: bool,
     ctx: &mut TxContext,
 ): Storage {
     // Check the period is within the allowed range.
-    assert!(epochs_ahead > 0, EInvalidEpochsAhead);
-    assert!(epochs_ahead <= self.future_accounting.max_epochs_ahead(), EInvalidEpochsAhead);
+    assert!(end_epoch_offset - start_epoch_offset > 0, EInvalidEpochsAhead);
+    assert!(end_epoch_offset <= self.future_accounting.max_epochs_ahead(), EInvalidEpochsAhead);
 
     // Check that the storage has a non-zero size.
     assert!(storage_amount > 0, EInvalidResourceSize);
 
-    // Account the space to reclaim in the future.
-    epochs_ahead.do!(|i| {
+    // Account for the used capacity for all epochs.
+    start_epoch_offset.range_do!(end_epoch_offset, |i| {
         let used_capacity = self
             .future_accounting
             .ring_lookup_mut(i)
@@ -234,11 +269,13 @@ fun reserve_space_without_payment(
         assert!(!check_capacity || used_capacity <= self.total_capacity_size, EStorageExceeded);
     });
 
-    let self_epoch = self.epoch();
+    let current_epoch = self.epoch();
+    let start_epoch = current_epoch + start_epoch_offset;
+    let end_epoch = current_epoch + end_epoch_offset;
 
     storage_resource::create_storage(
-        self_epoch,
-        self_epoch + epochs_ahead,
+        start_epoch,
+        end_epoch,
         storage_amount,
         ctx,
     )
@@ -478,6 +515,7 @@ public(package) fun certify_event_blob(
     let epochs_ahead = self.future_accounting.max_epochs_ahead();
     let storage = self.reserve_space_without_payment(
         encoded_blob_length(size, encoding_type, num_shards),
+        0,
         epochs_ahead,
         false, // Do not check total capacity, event blobs are certified already at this point.
         ctx,
@@ -546,6 +584,27 @@ public(package) fun add_subsidy(
     self.future_accounting.ring_lookup_mut(0).rewards_balance().join(subsidy_balance);
 }
 
+/// Adds rewards to the system for future epochs, where `subsidies[i]` is added to the rewards
+/// of epoch `system.epoch() + i`.
+public(package) fun add_per_epoch_subsidies(
+    self: &mut SystemStateInnerV1,
+    subsidies: vector<Balance<WAL>>,
+) {
+    assert!(
+        subsidies.length() <= self.future_accounting.max_epochs_ahead() as u64,
+        EInvalidEpochsAhead,
+    );
+    let mut epochs_in_future = 0;
+    subsidies.do!(|per_epoch_subsidy| {
+        self
+            .future_accounting
+            .ring_lookup_mut(epochs_in_future)
+            .rewards_balance()
+            .join(per_epoch_subsidy);
+        epochs_in_future = epochs_in_future + 1;
+    })
+}
+
 // === Accessors ===
 
 /// Get epoch. Uses the committee to get the epoch.
@@ -566,6 +625,11 @@ public(package) fun used_capacity_size(self: &SystemStateInnerV1): u64 {
 /// An accessor for the current committee.
 public(package) fun committee(self: &SystemStateInnerV1): &BlsCommittee {
     &self.committee
+}
+
+/// Read-only access to the accounting ring buffer.
+public(package) fun future_accounting(self: &SystemStateInnerV1): &FutureAccountingRingBuffer {
+    &self.future_accounting
 }
 
 #[test_only]
@@ -603,6 +667,35 @@ public(package) fun used_capacity_size_at_future_epoch(
 macro fun storage_units_from_size($size: u64): u64 {
     let size = $size;
     size.divide_and_round_up(BYTES_PER_UNIT_SIZE)
+}
+
+// === Protocol Version ===
+
+/// Check quorum of committee members and emit the protocol version event.
+public(package) fun update_protocol_version(
+    self: &SystemStateInnerV1,
+    cap: &StorageNodeCap,
+    signature: vector<u8>,
+    members_bitmap: vector<u8>,
+    message: vector<u8>,
+) {
+    assert!(self.committee().contains(&cap.node_id()), ENotCommitteeMember);
+
+    let certified_message = self
+        .committee
+        .verify_quorum_in_epoch(signature, members_bitmap, message);
+
+    let epoch = certified_message.cert_epoch();
+    let message = certified_message.protocol_version_message();
+    let start_epoch = message.start_epoch();
+    assert!(epoch == self.epoch(), EInvalidIdEpoch);
+    assert!(start_epoch >= self.epoch(), EInvalidStartEpoch);
+
+    events::emit_protocol_version(
+        epoch,
+        message.start_epoch(),
+        message.protocol_version(),
+    );
 }
 
 // === DenyList ===

--- a/mainnet-contracts/walrus/tests/system/blob_tests.move
+++ b/mainnet-contracts/walrus/tests/system/blob_tests.move
@@ -612,7 +612,7 @@ fun default_blob_id(): u256 {
     blob::derive_blob_id(ROOT_HASH, RS2, SIZE)
 }
 
-/// Utiliy macro that calls the given function on a new Blob.
+/// Utility macro that calls the given function on a new Blob.
 ///
 /// Creates the system, registers the default blob, and calls the given function with the blob.
 /// Finally, it destroys the blob and returns the system.

--- a/mainnet-contracts/walrus/tests/system/deny_list_tests.move
+++ b/mainnet-contracts/walrus/tests/system/deny_list_tests.move
@@ -7,6 +7,10 @@ module walrus::deny_list_tests;
 use std::{bcs, unit_test::assert_eq};
 use walrus::messages;
 
+// See `messages.move` for the list of message types.
+const DENY_LIST_UPDATE_MSG_TYPE: u8 = 4;
+const DENY_LIST_BLOB_DELETED_MSG_TYPE: u8 = 5;
+
 #[test]
 fun deny_list_update() {
     let bytes = new_deny_list_update_message(@0x1.to_id(), 1, 1, 1u256);
@@ -44,24 +48,24 @@ fun deny_list_blob_deleted_invalid_message_type() {
     message.deny_list_blob_deleted_message();
 }
 
-fun new_deny_list_blob_deleted_message(blob_id: u256): vector<u8> {
-    let mut bytes = vector[4, 0, 3]; // intent type, version, app id
-    bytes.append(bcs::to_bytes(&1u32)); // epoch
-    bytes.append(bcs::to_bytes(&blob_id));
-    bytes
-}
-
 fun new_deny_list_update_message(
     id: ID,
     deny_list_sequence_number: u64,
     deny_list_size: u64,
     deny_list_root: u256,
 ): vector<u8> {
-    let mut bytes = vector[3, 0, 3]; // intent type, version, app id
+    let mut bytes = vector[DENY_LIST_UPDATE_MSG_TYPE, 0, 3]; // intent type, version, app id
     bytes.append(bcs::to_bytes(&1u32)); // epoch
     bytes.append(bcs::to_bytes(&id));
     bytes.append(bcs::to_bytes(&deny_list_sequence_number));
     bytes.append(bcs::to_bytes(&deny_list_size));
     bytes.append(bcs::to_bytes(&deny_list_root));
+    bytes
+}
+
+fun new_deny_list_blob_deleted_message(blob_id: u256): vector<u8> {
+    let mut bytes = vector[DENY_LIST_BLOB_DELETED_MSG_TYPE, 0, 3]; // intent type, version, app id
+    bytes.append(bcs::to_bytes(&1u32)); // epoch
+    bytes.append(bcs::to_bytes(&blob_id));
     bytes
 }

--- a/mainnet-contracts/walrus/tests/test_node.move
+++ b/mainnet-contracts/walrus/tests/test_node.move
@@ -83,7 +83,7 @@ public fun update_deny_list_message(
     sequence_number: u64,
 ): vector<u8> {
     let certified_message = vector[
-        bcs::to_bytes(&3u8), // intent type for deny list update
+        bcs::to_bytes(&4u8), // intent type for deny list update
         bcs::to_bytes(&0u8), // intent version
         bcs::to_bytes(&3u8), // app ID
         bcs::to_bytes(&epoch), // epoch
@@ -92,6 +92,25 @@ public fun update_deny_list_message(
         bcs::to_bytes(&sequence_number), // sequence number
         bcs::to_bytes(&size), // deny list size
         bcs::to_bytes(&root), // deny list root
+    ];
+
+    certified_message.flatten()
+}
+
+public fun protocol_version_updated_message(
+    _self: &TestStorageNode,
+    epoch: u32,
+    start_epoch: u32,
+    protocol_version: u64,
+): vector<u8> {
+    let certified_message = vector[
+        bcs::to_bytes(&6u8), // intent type for protocol version update
+        bcs::to_bytes(&0u8), // intent version
+        bcs::to_bytes(&3u8), // app ID
+        bcs::to_bytes(&epoch), // epoch
+        // protocol version update message
+        bcs::to_bytes(&start_epoch), // node ID
+        bcs::to_bytes(&protocol_version), // protocol version
     ];
 
     certified_message.flatten()

--- a/mainnet-contracts/walrus/tests/test_utils.move
+++ b/mainnet-contracts/walrus/tests/test_utils.move
@@ -99,7 +99,7 @@ public fun current(self: &mut ContextRunner): (WalrusContext, &mut TxContext) {
     (wctx(self.epoch, self.committee_selected), &mut self.ctx)
 }
 
-/// Selects committee
+/// Selects committee.
 public fun select_committee(self: &mut ContextRunner): (WalrusContext, &mut TxContext) {
     self.committee_selected = true;
     (wctx(self.epoch, self.committee_selected), &mut self.ctx)
@@ -325,7 +325,7 @@ public fun pad_bls_sk(sk: &vector<u8>): vector<u8> {
     sk
 }
 
-/// Returns the secret key scalar 117
+/// Returns the secret key scalar 117.
 public fun bls_sk_for_testing(): vector<u8> {
     pad_bls_sk(&x"75")
 }
@@ -400,6 +400,11 @@ public fun signers_to_bitmap(signers: &vector<u16>): vector<u8> {
 /// Number of FROST per WAL.
 public fun frost_per_wal(): u64 {
     1_000_000_000
+}
+
+/// Convenience function to convert WAL to FROST.
+public fun wal_to_frost(amount: u64): u64 {
+    amount * frost_per_wal()
 }
 
 // === Unit Tests ===


### PR DESCRIPTION
## Description

This PR prepares the walrus mainnet contracts for the planned upgrade. The branch is used for voting on the upgrade and should only be merged once the upgrade is committed.

Edit: The upgrade is now committed on chain, the new package address is `0xfa65cb2d62f4d39e60346fb7d501c12538ca2bbc646eaa37ece2aec5f897814e`

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
