### PR TITLE
fix: use correct version in testnet-contracts

### DIFF
--- a/contracts/subsidies/Move.lock
+++ b/contracts/subsidies/Move.lock
@@ -40,7 +40,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.52.1"
+compiler-version = "1.52.2"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/contracts/wal/Move.lock
+++ b/contracts/wal/Move.lock
@@ -21,7 +21,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.52.1"
+compiler-version = "1.52.2"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/contracts/wal_exchange/Move.lock
+++ b/contracts/wal_exchange/Move.lock
@@ -30,6 +30,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.52.1"
+compiler-version = "1.52.2"
 edition = "2024.beta"
 flavor = "sui"

--- a/contracts/walrus/Move.lock
+++ b/contracts/walrus/Move.lock
@@ -30,7 +30,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.52.1"
+compiler-version = "1.52.2"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/contracts/walrus_subsidies/Move.lock
+++ b/contracts/walrus_subsidies/Move.lock
@@ -40,6 +40,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.52.1"
+compiler-version = "1.52.2"
 edition = "2024.beta"
 flavor = "sui"

--- a/contracts/walrus_subsidies/sources/walrus_subsidies.move
+++ b/contracts/walrus_subsidies/sources/walrus_subsidies.move
@@ -24,15 +24,17 @@ const EWrongVersion: u64 = 1;
 // without requiring the AdminCap.
 
 /// The current version of this contract.
-const VERSION: u64 = 1;
+const VERSION: u64 = 2;
 
 /// Helper struct to get the package ID for the version 1 of this contract.
 public struct V1()
+/// Helper struct to get the package ID for the version 2 of this contract.
+public struct V2()
 
 /// Returns the package ID for the current version of this contract.
 /// Needs to be updated whenever the package is upgraded.
 fun package_id_for_current_version(): ID {
-    package_id_for_type<V1>()
+    package_id_for_type<V2>()
 }
 
 /// Returns the package ID for the given type.
@@ -226,5 +228,5 @@ use std::unit_test::assert_eq;
 #[test]
 fun test_package_id_for_current_version() {
     let package_id = package_id_for_current_version();
-    assert_eq!(type_name::get<V1>().get_address(), package_id.to_address().to_ascii_string());
+    assert_eq!(type_name::get<V2>().get_address(), package_id.to_address().to_ascii_string());
 }

--- a/testnet-contracts/walrus_subsidies/sources/walrus_subsidies.move
+++ b/testnet-contracts/walrus_subsidies/sources/walrus_subsidies.move
@@ -24,17 +24,15 @@ const EWrongVersion: u64 = 1;
 // without requiring the AdminCap.
 
 /// The current version of this contract.
-const VERSION: u64 = 2;
+const VERSION: u64 = 1;
 
 /// Helper struct to get the package ID for the version 1 of this contract.
 public struct V1()
-/// Helper struct to get the package ID for the version 2 of this contract.
-public struct V2()
 
 /// Returns the package ID for the current version of this contract.
 /// Needs to be updated whenever the package is upgraded.
 fun package_id_for_current_version(): ID {
-    package_id_for_type<V2>()
+    package_id_for_type<V1>()
 }
 
 /// Returns the package ID for the given type.
@@ -228,5 +226,5 @@ use std::unit_test::assert_eq;
 #[test]
 fun test_package_id_for_current_version() {
     let package_id = package_id_for_current_version();
-    assert_eq!(type_name::get<V2>().get_address(), package_id.to_address().to_ascii_string());
+    assert_eq!(type_name::get<V1>().get_address(), package_id.to_address().to_ascii_string());
 }


### PR DESCRIPTION
## Description

I discovered that after deploying the walrus_subsidies contract on testnet, I accidentally bumped the version on the `testnet-contracts` instead of `contracts`. This fixes that. I checked that the correct version is deployed on testnet.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
