### PR TITLE
fix: verify notes field

### DIFF
--- a/.github/workflows/create-release-announce.yml
+++ b/.github/workflows/create-release-announce.yml
@@ -137,7 +137,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
         with:
           fetch-depth: 0
-          ref: main
+          ref: ebmifa/fix_release_create
 
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # pin@v5.6.0

--- a/.github/workflows/create-release-announce.yml
+++ b/.github/workflows/create-release-announce.yml
@@ -137,7 +137,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
         with:
           fetch-depth: 0
-          ref: ebmifa/fix_release_create
+          ref: main
 
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # pin@v5.6.0

--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -107,8 +107,12 @@ def git(*args):
     return subprocess.check_output(["git"] + list(args)).decode().strip()
 
 def parse_notes(pr, notes):
-    # # Find the release notes section
     result = {}
+    # verify notes param
+    if not isinstance(notes, (str, bytes)) or not notes:
+        return pr, result
+
+    # Find the release notes section
     match = RE_HEADING.search(notes)
     if not match:
         return pr, result


### PR DESCRIPTION
## Description
verify notes field:
```
Traceback (most recent call last):
  File "/home/runner/work/walrus/walrus/./scripts/release_notes.py", line 309, in <module>
    do_generate(args["from"], args["to"])
  File "/home/runner/work/walrus/walrus/./scripts/release_notes.py", line 282, in do_generate
    pr, notes = extract_notes_for_commit(commit)
  File "/home/runner/work/walrus/walrus/./scripts/release_notes.py", line 217, in extract_notes_for_commit
    return parse_notes(pr, message)
  File "/home/runner/work/walrus/walrus/./scripts/release_notes.py", line 112, in parse_notes
    match = RE_HEADING.search(notes)
TypeError: expected string or bytes-like object
```

## Test plan
```
eugene@eugene-dev ~/code/walrus (ebmifa/fix_release_create) $ python3 ./scripts/release_notes.py generate b37047ff2adbfab3fe38da69bf8609b29c884e33 2c369d9b99ae4fdae333c01796e246fdfcca2579
## Storage node

https://github.com/MystenLabs/walrus/pull/2360:
When the TLS certificate is updated, only restart the node if the currently loaded certificate is about to expire or the subject or extensions have changed. Also add warning and error logs for (almost) expired certificates.
```