### PR TITLE
chore: update workflow to create multisig tx to transfer subsidy funds

### DIFF
--- a/.github/workflows/create-tx-for-multisig.yml
+++ b/.github/workflows/create-tx-for-multisig.yml
@@ -8,7 +8,8 @@ on:
         type: choice
         options:
           - upgrade-subsidies
-          - migrate-subsidies
+          - upgrade-walrus-subsidies
+          - transfer-subsidies-funds
       rpc:
         description: "RPC url"
         required: true

--- a/scripts/create_multisig_tx.sh
+++ b/scripts/create_multisig_tx.sh
@@ -16,12 +16,14 @@ WALRUS_OPS="0x23eb7ccbbb4a21afea8b1256475e255b3cd84083ca79fa1f1a9435ab93d2b71b"
 # Object IDs
 SUBSIDIES_ADMIN_CAP="0x7cd09be8545e524217e6f35e5c306b64e3545594879dc2590e024f42bce439c6"
 SUBSIDIES_UPGRADE_CAP="0x632e10712d32b0851a1109d5a7f09680d11c74ffa5ba50eef7f14d85385cb615"
+WALRUS_SUBSIDIES_UPGRADE_CAP="0x0f73338243cc49e217d49ecfad806fa80f3ef48357e9b12614d8e57027fa0a75"
+WALRUS_SUBSIDIES_ADMIN_CAP="0xd62d3d5b43dae752464afa2a8354fe52e0c31619778e8ab88c2e9a37c8349d04"
 
 
 usage() {
   echo "Usage: $0 [OPTIONS]"
   echo "OPTIONS:"
-  echo "  -t <tx_type> Transaction type, mandatory ('upgrade-subsidies', 'migrate-subsidies')"
+  echo "  -t <tx_type> Transaction type, mandatory ('upgrade-walrus-subsidies', 'transfer-subsidies-funds')"
   echo "  -g <obj_id>  Gas object ID, defaults to gas object with highest balance"
 }
 
@@ -35,30 +37,35 @@ gas_obj_for_addr() {
   fi
 }
 
-upgrade_subsidies() {
+upgrade_walrus_subsidies() {
   GAS=$(gas_obj_for_addr $WALRUS_ADMIN)
   GAS_BUDGET=$(sui client object $GAS --json | jq -r '.content.fields.balance')
-  CONTRACT_DIR=mainnet-contracts/subsidies
+  CONTRACT_DIR=mainnet-contracts/walrus_subsidies
   sui client \
     upgrade \
     --gas $GAS \
     --gas-budget $GAS_BUDGET \
-    --upgrade-capability $SUBSIDIES_UPGRADE_CAP \
+    --upgrade-capability $WALRUS_SUBSIDIES_UPGRADE_CAP \
     $CONTRACT_DIR \
     --serialize-unsigned-transaction
 }
 
-migrate_subsidies() {
+transfer_subsidies_funds() {
   GAS=$(gas_obj_for_addr $WALRUS_OPS)
   GAS_BUDGET=$(sui client object $GAS --json | jq -r '.content.fields.balance')
   SUBSIDIES_PACKAGE=$(sui client object $SUBSIDIES_UPGRADE_CAP --json | jq -r '.content.fields.package')
   SUBSIDIES_OBJECT=$(sui client object $SUBSIDIES_ADMIN_CAP --json | jq -r '.content.fields.subsidies_id' )
+  WALRUS_SUBSIDIES_PKG=$(sui client object $WALRUS_SUBSIDIES_UPGRADE_CAP --json | jq -r '.content.fields.package' )
+  WALRUS_SUBSIDIES_OBJECT=$(sui client object $WALRUS_SUBSIDIES_ADMIN_CAP --json | jq -r '.content.fields.subsidies_id' )
   sui client \
     ptb \
     --gas-coin @$GAS \
     --gas-budget $GAS_BUDGET \
-    --move-call $SUBSIDIES_PACKAGE::subsidies::migrate \
-    @$SUBSIDIES_OBJECT @$SUBSIDIES_ADMIN_CAP @$SUBSIDIES_PACKAGE \
+    --move-call $SUBSIDIES_PACKAGE::subsidies::withdraw_balance \
+    @$SUBSIDIES_OBJECT @$SUBSIDIES_ADMIN_CAP \
+    --assign balance \
+    --move-call $WALRUS_SUBSIDIES_PKG::walrus_subsidies::add_balance \
+    @$WALRUS_SUBSIDIES_OBJECT balance \
     --serialize-unsigned-transaction
 }
 
@@ -81,11 +88,11 @@ while getopts "t:g:h" arg; do
 done
 
 case "$TX_TYPE" in
-  upgrade-subsidies)
-    upgrade_subsidies
+  upgrade-walrus-subsidies)
+    upgrade_walrus_subsidies
     ;;
-  migrate-subsidies)
-    migrate_subsidies
+  transfer-subsidies-funds)
+    transfer_subsidies_funds
     ;;
   "")
     echo "Error: The transaction type must be specified" >&2


### PR DESCRIPTION
## Description

Adds the call to transfer funds from the subsidies contract to the walrus_subsidies contract to the multisig script.
Modifies the call to upgrade `walrus_subsidies` instead of `subsidies`.
 
## Test plan

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
