### PR TITLE
fix(node): mark events completed when cancelling sync for expired blobs (cherry-pick)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,7 +1900,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "checkpoint-downloader"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1918,7 +1918,7 @@ dependencies = [
  "tokio",
  "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
- "typed-store 1.29.0",
+ "typed-store 1.29.1",
  "walrus-sui",
  "walrus-utils",
 ]
@@ -12342,7 +12342,7 @@ dependencies = [
 
 [[package]]
 name = "typed-store"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "async-trait",
  "bcs",
@@ -12741,7 +12741,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-core"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -12766,7 +12766,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-e2e-tests"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "anyhow",
  "futures",
@@ -12797,7 +12797,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-orchestrator"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "aws-config",
  "aws-runtime",
@@ -12827,7 +12827,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-proc-macros"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "darling 0.21.0",
  "proc-macro2",
@@ -12838,7 +12838,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-proxy"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "anyhow",
  "axum 0.8.1",
@@ -12876,7 +12876,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-sdk"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "anyhow",
  "bimap",
@@ -12918,7 +12918,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-service"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13006,7 +13006,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "twox-hash 2.1.1",
- "typed-store 1.29.0",
+ "typed-store 1.29.1",
  "utoipa",
  "utoipa-redoc",
  "uuid",
@@ -13022,7 +13022,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-simtest"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -13039,7 +13039,7 @@ dependencies = [
  "sui-types",
  "tokio",
  "tracing",
- "typed-store 1.29.0",
+ "typed-store 1.29.1",
  "walrus-core",
  "walrus-proc-macros",
  "walrus-sdk",
@@ -13051,7 +13051,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-storage-node-client"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "axum 0.8.1",
  "axum-server 0.7.2",
@@ -13089,7 +13089,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-stress"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -13114,7 +13114,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-sui"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13168,7 +13168,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-test-utils"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -13178,7 +13178,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-upload-relay"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "anyhow",
  "axum 0.8.1",
@@ -13215,7 +13215,7 @@ dependencies = [
 
 [[package]]
 name = "walrus-utils"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ resolver = "2"
 authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024"
 license = "Apache-2.0"
-version = "1.29.0"
+version = "1.29.1"
 
 [workspace.dependencies]
 anyhow = "1.0.98"


### PR DESCRIPTION
## Description

Bumps the version to `v1.29.1` and cherry-picks #2354.

## Test plan

Test suite.