### PR TITLE
refactor: use let chains where applicable

### DIFF
--- a/crates/checkpoint-downloader/src/downloader.rs
+++ b/crates/checkpoint-downloader/src/downloader.rs
@@ -547,17 +547,16 @@ impl ParallelCheckpointDownloaderInner {
 /// it is logged as an error.
 /// Otherwise, it is logged as a debug.
 fn handle_checkpoint_error(err: &RetriableClientError, next_checkpoint: u64) {
-    if let RetriableClientError::RpcError(rpc_error) = err {
-        if let Some(checkpoint_height) = rpc_error.status.checkpoint_height() {
-            if next_checkpoint > checkpoint_height {
-                return tracing::trace!(
-                    next_checkpoint,
-                    checkpoint_height,
-                    message = rpc_error.status.message(),
-                    "failed to read next checkpoint, probably not produced yet",
-                );
-            }
-        }
+    if let RetriableClientError::RpcError(rpc_error) = err
+        && let Some(checkpoint_height) = rpc_error.status.checkpoint_height()
+        && next_checkpoint > checkpoint_height
+    {
+        return tracing::trace!(
+            next_checkpoint,
+            checkpoint_height,
+            message = rpc_error.status.message(),
+            "failed to read next checkpoint, probably not produced yet",
+        );
     }
     tracing::warn!(next_checkpoint, ?err, "failed to read next checkpoint");
 }

--- a/crates/walrus-orchestrator/src/client/aws.rs
+++ b/crates/walrus-orchestrator/src/client/aws.rs
@@ -228,12 +228,11 @@ impl AwsClient {
         let response = request.send().await?;
 
         // Return true if the response contains references to NVMe drives.
-        if let Some(info) = response.instance_types().first() {
-            if let Some(info) = info.instance_storage_info() {
-                if info.nvme_support() == Some(&EphemeralNvmeSupport::Required) {
-                    return Ok(true);
-                }
-            }
+        if let Some(info) = response.instance_types().first()
+            && let Some(info) = info.instance_storage_info()
+            && info.nvme_support() == Some(&EphemeralNvmeSupport::Required)
+        {
+            return Ok(true);
         }
         Ok(false)
     }

--- a/crates/walrus-orchestrator/src/orchestrator.rs
+++ b/crates/walrus-orchestrator/src/orchestrator.rs
@@ -126,10 +126,10 @@ impl<P> Orchestrator<P> {
             if client_instances.len() == parameters.clients {
                 break;
             }
-            if let Some(regional_instances) = instances_by_regions.get_mut(region) {
-                if let Some(instance) = regional_instances.pop_front() {
-                    client_instances.push(instance.clone());
-                }
+            if let Some(regional_instances) = instances_by_regions.get_mut(region)
+                && let Some(instance) = regional_instances.pop_front()
+            {
+                client_instances.push(instance.clone());
             }
         }
 

--- a/crates/walrus-proc-macros/src/derive_api_errors.rs
+++ b/crates/walrus-proc-macros/src/derive_api_errors.rs
@@ -484,10 +484,10 @@ where
 /// `concat!` to form a single `&'static str`.
 fn get_docstring(attrs: &[Attribute]) -> TokenStream {
     let description = attrs.iter().filter_map(|attr| {
-        if let Some(ident) = attr.path().get_ident() {
-            if ident == "doc" {
-                return attr.meta.require_name_value().ok().map(|v| &v.value);
-            }
+        if let Some(ident) = attr.path().get_ident()
+            && ident == "doc"
+        {
+            return attr.meta.require_name_value().ok().map(|v| &v.value);
         }
         None
     });

--- a/crates/walrus-sdk/src/client.rs
+++ b/crates/walrus-sdk/src/client.rs
@@ -375,10 +375,11 @@ impl<T: ReadClient> Client<T> {
         };
 
         // Return an error if the blob is not registered.
-        if let Some(status) = blob_status {
-            if matches!(status, BlobStatus::Nonexistent | BlobStatus::Invalid { .. }) {
-                return Err(ClientError::from(ClientErrorKind::BlobIdDoesNotExist));
-            }
+        if matches!(
+            blob_status,
+            Some(BlobStatus::Nonexistent | BlobStatus::Invalid { .. })
+        ) {
+            return Err(ClientError::from(ClientErrorKind::BlobIdDoesNotExist));
         }
 
         // Read from the epoch of certification, or the current epoch if so far we have not been
@@ -2153,11 +2154,11 @@ impl<T> Client<T> {
     /// Returns a [`ClientError`] with [`ClientErrorKind::BlobIdBlocked`] if the provided blob ID is
     /// contained in the blocklist.
     fn check_blob_id(&self, blob_id: &BlobId) -> ClientResult<()> {
-        if let Some(blocklist) = &self.blocklist {
-            if blocklist.is_blocked(blob_id) {
-                tracing::debug!(%blob_id, "encountered blocked blob ID");
-                return Err(ClientErrorKind::BlobIdBlocked(*blob_id).into());
-            }
+        if let Some(blocklist) = &self.blocklist
+            && blocklist.is_blocked(blob_id)
+        {
+            tracing::debug!(%blob_id, "encountered blocked blob ID");
+            return Err(ClientErrorKind::BlobIdBlocked(*blob_id).into());
         }
         Ok(())
     }

--- a/crates/walrus-service/src/client/daemon/auth.rs
+++ b/crates/walrus-service/src/client/daemon/auth.rs
@@ -141,37 +141,38 @@ impl Claim {
         }
 
         if let Some(body_size_upper_hint) = body_size_hint.upper() {
-            if let Some(max_size) = self.max_size {
-                if body_size_upper_hint > max_size {
-                    tracing::debug!(
-                        max_size,
-                        body_size_upper_hint,
-                        "upload with body size greater than max_size"
-                    );
-                    return Err(PublisherAuthError::InvalidSize);
-                }
-            }
-            if let Some(size) = self.size {
-                if body_size_upper_hint < size {
-                    tracing::debug!(
-                        size,
-                        body_size_upper_hint,
-                        "body does not match the size specified in the JWT (upper hint mismatch)"
-                    );
-                    return Err(PublisherAuthError::InvalidSize);
-                }
-            }
-        }
-        let body_size_lower_hint = body_size_hint.lower();
-        if let Some(size) = self.size {
-            if body_size_lower_hint > 0 && body_size_lower_hint > size {
+            if let Some(max_size) = self.max_size
+                && body_size_upper_hint > max_size
+            {
                 tracing::debug!(
-                    size,
-                    body_size_lower_hint,
-                    "body does not match the size specified in the JWT (lower hint mismatch)"
+                    max_size,
+                    body_size_upper_hint,
+                    "upload with body size greater than max_size"
                 );
                 return Err(PublisherAuthError::InvalidSize);
             }
+            if let Some(size) = self.size
+                && body_size_upper_hint < size
+            {
+                tracing::debug!(
+                    size,
+                    body_size_upper_hint,
+                    "body does not match the size specified in the JWT (upper hint mismatch)"
+                );
+                return Err(PublisherAuthError::InvalidSize);
+            }
+        }
+        let body_size_lower_hint = body_size_hint.lower();
+        if let Some(size) = self.size
+            && body_size_lower_hint > 0
+            && body_size_lower_hint > size
+        {
+            tracing::debug!(
+                size,
+                body_size_lower_hint,
+                "body does not match the size specified in the JWT (lower hint mismatch)"
+            );
+            return Err(PublisherAuthError::InvalidSize);
         }
 
         if let Err(error) = self.check_epochs(query.epochs) {

--- a/crates/walrus-service/src/client/daemon/routes.rs
+++ b/crates/walrus-service/src/client/daemon/routes.rs
@@ -162,12 +162,12 @@ fn populate_response_headers_from_attributes(
     allowed_headers: Option<&HashSet<String>>,
 ) {
     for (key, value) in attribute.iter() {
-        if !key.is_empty() && allowed_headers.is_none_or(|headers| headers.contains(key)) {
-            if let (Ok(header_name), Ok(header_value)) =
+        if !key.is_empty()
+            && allowed_headers.is_none_or(|headers| headers.contains(key))
+            && let (Ok(header_name), Ok(header_value)) =
                 (HeaderName::from_str(key), HeaderValue::from_str(value))
-            {
-                headers.insert(header_name, header_value);
-            }
+        {
+            headers.insert(header_name, header_value);
         }
     }
 }
@@ -210,14 +210,14 @@ pub(super) async fn get_blob_by_object_id<T: WalrusReadClient>(
             .await;
 
             // If the response was successful, add our additional metadata headers
-            if response.status() == StatusCode::OK {
-                if let Some(attribute) = attribute {
-                    populate_response_headers_from_attributes(
-                        response.headers_mut(),
-                        &attribute,
-                        Some(&response_header_config.allowed_headers),
-                    );
-                }
+            if response.status() == StatusCode::OK
+                && let Some(attribute) = attribute
+            {
+                populate_response_headers_from_attributes(
+                    response.headers_mut(),
+                    &attribute,
+                    Some(&response_header_config.allowed_headers),
+                );
             }
 
             response
@@ -306,10 +306,10 @@ pub(super) async fn put_blob<T: WalrusWriteClient>(
     blob: Bytes,
 ) -> Response {
     // Check if there is an authorization claim, and use it to check the size.
-    if let Some(TypedHeader(header)) = bearer_header {
-        if let Err(error) = check_blob_size(header, blob.len()) {
-            return error.into_response();
-        }
+    if let Some(TypedHeader(header)) = bearer_header
+        && let Err(error) = check_blob_size(header, blob.len())
+    {
+        return error.into_response();
     }
 
     let blob_persistence = match query.blob_persistence() {
@@ -365,15 +365,15 @@ fn check_blob_size(
 
     match Claim::from_token(bearer_header.token().trim(), &default_key, &validation) {
         Ok(claim) => {
-            if let Some(max_size) = claim.max_size {
-                if blob_size as u64 > max_size {
-                    return Err(PublisherAuthError::InvalidSize);
-                }
+            if let Some(max_size) = claim.max_size
+                && blob_size as u64 > max_size
+            {
+                return Err(PublisherAuthError::InvalidSize);
             }
-            if let Some(size) = claim.size {
-                if blob_size as u64 != size {
-                    return Err(PublisherAuthError::InvalidSize);
-                }
+            if let Some(size) = claim.size
+                && blob_size as u64 != size
+            {
+                return Err(PublisherAuthError::InvalidSize);
             }
             Ok(())
         }
@@ -898,10 +898,10 @@ pub(super) async fn put_quilt<T: WalrusWriteClient>(
         }
     };
 
-    if let Some(TypedHeader(header)) = bearer_header {
-        if let Err(error) = check_blob_size(header, quilt.data().len()) {
-            return error.into_response();
-        }
+    if let Some(TypedHeader(header)) = bearer_header
+        && let Err(error) = check_blob_size(header, quilt.data().len())
+    {
+        return error.into_response();
     }
 
     let result = client

--- a/crates/walrus-service/src/event/event_blob_downloader.rs
+++ b/crates/walrus-service/src/event/event_blob_downloader.rs
@@ -209,10 +209,10 @@ impl EventBlobDownloader {
                 event_blob.store_as_file(&blob_path)?;
             }
 
-            if let Some(starting_checkpoint_to_process) = starting_checkpoint_to_process {
-                if event_blob.start_checkpoint_sequence_number() <= starting_checkpoint_to_process {
-                    break;
-                }
+            if let Some(starting_checkpoint_to_process) = starting_checkpoint_to_process
+                && event_blob.start_checkpoint_sequence_number() <= starting_checkpoint_to_process
+            {
+                break;
             }
 
             event_blob_id = event_blob.prev_blob_id();

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -926,15 +926,15 @@ impl StorageNode {
         )?;
 
         // Reposition the event blob writer if it is behind the first available event.
-        if let Some(writer) = event_blob_writer {
-            if writer_starting_index < first_available_event_index {
-                tracing::info!(
-                    "repositioning event blob writer cursor from {} to {}",
-                    writer_starting_index,
-                    first_available_event_index
-                );
-                writer.update(init_state).await?;
-            }
+        if let Some(writer) = event_blob_writer
+            && writer_starting_index < first_available_event_index
+        {
+            tracing::info!(
+                "repositioning event blob writer cursor from {} to {}",
+                writer_starting_index,
+                first_available_event_index
+            );
+            writer.update(init_state).await?;
         }
 
         // Reset the starting indices to the first event that is available for processing and
@@ -1152,12 +1152,12 @@ impl StorageNode {
                     sui_macros::fail_point!("process-event-after");
                 }
 
-                if element_index >= writer_starting_index {
-                    if let Some(writer) = &mut event_blob_writer {
-                        sui_macros::fail_point!("write-event-before");
-                        writer.write(stream_element.clone(), element_index).await?;
-                        sui_macros::fail_point!("write-event-after");
-                    }
+                if element_index >= writer_starting_index
+                    && let Some(writer) = &mut event_blob_writer
+                {
+                    sui_macros::fail_point!("write-event-before");
+                    writer.write(stream_element.clone(), element_index).await?;
+                    sui_macros::fail_point!("write-event-after");
                 }
 
                 anyhow::Result::<()>::Ok(())
@@ -1242,14 +1242,14 @@ impl StorageNode {
             "error.type" = field::Empty,
         );
 
-        if maybe_epoch_at_start.is_some() {
-            if let EventStreamElement::ContractEvent(ref event) = stream_element.element {
-                self.check_if_node_lagging_and_enter_recovery_mode(
-                    event,
-                    node_status,
-                    maybe_epoch_at_start,
-                )?;
-            }
+        if maybe_epoch_at_start.is_some()
+            && let EventStreamElement::ContractEvent(ref event) = stream_element.element
+        {
+            self.check_if_node_lagging_and_enter_recovery_mode(
+                event,
+                node_status,
+                maybe_epoch_at_start,
+            )?;
         }
 
         // Ignore the error here since this is a best effort operation, and we don't

--- a/crates/walrus-service/src/node/blob_sync.rs
+++ b/crates/walrus-service/src/node/blob_sync.rs
@@ -93,17 +93,17 @@ impl BlobSyncHandler {
 
                     // Collect handles to be awaited
                     for (blob_id, handle) in syncs.iter_mut() {
-                        if let Some(sync_handle) = &handle.blob_sync_handle {
-                            if sync_handle.is_finished() {
-                                tracing::info!(
-                                    walrus.blob_id = %blob_id,
-                                    "blob sync monitor observed blob sync finished"
-                                );
-                                if let Some(join_handle) = handle.blob_sync_handle.take() {
-                                    handles.push((*blob_id, join_handle));
-                                }
-                                completed.push(*blob_id);
+                        if let Some(sync_handle) = &handle.blob_sync_handle
+                            && sync_handle.is_finished()
+                        {
+                            tracing::info!(
+                            walrus.blob_id = %blob_id,
+                                "blob sync monitor observed blob sync finished"
+                            );
+                            if let Some(join_handle) = handle.blob_sync_handle.take() {
+                                handles.push((*blob_id, join_handle));
                             }
+                            completed.push(*blob_id);
                         }
                     }
 

--- a/crates/walrus-service/src/node/db_checkpoint.rs
+++ b/crates/walrus-service/src/node/db_checkpoint.rs
@@ -748,11 +748,11 @@ impl DbCheckpointManager {
             return Err(DbCheckpointError::Other(error.into()));
         }
 
-        if let Some(handle) = self.schedule_loop_handle.take() {
-            if let Err(error) = handle.await {
-                tracing::warn!(?error, "error joining schedule loop");
-                return Err(DbCheckpointError::Other(error.into()));
-            }
+        if let Some(handle) = self.schedule_loop_handle.take()
+            && let Err(error) = handle.await
+        {
+            tracing::warn!(?error, "error joining schedule loop");
+            return Err(DbCheckpointError::Other(error.into()));
         }
 
         Ok(())

--- a/crates/walrus-service/src/node/epoch_change_driver.rs
+++ b/crates/walrus-service/src/node/epoch_change_driver.rs
@@ -305,20 +305,20 @@ impl Future for EpochChangeDriverInner<'_> {
             .clone_from(cx.waker());
 
         tracing::info_span!("scheduled_end_voting").in_scope(|| {
-            if let Some((_, end_voting_future)) = this.end_voting_future.as_mut() {
-                if let Poll::Ready(()) = end_voting_future.poll_unpin(cx) {
-                    tracing::trace!("voting-end future completed");
-                    this.end_voting_future = None;
-                }
+            if let Some((_, end_voting_future)) = this.end_voting_future.as_mut()
+                && let Poll::Ready(()) = end_voting_future.poll_unpin(cx)
+            {
+                tracing::trace!("voting-end future completed");
+                this.end_voting_future = None;
             }
         });
 
         tracing::info_span!("scheduled_initiate_epoch_change").in_scope(|| {
-            if let Some((_, epoch_change_start)) = this.epoch_change_start_future.as_mut() {
-                if let Poll::Ready(()) = epoch_change_start.poll_unpin(cx) {
-                    tracing::trace!("epoch-change-start future completed");
-                    this.epoch_change_start_future = None;
-                }
+            if let Some((_, epoch_change_start)) = this.epoch_change_start_future.as_mut()
+                && let Poll::Ready(()) = epoch_change_start.poll_unpin(cx)
+            {
+                tracing::trace!("epoch-change-start future completed");
+                this.epoch_change_start_future = None;
             }
         });
 

--- a/crates/walrus-service/src/node/storage/shard.rs
+++ b/crates/walrus-service/src/node/storage/shard.rs
@@ -1091,14 +1091,14 @@ impl ShardStorage {
             self.record_pending_recovery_metrics(&node, total_blobs_pending_recovery);
 
             // Wait for some futures to complete if we reach the concurrent blob recovery limit
-            if futures.len() >= config.max_concurrent_blob_recovery_during_shard_recovery {
-                if let Some(Err(error)) = futures.next().await {
-                    tracing::error!(
-                        ?error,
-                        "error recovering missing blob sliver. \
+            if futures.len() >= config.max_concurrent_blob_recovery_during_shard_recovery
+                && let Some(Err(error)) = futures.next().await
+            {
+                tracing::error!(
+                    ?error,
+                    "error recovering missing blob sliver. \
                         blob is not removed from pending_recover_slivers"
-                    );
-                }
+                );
             }
         }
 

--- a/crates/walrus-storage-node-client/src/client/middleware.rs
+++ b/crates/walrus-storage-node-client/src/client/middleware.rs
@@ -568,10 +568,10 @@ struct HeaderInjector<'a>(pub &'a mut HeaderMap);
 
 impl Injector for HeaderInjector<'_> {
     fn set(&mut self, key: &str, value: String) {
-        if let Ok(name) = HeaderName::from_bytes(key.as_bytes()) {
-            if let Ok(val) = HeaderValue::from_str(&value) {
-                self.0.insert(name, val);
-            }
+        if let Ok(name) = HeaderName::from_bytes(key.as_bytes())
+            && let Ok(val) = HeaderValue::from_str(&value)
+        {
+            self.0.insert(name, val);
         }
     }
 }

--- a/crates/walrus-upload-relay/src/tip/check.rs
+++ b/crates/walrus-upload-relay/src/tip/check.rs
@@ -56,11 +56,11 @@ pub(crate) fn check_tx_freshness(
         }
     };
 
-    if let Some(diff) = cur_timestamp.checked_sub(tx_timestamp) {
-        if diff > freshness_threshold {
-            tracing::debug!(?diff, "the transaction is too old");
-            return Err(TipError::TxTooOld);
-        }
+    if let Some(diff) = cur_timestamp.checked_sub(tx_timestamp)
+        && diff > freshness_threshold
+    {
+        tracing::debug!(?diff, "the transaction is too old");
+        return Err(TipError::TxTooOld);
     }
 
     Ok(())

--- a/crates/walrus-utils/src/backoff.rs
+++ b/crates/walrus-utils/src/backoff.rs
@@ -93,10 +93,10 @@ impl ExponentialBackoffState {
     }
 
     pub fn next_delay<R: Rng + ?Sized>(&mut self, rng: &mut R) -> Option<Duration> {
-        if let Some(max_retries) = self.max_retries {
-            if self.sequence_index >= max_retries {
-                return None;
-            }
+        if let Some(max_retries) = self.max_retries
+            && self.sequence_index >= max_retries
+        {
+            return None;
         }
 
         let next_delay_value = self


### PR DESCRIPTION
## Description

[Let chains][let-chains] were stabilized in Rust 1.88 for edition 2024. This allows us to reduce the indentation level in some places.

[let-chains]: https://blog.rust-lang.org/2025/06/26/Rust-1.88.0/#let-chains

## Test plan

Test suite.