### PR TITLE
fix: use sui 1.53.1 patch without simulated execution latency

### DIFF
--- a/scripts/simtest/cargo-simtest
+++ b/scripts/simtest/cargo-simtest
@@ -60,6 +60,49 @@ else
   )
 fi
 
+# Patch all Sui dependencies to use sui 1.53.1 with simulated execution latency turned off.
+# TODO(WAL-961): remove once Sui dependency is moved forward from testnet-v1.53.1.
+cargo_patch_args+=(
+  --config 'patch."https://github.com/MystenLabs/sui".move-core-types.git = "https://github.com/halfprice/sui"'
+  --config 'patch."https://github.com/MystenLabs/sui".move-core-types.rev = "655131bd6c1c8da8247cd440bbc74892e38e2ef1"'
+  --config 'patch."https://github.com/MystenLabs/sui".move-package.git = "https://github.com/halfprice/sui"'
+  --config 'patch."https://github.com/MystenLabs/sui".move-package.rev = "655131bd6c1c8da8247cd440bbc74892e38e2ef1"'
+  --config 'patch."https://github.com/MystenLabs/sui".mysten-metrics.git = "https://github.com/halfprice/sui"'
+  --config 'patch."https://github.com/MystenLabs/sui".mysten-metrics.rev = "655131bd6c1c8da8247cd440bbc74892e38e2ef1"'
+  --config 'patch."https://github.com/MystenLabs/sui".sui-config.git = "https://github.com/halfprice/sui"'
+  --config 'patch."https://github.com/MystenLabs/sui".sui-config.rev = "655131bd6c1c8da8247cd440bbc74892e38e2ef1"'
+  --config 'patch."https://github.com/MystenLabs/sui".sui-json-rpc-api.git = "https://github.com/halfprice/sui"'
+  --config 'patch."https://github.com/MystenLabs/sui".sui-json-rpc-api.rev = "655131bd6c1c8da8247cd440bbc74892e38e2ef1"'
+  --config 'patch."https://github.com/MystenLabs/sui".sui-json-rpc-types.git = "https://github.com/halfprice/sui"'
+  --config 'patch."https://github.com/MystenLabs/sui".sui-json-rpc-types.rev = "655131bd6c1c8da8247cd440bbc74892e38e2ef1"'
+  --config 'patch."https://github.com/MystenLabs/sui".sui-keys.git = "https://github.com/halfprice/sui"'
+  --config 'patch."https://github.com/MystenLabs/sui".sui-keys.rev = "655131bd6c1c8da8247cd440bbc74892e38e2ef1"'
+  --config 'patch."https://github.com/MystenLabs/sui".sui-macros.git = "https://github.com/halfprice/sui"'
+  --config 'patch."https://github.com/MystenLabs/sui".sui-macros.rev = "655131bd6c1c8da8247cd440bbc74892e38e2ef1"'
+  --config 'patch."https://github.com/MystenLabs/sui".sui-move-build.git = "https://github.com/halfprice/sui"'
+  --config 'patch."https://github.com/MystenLabs/sui".sui-move-build.rev = "655131bd6c1c8da8247cd440bbc74892e38e2ef1"'
+  --config 'patch."https://github.com/MystenLabs/sui".sui-package-management.git = "https://github.com/halfprice/sui"'
+  --config 'patch."https://github.com/MystenLabs/sui".sui-package-management.rev = "655131bd6c1c8da8247cd440bbc74892e38e2ef1"'
+  --config 'patch."https://github.com/MystenLabs/sui".sui-package-resolver.git = "https://github.com/halfprice/sui"'
+  --config 'patch."https://github.com/MystenLabs/sui".sui-package-resolver.rev = "655131bd6c1c8da8247cd440bbc74892e38e2ef1"'
+  --config 'patch."https://github.com/MystenLabs/sui".sui-protocol-config.git = "https://github.com/halfprice/sui"'
+  --config 'patch."https://github.com/MystenLabs/sui".sui-protocol-config.rev = "655131bd6c1c8da8247cd440bbc74892e38e2ef1"'
+  --config 'patch."https://github.com/MystenLabs/sui".sui-rpc-api.git = "https://github.com/halfprice/sui"'
+  --config 'patch."https://github.com/MystenLabs/sui".sui-rpc-api.rev = "655131bd6c1c8da8247cd440bbc74892e38e2ef1"'
+  --config 'patch."https://github.com/MystenLabs/sui".sui-sdk.git = "https://github.com/halfprice/sui"'
+  --config 'patch."https://github.com/MystenLabs/sui".sui-sdk.rev = "655131bd6c1c8da8247cd440bbc74892e38e2ef1"'
+  --config 'patch."https://github.com/MystenLabs/sui".sui-simulator.git = "https://github.com/halfprice/sui"'
+  --config 'patch."https://github.com/MystenLabs/sui".sui-simulator.rev = "655131bd6c1c8da8247cd440bbc74892e38e2ef1"'
+  --config 'patch."https://github.com/MystenLabs/sui".sui-storage.git = "https://github.com/halfprice/sui"'
+  --config 'patch."https://github.com/MystenLabs/sui".sui-storage.rev = "655131bd6c1c8da8247cd440bbc74892e38e2ef1"'
+  --config 'patch."https://github.com/MystenLabs/sui".sui-types.git = "https://github.com/halfprice/sui"'
+  --config 'patch."https://github.com/MystenLabs/sui".sui-types.rev = "655131bd6c1c8da8247cd440bbc74892e38e2ef1"'
+  --config 'patch."https://github.com/MystenLabs/sui".telemetry-subscribers.git = "https://github.com/halfprice/sui"'
+  --config 'patch."https://github.com/MystenLabs/sui".telemetry-subscribers.rev = "655131bd6c1c8da8247cd440bbc74892e38e2ef1"'
+  --config 'patch."https://github.com/MystenLabs/sui".test-cluster.git = "https://github.com/halfprice/sui"'
+  --config 'patch."https://github.com/MystenLabs/sui".test-cluster.rev = "655131bd6c1c8da8247cd440bbc74892e38e2ef1"'
+)
+
 # Mock out the blst crate to massively speed up the simulation.
 # You should not assume that test runs will be repeatable with and without blst mocking,
 # as blst samples from the PRNG when not mocked.


### PR DESCRIPTION
## Description

The artificially increased execution latency makes many integration test fail with congestion control error, even with retry.

The simulated latency is a bit unrealistic and unnecessarily reflects actual situation. [There is a patch](https://github.com/MystenLabs/sui/pull/22988) in sui 1.53.1 release,
so we want to use that patch so that the simulated execution latency is turned off.

Node that we can't point the sui dependency to a different branch (it always give me the error `points to the same source, but patches must point to different sources`), so I forked the branch to my repo and use that in simtest. It is the same commit, and also this is a simtest only change and shouldn't affect any prod code.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
