### PR TITLE
chore: stop the test when node exits with an error in simtest

### DIFF
--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -468,10 +468,11 @@ impl SimStorageNodeHandle {
                                 // Do not put any code after this point, as it won't be executed.
                                 // kill_current_node is implemented using a panic.
                             } else {
-                                // TODO(WAL-912): we need to alert the test if the node is stopped
-                                // unexpectedly. Currently, node crashing may not be noticed and
-                                // the test will hang.
-                                tracing::info!("node stopped with error: {e}");
+                                tracing::error!("node stopped with error: {e}");
+
+                                // In simtest, we don't expect node to exit with an error. Panic
+                                // the test process to fail the test early.
+                                panic!("node stopped with error: {e}");
                             }
                         }
                         Ok(()) => {


### PR DESCRIPTION
## Description

We have seen in many tests that when node is terminated, the test may not necessarily stop and it's hard to debug
the side effects of losing a node. We should just stop the test if the node exits with an error, which shouldn't happen
in simtest.

Resolve WAL-912

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
