### PR TITLE
fix: count ClientErrorKind::NoMetadataReceived as blob not exist when reading event blob

### DIFF
--- a/crates/walrus-sdk/src/error.rs
+++ b/crates/walrus-sdk/src/error.rs
@@ -106,6 +106,24 @@ impl ClientError {
                 | ClientErrorKind::CommitteeChangeNotified
         )
     }
+
+    /// Returns `true` if the error indicates that a blob is not available to read.
+    ///
+    /// Reading a blob that is being uploaded or being expired can result in different errors,
+    /// depending on the state of the blob.
+    pub fn is_blob_not_available_to_read_error(&self) -> bool {
+        matches!(
+            self.kind.as_ref(),
+            // Blob does not exist in the system.
+            ClientErrorKind::BlobIdDoesNotExist
+                // Blob may be exist, but we do not have enough slivers to reconstruct it.
+                | ClientErrorKind::NotEnoughSlivers
+                // Blob may be exist, but no metadata is uploaded yet
+                | ClientErrorKind::NoMetadataReceived
+                // Blob does not have a valid status in all storage nodes.
+                | ClientErrorKind::NoValidStatusReceived
+        )
+    }
 }
 
 impl From<QuiltError> for ClientError {


### PR DESCRIPTION
## Description

This is another ClientError that can be returned when the latest certified event blob is being propagated to storage
nodes.

## Test plan

100 simtest_test_registered_node_update_protocol_key

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
