### PR TITLE
fix(node): handle updated TLS certificates more gracefully

### DIFF
--- a/crates/walrus-service/Cargo.toml
+++ b/crates/walrus-service/Cargo.toml
@@ -173,6 +173,7 @@ x509-cert = { workspace = true, optional = true }
 hex.workspace = true
 http-body-util.workspace = true
 mockall.workspace = true
+rcgen = { workspace = true, features = ["pem"] }
 ring = "0.17.14"
 tempfile.workspace = true
 walrus-core = { workspace = true, features = ["test-utils"] }

--- a/crates/walrus-service/bin/node.rs
+++ b/crates/walrus-service/bin/node.rs
@@ -1366,7 +1366,11 @@ impl StorageNodeRuntime {
                     "unable to notify that the node has exited, but shutdown is not in progress?"
                 )
             }
-            if let Err(ref error) = result {
+            if let Err(ref error) = result
+                && error.downcast_ref::<SyncNodeConfigError>().is_none()
+            {
+                // Only log an error if it is not due to to the config sync (as those are handled
+                // separately).
                 tracing::error!(?error, "storage node exited with an error");
             }
 

--- a/crates/walrus-service/src/node/committee/node_service.rs
+++ b/crates/walrus-service/src/node/committee/node_service.rs
@@ -381,7 +381,7 @@ impl DefaultNodeServiceFactory {
 
     /// Skips the use of proxies or the loading of native certificates, as these require interacting
     /// with the operating system and can significantly slow down the construction of new instances.
-    #[cfg(feature = "test-utils")]
+    #[cfg(any(test, feature = "test-utils"))]
     pub fn avoid_system_services() -> Self {
         Self {
             disable_use_proxy: true,

--- a/crates/walrus-service/src/node/server.rs
+++ b/crates/walrus-service/src/node/server.rs
@@ -497,7 +497,7 @@ fn create_self_signed_certificate(
     }
 }
 
-fn to_pkcs8_key_pair(keypair: &NetworkKeyPair) -> RcGenKeyPair {
+pub(crate) fn to_pkcs8_key_pair(keypair: &NetworkKeyPair) -> RcGenKeyPair {
     let secret_key: SecretKey = Secp256r1PrivateKey::from_bytes(keypair.as_ref().as_bytes())
         .expect("encode-decode of private key must not fail")
         .privkey


### PR DESCRIPTION
## Description

- Only restart the node if the currently loaded certificate is about to expire or the subject or extensions have changed.
- Log warnings when the certificate on disk is about to expire.
- Log errors when the certificate is expired.
- Don't log an error when a node restart is caused by a changed configuration.

As certificates are normally valid for 3 months and renewed every month, while nodes are restarted ever 2 weeks due to new releases, this approach virtually guarantees that the node never restarts automatically because of an updated certificate.

Closes WAL-832
Closes WAL-886

## Test plan

Modified/added unit test.

---

## Release notes

- [x] Storage node: When the TLS certificate is updated, only restart the node if the currently loaded certificate is about to expire or the subject or extensions have changed. Also add warning and error logs for (almost) expired certificates.
