### PR TITLE
chore: add multisig for setting subsidy rates to workflow

### DIFF
--- a/.github/workflows/create-tx-for-multisig.yml
+++ b/.github/workflows/create-tx-for-multisig.yml
@@ -7,9 +7,8 @@ on:
         description: "select transaction type to create"
         type: choice
         options:
-          - upgrade-subsidies
           - upgrade-walrus-subsidies
-          - transfer-subsidies-funds
+          - set-walrus-subsidy-rates
       rpc:
         description: "RPC url"
         required: true
@@ -22,6 +21,18 @@ on:
       commit:
         description: "commit hash of the walrus repo to create the transaction"
         required: true
+        type: string
+      base_subsidy_frost:
+        description: "base subsidy in FROST (only for set-walrus-subsidy-rates)"
+        required: false
+        type: string
+      per_shard_subsidy_frost:
+        description: "per shard subsidy in FROST (only for set-walrus-subsidy-rates)"
+        required: false
+        type: string
+      subsidy_rate_basis_points:
+        description: "subsidy rate in basis points (only for set-walrus-subsidy-rates)"
+        required: false
         type: string
 
 jobs:
@@ -55,7 +66,13 @@ jobs:
       - name: Create unsigned transaction for multisig
         run: |
           mkdir -p artifacts
-          ./scripts/create_multisig_tx.sh -t '${{ inputs.transaction_type }}' -g '${{ inputs.gas_object_id }}' >artifacts/tx-data.txt
+          ./scripts/create_multisig_tx.sh \
+            -t '${{ inputs.transaction_type }}' \
+            -g '${{ inputs.gas_object_id }}' \
+            -b '${{ inputs.base_subsidy_frost }}' \
+            -s '${{ inputs.per_shard_subsidy_frost }}' \
+            -r '${{ inputs.subsidy_rate_basis_points }}' \
+            >artifacts/tx-data.txt
 
       - name: Show Transaction Data (To sign)
         run: |

--- a/.github/workflows/create-tx-for-multisig.yml
+++ b/.github/workflows/create-tx-for-multisig.yml
@@ -8,7 +8,8 @@ on:
         type: choice
         options:
           - upgrade-subsidies
-          - migrate-subsidies
+          - upgrade-walrus-subsidies
+          - transfer-subsidies-funds
       rpc:
         description: "RPC url"
         required: true

--- a/scripts/create_multisig_tx.sh
+++ b/scripts/create_multisig_tx.sh
@@ -16,12 +16,14 @@ WALRUS_OPS="0x23eb7ccbbb4a21afea8b1256475e255b3cd84083ca79fa1f1a9435ab93d2b71b"
 # Object IDs
 SUBSIDIES_ADMIN_CAP="0x7cd09be8545e524217e6f35e5c306b64e3545594879dc2590e024f42bce439c6"
 SUBSIDIES_UPGRADE_CAP="0x632e10712d32b0851a1109d5a7f09680d11c74ffa5ba50eef7f14d85385cb615"
+WALRUS_SUBSIDIES_UPGRADE_CAP="0x0f73338243cc49e217d49ecfad806fa80f3ef48357e9b12614d8e57027fa0a75"
+WALRUS_SUBSIDIES_ADMIN_CAP="0xd62d3d5b43dae752464afa2a8354fe52e0c31619778e8ab88c2e9a37c8349d04"
 
 
 usage() {
   echo "Usage: $0 [OPTIONS]"
   echo "OPTIONS:"
-  echo "  -t <tx_type> Transaction type, mandatory ('upgrade-subsidies', 'migrate-subsidies')"
+  echo "  -t <tx_type> Transaction type, mandatory ('upgrade-walrus-subsidies', 'transfer-subsidies-funds')"
   echo "  -g <obj_id>  Gas object ID, defaults to gas object with highest balance"
 }
 
@@ -35,30 +37,35 @@ gas_obj_for_addr() {
   fi
 }
 
-upgrade_subsidies() {
+upgrade_walrus_subsidies() {
   GAS=$(gas_obj_for_addr $WALRUS_ADMIN)
   GAS_BUDGET=$(sui client object $GAS --json | jq -r '.content.fields.balance')
-  CONTRACT_DIR=mainnet-contracts/subsidies
+  CONTRACT_DIR=mainnet-contracts/walrus_subsidies
   sui client \
     upgrade \
     --gas $GAS \
     --gas-budget $GAS_BUDGET \
-    --upgrade-capability $SUBSIDIES_UPGRADE_CAP \
+    --upgrade-capability $WALRUS_SUBSIDIES_UPGRADE_CAP \
     $CONTRACT_DIR \
     --serialize-unsigned-transaction
 }
 
-migrate_subsidies() {
+transfer_subsidies_funds() {
   GAS=$(gas_obj_for_addr $WALRUS_OPS)
   GAS_BUDGET=$(sui client object $GAS --json | jq -r '.content.fields.balance')
   SUBSIDIES_PACKAGE=$(sui client object $SUBSIDIES_UPGRADE_CAP --json | jq -r '.content.fields.package')
   SUBSIDIES_OBJECT=$(sui client object $SUBSIDIES_ADMIN_CAP --json | jq -r '.content.fields.subsidies_id' )
+  WALRUS_SUBSIDIES_PKG=$(sui client object $WALRUS_SUBSIDIES_UPGRADE_CAP --json | jq -r '.content.fields.package' )
+  WALRUS_SUBSIDIES_OBJECT=$(sui client object $WALRUS_SUBSIDIES_ADMIN_CAP --json | jq -r '.content.fields.subsidies_id' )
   sui client \
     ptb \
     --gas-coin @$GAS \
     --gas-budget $GAS_BUDGET \
-    --move-call $SUBSIDIES_PACKAGE::subsidies::migrate \
-    @$SUBSIDIES_OBJECT @$SUBSIDIES_ADMIN_CAP @$SUBSIDIES_PACKAGE \
+    --move-call $SUBSIDIES_PACKAGE::subsidies::withdraw_balance \
+    @$SUBSIDIES_OBJECT @$SUBSIDIES_ADMIN_CAP \
+    --assign balance \
+    --move-call $WALRUS_SUBSIDIES_PKG::walrus_subsidies::add_balance \
+    @$WALRUS_SUBSIDIES_OBJECT balance \
     --serialize-unsigned-transaction
 }
 
@@ -81,11 +88,11 @@ while getopts "t:g:h" arg; do
 done
 
 case "$TX_TYPE" in
-  upgrade-subsidies)
-    upgrade_subsidies
+  upgrade-walrus-subsidies)
+    upgrade_walrus_subsidies
     ;;
-  migrate-subsidies)
-    migrate_subsidies
+  transfer-subsidies-funds)
+    transfer_subsidies_funds
     ;;
   "")
     echo "Error: The transaction type must be specified" >&2

--- a/scripts/create_multisig_tx.sh
+++ b/scripts/create_multisig_tx.sh
@@ -8,14 +8,15 @@
 
 GAS_OBJECT_ID=""
 TX_TYPE=""
+BASE_SUBSIDY_FROST=""
+PER_SHARD_SUBSIDY_FROST=""
+SUBSIDY_RATE_BASIS_POINTS=""
 
 # Addresses
 WALRUS_ADMIN="0x62a69ba94e191634841cc4d196e70ec3e4667fc78013ae6d7405a0c593b39f1e"
 WALRUS_OPS="0x23eb7ccbbb4a21afea8b1256475e255b3cd84083ca79fa1f1a9435ab93d2b71b"
 
 # Object IDs
-SUBSIDIES_ADMIN_CAP="0x7cd09be8545e524217e6f35e5c306b64e3545594879dc2590e024f42bce439c6"
-SUBSIDIES_UPGRADE_CAP="0x632e10712d32b0851a1109d5a7f09680d11c74ffa5ba50eef7f14d85385cb615"
 WALRUS_SUBSIDIES_UPGRADE_CAP="0x0f73338243cc49e217d49ecfad806fa80f3ef48357e9b12614d8e57027fa0a75"
 WALRUS_SUBSIDIES_ADMIN_CAP="0xd62d3d5b43dae752464afa2a8354fe52e0c31619778e8ab88c2e9a37c8349d04"
 
@@ -23,8 +24,11 @@ WALRUS_SUBSIDIES_ADMIN_CAP="0xd62d3d5b43dae752464afa2a8354fe52e0c31619778e8ab88c
 usage() {
   echo "Usage: $0 [OPTIONS]"
   echo "OPTIONS:"
-  echo "  -t <tx_type> Transaction type, mandatory ('upgrade-walrus-subsidies', 'transfer-subsidies-funds')"
+  echo "  -t <tx_type> Transaction type, mandatory ('upgrade-walrus-subsidies', 'set-walrus-subsidy-rates')"
   echo "  -g <obj_id>  Gas object ID, defaults to gas object with highest balance"
+  echo "  -b <base_subsidy_frost> Base subsidy in FROST (only for set-walrus-subsidy-rates)"
+  echo "  -s <per_shard_subsidy_frost> Per shard subsidy in FROST (only for set-walrus-subsidy-rates)"
+  echo "  -r <subsidy_rate_basis_points> Subsidy rate in basis points (only for set-walrus-subsidy-rates)"
 }
 
 gas_obj_for_addr() {
@@ -50,32 +54,48 @@ upgrade_walrus_subsidies() {
     --serialize-unsigned-transaction
 }
 
-transfer_subsidies_funds() {
+set_walrus_subsidy_rates() {
   GAS=$(gas_obj_for_addr $WALRUS_OPS)
   GAS_BUDGET=$(sui client object $GAS --json | jq -r '.content.fields.balance')
-  SUBSIDIES_PACKAGE=$(sui client object $SUBSIDIES_UPGRADE_CAP --json | jq -r '.content.fields.package')
-  SUBSIDIES_OBJECT=$(sui client object $SUBSIDIES_ADMIN_CAP --json | jq -r '.content.fields.subsidies_id' )
   WALRUS_SUBSIDIES_PKG=$(sui client object $WALRUS_SUBSIDIES_UPGRADE_CAP --json | jq -r '.content.fields.package' )
   WALRUS_SUBSIDIES_OBJECT=$(sui client object $WALRUS_SUBSIDIES_ADMIN_CAP --json | jq -r '.content.fields.subsidies_id' )
-  sui client \
+
+  CMD="sui client \
     ptb \
     --gas-coin @$GAS \
-    --gas-budget $GAS_BUDGET \
-    --move-call $SUBSIDIES_PACKAGE::subsidies::withdraw_balance \
-    @$SUBSIDIES_OBJECT @$SUBSIDIES_ADMIN_CAP \
-    --assign balance \
-    --move-call $WALRUS_SUBSIDIES_PKG::walrus_subsidies::add_balance \
-    @$WALRUS_SUBSIDIES_OBJECT balance \
-    --serialize-unsigned-transaction
+    --gas-budget $GAS_BUDGET"
+  if [[ -n $BASE_SUBSIDY_FROST ]]; then
+    CMD="$CMD --move-call $WALRUS_SUBSIDIES_PKG::walrus_subsidies::set_base_subsidy \
+    @$WALRUS_SUBSIDIES_OBJECT @$WALRUS_SUBSIDIES_ADMIN_CAP $BASE_SUBSIDY_FROST"
+  fi
+  if [[ -n $PER_SHARD_SUBSIDY_FROST ]]; then
+    CMD="$CMD --move-call $WALRUS_SUBSIDIES_PKG::walrus_subsidies::set_per_shard_subsidy \
+    @$WALRUS_SUBSIDIES_OBJECT @$WALRUS_SUBSIDIES_ADMIN_CAP $PER_SHARD_SUBSIDY_FROST"
+  fi
+  if [[ -n $SUBSIDY_RATE_BASIS_POINTS ]]; then
+    CMD="$CMD --move-call $WALRUS_SUBSIDIES_PKG::walrus_subsidies::set_system_subsidy_rate \
+    @$WALRUS_SUBSIDIES_OBJECT @$WALRUS_SUBSIDIES_ADMIN_CAP $SUBSIDY_RATE_BASIS_POINTS"
+  fi
+  $CMD --serialize-unsigned-transaction
 }
 
-while getopts "t:g:h" arg; do
+
+while getopts "t:g:b:s:r:h" arg; do
   case "${arg}" in
     t)
       TX_TYPE=${OPTARG}
       ;;
     g)
       GAS_OBJECT_ID=${OPTARG}
+      ;;
+    b)
+      BASE_SUBSIDY_FROST=${OPTARG}
+      ;;
+    s)
+      PER_SHARD_SUBSIDY_FROST=${OPTARG}
+      ;;
+    r)
+      SUBSIDY_RATE_BASIS_POINTS=${OPTARG}
       ;;
     h)
       usage
@@ -91,8 +111,8 @@ case "$TX_TYPE" in
   upgrade-walrus-subsidies)
     upgrade_walrus_subsidies
     ;;
-  transfer-subsidies-funds)
-    transfer_subsidies_funds
+  set-walrus-subsidy-rates)
+    set_walrus_subsidy_rates
     ;;
   "")
     echo "Error: The transaction type must be specified" >&2


### PR DESCRIPTION
## Description

Adds a command to set the subsidy rates in the new `walrus_subsidies` object.
Also cleans up commands for the old subsidies that are no longer used after the multisig from [this workflow run](https://github.com/MystenLabs/walrus/actions/runs/16620981332) goes through.

## Test plan

Locally ran script with dry-run (instead of serialized-unsigned) to check that the transaction gets created correctly.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
