### PR TITLE
fix: retry reading first event blob when encounter non-exist error

### DIFF
--- a/crates/walrus-simtest/tests/simtest_param_sync.rs
+++ b/crates/walrus-simtest/tests/simtest_param_sync.rs
@@ -155,7 +155,7 @@ mod tests {
             // Fetch the remote config.
             let remote_config = test_get_synced_node_config_set(client, node_id).await?;
 
-            let local_config = config.read().await;
+            let local_config = config.read().await.clone();
 
             tracing::info!(
                 "Comparing local and remote configs:\n\
@@ -205,8 +205,6 @@ mod tests {
                 tracing::info!("node config is now in sync with on-chain state");
                 return Ok(());
             }
-            // Release the read lock explicitly before sleeping.
-            drop(local_config);
 
             tokio::time::sleep(Duration::from_secs(5)).await;
         }


### PR DESCRIPTION
## Description

It's possible that 1 certified status from 1 storage node results in `read_blob_status()` returning certified status, but
event blob may still not be available for reads due to delay in propagating register/certify events to other storage nodes.
Similar to reading the blob status, also retrying reading first event blob if encountering non-existence error.

## Test plan

100 test_registered_node_update_protocol_key run passed, was failing with high probability before.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
