### PR TITLE
feat: Remove legacy event processor from the codebase

### DIFF
--- a/crates/walrus-e2e-tests/tests/test_event_blobs.rs
+++ b/crates/walrus-e2e-tests/tests/test_event_blobs.rs
@@ -22,7 +22,6 @@ async fn test_event_blobs() -> anyhow::Result<()> {
     let (_sui_cluster, _cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
         .with_test_nodes_config(TestNodesConfig {
             node_weights: vec![2, 2],
-            use_legacy_event_processor: false,
             ..Default::default()
         })
         .build()
@@ -82,7 +81,6 @@ async fn test_disabled_event_blob_writer() -> anyhow::Result<()> {
     let (_sui_cluster, _cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
         .with_test_nodes_config(TestNodesConfig {
             node_weights: vec![1, 1],
-            use_legacy_event_processor: false,
             disable_event_blob_writer: true,
             ..Default::default()
         })

--- a/crates/walrus-sdk/src/client.rs
+++ b/crates/walrus-sdk/src/client.rs
@@ -1118,6 +1118,13 @@ impl Client<SuiContractClient> {
             return Err(ClientError::from(ClientErrorKind::CommitteeChangeNotified));
         }
 
+        if cfg!(any(test, feature = "test-utils")) {
+            // Sleep for 30 seconds to allow the nodes to see registered blobs.
+            // This is only neededfor testing purposes.
+            tracing::info!("sleeping for 30 seconds");
+            tokio::time::sleep(Duration::from_millis(30_000)).await;
+        }
+
         let get_certificates_timer = Instant::now();
         // Get the blob certificates, possibly storing slivers, while checking if the committee has
         // changed in the meantime.

--- a/crates/walrus-service/bin/deploy.rs
+++ b/crates/walrus-service/bin/deploy.rs
@@ -203,9 +203,6 @@ struct GenerateDryRunConfigsArgs {
     /// sending another request.
     #[arg(long, value_parser = humantime::parse_duration)]
     faucet_cooldown: Option<Duration>,
-    /// Use the legacy event processor instead of the standard checkpoint-based event processor.
-    #[arg(long)]
-    use_legacy_event_provider: bool,
     /// Disable the event blob writer.
     /// This will disable the event blob writer and the event blob writer service.
     #[arg(long)]
@@ -478,7 +475,6 @@ mod commands {
             listening_ips,
             set_db_path,
             faucet_cooldown,
-            use_legacy_event_provider,
             disable_event_blob_writer,
             backup_database_url,
             rpc_fallback_config_args,
@@ -577,7 +573,6 @@ mod commands {
                 .as_ref()
                 .and_then(|args| args.to_config()),
             &mut admin_contract_client,
-            use_legacy_event_provider,
             disable_event_blob_writer,
             sui_amount,
             sui_client_request_timeout,

--- a/crates/walrus-service/bin/node.rs
+++ b/crates/walrus-service/bin/node.rs
@@ -697,7 +697,6 @@ mod commands {
                 .map(|config| config.into())
                 .expect("Sui configuration must be present"),
             config.event_processor_config.clone(),
-            config.use_legacy_event_provider,
             &config.storage_path,
             &metrics_runtime.registry,
             cancel_token.child_token(),

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -147,7 +147,7 @@ use self::{
         ShardStorage,
         blob_info::{BlobInfoApi, CertifiedBlobInfoApi},
     },
-    system_events::{EventManager, SuiSystemEventProvider},
+    system_events::EventManager,
 };
 use crate::{
     common::config::SuiConfig,
@@ -404,19 +404,14 @@ impl StorageNodeBuilder {
                 None
             };
 
-        let event_manager: Box<dyn EventManager> = if let Some(event_manager) = self.event_manager {
-            event_manager
-        } else {
-            let (read_client, sui_config) = sui_config_and_client
-                .as_ref()
-                .expect("this is always created if self.event_manager.is_none()");
-
-            if config.use_legacy_event_provider {
-                Box::new(SuiSystemEventProvider::new(
-                    read_client.clone(),
-                    sui_config.event_polling_interval,
-                ))
+        let event_manager: Box<dyn EventManager> = {
+            if let Some(event_manager) = self.event_manager {
+                event_manager
             } else {
+                let (read_client, sui_config) = sui_config_and_client
+                    .as_ref()
+                    .expect("this is always created if self.event_manager.is_none()");
+
                 let rpc_addresses =
                     combine_rpc_urls(&sui_config.rpc, &sui_config.additional_rpc_endpoints);
                 let processor_config = EventProcessorRuntimeConfig {

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -133,15 +133,8 @@ pub struct StorageNodeConfig {
     #[serde(default, skip_serializing_if = "defaults::is_default")]
     pub shard_sync_config: ShardSyncConfig,
     /// Configuration for the event processor.
-    ///
-    /// This is ignored if `use_legacy_event_provider` is set to `true`.
     #[serde(default, skip_serializing_if = "defaults::is_default")]
     pub event_processor_config: EventProcessorConfig,
-    /// Use the legacy event provider.
-    ///
-    /// This is deprecated and will be removed in the future.
-    #[serde(default, skip_serializing_if = "defaults::is_default")]
-    pub use_legacy_event_provider: bool,
     /// Disable the event-blob writer
     #[serde(default, skip_serializing_if = "defaults::is_default")]
     pub disable_event_blob_writer: bool,
@@ -214,7 +207,6 @@ impl Default for StorageNodeConfig {
             tls: Default::default(),
             shard_sync_config: Default::default(),
             event_processor_config: Default::default(),
-            use_legacy_event_provider: false,
             disable_event_blob_writer: Default::default(),
             commission_rate: defaults::commission_rate(),
             voting_params: VotingParams {

--- a/crates/walrus-service/src/node/system_events.rs
+++ b/crates/walrus-service/src/node/system_events.rs
@@ -3,7 +3,7 @@
 
 //! Walrus events observed by the storage node.
 
-use std::{fmt::Debug, future::ready, pin::Pin, sync::Arc, thread, time::Duration};
+use std::{fmt::Debug, future::ready, pin::Pin, sync::Arc, thread};
 
 use anyhow::Error;
 use async_trait::async_trait;
@@ -13,14 +13,12 @@ use sui_types::{digests::TransactionDigest, event::EventID};
 use tokio::time::MissedTickBehavior;
 use tokio_stream::{Stream, wrappers::IntervalStream};
 use tracing::Level;
-use walrus_sui::client::{ReadClient, SuiReadClient};
 
 use super::{STATUS_PENDING, STATUS_PERSISTED, StorageNodeInner};
 use crate::{
-    common::config::SuiConfig,
     event::{
         event_processor::processor::EventProcessor,
-        events::{CheckpointEventPosition, EventStreamCursor, InitState, PositionedStreamEvent},
+        events::{EventStreamCursor, InitState, PositionedStreamEvent},
     },
     node::{metrics::STATUS_HIGHEST_FINISHED, storage::EventProgress},
 };
@@ -161,32 +159,6 @@ impl CompletableHandle for Option<EventHandle> {
     }
 }
 
-/// A [`SystemEventProvider`] that uses a [`SuiReadClient`] to fetch events.
-#[derive(Debug, Clone)]
-pub struct SuiSystemEventProvider {
-    read_client: SuiReadClient,
-    polling_interval: Duration,
-}
-
-impl SuiSystemEventProvider {
-    /// Creates a new provider with the supplied [`SuiReadClient`], which polls
-    /// for new events every polling_interval.
-    pub fn new(read_client: SuiReadClient, polling_interval: Duration) -> Self {
-        Self {
-            read_client,
-            polling_interval,
-        }
-    }
-
-    /// Creates a new provider with for a [`SuiReadClient`] constructed from the config.
-    pub async fn from_config(config: &SuiConfig) -> Result<Self, anyhow::Error> {
-        Ok(Self::new(
-            config.new_read_client().await?,
-            config.event_polling_interval,
-        ))
-    }
-}
-
 /// A provider of system events to a storage node.
 #[async_trait]
 pub trait SystemEventProvider: std::fmt::Debug + Sync + Send {
@@ -228,49 +200,6 @@ pub trait EventRetentionManager: std::fmt::Debug + Sync + Send {
 pub trait EventManager: SystemEventProvider + EventRetentionManager {
     /// Get the latest checkpoint sequence number.
     fn latest_checkpoint_sequence_number(&self) -> Option<u64>;
-}
-
-#[async_trait]
-impl SystemEventProvider for SuiSystemEventProvider {
-    async fn events(
-        &self,
-        cursor: EventStreamCursor,
-    ) -> Result<Box<dyn Stream<Item = PositionedStreamEvent> + Send + Sync + 'life0>, anyhow::Error>
-    {
-        tracing::info!(?cursor, "resuming from event");
-        let events = self
-            .read_client
-            .event_stream(self.polling_interval, cursor.event_id)
-            .await?;
-        let event_stream = events
-            .map(|event| PositionedStreamEvent::new(event, CheckpointEventPosition::new(0, 0)));
-        Ok(Box::new(event_stream))
-    }
-
-    async fn init_state(
-        &self,
-        _from: EventStreamCursor,
-    ) -> Result<Option<InitState>, anyhow::Error> {
-        Ok(None)
-    }
-
-    fn as_event_processor(&self) -> Option<&EventProcessor> {
-        None
-    }
-}
-
-#[async_trait]
-impl EventRetentionManager for SuiSystemEventProvider {
-    async fn drop_events_before(&self, _cursor: EventStreamCursor) -> Result<(), anyhow::Error> {
-        Ok(())
-    }
-}
-
-#[async_trait]
-impl EventManager for SuiSystemEventProvider {
-    fn latest_checkpoint_sequence_number(&self) -> Option<u64> {
-        None
-    }
 }
 
 #[async_trait]

--- a/crates/walrus-service/src/testbed.rs
+++ b/crates/walrus-service/src/testbed.rs
@@ -569,7 +569,6 @@ pub async fn create_storage_node_configs(
     faucet_cooldown: Option<Duration>,
     rpc_fallback_config: Option<RpcFallbackConfig>,
     admin_contract_client: &mut SuiContractClient,
-    use_legacy_event_provider: bool,
     disable_event_blob_writer: bool,
     sui_amount: u64,
     sui_client_request_timeout: Option<Duration>,
@@ -581,7 +580,6 @@ pub async fn create_storage_node_configs(
         ?set_config_dir,
         ?set_db_path,
         ?faucet_cooldown,
-        use_legacy_event_provider,
         disable_event_blob_writer,
         "starting to create storage-node configs"
     );
@@ -724,7 +722,6 @@ pub async fn create_storage_node_configs(
             tls: Default::default(),
             shard_sync_config: Default::default(),
             event_processor_config: Default::default(),
-            use_legacy_event_provider,
             disable_event_blob_writer,
             commission_rate: node.commission_rate,
             voting_params: VotingParams {

--- a/crates/walrus-simtest/tests/simtest.rs
+++ b/crates/walrus-simtest/tests/simtest.rs
@@ -138,7 +138,6 @@ mod tests {
             .with_epoch_duration(Duration::from_secs(30))
             .with_test_nodes_config(TestNodesConfig {
                 node_weights: node_weights.clone(),
-                use_legacy_event_processor: false,
                 ..Default::default()
             })
             .with_communication_config(
@@ -629,7 +628,6 @@ mod tests {
             .with_epoch_duration(Duration::from_secs(30))
             .with_test_nodes_config(TestNodesConfig {
                 node_weights: vec![1, 2, 3, 3, 4],
-                use_legacy_event_processor: false,
                 node_recovery_config: Some(node_recovery_config),
                 ..Default::default()
             })
@@ -793,7 +791,6 @@ mod tests {
             .with_epoch_duration(Duration::from_secs(30))
             .with_test_nodes_config(TestNodesConfig {
                 node_weights: vec![1, 2, 3, 3, 4],
-                use_legacy_event_processor: false,
                 ..Default::default()
             })
             .with_communication_config(

--- a/crates/walrus-simtest/tests/simtest_failure.rs
+++ b/crates/walrus-simtest/tests/simtest_failure.rs
@@ -218,7 +218,6 @@ mod tests {
             .with_epoch_duration(Duration::from_secs(30))
             .with_test_nodes_config(TestNodesConfig {
                 node_weights: vec![1, 2, 3, 3, 4],
-                use_legacy_event_processor: false,
                 node_recovery_config: Some(node_recovery_config),
                 ..Default::default()
             })
@@ -347,7 +346,6 @@ mod tests {
             .with_epoch_duration(Duration::from_secs(10))
             .with_test_nodes_config(TestNodesConfig {
                 node_weights: vec![2, 2, 3, 3, 3],
-                use_legacy_event_processor: false,
                 ..Default::default()
             })
             .with_communication_config(
@@ -512,7 +510,6 @@ mod tests {
             .with_epoch_duration(Duration::from_secs(10))
             .with_test_nodes_config(TestNodesConfig {
                 node_weights: vec![2, 2, 3, 3, 3],
-                use_legacy_event_processor: false,
                 ..Default::default()
             })
             .with_communication_config(
@@ -605,7 +602,6 @@ mod tests {
             .with_epoch_duration(Duration::from_secs(30))
             .with_test_nodes_config(TestNodesConfig {
                 node_weights: vec![1, 2, 3, 3, 4],
-                use_legacy_event_processor: false,
                 ..Default::default()
             })
             .with_communication_config(

--- a/crates/walrus-simtest/tests/simtest_param_sync.rs
+++ b/crates/walrus-simtest/tests/simtest_param_sync.rs
@@ -218,7 +218,6 @@ mod tests {
                 .with_epoch_duration(Duration::from_secs(30))
                 .with_test_nodes_config(TestNodesConfig {
                     node_weights: vec![1, 2, 3, 3, 4, 0],
-                    use_legacy_event_processor: false,
                     enable_node_config_synchronizer: true,
                     ..Default::default()
                 })
@@ -406,7 +405,6 @@ mod tests {
             .with_epoch_duration(Duration::from_secs(10))
             .with_test_nodes_config(TestNodesConfig {
                 node_weights: vec![1, 2, 3, 3, 4, 2],
-                use_legacy_event_processor: false,
                 enable_node_config_synchronizer: true,
                 ..Default::default()
             })
@@ -486,7 +484,6 @@ mod tests {
                 .with_epoch_duration(Duration::from_secs(30))
                 .with_test_nodes_config(TestNodesConfig {
                     node_weights: vec![1, 2, 3, 3, 4, 0],
-                    use_legacy_event_processor: false,
                     enable_node_config_synchronizer: true,
                     ..Default::default()
                 })
@@ -731,7 +728,6 @@ mod tests {
             .with_epoch_duration(Duration::from_secs(10))
             .with_test_nodes_config(TestNodesConfig {
                 node_weights: vec![1, 2, 3, 3, 4, 2],
-                use_legacy_event_processor: false,
                 enable_node_config_synchronizer: true,
                 ..Default::default()
             })


### PR DESCRIPTION
## Description

This PR removes the lagacy event processor from the codebase, as the description says.

Closes WAL-405

## Test plan

Existing tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
