### PR TITLE
fix(deps): bump all Sui dependencies to `v1.53.1`

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -30,7 +30,7 @@ env:
   # Don't emit giant backtraces in the CI logs.
   RUST_BACKTRACE: short
   RUSTDOCFLAGS: -D warnings
-  SUI_TAG: testnet-v1.52.1
+  SUI_TAG: testnet-v1.53.1
 
 jobs:
   diff:

--- a/.github/workflows/scheduled_reports.yml
+++ b/.github/workflows/scheduled_reports.yml
@@ -30,7 +30,7 @@ env:
   # Don't emit giant backtraces in the CI logs.
   RUST_BACKTRACE: short
   RUSTDOCFLAGS: -D warnings
-  SUI_TAG: testnet-v1.52.1
+  SUI_TAG: testnet-v1.53.1
 
 jobs:
   test-coverage:

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
       pull-requests: write
     env:
-      SUI_TAG: testnet-v1.52.1
+      SUI_TAG: testnet-v1.53.1
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # pin@v5.6.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes-gcm-siv"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae0784134ba9375416d469ec31e7c5f9fa94405049cf08c5ce5b4698be673e0d"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "polyval",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1439,8 +1454,8 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bin-version"
-version = "1.52.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+version = "1.53.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "const-str 0.5.7",
  "git-version",
@@ -2144,7 +2159,7 @@ dependencies = [
 [[package]]
 name = "consensus-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "fastcrypto",
  "mysten-network",
@@ -2156,7 +2171,7 @@ dependencies = [
 [[package]]
 name = "consensus-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -2213,7 +2228,7 @@ dependencies = [
 [[package]]
 name = "consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "base64 0.21.7",
  "consensus-config",
@@ -3299,7 +3314,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -3422,11 +3437,12 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fastcrypto"
-version = "0.1.8"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=69d496c71fb37e3d22fe85e5bbfd4256d61422b9#69d496c71fb37e3d22fe85e5bbfd4256d61422b9"
+version = "0.1.9"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=16fa86d0dd943024a9088d46850a72ecd55b7f46#16fa86d0dd943024a9088d46850a72ecd55b7f46"
 dependencies = [
  "aes",
  "aes-gcm",
+ "aes-gcm-siv",
  "ark-ec",
  "ark-ff",
  "ark-secp256r1",
@@ -3477,7 +3493,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-derive"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=69d496c71fb37e3d22fe85e5bbfd4256d61422b9#69d496c71fb37e3d22fe85e5bbfd4256d61422b9"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=16fa86d0dd943024a9088d46850a72ecd55b7f46#16fa86d0dd943024a9088d46850a72ecd55b7f46"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -3486,7 +3502,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-tbls"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=69d496c71fb37e3d22fe85e5bbfd4256d61422b9#69d496c71fb37e3d22fe85e5bbfd4256d61422b9"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=16fa86d0dd943024a9088d46850a72ecd55b7f46#16fa86d0dd943024a9088d46850a72ecd55b7f46"
 dependencies = [
  "bcs",
  "digest 0.10.7",
@@ -3505,7 +3521,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-vdf"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=69d496c71fb37e3d22fe85e5bbfd4256d61422b9#69d496c71fb37e3d22fe85e5bbfd4256d61422b9"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=16fa86d0dd943024a9088d46850a72ecd55b7f46#16fa86d0dd943024a9088d46850a72ecd55b7f46"
 dependencies = [
  "bcs",
  "fastcrypto",
@@ -3522,7 +3538,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-zkp"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=69d496c71fb37e3d22fe85e5bbfd4256d61422b9#69d496c71fb37e3d22fe85e5bbfd4256d61422b9"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=16fa86d0dd943024a9088d46850a72ecd55b7f46#16fa86d0dd943024a9088d46850a72ecd55b7f46"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -4755,6 +4771,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5618,12 +5645,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 
 [[package]]
 name = "move-abstract-interpreter-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "move-binary-format",
 ]
@@ -5631,12 +5658,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "enum-compat-util",
@@ -5652,12 +5679,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5673,7 +5700,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "indexmap 2.10.0",
@@ -5686,7 +5713,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -5701,7 +5728,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -5711,7 +5738,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
@@ -5726,7 +5753,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
@@ -5741,7 +5768,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
@@ -5756,7 +5783,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5777,7 +5804,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5813,7 +5840,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5838,7 +5865,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5863,7 +5890,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5884,7 +5911,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "clap",
@@ -5907,7 +5934,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -5925,7 +5952,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "hex",
@@ -5938,7 +5965,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -5951,7 +5978,7 @@ dependencies = [
 [[package]]
 name = "move-model-2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5974,7 +6001,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "clap",
@@ -6010,7 +6037,7 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "enum-compat-util",
  "quote",
@@ -6020,7 +6047,7 @@ dependencies = [
 [[package]]
 name = "move-regex-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "itertools 0.10.5",
  "move-binary-format",
@@ -6031,7 +6058,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -6046,7 +6073,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v0"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -6061,7 +6088,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v1"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -6076,7 +6103,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v2"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -6091,7 +6118,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "once_cell",
  "phf",
@@ -6101,7 +6128,7 @@ dependencies = [
 [[package]]
 name = "move-trace-format"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -6113,7 +6140,7 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "move-binary-format",
  "once_cell",
@@ -6122,7 +6149,7 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "move-vm-config",
  "once_cell",
@@ -6134,7 +6161,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "better_any",
  "fail",
@@ -6154,7 +6181,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "better_any",
  "fail",
@@ -6173,7 +6200,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "better_any",
  "fail",
@@ -6192,7 +6219,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "better_any",
  "fail",
@@ -6211,7 +6238,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6225,7 +6252,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -6238,7 +6265,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -6251,7 +6278,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -6264,7 +6291,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -6277,7 +6304,7 @@ dependencies = [
 [[package]]
 name = "msim"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=cad62679fd180a48c665f842cb80045f8fcfdee9#cad62679fd180a48c665f842cb80045f8fcfdee9"
+source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=192bd9590f8552d5a1c5debf66c4ff2672af037e#192bd9590f8552d5a1c5debf66c4ff2672af037e"
 dependencies = [
  "ahash 0.7.8",
  "async-task",
@@ -6306,7 +6333,7 @@ dependencies = [
 [[package]]
 name = "msim-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=cad62679fd180a48c665f842cb80045f8fcfdee9#cad62679fd180a48c665f842cb80045f8fcfdee9"
+source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=192bd9590f8552d5a1c5debf66c4ff2672af037e#192bd9590f8552d5a1c5debf66c4ff2672af037e"
 dependencies = [
  "darling 0.14.4",
  "proc-macro2",
@@ -6395,7 +6422,7 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 [[package]]
 name = "mysten-common"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "antithesis_sdk",
  "anyhow",
@@ -6417,7 +6444,7 @@ dependencies = [
 [[package]]
 name = "mysten-metrics"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "async-trait",
  "axum 0.8.1",
@@ -6438,7 +6465,7 @@ dependencies = [
 [[package]]
 name = "mysten-network"
 version = "0.2.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -6474,7 +6501,7 @@ dependencies = [
 [[package]]
 name = "mysten-service"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "axum 0.8.1",
@@ -7642,7 +7669,7 @@ dependencies = [
 [[package]]
 name = "prometheus-closure-metric"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -9154,7 +9181,7 @@ dependencies = [
 [[package]]
 name = "shared-crypto"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "bcs",
  "eyre",
@@ -9256,7 +9283,7 @@ dependencies = [
 [[package]]
 name = "simulacrum"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9643,7 +9670,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 [[package]]
 name = "sui-adapter-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9676,7 +9703,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9704,7 +9731,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9731,7 +9758,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9758,7 +9785,7 @@ dependencies = [
 [[package]]
 name = "sui-authority-aggregation"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "futures",
  "mysten-metrics",
@@ -9770,7 +9797,7 @@ dependencies = [
 [[package]]
 name = "sui-config"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anemo",
  "anyhow",
@@ -9803,7 +9830,7 @@ dependencies = [
 [[package]]
 name = "sui-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anemo",
  "antithesis_sdk",
@@ -9884,6 +9911,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-retry",
  "tokio-stream",
  "tracing",
  "twox-hash 1.6.3",
@@ -9918,7 +9946,7 @@ dependencies = [
 [[package]]
 name = "sui-data-ingestion-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9946,8 +9974,8 @@ dependencies = [
 
 [[package]]
 name = "sui-display"
-version = "1.52.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+version = "1.53.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -9959,7 +9987,7 @@ dependencies = [
 [[package]]
 name = "sui-enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -9967,7 +9995,7 @@ dependencies = [
 [[package]]
 name = "sui-execution"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-interpreter-v2",
@@ -10005,16 +10033,16 @@ dependencies = [
 
 [[package]]
 name = "sui-field-count"
-version = "1.52.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+version = "1.53.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "sui-field-count-derive",
 ]
 
 [[package]]
 name = "sui-field-count-derive"
-version = "1.52.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+version = "1.53.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -10023,7 +10051,7 @@ dependencies = [
 [[package]]
 name = "sui-framework"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -10036,8 +10064,8 @@ dependencies = [
 
 [[package]]
 name = "sui-framework-snapshot"
-version = "1.52.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+version = "1.53.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "bcs",
@@ -10052,7 +10080,7 @@ dependencies = [
 [[package]]
 name = "sui-genesis-builder"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "bcs",
@@ -10080,7 +10108,7 @@ dependencies = [
 [[package]]
 name = "sui-http"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "bytes",
  "http 1.3.1",
@@ -10099,8 +10127,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer"
-version = "1.52.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+version = "1.53.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10170,8 +10198,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-framework"
-version = "1.52.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+version = "1.53.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10207,8 +10235,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-framework-store-traits"
-version = "1.52.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+version = "1.53.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10218,8 +10246,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-metrics"
-version = "1.52.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+version = "1.53.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "axum 0.8.1",
@@ -10235,7 +10263,7 @@ dependencies = [
 [[package]]
 name = "sui-json"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "bcs",
@@ -10252,7 +10280,7 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -10311,7 +10339,7 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc-api"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -10331,7 +10359,7 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc-types"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "bcs",
@@ -10364,7 +10392,7 @@ dependencies = [
 [[package]]
 name = "sui-keys"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "bip32",
@@ -10383,7 +10411,7 @@ dependencies = [
 [[package]]
 name = "sui-macros"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "futures",
  "once_cell",
@@ -10394,7 +10422,7 @@ dependencies = [
 [[package]]
 name = "sui-metrics-push-client"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -10411,8 +10439,8 @@ dependencies = [
 
 [[package]]
 name = "sui-move-build"
-version = "1.52.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+version = "1.53.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -10437,7 +10465,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "bcs",
  "better_any",
@@ -10460,7 +10488,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "bcs",
  "better_any",
@@ -10481,7 +10509,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "bcs",
  "better_any",
@@ -10502,7 +10530,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "bcs",
  "better_any",
@@ -10522,8 +10550,8 @@ dependencies = [
 
 [[package]]
 name = "sui-name-service"
-version = "1.52.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+version = "1.53.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "bcs",
  "move-core-types",
@@ -10535,7 +10563,7 @@ dependencies = [
 [[package]]
 name = "sui-network"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -10574,8 +10602,8 @@ dependencies = [
 
 [[package]]
 name = "sui-node"
-version = "1.52.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+version = "1.53.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -10632,8 +10660,8 @@ dependencies = [
 
 [[package]]
 name = "sui-open-rpc"
-version = "1.52.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+version = "1.53.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "bcs",
  "schemars 0.8.21",
@@ -10645,7 +10673,7 @@ dependencies = [
 [[package]]
 name = "sui-open-rpc-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -10657,8 +10685,8 @@ dependencies = [
 
 [[package]]
 name = "sui-package-management"
-version = "1.52.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+version = "1.53.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -10676,7 +10704,7 @@ dependencies = [
 [[package]]
 name = "sui-package-resolver"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "async-trait",
  "bcs",
@@ -10693,8 +10721,8 @@ dependencies = [
 
 [[package]]
 name = "sui-pg-db"
-version = "1.52.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+version = "1.53.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10718,7 +10746,7 @@ dependencies = [
 [[package]]
 name = "sui-proc-macros"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -10730,7 +10758,7 @@ dependencies = [
 [[package]]
 name = "sui-protocol-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "clap",
  "fastcrypto",
@@ -10747,7 +10775,7 @@ dependencies = [
 [[package]]
 name = "sui-protocol-config-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10776,7 +10804,7 @@ dependencies = [
 [[package]]
 name = "sui-rpc-api"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -10822,8 +10850,8 @@ dependencies = [
 
 [[package]]
 name = "sui-sdk"
-version = "1.52.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+version = "1.53.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10876,7 +10904,7 @@ dependencies = [
 [[package]]
 name = "sui-simulator"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -10900,7 +10928,7 @@ dependencies = [
 [[package]]
 name = "sui-snapshot"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "bcs",
@@ -10928,8 +10956,8 @@ dependencies = [
 
 [[package]]
 name = "sui-sql-macro"
-version = "1.52.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+version = "1.53.1"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -10939,7 +10967,7 @@ dependencies = [
 [[package]]
 name = "sui-storage"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10989,7 +11017,7 @@ dependencies = [
 [[package]]
 name = "sui-swarm"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "futures",
@@ -11016,7 +11044,7 @@ dependencies = [
 [[package]]
 name = "sui-swarm-config"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anemo",
  "anyhow",
@@ -11043,7 +11071,7 @@ dependencies = [
 [[package]]
 name = "sui-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "reqwest",
  "serde",
@@ -11054,7 +11082,7 @@ dependencies = [
 [[package]]
 name = "sui-test-transaction-builder"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "bcs",
  "move-core-types",
@@ -11068,7 +11096,7 @@ dependencies = [
 [[package]]
 name = "sui-tls"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -11090,7 +11118,7 @@ dependencies = [
 [[package]]
 name = "sui-transaction-builder"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11107,7 +11135,7 @@ dependencies = [
 [[package]]
 name = "sui-transaction-checks"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "fastcrypto-zkp",
  "once_cell",
@@ -11122,7 +11150,7 @@ dependencies = [
 [[package]]
 name = "sui-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anemo",
  "anyhow",
@@ -11198,7 +11226,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -11214,7 +11242,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -11230,7 +11258,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -11245,7 +11273,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -11365,7 +11393,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "telemetry-subscribers"
 version = "0.2.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -11441,7 +11469,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 [[package]]
 name = "test-cluster"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "anyhow",
  "bcs",
@@ -11681,17 +11709,19 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio 1.0.3",
  "parking_lot 0.12.3",
  "pin-project-lite",
  "signal-hook-registry",
+ "slab",
  "socket2 0.5.8",
  "tokio-macros 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
@@ -11755,6 +11785,17 @@ dependencies = [
  "tokio",
  "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "whoami",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project",
+ "rand 0.8.5",
+ "tokio",
 ]
 
 [[package]]
@@ -12311,7 +12352,7 @@ dependencies = [
 [[package]]
 name = "typed-store"
 version = "0.4.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "async-trait",
  "backoff",
@@ -12372,7 +12413,7 @@ dependencies = [
 [[package]]
 name = "typed-store-derive"
 version = "0.3.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -12383,7 +12424,7 @@ dependencies = [
 [[package]]
 name = "typed-store-error"
 version = "0.4.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "serde",
  "thiserror 1.0.69",
@@ -12392,7 +12433,7 @@ dependencies = [
 [[package]]
 name = "typed-store-workspace-hack"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.52.1#6656ec8446e425115499bc23f245d2f2afc610f4"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.1#fdfd8641a3b3e7f30a8e506668f8ccc604df8a79"
 dependencies = [
  "cc",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ diesel-async = { version = "0.5", features = ["postgres"] }
 diesel_migrations = { version = "2.2.0", features = ["postgres"] }
 enum_dispatch = "0.3"
 eyre = "0.6.12"
-fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9" }
+fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "16fa86d0dd943024a9088d46850a72ecd55b7f46" }
 fdlimit = "0.3.0"
 futures = { version = "0.3.31", default-features = false, features = ["async-await", "std"] }
 futures-timer = "=3.0.3" # required for MSIM
@@ -76,9 +76,9 @@ jsonwebtoken = "9.3.1"
 md5 = "0.7.0"
 mime = "0.3.17"
 mockall = "0.12.1"
-move-core-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.52.1" }
-move-package = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.52.1" }
-mysten-metrics = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.52.1" }
+move-core-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.1" }
+move-package = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.1" }
+mysten-metrics = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.1" }
 num-bigint = { version = "0.4.5", default-features = false }
 object_store = { version = "0.11.2", features = ["gcp"] }
 once_cell = { version = "1.21.3" }
@@ -108,27 +108,27 @@ serde_with = { version = "3.14", features = ["base64"] }
 serde_yaml = "0.9"
 sha2 = "0.10.9"
 snap = "1.1.0"
-sui-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.52.1" }
-sui-json-rpc-api = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.52.1" }
-sui-json-rpc-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.52.1" }
-sui-keys = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.52.1" }
-sui-macros = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.52.1" }
-sui-move-build = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.52.1" }
-sui-package-management = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.52.1" }
-sui-package-resolver = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.52.1" }
-sui-protocol-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.52.1" }
-sui-rpc-api = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.52.1" }
-sui-sdk = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.52.1" }
-sui-simulator = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.52.1" }
-sui-storage = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.52.1" }
-sui-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.52.1" }
+sui-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.1" }
+sui-json-rpc-api = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.1" }
+sui-json-rpc-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.1" }
+sui-keys = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.1" }
+sui-macros = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.1" }
+sui-move-build = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.1" }
+sui-package-management = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.1" }
+sui-package-resolver = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.1" }
+sui-protocol-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.1" }
+sui-rpc-api = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.1" }
+sui-sdk = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.1" }
+sui-simulator = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.1" }
+sui-storage = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.1" }
+sui-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.1" }
 syn = "2.0"
 tap = "1.0.1"
-telemetry-subscribers = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.52.1" }
+telemetry-subscribers = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.1" }
 tempfile = "3.20.0"
-test-cluster = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.52.1" }
+test-cluster = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.1" }
 thiserror = "2.0.12"
-tokio = { version = "=1.44.2", features = ["macros", "rt-multi-thread", "signal"] }
+tokio = { version = "=1.46.1", features = ["macros", "rt-multi-thread", "signal"] }
 tokio-stream = "0.1.17"
 tokio-util = "0.7.13"
 tonic = { version = "0.13.1", default-features = false }

--- a/contracts/subsidies/Move.lock
+++ b/contracts/subsidies/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "B1DB2C8F44553E82D8C72AFC984D71D7280021103E90FBB9A36BF3883B6920BE"
+manifest_digest = "B4F9F9BF48402669C257AD6D8778FCBC01186A8AABD09FAB67C16D064F242B44"
 deps_digest = "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -12,11 +12,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.52.1", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.1", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.52.1", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.1", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -40,7 +40,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.52.2"
+compiler-version = "1.53.1"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/contracts/subsidies/Move.toml
+++ b/contracts/subsidies/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.52.1" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.53.1" }
 WAL = { local = "../wal" }
 Walrus = { local = "../walrus" }
 

--- a/contracts/subsidies/tests/subsidies_tests.move
+++ b/contracts/subsidies/tests/subsidies_tests.move
@@ -1,6 +1,7 @@
 // Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+#[allow(deprecated_usage)]
 #[test_only]
 module subsidies::subsidies_tests;
 

--- a/contracts/wal/Move.lock
+++ b/contracts/wal/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "73B1256D8F5FEB88338C0E732008BD622B6BA688E9DD516C1A08FB4247389CF1"
+manifest_digest = "8D1D707A67C745B724B86B96B1CCECA1DE291ABC8FF2B9F8C7C500B6884F7BF6"
 deps_digest = "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -10,18 +10,18 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.52.1", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.1", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.52.1", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.1", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
 ]
 
 [move.toolchain-version]
-compiler-version = "1.52.2"
+compiler-version = "1.53.1"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/contracts/wal/Move.toml
+++ b/contracts/wal/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.52.1" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.53.1" }
 
 [addresses]
 wal = "0x0"

--- a/contracts/wal_exchange/Move.lock
+++ b/contracts/wal_exchange/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "8A665842757B12E442DB6EE3330C88F696552E8EB3441AC3653A80B9F0E09D93"
+manifest_digest = "53ED64BF6087712F4A827BFF0646F737B39D9490017F62E42AE3DD60EFA560AF"
 deps_digest = "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -11,11 +11,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.52.1", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.1", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.52.1", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.1", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -30,6 +30,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.52.2"
+compiler-version = "1.53.1"
 edition = "2024.beta"
 flavor = "sui"

--- a/contracts/wal_exchange/Move.toml
+++ b/contracts/wal_exchange/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.52.1" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.53.1" }
 WAL = { local = "../wal" }
 
 [addresses]

--- a/contracts/walrus/Move.lock
+++ b/contracts/walrus/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "611912641B598A8DB32285FFF4D9B21221FD794D4B81BA046947B4C66E1C20A8"
+manifest_digest = "20876AB164E5C27CF846D9B8ED79FA11093D762845AA71610D60EAA41E5B12AA"
 deps_digest = "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -11,11 +11,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.52.1", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.1", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.52.1", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.1", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -30,7 +30,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.52.2"
+compiler-version = "1.53.1"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/contracts/walrus/Move.toml
+++ b/contracts/walrus/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.52.1" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.53.1" }
 WAL = { local = "../wal" }
 
 [addresses]

--- a/contracts/walrus_subsidies/Move.lock
+++ b/contracts/walrus_subsidies/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "6D918C5610F4028A2FAF845FBA5DD3233AE40C1F76CBD0220B0E77C5372C0845"
+manifest_digest = "A76600E929A04F672350C8C83649F16C392AE58222FBFFC5B10D4EA3000057A9"
 deps_digest = "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -12,11 +12,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.52.1", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.1", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.52.1", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.1", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -40,6 +40,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.52.2"
+compiler-version = "1.53.1"
 edition = "2024.beta"
 flavor = "sui"

--- a/contracts/walrus_subsidies/Move.toml
+++ b/contracts/walrus_subsidies/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.52.1" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.53.1" }
 WAL = { local = "../wal" }
 Walrus = { local = "../walrus" }
 

--- a/crates/walrus-simtest/src/test_utils.rs
+++ b/crates/walrus-simtest/src/test_utils.rs
@@ -104,9 +104,12 @@ pub mod simtest_utils {
         write_only: bool,
         deletable: bool,
         blobs_written: &mut HashSet<ObjectID>,
-        max_retry_count: usize,
+        max_retry_count: Option<usize>,
         epochs_max: Option<EpochCount>,
     ) -> anyhow::Result<()> {
+        const DEFAULT_MAX_RETRY_COUNT: usize = 2;
+        let max_retry_count = max_retry_count.unwrap_or(DEFAULT_MAX_RETRY_COUNT);
+
         // Get a random epoch length for the blob to be stored.
         let epoch_ahead = rand::thread_rng().gen_range(1..=epochs_max.unwrap_or(5));
 
@@ -275,7 +278,7 @@ pub mod simtest_utils {
     pub fn start_background_workload(
         client_clone: Arc<WithTempDir<Client<SuiContractClient>>>,
         write_only: bool,
-        max_retry_count: usize,
+        max_retry_count: Option<usize>,
         epochs_max: Option<EpochCount>,
     ) -> JoinHandle<()> {
         tokio::spawn(async move {

--- a/crates/walrus-simtest/tests/simtest.rs
+++ b/crates/walrus-simtest/tests/simtest.rs
@@ -925,13 +925,13 @@ mod tests {
     #[walrus_simtest]
     async fn test_quorum_contract_upgrade() -> anyhow::Result<()> {
         let deploy_dir = tempfile::TempDir::new().unwrap();
-        let epoch_duration_secs = Duration::from_secs(20);
+        let epoch_duration = Duration::from_secs(30);
         let (_sui_cluster_handle, mut walrus_cluster, client, system_ctx) =
             test_cluster::E2eTestSetupBuilder::new()
                 .with_deploy_directory(deploy_dir.path().to_path_buf())
                 .with_delegate_governance_to_admin_wallet()
                 .with_contract_directory(testnet_contract_dir().unwrap())
-                .with_epoch_duration(epoch_duration_secs)
+                .with_epoch_duration(epoch_duration)
                 .with_num_checkpoints_per_blob(20)
                 .build_generic::<SimStorageNodeHandle>()
                 .await?;
@@ -1028,7 +1028,7 @@ mod tests {
         simtest_utils::wait_for_nodes_to_reach_epoch(
             &walrus_cluster.nodes[..4],
             target_epoch,
-            2 * epoch_duration_secs,
+            2 * epoch_duration,
         )
         .await;
 

--- a/crates/walrus-simtest/tests/simtest.rs
+++ b/crates/walrus-simtest/tests/simtest.rs
@@ -98,7 +98,7 @@ mod tests {
             false,
             false,
             &mut blobs_written,
-            0,
+            None,
             None,
         )
         .await
@@ -160,7 +160,7 @@ mod tests {
 
         let client_arc = Arc::new(client);
         let workload_handle =
-            simtest_utils::start_background_workload(client_arc.clone(), true, 0, None);
+            simtest_utils::start_background_workload(client_arc.clone(), true, None, None);
 
         // Run the workload to get some data in the system.
         tokio::time::sleep(Duration::from_secs(60)).await;
@@ -288,7 +288,7 @@ mod tests {
         // Starts a background workload that a client keeps writing and retrieving data.
         // All requests should succeed even if a node crashes.
         let workload_handle =
-            simtest_utils::start_background_workload(client_arc.clone(), false, 0, None);
+            simtest_utils::start_background_workload(client_arc.clone(), false, None, None);
 
         // Run the workload to get some data in the system.
         tokio::time::sleep(Duration::from_secs(90)).await;
@@ -488,7 +488,7 @@ mod tests {
         let workload_handle = simtest_utils::start_background_workload(
             client_arc.clone(),
             false,
-            0,
+            None,
             Some(MAX_EPOCHS_AHEAD),
         );
 
@@ -658,7 +658,7 @@ mod tests {
         // Starts a background workload that a client keeps writing and retrieving data.
         // All requests should succeed even if a node crashes.
         let workload_handle =
-            simtest_utils::start_background_workload(client_arc.clone(), false, 0, None);
+            simtest_utils::start_background_workload(client_arc.clone(), false, None, None);
 
         // Run the workload to get some data in the system.
         tokio::time::sleep(Duration::from_secs(60)).await;
@@ -745,7 +745,7 @@ mod tests {
             .unwrap();
 
         let workload_handle =
-            simtest_utils::start_background_workload(Arc::new(client), true, 0, None);
+            simtest_utils::start_background_workload(Arc::new(client), true, None, None);
 
         // Run the workload to get some data in the system.
         tokio::time::sleep(Duration::from_secs(120)).await;
@@ -821,7 +821,7 @@ mod tests {
         // Starts a background workload that a client keeps writing and retrieving data.
         // All requests should succeed even if a node crashes.
         let workload_handle =
-            simtest_utils::start_background_workload(client_arc.clone(), false, 0, None);
+            simtest_utils::start_background_workload(client_arc.clone(), false, None, None);
 
         // Run the workload to get some data in the system.
         tokio::time::sleep(Duration::from_secs(60)).await;

--- a/crates/walrus-simtest/tests/simtest_failure.rs
+++ b/crates/walrus-simtest/tests/simtest_failure.rs
@@ -85,7 +85,7 @@ mod tests {
                 false,
                 false,
                 &mut blobs_written,
-                0,
+                None,
                 None,
             )
             .await
@@ -108,7 +108,7 @@ mod tests {
                     false,
                     false,
                     &mut blobs_written,
-                    0,
+                    None,
                     None,
                 )
                 .await
@@ -239,7 +239,7 @@ mod tests {
         // Starts a background workload that a client keeps writing and retrieving data.
         // All requests should succeed even if a node crashes.
         let workload_handle =
-            simtest_utils::start_background_workload(client_arc.clone(), false, 0, None);
+            simtest_utils::start_background_workload(client_arc.clone(), false, None, None);
 
         // Running the workload for 60 seconds to get some data in the system.
         tokio::time::sleep(Duration::from_secs(60)).await;
@@ -401,7 +401,7 @@ mod tests {
 
         // Use a higher write retry limit given that the epoch duration is short.
         let workload_handle =
-            simtest_utils::start_background_workload(client_arc.clone(), true, 5, None);
+            simtest_utils::start_background_workload(client_arc.clone(), true, Some(5), None);
 
         let next_fail_triggered = Arc::new(Mutex::new(Instant::now()));
         let next_fail_triggered_clone = next_fail_triggered.clone();
@@ -625,7 +625,7 @@ mod tests {
         // Starts a background workload that a client keeps writing and retrieving data.
         // All requests should succeed even if a node is lagging behind.
         let workload_handle =
-            simtest_utils::start_background_workload(client_arc.clone(), false, 0, None);
+            simtest_utils::start_background_workload(client_arc.clone(), false, None, None);
 
         // Running the workload for 60 seconds to get some data in the system.
         tokio::time::sleep(Duration::from_secs(60)).await;
@@ -821,7 +821,7 @@ mod tests {
 
         // Wait for the cluster to process some events.
         let workload_handle =
-            simtest_utils::start_background_workload(client_arc.clone(), false, 0, None);
+            simtest_utils::start_background_workload(client_arc.clone(), false, None, None);
         tokio::time::sleep(Duration::from_secs(30)).await;
 
         // Get the latest checkpoint from Sui.

--- a/crates/walrus-sui/src/utils.rs
+++ b/crates/walrus-sui/src/utils.rs
@@ -17,7 +17,7 @@ use move_core_types::language_storage::StructTag as MoveStructTag;
 use move_package::{BuildConfig as MoveBuildConfig, source_package::layout::SourcePackageLayout};
 use serde::{Deserialize, Serialize};
 use sui_config::{Config, SUI_KEYSTORE_FILENAME, sui_config_dir};
-use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
+use sui_keys::keystore::{AccountKeystore as _, FileBasedKeystore, Keystore};
 use sui_sdk::{
     rpc_types::{ObjectChange, Page, SuiObjectResponse, SuiTransactionBlockResponse},
     sui_client_config::{SuiClientConfig, SuiEnv},
@@ -323,7 +323,7 @@ pub fn create_wallet(
 
     let mut keystore = FileBasedKeystore::new(&keystore_path)?;
     let (new_address, _phrase, _scheme) =
-        keystore.generate_and_add_new_key(SignatureScheme::ED25519, None, None, None)?;
+        keystore.generate(SignatureScheme::ED25519, None, None, None)?;
 
     let keystore = Keystore::from(keystore);
 

--- a/docker/walrus-antithesis/sui_version.toml
+++ b/docker/walrus-antithesis/sui_version.toml
@@ -1,1 +1,1 @@
-SUI_VERSION = "testnet-v1.52.1"
+SUI_VERSION = "testnet-v1.53.1"

--- a/scripts/simtest/cargo-simtest
+++ b/scripts/simtest/cargo-simtest
@@ -54,9 +54,9 @@ if [[ -n "$LOCAL_MSIM_PATH" ]]; then
 else
   cargo_patch_args=(
     --config 'patch.crates-io.tokio.git = "https://github.com/MystenLabs/mysten-sim.git"'
-    --config 'patch.crates-io.tokio.rev = "cad62679fd180a48c665f842cb80045f8fcfdee9"'
+    --config 'patch.crates-io.tokio.rev = "192bd9590f8552d5a1c5debf66c4ff2672af037e"'
     --config 'patch.crates-io.futures-timer.git = "https://github.com/MystenLabs/mysten-sim.git"'
-    --config 'patch.crates-io.futures-timer.rev = "cad62679fd180a48c665f842cb80045f8fcfdee9"'
+    --config 'patch.crates-io.futures-timer.rev = "192bd9590f8552d5a1c5debf66c4ff2672af037e"'
   )
 fi
 

--- a/testnet-contracts/subsidies/Move.lock
+++ b/testnet-contracts/subsidies/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "79ED4797B7A15C2C0D3E8BEF1B5EE11A8B635D248C8B9B32245EF41C7EC9A900"
+manifest_digest = "B4F9F9BF48402669C257AD6D8778FCBC01186A8AABD09FAB67C16D064F242B44"
 deps_digest = "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -12,11 +12,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.51.1", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.1", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.51.1", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.1", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -40,7 +40,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.51.3"
+compiler-version = "1.53.1"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/testnet-contracts/subsidies/Move.toml
+++ b/testnet-contracts/subsidies/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.52.1" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.53.1" }
 WAL = { local = "../wal" }
 Walrus = { local = "../walrus" }
 

--- a/testnet-contracts/wal/Move.lock
+++ b/testnet-contracts/wal/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "3D99015FEF6F72B0C5EB3C5D15D0E05F07DF89A5DC07B1CE1B85A8B387FA1B86"
+manifest_digest = "8D1D707A67C745B724B86B96B1CCECA1DE291ABC8FF2B9F8C7C500B6884F7BF6"
 deps_digest = "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -10,18 +10,18 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.51.1", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.1", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.51.1", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.1", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
 ]
 
 [move.toolchain-version]
-compiler-version = "1.51.2"
+compiler-version = "1.53.1"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/testnet-contracts/wal/Move.toml
+++ b/testnet-contracts/wal/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.52.1" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.53.1" }
 
 [addresses]
 wal = "0x0"

--- a/testnet-contracts/wal_exchange/Move.lock
+++ b/testnet-contracts/wal_exchange/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "9FB74A953586B2DEBF55E16D0FC994A2CF441544EA8EB05D7BBBBEA4587FC861"
+manifest_digest = "53ED64BF6087712F4A827BFF0646F737B39D9490017F62E42AE3DD60EFA560AF"
 deps_digest = "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -11,11 +11,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.51.1", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.1", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.51.1", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.1", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -30,7 +30,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.51.2"
+compiler-version = "1.53.1"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/testnet-contracts/wal_exchange/Move.toml
+++ b/testnet-contracts/wal_exchange/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.52.1" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.53.1" }
 WAL = { local = "../wal" }
 
 [addresses]

--- a/testnet-contracts/walrus/Move.lock
+++ b/testnet-contracts/walrus/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "E8C01B2EAE30C7ECFFACB5957026E3B57C31D8A855A96FFAA4E5DDA440483AE6"
+manifest_digest = "20876AB164E5C27CF846D9B8ED79FA11093D762845AA71610D60EAA41E5B12AA"
 deps_digest = "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -11,11 +11,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.51.1", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.1", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.51.1", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.1", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -30,7 +30,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.51.2"
+compiler-version = "1.53.1"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/testnet-contracts/walrus/Move.toml
+++ b/testnet-contracts/walrus/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.52.1" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.53.1" }
 WAL = { local = "../wal" }
 
 [addresses]

--- a/testnet-contracts/walrus_subsidies/Move.lock
+++ b/testnet-contracts/walrus_subsidies/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "3E007CB22D00D0B3DD6A3907A56C6BDE96036B359B20AE503E3D432A406C8490"
+manifest_digest = "A76600E929A04F672350C8C83649F16C392AE58222FBFFC5B10D4EA3000057A9"
 deps_digest = "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -12,11 +12,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.51.1", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.1", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.51.1", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.1", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -40,7 +40,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.51.2"
+compiler-version = "1.53.1"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/testnet-contracts/walrus_subsidies/Move.toml
+++ b/testnet-contracts/walrus_subsidies/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.52.1" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.53.1" }
 WAL = { local = "../wal" }
 Walrus = { local = "../walrus" }
 


### PR DESCRIPTION
## Description

This includes some other related changes:
- Bump `tokio` to `1.46.1`.
- Bump `fastcrypto` to `16fa86d0dd943024a9088d46850a72ecd55b7f46`.
- Bump `msim` to `192bd9590f8552d5a1c5debf66c4ff2672af037e`.
- Add `allow(deprecated_usage)` to `subsidies_tests.move`.
- Minor required code changes.

## Test plan

Test suite.