### PR TITLE
ci: check if latest Sui version is used before creating a devnet release

### DIFF
--- a/.github/workflows/create-release-announce.yml
+++ b/.github/workflows/create-release-announce.yml
@@ -19,7 +19,12 @@ on:
           - testnet
           - mainnet
       announce:
-        description: Announce the release?
+        description: Whether to announce the release on Discord (not relevant for devnet)
+        type: boolean
+        default: true
+        required: true
+      check_sui_version:
+        description: Whether to check if the Sui version is the latest released version (only relevant for devnet releases)
         type: boolean
         default: true
         required: true
@@ -62,6 +67,30 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.walrus_commit }}
+
+      - name: Check if Sui version is the latest released version
+        if: ${{ inputs.check_sui_version == true && inputs.network == 'devnet' }}
+        shell: bash
+        run: |
+          latest_sui_version=$(
+            curl -s https://api.github.com/repos/MystenLabs/sui/releases/latest \
+              | awk -F \" -v RS="," '/tag_name/ {print $(NF-1)}' \
+              | awk -F -v '{print $2}'
+          )
+          used_sui_version=$(sed -n '/^sui-types =/s/.*tag = ".*-v\([0-9.]*\).*/\1/p' Cargo.toml)
+
+          latest_sui_major_minor=$(echo $latest_sui_version | cut -d. -f1,2)
+          used_sui_major_minor=$(echo $used_sui_version | cut -d. -f1,2)
+          if [[ $used_sui_major_minor == $latest_sui_major_minor ]]; then
+            echo "The Sui version used in the Cargo.toml file ($used_sui_version) matches the \
+              latest released version ($latest_sui_version) (ignoring patch version)."
+          else
+            echo "The Sui version used in the Cargo.toml file ($used_sui_version) does not match \
+              the latest released version ($latest_sui_version)."
+            echo "Please bump the Sui version in the Cargo.toml file to the latest released version before creating a new devnet release."
+            echo "This check can be disabled, but this should only be done in exceptional cases and after checking with the Walrus core team."
+            exit 1
+          fi
 
       - name: Update ${{ inputs.network }} branch
         shell: bash


### PR DESCRIPTION
## Description

It is crucial that the Sui version used for dependencies is as close to the deployed Sui version as possible. Lagging more than one minor version behind has caused outages in the past.

With this added check, we make sure to have an up-to-date Sui version in our dependencies when creating a new devnet release.

The check can be disabled to allow for special cases, for example, when using a specific commit for the dependencies instead of a tag.

## Test plan

Ran the added script manually with the expected results.
