### PR TITLE
chore: clean up old subsidies in the client and docs

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,7 +1,7 @@
 # Contracts Development
 
 This directory contains the contracts that are currently under development. The `VERSION` in
-the contracts sources (`walrus/sources/staking.move`, `walrus/sources/system.move`,
-`subsidies/sources/subsidies.move`) must be `1` more than the values in `testnet-contracts`.
+the contracts sources (`walrus/sources/staking.move`, `walrus/sources/system.move`) must be
+`1` more than the values in `testnet-contracts`.
 The `mainnet-contracts` directory contains the contracts currently deployed on Mainnet,
 whereas `testnet-contracts` contains the contracts deployed on Testnet.

--- a/crates/walrus-sdk/src/config.rs
+++ b/crates/walrus-sdk/src/config.rs
@@ -325,7 +325,6 @@ mod tests {
             system_object: 0xa2637d13d171b278eadfa8a3fbe8379b5e471e1f3739092e5243da17fc8090eb
             staking_object: 0xca7cf321e47a1fc9bfd032abc31b253f5063521fd5b4c431f2cdd3fee1b4ec00
             exchange_objects: []
-            subsidies_object: 0xca7cf321e47a1fc9bfd032abc31b253f5063521fd5b4c431f2cdd3fee1b4ec00
         "};
 
         let config: ClientConfig = serde_yaml::from_str(yaml)?;
@@ -335,16 +334,16 @@ mod tests {
     }
 
     #[test]
-    fn parses_no_subsidies_object_config_file() -> TestResult {
+    fn parses_old_config_file_containing_subsidies_object_without_error() -> TestResult {
         let yaml = indoc! {"
             system_object: 0xa2637d13d171b278eadfa8a3fbe8379b5e471e1f3739092e5243da17fc8090eb
             staking_object: 0xca7cf321e47a1fc9bfd032abc31b253f5063521fd5b4c431f2cdd3fee1b4ec00
+            subsidies_object: 0xca7cf321e47a1fc9bfd032abc31b253f5063521fd5b4c431f2cdd3fee1b4ec00
             exchange_objects:
                 - 0xa9b00f69d3b033e7b64acff2672b54fbb7c31361954251e235395dea8bd6dcac
         "};
 
-        let config: ClientConfig = serde_yaml::from_str(yaml)?;
-        assert!(config.contract_config.subsidies_object.is_none());
+        let _config: ClientConfig = serde_yaml::from_str(yaml)?;
 
         Ok(())
     }
@@ -354,7 +353,6 @@ mod tests {
         let yaml = indoc! {"
             system_object: 0xa2637d13d171b278eadfa8a3fbe8379b5e471e1f3739092e5243da17fc8090eb
             staking_object: 0xca7cf321e47a1fc9bfd032abc31b253f5063521fd5b4c431f2cdd3fee1b4ec00
-            subsidies_object: 0xca7cf321e47a1fc9bfd032abc31b253f5063521fd5b4c431f2cdd3fee1b4ec00
             exchange_objects:
                 - 0xa9b00f69d3b033e7b64acff2672b54fbb7c31361954251e235395dea8bd6dcac
         "};
@@ -370,7 +368,6 @@ mod tests {
         let yaml = indoc! {"
             system_object: 0xa2637d13d171b278eadfa8a3fbe8379b5e471e1f3739092e5243da17fc8090eb
             staking_object: 0xca7cf321e47a1fc9bfd032abc31b253f5063521fd5b4c431f2cdd3fee1b4ec00
-            subsidies_object: 0xca7cf321e47a1fc9bfd032abc31b253f5063521fd5b4c431f2cdd3fee1b4ec00
             exchange_objects:
                 - 0xa9b00f69d3b033e7b64acff2672b54fbb7c31361954251e235395dea8bd6dcac
                 - 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
@@ -387,7 +384,6 @@ mod tests {
         let yaml = indoc! {"
             system_object: 0xa2637d13d171b278eadfa8a3fbe8379b5e471e1f3739092e5243da17fc8090eb
             staking_object: 0xca7cf321e47a1fc9bfd032abc31b253f5063521fd5b4c431f2cdd3fee1b4ec00
-            subsidies_object: 0xca7cf321e47a1fc9bfd032abc31b253f5063521fd5b4c431f2cdd3fee1b4ec00
             exchange_objects:
                 - 0xa9b00f69d3b033e7b64acff2672b54fbb7c31361954251e235395dea8bd6dcac
             wallet_config: path/to/wallet

--- a/crates/walrus-sui/src/client.rs
+++ b/crates/walrus-sui/src/client.rs
@@ -1509,9 +1509,8 @@ impl SuiContractClientInner {
                 Err(SuiClientError::TransactionExecutionError(MoveExecutionError::System(
                     SystemError::EWrongVersion(_),
                 ))) => {
-                    // TODO(WAL-908): Change warning to credits.
                     tracing::warn!(
-                        "Walrus package version mismatch in subsidies call,
+                        "Walrus package version mismatch in credits call,
                             falling back to direct contract call"
                     );
                 }
@@ -1659,9 +1658,8 @@ impl SuiContractClientInner {
                 Err(SuiClientError::TransactionExecutionError(MoveExecutionError::System(
                     SystemError::EWrongVersion(_),
                 ))) => {
-                    // TODO(WAL-908): Change warning to credits.
                     tracing::warn!(
-                        "Walrus package version mismatch in subsidies call, \
+                        "Walrus package version mismatch in credits call, \
                             falling back to direct contract call"
                     );
                 }
@@ -2566,9 +2564,8 @@ impl SuiContractClientInner {
                 Err(SuiClientError::TransactionExecutionError(MoveExecutionError::System(
                     SystemError::EWrongVersion(_),
                 ))) => {
-                    // TODO(WAL-908): Change warning to credits.
                     tracing::warn!(
-                        "Walrus package version mismatch in subsidies
+                        "Walrus package version mismatch in credits call, \
                         call, falling back to direct contract call"
                     );
                 }
@@ -2674,9 +2671,8 @@ impl SuiContractClientInner {
                     MoveExecutionError::Staking(StakingError::EWrongVersion(_))
                     | MoveExecutionError::System(SystemError::EWrongVersion(_)),
                 )) => {
-                    // TODO(WAL-908): Change warning to credits.
                     tracing::warn!(
-                        "Walrus package version mismatch in subsidies call, \
+                        "Walrus package version mismatch in credits call, \
                             falling back to direct contract call"
                     );
                 }

--- a/crates/walrus-sui/src/client/contract_config.rs
+++ b/crates/walrus-sui/src/client/contract_config.rs
@@ -13,13 +13,6 @@ pub struct ContractConfig {
     pub system_object: ObjectID,
     /// Object ID of the Walrus staking object.
     pub staking_object: ObjectID,
-    /// Object ID of the subsidies object.
-    // TODO(WAL-908): Remove once the subsidies are no longer used client-side.
-    // Kept for backwards compatibility until then.
-    // For credits, the `credits_object` field should be used from the start.
-    // TODO(WAL-908): Update configs in `../../../../setup`
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub subsidies_object: Option<ObjectID>,
     /// Object ID of the credits object.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub credits_object: Option<ObjectID>,
@@ -35,7 +28,6 @@ impl ContractConfig {
             system_object,
             staking_object,
             credits_object: None,
-            subsidies_object: None,
             walrus_subsidies_object: None,
         }
     }

--- a/crates/walrus-sui/src/client/read_client.rs
+++ b/crates/walrus-sui/src/client/read_client.rs
@@ -332,10 +332,7 @@ impl SuiReadClient {
             walrus_subsidies: Arc::new(RwLock::new(None)),
             wal_type,
         };
-        if let Some(credits_object_id) = contract_config
-            .credits_object
-            .or(contract_config.subsidies_object)
-        {
+        if let Some(credits_object_id) = contract_config.credits_object {
             client.set_credits_object(credits_object_id).await?;
         }
         if let Some(walrus_subsidies_object_id) = contract_config.walrus_subsidies_object {
@@ -522,7 +519,6 @@ impl SuiReadClient {
                 .expect("mutex should not be poisoned")
                 .as_ref()
                 .map(|s| s.object_id),
-            subsidies_object: None,
             walrus_subsidies_object: self
                 .walrus_subsidies
                 .read()

--- a/crates/walrus-sui/src/client/transaction_builder.rs
+++ b/crates/walrus-sui/src/client/transaction_builder.rs
@@ -1695,12 +1695,9 @@ impl WalrusPtbBuilder {
                     .get_credits_object(credits_object_id)
                     .await?
                     .buyer_subsidy_rate;
-                // TODO: (WAL-905) Hack until new subsidy is integrated with system contract
-                if u64::from(buyer_subsidy_rate) == TEN_THOUSAND_BASIS_POINTS {
-                    0
-                } else {
-                    full_price
-                }
+                let subsidy =
+                    full_price * u64::from(buyer_subsidy_rate) / TEN_THOUSAND_BASIS_POINTS;
+                full_price - subsidy
             }
             Some(_) => full_price,
             None => full_price,

--- a/crates/walrus-sui/src/contracts.rs
+++ b/crates/walrus-sui/src/contracts.rs
@@ -411,9 +411,8 @@ pub mod wal_exchange {
 
 /// Module for tags corresponding to the Move module `subsidies`.
 ///
-/// This module will soon (TODO: WAL-908) only be used for Walrus credits and callsites to this
-/// module have been updated to be named "credits" in the rust codebase to avoid confusion with
-/// the `walrus_subsidies` module.
+/// This module is only used for Walrus credits. Callsites to this module have been updated to be
+/// named "credits" in the rust codebase to avoid confusion with the `walrus_subsidies` module.
 pub mod credits {
     use super::*;
 

--- a/crates/walrus-sui/src/test_utils/system_setup.rs
+++ b/crates/walrus-sui/src/test_utils/system_setup.rs
@@ -126,7 +126,6 @@ impl SystemContext {
             system_object: self.system_object,
             staking_object: self.staking_object,
             credits_object: self.credits_object,
-            subsidies_object: None,
             walrus_subsidies_object: self.walrus_subsidies_object,
         }
     }

--- a/crates/walrus-sui/src/types/move_structs.rs
+++ b/crates/walrus-sui/src/types/move_structs.rs
@@ -923,13 +923,12 @@ impl ExchangeRate {
 /// Sui type for a `subsidies::Subsidies` object. Called `Credits` here to avoid confusion with
 /// the new Walrus Subsidies contract.
 ///
-// TODO(WAL-908): Add explanation of credits to the docs once they are no longer used as subsidies.
-// Currently, the "credits" are still just the initial version of the subsidies. They are already
-// renamed now to make it easier to actually add the calls to the new subsidies without naming
-// confusion. The reason that we need to keep it in the codebase instead of removing it once we've
-// changed to the new subsidies is that the DevRel team have developed/are developing a credit
-// system (with the same interfaces as the current subsidies contract) for partners to allow them
-// to store blobs on Walrus without the need to actually receive WAL coins directly.
+/// The "credits" were previously used to subsidize clients purchasing storage. In this function
+/// they were superseded by the `walrus_subsidies` contract, which only provides subsidies on the
+/// system side.
+/// The same interfaces are still used as part of a credit system developed by the DevRel team that
+/// allows additionally subsidizing clients. Because of this, we keep the corresponding code-paths
+/// in the codebase, to provide backwards compatibility.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct Credits {
     /// The object ID of the object

--- a/docs/book/dev-guide/costs.md
+++ b/docs/book/dev-guide/costs.md
@@ -16,9 +16,9 @@ Sui transactions, and Sui objects on chain:
 - **Storage resources.** A storage resource is needed to store a blob, with an appropriate capacity
   and epoch duration.
   Storage resources can be acquired from the Walrus system contract while there is free space
-  available on the system against some WAL. Other options are also available, such as buying
-  them from the subsidy contract, having it transferred, or splitting a larger resource bought
-  occasionally into smaller ones (see discussion below).
+  available on the system against some WAL. Other options are also available, such as receiving it
+  from other parties, or splitting a larger resource bought occasionally into smaller ones (see
+  discussion below).
 
 - **Upload costs.** Upon blob registration, some WAL is charged to cover the costs of data upload.
   This ensures that deleting blobs and reusing the same storage resource for storing a new blob is
@@ -81,27 +81,23 @@ transactions:
   system contract and also cost of uploads.
 
 - The `walrus store --dry-run ...` command outputs the encoded size that is used in calculations
-  of WAL costs. The `--dry-run` parameter ensures no transactions are submitted on chain. Note
-  that currently, the estimated WAL cost **does not take subsidies into account** and as such is
-  an overestimate while subsidies are available.
+  of WAL costs. The `--dry-run` parameter ensures no transactions are submitted on chain.
 
 ## Managing and minimizing costs
 
 There are multiple ways of acquiring storage resources, which impact their costs.
 
 The primary means is by sending some WAL to the Walrus system contract to "buy" a storage resource
-for some size in bytes and a defined lifetime in epochs. Currently, the Walrus Foundation also
-operates a subsidy contract that allows acquiring storage resources at a lower WAL cost as compared
-with the System contract. The Walrus CLI and the publisher use the subsidy contract by default to
-lower costs if a subsidy object is included in the configuration file.
+for some size in bytes and a defined lifetime in epochs.
 
 Furthermore, before acquiring a storage resource, the CLI client will use any user-owned storage
 resource of an appropriate length (in epochs and size in bytes). However, the current implementation
 does not make any attempts yet to properly split or merge storage resources.
+
 <!-- TODO(WAL-363): Update this as soon as better storage management is implemented. -->
 
 There are a few ways to minimize costs associated with the need for storage resources. First,
-acquiring resources from either the system or subsidy contract involves at least one Sui
+acquiring resources from the system contract involves at least one Sui
 transaction interacting with a relatively complex shared object Sui smart contract. Therefore,
 acquiring larger storage resources at once both in length and size minimizes the SUI gas costs.
 Storage resources can then be split and merged to store smaller blobs or blobs for shorter time

--- a/docs/book/usage/networks.md
+++ b/docs/book/usage/networks.md
@@ -33,7 +33,6 @@ In case you wish to explore the Walrus contracts, their package IDs are the foll
 
 - WAL package: `0x356a26eb9e012a68958082340d4c4116e7f55615cf27affcff209cf0ae544f59`
 - Walrus package: `0xfdc88f7d7cf30afab2f82e8380d11ee8f70efb90e863d1de8616fae1bb09ea77`
-- Subsidies package: `0xd843c37d213ea683ec3519abe4646fd618f52d7fce1c4e9875a4144d53e21ebc`
 
 As these are inferred automatically from the object IDs above, there is no need to manually input
 them into the Walrus client configuration file. The latest published package IDs can also be found

--- a/docs/book/usage/setup.md
+++ b/docs/book/usage/setup.md
@@ -178,8 +178,7 @@ fixes. Follow the instructions in the `README.md` file to build and use Walrus f
 
 The Walrus client needs to know about the Sui objects that store the Walrus system and staking
 information, see the [developer guide](../dev-guide/sui-struct.md#system-and-staking-information).
-These need to be configured in a file `~/.config/walrus/client_config.yaml`. Additionally, a
-`subsidies` object can be specified, which will subsidize storage bought with the client.
+These need to be configured in a file `~/.config/walrus/client_config.yaml`.
 
 You can access Testnet and Mainnet via the following configuration. Note that this example Walrus
 CLI configuration refers to the standard location for Sui configuration
@@ -190,13 +189,15 @@ CLI configuration refers to the standard location for Sui configuration
 ```
 
 <!-- markdownlint-disable code-fence-style -->
-~~~admonish tip
+
+````admonish tip
 The easiest way to obtain the latest configuration is by downloading it directly from Walrus:
 
 ```sh
 curl https://docs.wal.app/setup/client_config.yaml -o ~/.config/walrus/client_config.yaml
 ```
-~~~
+````
+
 <!-- markdownlint-enable code-fence-style -->
 
 ### Custom path (optional) {#config-custom-path}
@@ -215,11 +216,6 @@ The configuration file currently supports the following parameters for each of t
 # deployment but then do not change over time.
 system_object: 0x2134d52768ea07e8c43570ef975eb3e4c27a39fa6396bef985b5abc58d03ddd2
 staking_object: 0x10b9d30c28448939ce6c4d6c6e0ffce4a7f8a4ada8248bdad09ef8b70e4a3904
-
-# The subsidies object allows the client to use the subsidies contract to purchase storage
-# which will reduce the cost of obtaining a storage resource and extending blobs and also
-# adds subsidies to the rewards of the staking pools.
-subsidies_object: 0xb606eb177899edc2130c93bf65985af7ec959a2755dc126c953755e59324209e
 
 # You can define a custom path to your Sui wallet configuration here. If this is unset or `null`
 # (default), the wallet is configured from `./sui_config.yaml` (relative to your current working

--- a/scripts/local-testbed.sh
+++ b/scripts/local-testbed.sh
@@ -178,8 +178,7 @@ if ! $use_existing_config; then
     --write-price 1 \
     --epoch-duration "$epoch_duration" \
     --contract-dir "$contract_dir" \
-    --with-wal-exchange \
-    --with-subsidies
+    --with-wal-exchange
 
   # Generate configs
   generate_dry_run_args=( --working-dir "$working_dir" )

--- a/setup/client_config.yaml
+++ b/setup/client_config.yaml
@@ -2,7 +2,6 @@ contexts:
   mainnet:
     system_object: 0x2134d52768ea07e8c43570ef975eb3e4c27a39fa6396bef985b5abc58d03ddd2
     staking_object: 0x10b9d30c28448939ce6c4d6c6e0ffce4a7f8a4ada8248bdad09ef8b70e4a3904
-    subsidies_object: 0xb606eb177899edc2130c93bf65985af7ec959a2755dc126c953755e59324209e
     exchange_objects: []
     wallet_config:
       # Optional path to the wallet config file.

--- a/setup/client_config_mainnet.yaml
+++ b/setup/client_config_mainnet.yaml
@@ -1,5 +1,4 @@
 system_object: 0x2134d52768ea07e8c43570ef975eb3e4c27a39fa6396bef985b5abc58d03ddd2
 staking_object: 0x10b9d30c28448939ce6c4d6c6e0ffce4a7f8a4ada8248bdad09ef8b70e4a3904
-subsidies_object: 0xb606eb177899edc2130c93bf65985af7ec959a2755dc126c953755e59324209e
 rpc_urls:
   - https://fullnode.mainnet.sui.io:443


### PR DESCRIPTION
## Description

Closes WAL-905
Closes WAL-908

## Test plan

Existing tests, added test to ensure that old configs don't break the client.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
