### PR TITLE
fix(node): fix handling of invalid blobs and deletions with incomplete history

### DIFF
--- a/crates/walrus-service/src/node/blob_event_processor.rs
+++ b/crates/walrus-service/src/node/blob_event_processor.rs
@@ -198,10 +198,7 @@ impl BackgroundEventProcessor {
         self.blob_sync_handler
             .cancel_sync_and_mark_event_complete(&event.blob_id)
             .await?;
-        self.node
-            .storage
-            .delete_blob_data(&event.blob_id, false)
-            .await?;
+        self.node.storage.delete_blob_data(&event.blob_id).await?;
 
         event_handle.mark_as_complete();
         Ok(())

--- a/crates/walrus-service/src/node/consistency_check.rs
+++ b/crates/walrus-service/src/node/consistency_check.rs
@@ -291,11 +291,14 @@ fn certified_blob_consistency_check(
             total_fully_stored,
             existence_check_error,
         }) => {
-            tracing::info!(?epoch, certified_blob_hash = ?blob_list_digest,
-                ?total_synced_scanned,
-                ?total_fully_stored,
-                ?existence_check_error,
-            "background blob info consistency check finished");
+            tracing::info!(
+                epoch,
+                certified_blob_hash = blob_list_digest,
+                total_synced_scanned,
+                total_fully_stored,
+                existence_check_error,
+                "background blob info consistency check finished"
+            );
 
             #[allow(clippy::cast_possible_wrap)] // wrapping is fine here
             walrus_utils::with_label!(node.metrics.blob_info_consistency_check, epoch_bucket)
@@ -405,8 +408,11 @@ fn compose_certified_object_blob_list_digest(
         }
     };
 
-    tracing::info!(?epoch, certified_blob_hash = ?blob_object_list_digest,
-            "background per-object blob info consistency check finished");
+    tracing::info!(
+        epoch,
+        certified_blob_hash = blob_object_list_digest,
+        "background per-object blob info consistency check finished"
+    );
     #[allow(clippy::cast_possible_wrap)] // wrapping is fine here
     walrus_utils::with_label!(
         node.metrics.per_object_blob_info_consistency_check,

--- a/crates/walrus-service/src/node/event_blob_writer.rs
+++ b/crates/walrus-service/src/node/event_blob_writer.rs
@@ -284,8 +284,7 @@ impl EventBlobWriterFactory {
         if !blobs_path.exists() {
             return Ok(());
         }
-        let blobs = fs::read_dir(blobs_path)?;
-        for blob in blobs {
+        for blob in fs::read_dir(blobs_path)? {
             let blob_path = blob?.path();
             if !blob_path.is_file() {
                 continue;
@@ -585,8 +584,8 @@ impl EventBlobWriterFactory {
             "found last certified event blob with metadata"
         );
         let current_certified = self.certified.get(&())?;
-        tracing::info!("current certified: {:?}", current_certified);
-        if current_certified.is_some_and(|current_certified| {
+        tracing::info!("current certified event blob: {current_certified:?}");
+        if current_certified.is_none_or(|current_certified| {
             event_blob.event_stream_cursor.element_index
                 > current_certified.event_cursor.element_index
         }) {
@@ -774,11 +773,9 @@ impl EventBlobWriterFactory {
 
         if !should_reset {
             tracing::info!(
-                "skipping reset: uncertified blobs ({}/{}) below threshold {}; last certified at \
-                checkpoint {}",
-                consecutive_uncertified,
-                total_uncertified_blobs,
-                num_uncertified_blob_threshold,
+                "skipping event-blob-writer reset: uncertified blobs \
+                ({consecutive_uncertified}/{total_uncertified_blobs}) below threshold \
+                {num_uncertified_blob_threshold}; last certified at checkpoint {}",
                 last_certified_event_blob.ending_checkpoint_sequence_number
             );
             return Ok(());

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -149,6 +149,14 @@ impl NodeStatus {
             NodeStatus::RecoveryCatchUp | NodeStatus::RecoveryCatchUpWithIncompleteHistory { .. }
         )
     }
+
+    /// Returns `true` if the node is catching up with incomplete history.
+    pub fn is_catching_up_with_incomplete_history(&self) -> bool {
+        matches!(
+            self,
+            NodeStatus::RecoveryCatchUpWithIncompleteHistory { .. }
+        )
+    }
 }
 
 impl Display for NodeStatus {

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -642,9 +642,13 @@ impl Storage {
 
     /// Deletes the metadata and slivers for the provided [`BlobId`] from the storage.
     #[tracing::instrument(skip_all)]
-    pub async fn delete_blob_data(&self, blob_id: &BlobId) -> Result<(), TypedStoreError> {
+    pub async fn delete_blob_data(
+        &self,
+        blob_id: &BlobId,
+        update_blob_info: bool,
+    ) -> Result<(), TypedStoreError> {
         let mut batch = self.metadata.batch();
-        self.delete_metadata(&mut batch, blob_id, true)?;
+        self.delete_metadata(&mut batch, blob_id, update_blob_info)?;
         self.delete_slivers(&mut batch, blob_id).await?;
         batch.write()?;
         Ok(())

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -641,14 +641,12 @@ impl Storage {
     }
 
     /// Deletes the metadata and slivers for the provided [`BlobId`] from the storage.
+    ///
+    /// This *does not* update the blob-info table in any way.
     #[tracing::instrument(skip_all)]
-    pub async fn delete_blob_data(
-        &self,
-        blob_id: &BlobId,
-        update_blob_info: bool,
-    ) -> Result<(), TypedStoreError> {
+    pub async fn delete_blob_data(&self, blob_id: &BlobId) -> Result<(), TypedStoreError> {
         let mut batch = self.metadata.batch();
-        self.delete_metadata(&mut batch, blob_id, update_blob_info)?;
+        self.delete_metadata(&mut batch, blob_id, false)?;
         self.delete_slivers(&mut batch, blob_id).await?;
         batch.write()?;
         Ok(())

--- a/crates/walrus-service/src/node/storage/blob_info.rs
+++ b/crates/walrus-service/src/node/storage/blob_info.rs
@@ -815,7 +815,9 @@ impl ValidBlobInfoV1 {
             && self
                 .latest_seen_deletable_certified_epoch
                 .is_some_and(|l| l > current_epoch);
-        exists_certified_permanent_blob || maybe_exists_certified_deletable_blob
+        self.initial_certified_epoch
+            .is_some_and(|epoch| epoch <= current_epoch)
+            && (exists_certified_permanent_blob || maybe_exists_certified_deletable_blob)
     }
 
     #[tracing::instrument]
@@ -1532,7 +1534,10 @@ mod per_object_blob_info {
 
     impl CertifiedBlobInfoApi for PerObjectBlobInfoV1 {
         fn is_certified(&self, current_epoch: Epoch) -> bool {
-            self.is_registered(current_epoch) && self.certified_epoch.is_some()
+            self.is_registered(current_epoch)
+                && self
+                    .certified_epoch
+                    .is_some_and(|epoch| epoch <= current_epoch)
         }
 
         fn initial_certified_epoch(&self) -> Option<Epoch> {

--- a/crates/walrus-service/src/node/storage/blob_info.rs
+++ b/crates/walrus-service/src/node/storage/blob_info.rs
@@ -1311,14 +1311,8 @@ impl Mergeable for BlobInfoV1 {
                 epoch,
                 event: status_event,
             }),
-            BlobInfoMergeOperand::MarkMetadataStored(_) => Some(
-                ValidBlobInfoV1 {
-                    is_metadata_stored: true,
-                    ..Default::default()
-                }
-                .into(),
-            ),
-            BlobInfoMergeOperand::ChangeStatus { .. } => {
+            BlobInfoMergeOperand::ChangeStatus { .. }
+            | BlobInfoMergeOperand::MarkMetadataStored(_) => {
                 tracing::error!(
                     ?operand,
                     "encountered an unexpected update for an untracked blob ID"
@@ -1695,6 +1689,8 @@ mod tests {
 
     param_test! {
         test_merge_new_expected_failure_cases: [
+            metadata_true: (BlobInfoMergeOperand::MarkMetadataStored(true)),
+            metadata_false: (BlobInfoMergeOperand::MarkMetadataStored(false)),
             certify_permanent: (BlobInfoMergeOperand::new_change_for_testing(
                 BlobStatusChangeType::Certify,false, 42, 314, event_id_for_testing()
             )),
@@ -1736,8 +1732,6 @@ mod tests {
                 epoch: 0,
                 status_event: event_id_for_testing()
             }),
-            metadata_true: (BlobInfoMergeOperand::MarkMetadataStored(true)),
-            metadata_false: (BlobInfoMergeOperand::MarkMetadataStored(false)),
         ]
     }
     fn test_merge_new_expected_success_cases_invariants(operand: BlobInfoMergeOperand) {

--- a/crates/walrus-simtest/tests/simtest.rs
+++ b/crates/walrus-simtest/tests/simtest.rs
@@ -430,6 +430,7 @@ mod tests {
     // - The catching-up node crashes and restarts.
     // - A blob is registered and certified in different epochs.
     // - A blob is deleted.
+    // - A blob is marked as invalid.
     // - The cursor of the event-blob writer is lagging more than MAX_EPOCHS_AHEAD epochs, but the
     //   node cursor is not.
     #[ignore = "ignore integration simtests by default"]


### PR DESCRIPTION
## Description

Previously, the node would not handle blob deletions and invalidations correctly while catching up with incomplete history. This makes the following changes:
- Allow handling `InvalidBlobId` events even when the corresponding blob is not yet tracked.
- Allow setting the `is_metadata_stored` flag for blobs that are not yet tracked.
- Do not log warnings when handling `BlobDeleted` events for untracked blobs while catching up with incomplete history.

Closes WAL-947
Also contributes to WAL-553 (fix skipping event blobs when starting with an incomplete history).

## Test plan

Started a new node on Testnet and had it catch up. No errors or warnings in the logs.

TODO: 
- [ ] Check why the `blob_info_consistency_check` differs.