### PR TITLE
chore: cleanup database table options hierarchy

### DIFF
--- a/crates/walrus-service/node_config_example.yaml
+++ b/crates/walrus-service/node_config_example.yaml
@@ -38,8 +38,7 @@ db_config:
     block_cache_size: 1073741824
     block_size: 65536
     pin_l0_filter_and_index_blocks_in_block_cache: true
-  node_status: null
-  metadata:
+  metadata_template:
     enable_blob_files: false
     min_blob_size: 0
     blob_file_size: 0
@@ -55,6 +54,23 @@ db_config:
     block_size: 65536
     pin_l0_filter_and_index_blocks_in_block_cache: true
     hard_pending_compaction_bytes_limit: 0
+  blob_info_template:
+    enable_blob_files: false
+    min_blob_size: 0
+    blob_file_size: 0
+    blob_compression_type: none
+    enable_blob_garbage_collection: false
+    blob_garbage_collection_age_cutoff: 0.0
+    blob_garbage_collection_force_threshold: 0.0
+    blob_compaction_read_ahead_size: 0
+    write_buffer_size: 67108864
+    target_file_size_base: 67108864
+    max_bytes_for_level_base: 536870912
+    block_cache_size: 536870912
+    block_size: 65536
+    pin_l0_filter_and_index_blocks_in_block_cache: true
+  node_status: null
+  metadata: null
   blob_info: null
   per_object_blob_info: null
   event_cursor: null

--- a/crates/walrus-service/node_config_example.yaml
+++ b/crates/walrus-service/node_config_example.yaml
@@ -41,7 +41,13 @@ db_config:
   node_status: null
   metadata:
     enable_blob_files: false
-    blob_compression_type: zstd
+    min_blob_size: 0
+    blob_file_size: 0
+    blob_compression_type: none
+    enable_blob_garbage_collection: false
+    blob_garbage_collection_age_cutoff: 0.0
+    blob_garbage_collection_force_threshold: 0.0
+    blob_compaction_read_ahead_size: 0
     write_buffer_size: 536870912
     target_file_size_base: 536870912
     max_bytes_for_level_base: 5368709120
@@ -49,10 +55,8 @@ db_config:
     block_size: 65536
     pin_l0_filter_and_index_blocks_in_block_cache: true
     hard_pending_compaction_bytes_limit: 0
-  blob_info:
-    block_cache_size: 536870912
-  per_object_blob_info:
-    block_cache_size: 536870912
+  blob_info: null
+  per_object_blob_info: null
   event_cursor: null
   shard: null
   shard_status: null

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -33,7 +33,7 @@ use rand::{Rng, SeedableRng, rngs::StdRng, thread_rng};
 use recovery_symbol_service::{RecoverySymbolRequest, RecoverySymbolService};
 use serde::Serialize;
 use start_epoch_change_finisher::StartEpochChangeFinisher;
-pub use storage::{DatabaseConfig, NodeStatus, Storage};
+pub use storage::{DatabaseConfig, DatabaseTableOptionsFactory, NodeStatus, Storage};
 use storage::{StorageShardLock, blob_info::PerObjectBlobInfoApi};
 #[cfg(msim)]
 use sui_macros::fail_point_if;

--- a/crates/walrus-service/src/node/dbtool.rs
+++ b/crates/walrus-service/src/node/dbtool.rs
@@ -20,13 +20,13 @@ use walrus_core::{
     metadata::{BlobMetadata, BlobMetadataApi},
 };
 
+use super::storage::DatabaseTableOptionsFactory;
 use crate::{
     event::{
         event_processor::db::constants::{self as event_processor_constants},
         events::{InitState, PositionedStreamEvent},
     },
     node::{
-        DatabaseConfig,
         event_blob_writer::{
             AttestedEventBlobMetadata,
             CertifiedEventBlobMetadata,
@@ -357,7 +357,7 @@ fn scan_events(db_path: PathBuf, start_event_index: u64, count: usize) -> Result
 }
 
 fn read_blob_info(db_path: PathBuf, start_blob_id: Option<BlobId>, count: usize) -> Result<()> {
-    let blob_info_options = blob_info_cf_options(&DatabaseConfig::default());
+    let blob_info_options = blob_info_cf_options(&DatabaseTableOptionsFactory::default());
     let db = DB::open_cf_with_opts_for_read_only(
         &RocksdbOptions::default(),
         db_path,
@@ -400,7 +400,8 @@ fn read_object_blob_info(
     start_object_id: Option<ObjectID>,
     count: usize,
 ) -> Result<()> {
-    let per_object_blob_info_options = per_object_blob_info_cf_options(&DatabaseConfig::default());
+    let per_object_blob_info_options =
+        per_object_blob_info_cf_options(&DatabaseTableOptionsFactory::default());
     let db = DB::open_cf_with_opts_for_read_only(
         &RocksdbOptions::default(),
         db_path,
@@ -439,7 +440,7 @@ fn read_object_blob_info(
 }
 
 fn count_certified_blobs(db_path: PathBuf, epoch: Epoch) -> Result<()> {
-    let blob_info_options = blob_info_cf_options(&DatabaseConfig::default());
+    let blob_info_options = blob_info_cf_options(&DatabaseTableOptionsFactory::default());
     let db = DB::open_cf_with_opts_for_read_only(
         &RocksdbOptions::default(),
         db_path,
@@ -520,7 +521,7 @@ fn read_blob_metadata(
         db_path,
         [(
             metadata_cf_name(),
-            metadata_options(&DatabaseConfig::default()),
+            metadata_options(&DatabaseTableOptionsFactory::default()),
         )],
         false,
     )?;
@@ -576,7 +577,7 @@ fn read_primary_slivers(
         db_path,
         [(
             primary_slivers_column_family_name(shard_index),
-            primary_slivers_column_family_options(&DatabaseConfig::default()),
+            primary_slivers_column_family_options(&DatabaseTableOptionsFactory::default()),
         )],
         false,
     )?;
@@ -624,7 +625,7 @@ fn read_secondary_slivers(
         db_path,
         [(
             secondary_slivers_column_family_name(shard_index),
-            secondary_slivers_column_family_options(&DatabaseConfig::default()),
+            secondary_slivers_column_family_options(&DatabaseTableOptionsFactory::default()),
         )],
         false,
     )?;

--- a/crates/walrus-service/src/node/event_blob_writer.rs
+++ b/crates/walrus-service/src/node/event_blob_writer.rs
@@ -45,6 +45,7 @@ use walrus_sui::{
 };
 use walrus_utils::metrics::Registry;
 
+use super::storage::DatabaseTableOptionsFactory;
 use crate::{
     event::{
         event_blob::{BlobEntry, EntryEncoding, EventBlob, SerializedEventID},
@@ -361,7 +362,9 @@ impl EventBlobWriterFactory {
         let db_path = Self::db_path(root_dir_path);
         fs::create_dir_all(db_path.as_path())?;
 
-        let mut db_opts = Options::from(&db_config.global());
+        let db_table_options_factory = DatabaseTableOptionsFactory::new(db_config.clone());
+
+        let mut db_opts = Options::from(&db_table_options_factory.global_db_options());
         let metric_conf = MetricConf::new("event_blob_writer");
         db_opts.create_missing_column_families(true);
         db_opts.create_if_missing(true);
@@ -370,30 +373,39 @@ impl EventBlobWriterFactory {
             Some(db_opts),
             metric_conf,
             &[
-                (PENDING, db_config.pending().to_options()),
-                (ATTESTED, db_config.attested().to_options()),
-                (CERTIFIED, db_config.certified().to_options()),
-                (FAILED_TO_ATTEST, db_config.failed_to_attest().to_options()),
+                (PENDING, db_table_options_factory.pending().to_options()),
+                (ATTESTED, db_table_options_factory.attested().to_options()),
+                (CERTIFIED, db_table_options_factory.certified().to_options()),
+                (
+                    FAILED_TO_ATTEST,
+                    db_table_options_factory.failed_to_attest().to_options(),
+                ),
             ],
         )?;
         if database.cf_handle(CERTIFIED).is_none() {
             database
-                .create_cf(CERTIFIED, &db_config.certified().to_options())
+                .create_cf(
+                    CERTIFIED,
+                    &db_table_options_factory.certified().to_options(),
+                )
                 .map_err(typed_store_err_from_rocks_err)?;
         }
         if database.cf_handle(ATTESTED).is_none() {
             database
-                .create_cf(ATTESTED, &db_config.attested().to_options())
+                .create_cf(ATTESTED, &db_table_options_factory.attested().to_options())
                 .map_err(typed_store_err_from_rocks_err)?;
         }
         if database.cf_handle(PENDING).is_none() {
             database
-                .create_cf(PENDING, &db_config.pending().to_options())
+                .create_cf(PENDING, &db_table_options_factory.pending().to_options())
                 .map_err(typed_store_err_from_rocks_err)?;
         }
         if database.cf_handle(FAILED_TO_ATTEST).is_none() {
             database
-                .create_cf(FAILED_TO_ATTEST, &db_config.failed_to_attest().to_options())
+                .create_cf(
+                    FAILED_TO_ATTEST,
+                    &db_table_options_factory.failed_to_attest().to_options(),
+                )
                 .map_err(typed_store_err_from_rocks_err)?;
         }
         let certified: DBMap<(), CertifiedEventBlobMetadata> = DBMap::reopen(

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -61,7 +61,7 @@ pub(crate) mod blob_info;
 pub(crate) mod constants;
 
 mod database_config;
-pub use database_config::DatabaseConfig;
+pub use database_config::{DatabaseConfig, DatabaseTableOptionsFactory};
 
 mod event_cursor_table;
 pub(super) use event_cursor_table::EventProgress;
@@ -82,12 +82,14 @@ pub(crate) use shard::{
     shard_sync_progress_column_family_options,
 };
 
-pub(crate) fn metadata_options(db_config: &DatabaseConfig) -> Options {
-    db_config.metadata().to_options()
+pub(crate) fn metadata_options(db_table_options_factory: &DatabaseTableOptionsFactory) -> Options {
+    db_table_options_factory.metadata().to_options()
 }
 
-pub(crate) fn node_status_options(db_config: &DatabaseConfig) -> Options {
-    db_config.node_status().to_options()
+pub(crate) fn node_status_options(
+    db_table_options_factory: &DatabaseTableOptionsFactory,
+) -> Options {
+    db_table_options_factory.node_status().to_options()
 }
 
 /// The status of the node.
@@ -183,7 +185,7 @@ pub struct Storage {
     blob_info: BlobInfoTable,
     event_cursor: EventCursorTable,
     shards: Arc<RwLock<HashMap<ShardIndex, Arc<ShardStorage>>>>,
-    config: DatabaseConfig,
+    db_table_options_factory: DatabaseTableOptionsFactory,
     metrics: Arc<CommonDatabaseMetrics>,
     metrics_registry: Registry,
 }
@@ -211,7 +213,9 @@ impl Storage {
         metrics_config: MetricConf,
         registry: Registry,
     ) -> Result<Self, anyhow::Error> {
-        let mut db_opts = Options::from(&db_config.global);
+        let db_table_options_factory = DatabaseTableOptionsFactory::new(db_config);
+
+        let mut db_opts = Options::from(&db_table_options_factory.global_db_options());
         db_opts.create_missing_column_families(true);
         db_opts.create_if_missing(true);
 
@@ -230,34 +234,35 @@ impl Storage {
                 [
                     (
                         primary_slivers_column_family_name(id),
-                        primary_slivers_column_family_options(&db_config),
+                        primary_slivers_column_family_options(&db_table_options_factory),
                     ),
                     (
                         secondary_slivers_column_family_name(id),
-                        secondary_slivers_column_family_options(&db_config),
+                        secondary_slivers_column_family_options(&db_table_options_factory),
                     ),
                     (
                         shard_status_column_family_name(id),
-                        shard_status_column_family_options(&db_config),
+                        shard_status_column_family_options(&db_table_options_factory),
                     ),
                     (
                         shard_sync_progress_column_family_name(id),
-                        shard_sync_progress_column_family_options(&db_config),
+                        shard_sync_progress_column_family_options(&db_table_options_factory),
                     ),
                     (
                         pending_recover_slivers_column_family_name(id),
-                        pending_recover_slivers_column_family_options(&db_config),
+                        pending_recover_slivers_column_family_options(&db_table_options_factory),
                     ),
                 ]
             })
             .collect::<Vec<_>>();
 
         let node_status_cf_name = node_status_cf_name();
-        let node_status_options = node_status_options(&db_config);
-        let metadata_options = metadata_options(&db_config);
+        let node_status_options = node_status_options(&db_table_options_factory);
+        let metadata_options = metadata_options(&db_table_options_factory);
         let metadata_cf_name = metadata_cf_name();
-        let blob_info_column_families = BlobInfoTable::options(&db_config);
-        let (event_cursor_cf_name, event_cursor_options) = EventCursorTable::options(&db_config);
+        let blob_info_column_families = BlobInfoTable::options(&db_table_options_factory);
+        let (event_cursor_cf_name, event_cursor_options) =
+            EventCursorTable::options(&db_table_options_factory);
 
         let expected_column_families: Vec<_> = shard_column_families
             .iter_mut()
@@ -300,8 +305,14 @@ impl Storage {
             existing_shards_ids
                 .into_iter()
                 .map(|id| {
-                    ShardStorage::create_or_reopen(id, &database, &db_config, None, &registry)
-                        .map(|shard| (id, Arc::new(shard)))
+                    ShardStorage::create_or_reopen(
+                        id,
+                        &database,
+                        &db_table_options_factory,
+                        None,
+                        &registry,
+                    )
+                    .map(|shard| (id, Arc::new(shard)))
                 })
                 .collect::<Result<_, _>>()?,
         ));
@@ -313,7 +324,7 @@ impl Storage {
             blob_info,
             event_cursor,
             shards,
-            config: db_config,
+            db_table_options_factory,
             metrics: Arc::new(CommonDatabaseMetrics::new_with_id(
                 &registry,
                 "storage".to_owned(),
@@ -382,7 +393,7 @@ impl Storage {
                     let shard_storage = ShardStorage::create_or_reopen(
                         shard_index,
                         &self.database,
-                        &self.config,
+                        &self.db_table_options_factory,
                         Some(ShardStatus::None),
                         &self.metrics_registry,
                     )
@@ -1338,22 +1349,24 @@ pub(crate) mod tests {
         let storage = empty_storage().await;
 
         let primary_cfs_name = primary_slivers_column_family_name(test_shard_index);
-        let primary_cfs_options = primary_slivers_column_family_options(&DatabaseConfig::default());
+        let primary_cfs_options =
+            primary_slivers_column_family_options(&DatabaseTableOptionsFactory::default());
 
         let secondary_cfs_name = secondary_slivers_column_family_name(test_shard_index);
         let secondary_cfs_options =
-            secondary_slivers_column_family_options(&DatabaseConfig::default());
+            secondary_slivers_column_family_options(&DatabaseTableOptionsFactory::default());
 
         let status_cfs_name = shard_status_column_family_name(test_shard_index);
-        let status_cfs = shard_status_column_family_options(&DatabaseConfig::default());
+        let status_cfs =
+            shard_status_column_family_options(&DatabaseTableOptionsFactory::default());
 
         let sync_progress_cfs_name = shard_sync_progress_column_family_name(test_shard_index);
         let sync_progress_cfs =
-            shard_sync_progress_column_family_options(&DatabaseConfig::default());
+            shard_sync_progress_column_family_options(&DatabaseTableOptionsFactory::default());
 
         let pending_recover_cfs_name = pending_recover_slivers_column_family_name(test_shard_index);
         let pending_recover_cfs =
-            pending_recover_slivers_column_family_options(&DatabaseConfig::default());
+            pending_recover_slivers_column_family_options(&DatabaseTableOptionsFactory::default());
 
         // Create all but secondary sliver column family. When restarting the storage, the
         // shard should not be detected as existing.

--- a/crates/walrus-service/src/node/storage/blob_info.rs
+++ b/crates/walrus-service/src/node/storage/blob_info.rs
@@ -26,7 +26,7 @@ use walrus_sui::types::{BlobCertified, BlobDeleted, BlobEvent, BlobRegistered, I
 
 use self::per_object_blob_info::PerObjectBlobInfoMergeOperand;
 pub(crate) use self::per_object_blob_info::{PerObjectBlobInfo, PerObjectBlobInfoApi};
-use super::{DatabaseConfig, constants, database_config::DatabaseTableOptions};
+use super::{constants, database_config::DatabaseTableOptionsFactory};
 
 pub type BlobInfoIterator<'a> = BlobInfoIter<
     BlobId,
@@ -48,8 +48,8 @@ pub(super) struct BlobInfoTable {
 }
 
 /// Returns the options for the aggregate blob info column family.
-pub(crate) fn blob_info_cf_options(db_config: &DatabaseConfig) -> Options {
-    let mut options = db_config.blob_info().to_options();
+pub(crate) fn blob_info_cf_options(db_options: &DatabaseTableOptionsFactory) -> Options {
+    let mut options = db_options.blob_info().to_options();
     options.set_merge_operator("merge blob info", merge_mergeable::<BlobInfo>, |_, _, _| {
         None
     });
@@ -57,8 +57,8 @@ pub(crate) fn blob_info_cf_options(db_config: &DatabaseConfig) -> Options {
 }
 
 /// Returns the options for the per object blob info column family.
-pub(crate) fn per_object_blob_info_cf_options(db_config: &DatabaseConfig) -> Options {
-    let mut options = db_config.per_object_blob_info().to_options();
+pub(crate) fn per_object_blob_info_cf_options(db_options: &DatabaseTableOptionsFactory) -> Options {
+    let mut options = db_options.per_object_blob_info().to_options();
     options.set_merge_operator(
         "merge per object blob info",
         merge_mergeable::<PerObjectBlobInfo>,
@@ -106,21 +106,21 @@ impl BlobInfoTable {
         Ok(())
     }
 
-    pub fn options(db_config: &DatabaseConfig) -> Vec<(&'static str, Options)> {
+    pub fn options(db_options: &DatabaseTableOptionsFactory) -> Vec<(&'static str, Options)> {
         vec![
             (
                 constants::aggregate_blob_info_cf_name(),
-                blob_info_cf_options(db_config),
+                blob_info_cf_options(db_options),
             ),
             (
                 constants::per_object_blob_info_cf_name(),
-                per_object_blob_info_cf_options(db_config),
+                per_object_blob_info_cf_options(db_options),
             ),
             (
                 constants::event_index_cf_name(),
                 // Doesn't make sense to have special options for the table containing a single
                 // value.
-                DatabaseTableOptions::default().to_options(),
+                db_options.standard().to_options(),
             ),
         ]
     }

--- a/crates/walrus-service/src/node/storage/event_cursor_table.rs
+++ b/crates/walrus-service/src/node/storage/event_cursor_table.rs
@@ -18,8 +18,8 @@ use typed_store::{
 };
 
 use super::{
-    DatabaseConfig,
     constants::{event_cursor_cf_name, event_cursor_key},
+    database_config::DatabaseTableOptionsFactory,
     event_sequencer::EventSequencer,
 };
 
@@ -108,8 +108,8 @@ impl EventCursorTable {
         Ok(this)
     }
 
-    pub fn options(config: &DatabaseConfig) -> (&'static str, Options) {
-        let mut options = config.event_cursor().to_options();
+    pub fn options(db_options: &DatabaseTableOptionsFactory) -> (&'static str, Options) {
+        let mut options = db_options.event_cursor().to_options();
         options.set_merge_operator(
             "update_cursor_and_progress",
             update_cursor_and_progress,

--- a/crates/walrus-simtest/tests/simtest.rs
+++ b/crates/walrus-simtest/tests/simtest.rs
@@ -27,12 +27,9 @@ mod tests {
     use sui_simulator::configs::{env_config, uniform_latency_ms};
     use tempfile::TempDir;
     use tokio::sync::RwLock;
-    use walrus_core::{DEFAULT_ENCODING, EncodingType, EpochCount};
+    use walrus_core::EpochCount;
     use walrus_proc_macros::walrus_simtest;
-    use walrus_sdk::{
-        client::{Client, StoreArgs},
-        store_optimizations::StoreOptimizations,
-    };
+    use walrus_sdk::client::{Client, StoreArgs};
     use walrus_service::{
         client::ClientCommunicationConfig,
         event::event_processor::config::EventProcessorConfig,

--- a/crates/walrus-simtest/tests/simtest_event_blob.rs
+++ b/crates/walrus-simtest/tests/simtest_event_blob.rs
@@ -19,7 +19,7 @@ mod tests {
     use walrus_proc_macros::walrus_simtest;
     use walrus_sdk::{client::Client, config::ClientCommunicationConfig};
     use walrus_service::{
-        node::{DatabaseConfig, event_blob_writer::CertifiedEventBlobMetadata},
+        node::{DatabaseTableOptionsFactory, event_blob_writer::CertifiedEventBlobMetadata},
         test_utils::{SimStorageNodeHandle, TestCluster, TestNodesConfig, test_cluster},
     };
     use walrus_simtest::test_utils::{simtest_utils, simtest_utils::BlobInfoConsistencyCheck};
@@ -154,25 +154,26 @@ mod tests {
             .storage_path
             .join("event_blob_writer")
             .join("db");
+        let db_table_options_factory = DatabaseTableOptionsFactory::default();
         let db = Arc::new(rocksdb::DB::open_cf_with_opts_for_read_only(
             &RocksdbOptions::default(),
             db_path,
             [
                 (
                     "pending_blob_store",
-                    DatabaseConfig::default().pending().to_options(),
+                    db_table_options_factory.pending().to_options(),
                 ),
                 (
                     "attested_blob_store",
-                    DatabaseConfig::default().attested().to_options(),
+                    db_table_options_factory.attested().to_options(),
                 ),
                 (
                     "certified_blob_store",
-                    DatabaseConfig::default().certified().to_options(),
+                    db_table_options_factory.certified().to_options(),
                 ),
                 (
                     "failed_to_attest_blob_store",
-                    DatabaseConfig::default().failed_to_attest().to_options(),
+                    db_table_options_factory.failed_to_attest().to_options(),
                 ),
             ],
             false,


### PR DESCRIPTION
## Description

The existing DatabaseConfig is quite confusing. First of all, DatabaseTableOptions defines all the default CF options (standard, optmized_for_blobs), and then the DatabaseConfig can override any of these basic template, as well as any
individual CF options. What's more confusing is that when overriding the basic template, we take, e.g. DatabaseConfig::standard, only from DatabaseConfig completely, but when overriding individual CF options, it inherits the basic option first, and then override any fields that exist in the DatabaseConfig.

This PR attempts to make DB option setup clearer and not introduce any breaking change. It tries to clearly assign functionalities to 3 structures:

- DatabseTableOptions: this is where the options and default templates are defined.
- DatabaseConfig: this is the option config included in the StorageNodeConfig. Any fields that do not exist (or set to None) in the DatabaseConfig, the corresponding CF options will always inherit from their default template.
- DatabaseTableOptionsFactory: this is the object where each CF's options are generated by combining the template from DatabaseTableOptions and any overrides in DatabaseConfig.

To sum up, and how to set table option after this PR:
- each CF's option derives from one of the 4 basic templates: standard, optimized_for_blobs, metadata, and blob_info.
- Any fields added in DatabaseConfig only overrides that specific fields in the CF's options. All other fields are inherited from their default template.

The creation of DatabaseTableOptionsFactory is also where the shared blob cache pool going to be implemented.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
