### PR TITLE
ci: fix GCP bucket name for upload

### DIFF
--- a/.github/workflows/attach-binaries-to-release.yml
+++ b/.github/workflows/attach-binaries-to-release.yml
@@ -196,7 +196,7 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@7c6e11cb7291594c5dfe0bc1dd9cd905e31e600c # pin@v2
         with:
           path: "./tmp"
-          destination: "mysten-walrus-binaries"
+          destination: "mysten-walrus-releases"
           parent: false
 
       - name: Upload release artifacts for ${{ matrix.os }} platform


### PR DESCRIPTION
## Description

Fix for #2367.

## Test plan

See [this workflow run](https://github.com/MystenLabs/walrus/actions/runs/16477073816/job/46581467339).