### PR TITLE
feat: Move test_quorum_contract_upgrade test to simtest env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13039,6 +13039,7 @@ dependencies = [
  "sui-rpc-api",
  "sui-simulator",
  "sui-types",
+ "tempfile",
  "tokio",
  "tracing",
  "typed-store 1.30.0",

--- a/crates/walrus-service/src/event/event_processor/processor.rs
+++ b/crates/walrus-service/src/event/event_processor/processor.rs
@@ -154,9 +154,12 @@ impl EventProcessor {
             runtime_config.db_path.join("recovery"),
             metrics_registry,
         );
-        catchup_manager
+        if let Err(e) = catchup_manager
             .catchup(config.event_stream_catchup_min_checkpoint_lag)
-            .await?;
+            .await
+        {
+            tracing::error!("failed to catchup using event blobs: {e}");
+        }
 
         if event_processor.stores.checkpoint_store.is_empty() {
             let (committee, verified_checkpoint) = get_bootstrap_committee_and_checkpoint(

--- a/crates/walrus-simtest/Cargo.toml
+++ b/crates/walrus-simtest/Cargo.toml
@@ -19,6 +19,7 @@ sui-macros.workspace = true
 sui-protocol-config.workspace = true
 sui-rpc-api.workspace = true
 sui-types.workspace = true
+tempfile.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 typed-store.workspace = true

--- a/crates/walrus-sui/src/system_setup.rs
+++ b/crates/walrus-sui/src/system_setup.rs
@@ -85,7 +85,11 @@ pub async fn compile_package(
     chain_id: Option<String>,
 ) -> Result<(CompiledPackage, MoveBuildConfig)> {
     tokio::task::spawn_blocking(|| {
-        compile_package_inner_blocking(package_path, build_config, chain_id)
+        sui_macros::nondeterministic!(compile_package_inner_blocking(
+            package_path,
+            build_config,
+            chain_id
+        ))
     })
     .await?
 }


### PR DESCRIPTION
## Description

This PR moves the test `test_quorum_contract_upgrade` to simtest environment, but I had to do a few changes to make it work. This is the main difference from tokio env about waiting for nodes to reach a particular epoch:
```
 // Wait for the nodes to reach the migration epoch.
let target_epoch = upgrade_epoch + 1;
loop {
    let mut all_nodes_ready = true;
    for node in &walrus_cluster.nodes {
        let current_epoch = simtest_utils::get_current_epoch_from_node(node).await;
        if current_epoch < target_epoch {
            all_nodes_ready = false;
            break;
        }
    }
    if all_nodes_ready {
        break;
    }
    tokio::time::sleep(Duration::from_secs(5)).await;
}
```
And then I also added restart of all nodes after package upgrade as that is what actually changes their view of the current package id in event processor. To ensure things work after restart, I then stored a blob to ensure it works.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
