### PR TITLE
fix(client): add HTML error codes to retriable RPC errors

### DIFF
--- a/crates/walrus-sui/src/client/retry_client/retriable_rpc_error.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_rpc_error.rs
@@ -8,7 +8,7 @@ use std::fmt::Debug;
 use super::{super::SuiClientError, CheckpointRpcError, FallbackError, RetriableClientError};
 
 /// The list of HTTP status codes that are retriable.
-const RETRIABLE_RPC_ERRORS: &[&str] = &["408", "429", "500", "502", "504"];
+const RETRIABLE_RPC_ERRORS: &[&str] = &["408", "429", "500", "502", "503", "504"];
 /// The list of gRPC status codes that are retriable.
 const RETRIABLE_GRPC_ERRORS: &[tonic::Code] = &[
     tonic::Code::ResourceExhausted,

--- a/crates/walrus-sui/src/client/retry_client/retriable_rpc_error.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_rpc_error.rs
@@ -8,7 +8,7 @@ use std::fmt::Debug;
 use super::{super::SuiClientError, CheckpointRpcError, FallbackError, RetriableClientError};
 
 /// The list of HTTP status codes that are retriable.
-const RETRIABLE_RPC_ERRORS: &[&str] = &["429", "500", "502"];
+const RETRIABLE_RPC_ERRORS: &[&str] = &["408", "429", "500", "502", "504"];
 /// The list of gRPC status codes that are retriable.
 const RETRIABLE_GRPC_ERRORS: &[tonic::Code] = &[
     tonic::Code::ResourceExhausted,


### PR DESCRIPTION
## Description

The RPC can sometimes timeout if it is under load or during epoch change. It is important to retry within the retry client to ensure that the same transaction is repeated (and therefore no locked objects can occur).

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
