### PR TITLE
feat: Add metric to track negative point lookups and granular data usage

### DIFF
--- a/crates/typed-store/src/metrics.rs
+++ b/crates/typed-store/src/metrics.rs
@@ -336,6 +336,10 @@ impl ColumnFamilyMetrics {
 pub struct OperationMetrics {
     /// Rocksdb iter latency in seconds
     pub rocksdb_iter_latency_seconds: HistogramVec,
+    /// Rocksdb iter key bytes
+    pub rocksdb_iter_key_bytes: HistogramVec,
+    /// Rocksdb iter value bytes
+    pub rocksdb_iter_value_bytes: HistogramVec,
     /// Rocksdb iter size in bytes
     pub rocksdb_iter_bytes: HistogramVec,
     /// Rocksdb iter num keys
@@ -344,6 +348,12 @@ pub struct OperationMetrics {
     pub rocksdb_get_latency_seconds: HistogramVec,
     /// Rocksdb get bytes
     pub rocksdb_get_bytes: HistogramVec,
+    /// Rocksdb get key bytes
+    pub rocksdb_get_key_bytes: HistogramVec,
+    /// Rocksdb get value bytes
+    pub rocksdb_get_value_bytes: HistogramVec,
+    /// Rocksdb contains_key latency in seconds
+    pub rocksdb_contains_key_latency_seconds: HistogramVec,
     /// Rocksdb multiget latency in seconds
     pub rocksdb_multiget_latency_seconds: HistogramVec,
     /// Rocksdb multiget bytes
@@ -352,8 +362,16 @@ pub struct OperationMetrics {
     pub rocksdb_put_latency_seconds: HistogramVec,
     /// Rocksdb put bytes
     pub rocksdb_put_bytes: HistogramVec,
+    /// Rocksdb put key bytes
+    pub rocksdb_put_key_bytes: HistogramVec,
+    /// Rocksdb put value bytes
+    pub rocksdb_put_value_bytes: HistogramVec,
     /// Rocksdb batch put bytes
     pub rocksdb_batch_put_bytes: HistogramVec,
+    /// Rocksdb batch put key bytes
+    pub rocksdb_batch_put_key_bytes: HistogramVec,
+    /// Rocksdb batch put value bytes
+    pub rocksdb_batch_put_value_bytes: HistogramVec,
     /// Rocksdb delete latency in seconds
     pub rocksdb_delete_latency_seconds: HistogramVec,
     /// Rocksdb delete calls
@@ -405,9 +423,25 @@ impl OperationMetrics {
                 registry,
             )
             .unwrap(),
+            rocksdb_iter_key_bytes: register_histogram_vec_with_registry!(
+                "rocksdb_iter_key_bytes",
+                "Rocksdb iter key size in bytes",
+                &["cf_name"],
+                bucket_vec.clone(),
+                registry,
+            )
+            .unwrap(),
             rocksdb_iter_bytes: register_histogram_vec_with_registry!(
                 "rocksdb_iter_bytes",
                 "Rocksdb iter size in bytes",
+                &["cf_name"],
+                bucket_vec.clone(),
+                registry,
+            )
+            .unwrap(),
+            rocksdb_iter_value_bytes: register_histogram_vec_with_registry!(
+                "rocksdb_iter_value_bytes",
+                "Rocksdb iter value size in bytes",
                 &["cf_name"],
                 bucket_vec.clone(),
                 registry,
@@ -422,8 +456,8 @@ impl OperationMetrics {
             .unwrap(),
             rocksdb_get_latency_seconds: register_histogram_vec_with_registry!(
                 "rocksdb_get_latency_seconds",
-                "Rocksdb get latency in seconds",
-                &["cf_name"],
+                "Rocksdb get latency in seconds. `found` label is true if key was found",
+                &["cf_name", "found"],
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
@@ -433,6 +467,30 @@ impl OperationMetrics {
                 "Rocksdb get call returned data size in bytes",
                 &["cf_name"],
                 bucket_vec.clone(),
+                registry,
+            )
+            .unwrap(),
+            rocksdb_get_key_bytes: register_histogram_vec_with_registry!(
+                "rocksdb_get_key_bytes",
+                "Rocksdb get call key size in bytes",
+                &["cf_name"],
+                bucket_vec.clone(),
+                registry
+            )
+            .unwrap(),
+            rocksdb_get_value_bytes: register_histogram_vec_with_registry!(
+                "rocksdb_get_value_bytes",
+                "Rocksdb get call returned value size in bytes",
+                &["cf_name"],
+                bucket_vec.clone(),
+                registry
+            )
+            .unwrap(),
+            rocksdb_contains_key_latency_seconds: register_histogram_vec_with_registry!(
+                "rocksdb_contains_key_latency_seconds",
+                "Rocksdb contains_key latency in seconds. `found` label is true if key was found",
+                &["cf_name", "found"],
+                LATENCY_SEC_BUCKETS.to_vec(),
                 registry
             )
             .unwrap(),
@@ -462,7 +520,23 @@ impl OperationMetrics {
             .unwrap(),
             rocksdb_put_bytes: register_histogram_vec_with_registry!(
                 "rocksdb_put_bytes",
-                "Rocksdb put call puts data size in bytes",
+                "Rocksdb put call returned data size in bytes",
+                &["cf_name"],
+                bucket_vec.clone(),
+                registry,
+            )
+            .unwrap(),
+            rocksdb_put_key_bytes: register_histogram_vec_with_registry!(
+                "rocksdb_put_key_bytes",
+                "Rocksdb put call key size in bytes",
+                &["cf_name"],
+                bucket_vec.clone(),
+                registry,
+            )
+            .unwrap(),
+            rocksdb_put_value_bytes: register_histogram_vec_with_registry!(
+                "rocksdb_put_value_bytes",
+                "Rocksdb put call value size in bytes",
                 &["cf_name"],
                 bucket_vec.clone(),
                 registry,
@@ -471,6 +545,22 @@ impl OperationMetrics {
             rocksdb_batch_put_bytes: register_histogram_vec_with_registry!(
                 "rocksdb_batch_put_bytes",
                 "Rocksdb batch put call puts data size in bytes",
+                &["cf_name"],
+                bucket_vec.clone(),
+                registry,
+            )
+            .unwrap(),
+            rocksdb_batch_put_key_bytes: register_histogram_vec_with_registry!(
+                "rocksdb_batch_put_key_bytes",
+                "Rocksdb batch put call puts key data size in bytes",
+                &["cf_name"],
+                bucket_vec.clone(),
+                registry,
+            )
+            .unwrap(),
+            rocksdb_batch_put_value_bytes: register_histogram_vec_with_registry!(
+                "rocksdb_batch_put_value_bytes",
+                "Rocksdb batch put call puts value data size in bytes",
                 &["cf_name"],
                 bucket_vec.clone(),
                 registry,


### PR DESCRIPTION
## Description

This PR introduces some granular metrics for typed-store to provide better visibility into database operations, especially for point lookups:
1. Negative Lookup Metric to allows distinguishing between lookups for existing keys and non-existing keys (negative lookups). Added to `contains_key` and `get`
2. Metrics to track both `key` and `value` bytes separately which offers deeper insight into data usage pattern.
3. The logic for managing iterator-related metrics is refactored into a new IterContext struct.

## Test plan

Existing tests