### PR TITLE
fix(sdk): reduce verbosity of some log entries

### DIFF
--- a/crates/walrus-sdk/src/client/refresh.rs
+++ b/crates/walrus-sdk/src/client/refresh.rs
@@ -114,7 +114,7 @@ impl<T: ReadClient> CommitteesRefresher<T> {
                         "auto-refreshing the active committee"
                     );
                     let _ = self.refresh().await.inspect_err(|error| {
-                        tracing::error!(
+                        tracing::warn!(
                             %error,
                             "failed to refresh the active committee; \
                             retrying again at the next interval",
@@ -128,7 +128,7 @@ impl<T: ReadClient> CommitteesRefresher<T> {
                         );
                         if request.is_refresh() {
                             let _ = self.refresh_if_stale().await.inspect_err(|error| {
-                                tracing::error!(
+                                tracing::warn!(
                                     %error,
                                     "failed to refresh the active committee; \
                                     retrying again at the next interval",
@@ -148,7 +148,7 @@ impl<T: ReadClient> CommitteesRefresher<T> {
                                 tracing::info!("failed to send the committee and price")
                             });
                     } else {
-                        tracing::info!("the channel is closed, stopping the refresher");
+                        tracing::debug!("the channel is closed, stopping the refresher");
                         break;
                     }
                 }


### PR DESCRIPTION
## Description

Reduces the log level for three log statements in the SDK:
- `the channel is closed, stopping the refresher` is not useful for most people and may cause confusion.
- `failed to refresh the active committee; retrying again at the next interval` is not critical and should thus just be a warning (no error).

## Test plan

Not needed.