### PR TITLE
chore: extend the backup lifetime of archived blobs

### DIFF
--- a/crates/walrus-service/src/backup/garbage_collector.rs
+++ b/crates/walrus-service/src/backup/garbage_collector.rs
@@ -88,7 +88,7 @@ async fn collect_garbage(
                                     state = 'archived' AND
                                     (initiate_gc_after IS NULL OR initiate_gc_after < NOW()) AND
                                     COALESCE(
-                                        end_epoch <= (
+                                        end_epoch + 2 <= (
                                             SELECT MAX(epoch) FROM epoch_change_start_event),
                                         FALSE)
                                 LIMIT 15


### PR DESCRIPTION
## Description

Ensure that backup blobs live longer than their expiry by 2 extra epochs to make them more available for emergency use-cases.

## Test plan

CI Pipeline