### PR TITLE
fix: ensure sufficient time in the subsidies test to trigger subsidies

### DIFF
--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -1284,8 +1284,10 @@ async fn test_walrus_subsidies_get_called_by_node() -> TestResult {
     // Use basic_store_and_read with our pre_read_hook.
     basic_store_and_read(&client, 4, 314, || Ok(())).await?;
 
-    // Wait for the cluster to reach the next epoch.
-    cluster.wait_for_nodes_to_reach_epoch(epoch + 1).await;
+    // Wait for the cluster to reach two epochs ahead of the current epoch. This is to ensure that
+    // the subsidies are processed at least once between checking the initial and final funds, since
+    // there is a full epoch between the two checks.
+    cluster.wait_for_nodes_to_reach_epoch(epoch + 2).await;
 
     let final_subsidies_funds = client
         .as_ref()


### PR DESCRIPTION
## Description

Makes sure that there is at least one full epoch between comparing the balance of the subsidy object, s.t. it is definitely triggered in the walrus_subsidies test.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
