### PR TITLE
fix: add simple checks to avoid unnecessary computations where possible

### DIFF
--- a/crates/walrus-core/src/encoding.rs
+++ b/crates/walrus-core/src/encoding.rs
@@ -70,7 +70,6 @@ pub use symbols::{
     RecoverySymbolPair,
     SecondaryRecoverySymbol,
     Symbols,
-    min_symbols_for_recovery,
 };
 
 mod utils;

--- a/crates/walrus-core/src/encoding.rs
+++ b/crates/walrus-core/src/encoding.rs
@@ -29,6 +29,7 @@ pub use config::{
     EncodingConfigTrait,
     MAX_SOURCE_SYMBOLS,
     ReedSolomonEncodingConfig,
+    RequiredSymbolsCount,
     encoded_blob_length_for_n_shards,
     encoded_slivers_length_for_n_shards,
     max_blob_size_for_n_shards,

--- a/crates/walrus-core/src/encoding/common.rs
+++ b/crates/walrus-core/src/encoding/common.rs
@@ -6,7 +6,9 @@ use serde::{Deserialize, Serialize};
 use crate::SliverType;
 
 /// Marker trait to indicate the encoding axis (primary or secondary).
-pub trait EncodingAxis: Clone + PartialEq + Eq + Default + core::fmt::Debug {
+pub trait EncodingAxis:
+    Clone + PartialEq + Eq + Default + core::fmt::Debug + Send + Sync + 'static
+{
     /// The complementary encoding axis.
     type OrthogonalAxis: EncodingAxis;
     /// Whether this corresponds to the primary (true) or secondary (false) encoding.

--- a/crates/walrus-core/src/encoding/config.rs
+++ b/crates/walrus-core/src/encoding/config.rs
@@ -110,11 +110,9 @@ pub trait EncodingConfigTrait {
     }
 
     /// Returns the number of valid symbols required to recover a sliver of [`EncodingAxis`] `T`.
-    // Important: This is an *exact* value. If a future encoding requires a variable number of
-    // symbols, the interface here needs to be changed.
     #[inline]
-    fn n_symbols_for_recovery<T: EncodingAxis>(&self) -> usize {
-        self.n_source_symbols::<T::OrthogonalAxis>().get().into()
+    fn n_symbols_for_recovery<T: EncodingAxis>(&self) -> RequiredSymbolsCount {
+        RequiredSymbolsCount::Exact(self.n_source_symbols::<T::OrthogonalAxis>().get().into())
     }
 
     /// Returns the number of shards as a `usize`.
@@ -241,6 +239,20 @@ pub trait EncodingConfigTrait {
     fn max_sliver_size(&self) -> u64 {
         max_sliver_size_for_n_secondary(self.n_secondary_source_symbols(), self.encoding_type())
     }
+}
+
+/// The number of symbols required to recover a sliver.
+///
+/// For our current RS2 encoding, which is based on Reed-Solomon codes, the number of symbols
+/// required to recover a sliver is exactly the number of source symbols. This could be different
+/// for future encodings that use other types of erasure codes.
+// Important: Currently, quite some code assumes that the number of symbols required to recover a
+// sliver is an exact number. This code needs to be changed if this enum is extended in the future.
+// By explicitly matching on `Exact`, we ensure that the compiler will warn us in that case.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RequiredSymbolsCount {
+    /// An exact number of symbols required to recover a sliver.
+    Exact(usize),
 }
 
 /// Configuration parameters for the encoding.

--- a/crates/walrus-core/src/encoding/config.rs
+++ b/crates/walrus-core/src/encoding/config.rs
@@ -109,6 +109,14 @@ pub trait EncodingConfigTrait {
         }
     }
 
+    /// Returns the number of valid symbols required to recover a sliver of [`EncodingAxis`] `T`.
+    // Important: This is an *exact* value. If a future encoding requires a variable number of
+    // symbols, the interface here needs to be changed.
+    #[inline]
+    fn n_symbols_for_recovery<T: EncodingAxis>(&self) -> usize {
+        self.n_source_symbols::<T::OrthogonalAxis>().get().into()
+    }
+
     /// Returns the number of shards as a `usize`.
     #[inline]
     fn n_shards_as_usize(&self) -> usize {

--- a/crates/walrus-core/src/encoding/errors.rs
+++ b/crates/walrus-core/src/encoding/errors.rs
@@ -6,7 +6,7 @@ use core::num::NonZeroU16;
 
 use thiserror::Error;
 
-use crate::SliverIndex;
+use crate::{SliverIndex, merkle::MerkleProofError};
 
 /// Error indicating that the data is too large to be encoded/decoded.
 #[derive(Debug, Error, PartialEq, Eq, Clone)]
@@ -138,8 +138,8 @@ pub enum SymbolVerificationError {
     #[error("the symbol size does not match the metadata")]
     SymbolSizeMismatch,
     /// The verification of the Merkle proof failed.
-    #[error("verification of the Merkle proof failed")]
-    InvalidProof,
+    #[error("verification of the Merkle proof failed: {0}")]
+    InvalidProof(#[from] MerkleProofError),
     /// The provided metadata is itself invalid.
     #[error("the metadata is invalid")]
     InvalidMetadata,

--- a/crates/walrus-core/src/encoding/slivers.rs
+++ b/crates/walrus-core/src/encoding/slivers.rs
@@ -25,7 +25,6 @@ use super::{
     SliverRecoveryOrVerificationError,
     Symbols,
     errors::{SliverRecoveryError, SliverVerificationError},
-    symbols,
 };
 use crate::{
     SliverIndex,
@@ -234,13 +233,13 @@ impl<T: EncodingAxis> SliverData<T> {
             .expect("we have exactly `n_shards` symbols and the bound was checked"))
     }
 
-    /// Recovers a [`Sliver`] from the provided recovery symbols.
+    /// Recovers a [`SliverData`] from the provided recovery symbols.
     ///
-    /// Returns the recovered [`Sliver`] if decoding succeeds or `None` if decoding fails.
+    /// Returns the recovered [`SliverData`] if decoding succeeds or `None` if decoding fails.
     ///
     /// Does *not perform any checks* on the provided symbols; in particular, it does not verify any
     /// proofs.
-    fn recover_sliver_without_verification<I, U>(
+    pub fn recover_sliver_without_verification<I, U>(
         recovery_symbols: I,
         target_index: SliverIndex,
         symbol_size: NonZeroU16,
@@ -248,67 +247,40 @@ impl<T: EncodingAxis> SliverData<T> {
     ) -> Option<Self>
     where
         I: IntoIterator,
-        I::IntoIter: Iterator<Item = RecoverySymbol<T, U>>,
+        I::IntoIter: Iterator<Item = RecoverySymbol<T, U>> + ExactSizeIterator,
         U: MerkleAuth,
     {
+        let recovery_symbols = recovery_symbols.into_iter();
+        if recovery_symbols.len() < config.n_symbols_for_recovery::<T>() {
+            // We don't even have to attempt decoding if we don't have enough recovery symbols.
+            return None;
+        }
         config
             .decode_from_decoding_symbols(
                 symbol_size,
-                recovery_symbols
-                    .into_iter()
-                    .map(RecoverySymbol::into_decoding_symbol),
+                recovery_symbols.map(RecoverySymbol::into_decoding_symbol),
             )
             .map(|data| SliverData::new(data, symbol_size, target_index))
     }
 
-    /// Recovers a [`SliverData`] from the provided recovery symbols, verifying each symbol.
-    ///
-    /// Returns the recovered [`SliverData`] if decoding succeeds or a [`SliverRecoveryError`] if
-    /// decoding fails.
-    ///
-    /// Symbols that fail verification are logged and dropped.
-    pub fn recover_sliver<I, U>(
-        recovery_symbols: I,
-        target_index: SliverIndex,
-        metadata: &BlobMetadata,
-        encoding_config: &EncodingConfig,
-    ) -> Result<Self, SliverRecoveryError>
-    where
-        I: IntoIterator,
-        I::IntoIter: Iterator<Item = RecoverySymbol<T, U>>,
-        U: MerkleAuth,
-    {
-        let symbol_size = metadata.symbol_size(encoding_config)?;
-        Self::recover_sliver_without_verification(
-            symbols::filter_recovery_symbols_and_log_invalid(
-                recovery_symbols,
-                metadata,
-                encoding_config,
-                target_index,
-            ),
-            target_index,
-            symbol_size,
-            &encoding_config.get_for_type(metadata.encoding_type()),
-        )
-        .ok_or(SliverRecoveryError::DecodingFailure)
-    }
-
     /// Attempts to recover a sliver from the provided recovery symbols.
+    ///
+    /// The function *does not* verify the recovery symbols. It is the caller's responsibility to
+    /// ensure that the recovery symbols have been verified to be useable to recover the identified
+    /// symbol.
+    ///
+    /// It is also the caller's responsibility to ensure that the number of recovery symbols is
+    /// sufficient to recover the sliver (an error is returned if this is not the case).
     ///
     /// If recovery succeeds an the recovered sliver is verified successfully against the metadata,
     /// that sliver is returned. If the recovered sliver is inconsistent with the metadata, an
     /// [`InconsistencyProof`] is generated and returned. If recovery fails or another error occurs,
     /// a [`SliverRecoveryError`] is returned.
-    ///
-    /// If `verify_symbols` is set to true, symbols that fail verification are logged and
-    /// dropped. Otherwise, it is the caller's responsibility to ensure that the recovery symbols
-    /// have been verified to be useable to recover the identified symbol.
     pub fn recover_sliver_or_generate_inconsistency_proof<I, U>(
-        recovery_symbols: I,
+        verified_recovery_symbols: I,
         target_index: SliverIndex,
         metadata: &BlobMetadata,
         encoding_config: &EncodingConfig,
-        verify_symbols: bool,
     ) -> Result<SliverOrInconsistencyProof<T, U>, SliverRecoveryOrVerificationError>
     where
         I: IntoIterator,
@@ -316,30 +288,30 @@ impl<T: EncodingAxis> SliverData<T> {
         U: MerkleAuth,
     {
         let symbol_size = metadata.symbol_size(encoding_config)?;
-        let filtered_recovery_symbols: Vec<_> = if verify_symbols {
-            symbols::filter_recovery_symbols_and_log_invalid(
-                recovery_symbols,
-                metadata,
-                encoding_config,
-                target_index,
-            )
-            .collect()
-        } else {
-            recovery_symbols.into_iter().collect()
-        };
+        let config_enum = encoding_config.get_for_type(metadata.encoding_type());
+
+        // Important: For RS2 encoding, the number of recovery symbols required to reconstruct a
+        // sliver is fixed, allowing to specify an exact number of symbols for the recovery
+        // proof. This may not be the case for other future encodings, in which case this
+        // error type and the corresponding checks may have to be adjusted.
+        let n_symbols_required = config_enum.n_symbols_for_recovery::<T>();
+        let verified_recovery_symbols: Vec<_> = verified_recovery_symbols
+            .into_iter()
+            .take(n_symbols_required)
+            .collect();
 
         let sliver = Self::recover_sliver_without_verification(
-            filtered_recovery_symbols.clone(),
+            verified_recovery_symbols.clone(),
             target_index,
             symbol_size,
-            &encoding_config.get_for_type(metadata.encoding_type()),
+            &config_enum,
         )
         .ok_or(SliverRecoveryError::DecodingFailure)?;
 
         match sliver.verify(encoding_config, metadata) {
             Ok(()) => Ok(sliver.into()),
             Err(SliverVerificationError::MerkleRootMismatch) => {
-                Ok(InconsistencyProof::new(target_index, filtered_recovery_symbols).into())
+                Ok(InconsistencyProof::new(target_index, verified_recovery_symbols).into())
             }
             // Any other error indicates an internal problem, not an inconsistent blob.
             Err(e) => Err(e.into()),
@@ -649,7 +621,7 @@ mod tests {
         blob: &[u8],
     ) -> Result {
         let n_shards = 3 * (source_symbols_primary + source_symbols_secondary);
-        let (config, pairs, metadata) = create_config_and_encode_pairs_and_get_metadata(
+        let (encoding_config, pairs, metadata) = create_config_and_encode_pairs_and_get_metadata(
             source_symbols_primary,
             source_symbols_secondary,
             n_shards,
@@ -657,37 +629,36 @@ mod tests {
             blob,
         );
         let n_to_recover_from = source_symbols_primary.max(source_symbols_secondary).into();
+        let encoding_config_enum = encoding_config.get_for_type(metadata.encoding_type());
+        let symbol_size = metadata.symbol_size(&encoding_config)?;
 
         for pair in pairs.iter() {
             // Get a random subset of recovery symbols.
             let recovery_symbols: Vec<_> = random_subset(
                 pairs.iter().map(|p| {
-                    p.recovery_symbol_pair_for_sliver(
-                        pair.index(),
-                        &config.get_for_type(metadata.encoding_type()),
-                    )
-                    .unwrap()
+                    p.recovery_symbol_pair_for_sliver(pair.index(), &encoding_config_enum)
+                        .unwrap()
                 }),
                 n_to_recover_from,
             )
             .collect();
 
             // Recover the primary sliver.
-            let recovered = SliverData::recover_sliver(
+            let recovered = SliverData::recover_sliver_without_verification(
                 recovery_symbols.iter().map(|s| s.primary.clone()),
                 pair.primary.index,
-                &metadata,
-                &config,
+                symbol_size,
+                &encoding_config_enum,
             )
             .unwrap();
             assert_eq!(recovered, pair.primary);
 
             // Recover the secondary sliver.
-            let recovered = SliverData::recover_sliver(
+            let recovered = SliverData::recover_sliver_without_verification(
                 recovery_symbols.iter().map(|s| s.secondary.clone()),
                 pair.secondary.index,
-                &metadata,
-                &config,
+                symbol_size,
+                &encoding_config_enum,
             )
             .unwrap();
             assert_eq!(recovered, pair.secondary);
@@ -728,14 +699,15 @@ mod tests {
     }
     fn test_recover_all_slivers_from_f_plus_1(encoding_type: EncodingType, f: u16, blob: &[u8]) {
         let n_shards = 3 * f + 1;
-        let (config, pairs, metadata) = create_config_and_encode_pairs_and_get_metadata(
+        let (encoding_config, pairs, metadata) = create_config_and_encode_pairs_and_get_metadata(
             f,
             2 * f,
             n_shards,
             encoding_type,
             blob,
         );
-        let config_enum = config.get_for_type(metadata.encoding_type());
+        let encoding_config_enum = encoding_config.get_for_type(metadata.encoding_type());
+        let symbol_size = metadata.symbol_size(&encoding_config).unwrap();
 
         // Keep only the first `to_reconstruct_from` primary slivers.
         let to_reconstruct_from = f + 1;
@@ -749,13 +721,14 @@ mod tests {
         let secondary_slivers = (0..n_shards)
             .map(|target_index| {
                 let index = SliverPairIndex(target_index);
-                SliverData::<Secondary>::recover_sliver(
-                    primary_slivers
-                        .iter()
-                        .map(|p| p.recovery_symbol_for_sliver(index, &config_enum).unwrap()),
+                SliverData::<Secondary>::recover_sliver_without_verification(
+                    primary_slivers.iter().map(|p| {
+                        p.recovery_symbol_for_sliver(index, &encoding_config_enum)
+                            .unwrap()
+                    }),
                     SliverIndex(n_shards - 1 - target_index),
-                    &metadata,
-                    &config,
+                    symbol_size,
+                    &encoding_config_enum,
                 )
                 .unwrap()
             })
@@ -764,14 +737,22 @@ mod tests {
         // Recover the missing primary slivers from 2f+1 of the reconstructed secondary slivers.
         primary_slivers.extend((to_reconstruct_from..n_shards).map(|target_index| {
             let index = SliverPairIndex(target_index);
-            SliverData::<Primary>::recover_sliver(
+            SliverData::<Primary>::recover_sliver_without_verification(
                 secondary_slivers
                     .iter()
-                    .take(config_enum.n_secondary_source_symbols().get().into())
-                    .map(|s| s.recovery_symbol_for_sliver(index, &config_enum).unwrap()),
+                    .take(
+                        encoding_config_enum
+                            .n_secondary_source_symbols()
+                            .get()
+                            .into(),
+                    )
+                    .map(|s| {
+                        s.recovery_symbol_for_sliver(index, &encoding_config_enum)
+                            .unwrap()
+                    }),
                 index.into(),
-                &metadata,
-                &config,
+                symbol_size,
+                &encoding_config_enum,
             )
             .unwrap()
         }));
@@ -811,7 +792,8 @@ mod tests {
                 sliver
                     .recovery_symbol_for_sliver(shard_pair_index, &config)
                     .unwrap()
-                    .verify_proof(&merkle_tree.root(), index.into())
+                    .verify_proof(&merkle_tree.root(), n_shards.into(), index.into())
+                    .is_ok()
             );
         }
     }

--- a/crates/walrus-core/src/inconsistency.rs
+++ b/crates/walrus-core/src/inconsistency.rs
@@ -53,23 +53,35 @@ use crate::{
     encoding::{
         EncodingAxis,
         EncodingConfig,
+        EncodingConfigEnum,
+        EncodingConfigTrait as _,
         Primary,
         RecoverySymbol,
         Secondary,
         SliverData,
-        SliverRecoveryError,
         SliverVerificationError,
     },
+    ensure,
     merkle::MerkleAuth,
-    metadata::BlobMetadata,
+    metadata::{BlobMetadata, BlobMetadataApi as _},
 };
 
 /// Failure cases when verifying an [`InconsistencyProof`].
 #[derive(thiserror::Error, Debug, PartialEq)]
 pub enum InconsistencyVerificationError {
-    /// No sliver can be decoded from the authentic recovery symbols.
-    #[error(transparent)]
-    RecoveryFailure(#[from] SliverRecoveryError),
+    /// The number of recovery symbols is incorrect.
+    // Important: For RS2 encoding, the number of recovery symbols required to reconstruct a sliver
+    // is fixed, allowing to specify an exact number of symbols for the recovery proof. This may not
+    // be the case for other future encodings, in which case this error type and the corresponding
+    // checks may have to be adjusted.
+    #[error("the number of recovery symbols is incorrect (expected: {0}, actual: {1})")]
+    IncorrectSymbolCount(usize, usize),
+    /// Some recovery symbols are invalid.
+    #[error("some recovery symbols are invalid")]
+    InvalidRecoverySymbols,
+    /// No sliver can be decoded from the recovery symbols.
+    #[error("no sliver can be decoded from the recovery symbols")]
+    RecoveryFailure,
     /// An error occurred during the verification of the target sliver.
     #[error(transparent)]
     VerificationError(#[from] SliverVerificationError),
@@ -87,7 +99,6 @@ pub type SecondaryInconsistencyProof<U> = InconsistencyProof<Secondary, U>;
 /// The structure of an inconsistency proof.
 ///
 /// See [the module documentation][self] for further details.
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(bound(
     deserialize = "for<'a> RecoverySymbol<T, U>: Deserialize<'a>",
@@ -96,6 +107,8 @@ pub type SecondaryInconsistencyProof<U> = InconsistencyProof<Secondary, U>;
 pub struct InconsistencyProof<T: EncodingAxis, U: MerkleAuth> {
     target_sliver_index: SliverIndex,
     recovery_symbols: Vec<RecoverySymbol<T, U>>,
+    /// The encoding axis is the type of the sliver that can be recovered through the
+    /// `recovery_symbols`.
     _encoding_axis: PhantomData<T>,
 }
 
@@ -114,6 +127,44 @@ impl<T: EncodingAxis, U: MerkleAuth> InconsistencyProof<T, U> {
         }
     }
 
+    /// Checks that the proof contains the correct number of recovery symbols and that they are
+    /// valid.
+    ///
+    /// By checking the recovery symbols, we also check that the metadata
+    fn check_recovery_symbols(
+        &self,
+        metadata: &BlobMetadata,
+        symbol_size: usize,
+        encoding_config: &EncodingConfig,
+    ) -> Result<(), InconsistencyVerificationError> {
+        // For RS2 encoding, the number of recovery symbols is equal to the number of source
+        // symbols of the corresponding encoding axis. This may not be the case for other future
+        // encodings; the following match ensures that this will be revisited when we add new
+        // encodings.
+        let EncodingConfigEnum::ReedSolomon(rs_encoding_config) =
+            encoding_config.get_for_type(metadata.encoding_type());
+        let expected_symbol_count = rs_encoding_config.n_symbols_for_recovery::<T>();
+        ensure!(
+            self.recovery_symbols.len() == expected_symbol_count,
+            InconsistencyVerificationError::IncorrectSymbolCount(
+                expected_symbol_count,
+                self.recovery_symbols.len(),
+            )
+        );
+        ensure!(
+            self.recovery_symbols.iter().all(|symbol| symbol
+                .verify(
+                    encoding_config.n_shards(),
+                    symbol_size,
+                    metadata,
+                    self.target_sliver_index
+                )
+                .is_ok()),
+            InconsistencyVerificationError::InvalidRecoverySymbols
+        );
+        Ok(())
+    }
+
     /// Verifies the inconsistency proof.
     ///
     /// Returns `Ok(())` if the proof is correct, otherwise returns an
@@ -123,12 +174,17 @@ impl<T: EncodingAxis, U: MerkleAuth> InconsistencyProof<T, U> {
         metadata: &BlobMetadata,
         encoding_config: &EncodingConfig,
     ) -> Result<(), InconsistencyVerificationError> {
-        let sliver = SliverData::recover_sliver(
+        let symbol_size = metadata
+            .symbol_size(encoding_config)
+            .map_err(|_| InconsistencyVerificationError::RecoveryFailure)?;
+        self.check_recovery_symbols(metadata, symbol_size.get().into(), encoding_config)?;
+        let sliver = SliverData::recover_sliver_without_verification(
             self.recovery_symbols,
             self.target_sliver_index,
-            metadata,
-            encoding_config,
-        )?;
+            symbol_size,
+            &encoding_config.get_for_type(metadata.encoding_type()),
+        )
+        .ok_or(InconsistencyVerificationError::RecoveryFailure)?;
         match sliver.verify(encoding_config, metadata) {
             Ok(()) => Err(InconsistencyVerificationError::SliverNotInconsistent),
             Err(SliverVerificationError::MerkleRootMismatch) => Ok(()),
@@ -169,11 +225,7 @@ mod tests {
     use walrus_test_utils::Result;
 
     use super::*;
-    use crate::{
-        encoding::EncodingConfigTrait as _,
-        merkle::Node,
-        test_utils::generate_config_metadata_and_valid_recovery_symbols,
-    };
+    use crate::{merkle::Node, test_utils::generate_config_metadata_and_valid_recovery_symbols};
 
     #[test]
     fn valid_inconsistency_proof() -> Result<()> {
@@ -194,10 +246,10 @@ mod tests {
         let inconsistency_proof =
             InconsistencyProof::new(SliverIndex(target_sliver_index.get() + 1), recovery_symbols);
 
-        assert!(matches!(
+        assert_eq!(
             inconsistency_proof.verify(metadata.metadata(), &encoding_config),
-            Err(InconsistencyVerificationError::RecoveryFailure(_))
-        ));
+            Err(InconsistencyVerificationError::InvalidRecoverySymbols)
+        );
         Ok(())
     }
 
@@ -207,31 +259,32 @@ mod tests {
             generate_config_metadata_and_valid_recovery_symbols()?;
         let inconsistency_proof = InconsistencyProof::new(target_sliver_index, recovery_symbols);
 
-        assert!(matches!(
+        assert_eq!(
             inconsistency_proof.verify(metadata.metadata(), &encoding_config),
             Err(InconsistencyVerificationError::SliverNotInconsistent)
-        ));
+        );
         Ok(())
     }
 
     #[test]
-    fn invalid_inconsistency_proof_because_sliver_cannot_be_decoded() -> Result<()> {
+    fn invalid_inconsistency_proof_because_of_insufficient_recovery_symbols() -> Result<()> {
         let (encoding_config, metadata, target_sliver_index, mut recovery_symbols) =
             generate_config_metadata_and_valid_recovery_symbols()?;
-        recovery_symbols.truncate(
-            usize::from(
-                encoding_config
-                    .get_for_type(metadata.metadata().encoding_type())
-                    .n_secondary_source_symbols()
-                    .get(),
-            ) - 1,
-        );
+        let required_symbol_count: usize = encoding_config
+            .get_for_type(metadata.metadata().encoding_type())
+            .n_secondary_source_symbols()
+            .get()
+            .into();
+        recovery_symbols.truncate(required_symbol_count - 1);
         let inconsistency_proof = InconsistencyProof::new(target_sliver_index, recovery_symbols);
 
-        assert!(matches!(
+        assert_eq!(
             inconsistency_proof.verify(metadata.metadata(), &encoding_config),
-            Err(InconsistencyVerificationError::RecoveryFailure(_))
-        ));
+            Err(InconsistencyVerificationError::IncorrectSymbolCount(
+                required_symbol_count,
+                required_symbol_count - 1
+            ))
+        );
         Ok(())
     }
 }

--- a/crates/walrus-core/src/lib.rs
+++ b/crates/walrus-core/src/lib.rs
@@ -9,10 +9,10 @@
 extern crate alloc;
 extern crate std;
 
-use alloc::vec::Vec;
 #[allow(unused)]
 #[cfg(feature = "utoipa")]
-use alloc::{format, string::String};
+use alloc::format;
+use alloc::{string::String, vec::Vec};
 use core::{
     fmt::{self, Debug, Display},
     num::NonZeroU16,

--- a/crates/walrus-core/src/merkle.rs
+++ b/crates/walrus-core/src/merkle.rs
@@ -352,6 +352,8 @@ fn path_length(n_leaves: usize) -> usize {
 
 #[cfg(test)]
 mod test {
+    use walrus_test_utils::param_test;
+
     use super::*;
 
     const TEST_INPUT: [&[u8]; 9] = [
@@ -442,5 +444,23 @@ mod test {
                 );
             }
         }
+    }
+
+    param_test! {
+        test_path_length: [
+            zero: (0, 0),
+            one: (1, 0),
+            two: (2, 1),
+            three: (3, 2),
+            four: (4, 2),
+            five: (5, 3),
+            six: (6, 3),
+            seven: (7, 3),
+            eight: (8, 3),
+            nine: (9, 4),
+        ]
+    }
+    fn test_path_length(n_leaves: usize, expected_path_length: usize) {
+        assert_eq!(path_length(n_leaves), expected_path_length);
     }
 }

--- a/crates/walrus-core/src/merkle.rs
+++ b/crates/walrus-core/src/merkle.rs
@@ -10,6 +10,8 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::Level;
 
+use crate::ensure;
+
 /// The length of the digests used in the merkle tree.
 pub const DIGEST_LEN: usize = 32;
 
@@ -17,10 +19,19 @@ const LEAF_PREFIX: [u8; 1] = [0];
 const INNER_PREFIX: [u8; 1] = [1];
 const EMPTY_NODE: [u8; DIGEST_LEN] = [0; DIGEST_LEN];
 
-/// Returned if the specified index is out of bounds for a Merkle tree or proof.
-#[derive(Error, Debug, PartialEq, Eq)]
-#[error("index {0} is too large")]
-pub struct LeafIndexOutOfBounds(usize);
+/// Errors that can occur when generating or verifying a Merkle proof.
+#[derive(Error, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MerkleProofError {
+    /// The proof's path length is larger than the maximum allowed path length.
+    #[error("the proof's path length is larger than the maximum path length")]
+    PathLengthTooLarge,
+    /// The leaf index is too large.
+    #[error("index {0} is too large")]
+    LeafIndexOutOfBounds(usize),
+    /// The root hash does not match the computed root.
+    #[error("the root hash does not match the computed root")]
+    RootMismatch,
+}
 
 /// A node in the Merkle tree.
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
@@ -66,14 +77,28 @@ impl AsRef<[u8]> for Node {
 pub trait MerkleAuth: Clone + alloc::fmt::Debug {
     /// Verifies the proof given a Merkle root and the leaf data.
     #[tracing::instrument(level = Level::DEBUG, skip(self, leaf))]
-    fn verify_proof(&self, root: &Node, leaf: &[u8], leaf_index: usize) -> bool {
-        self.compute_root(leaf, leaf_index).as_ref() == Some(root)
+    fn verify_proof(
+        &self,
+        root: &Node,
+        leaf_count: usize,
+        leaf: &[u8],
+        leaf_index: usize,
+    ) -> Result<(), MerkleProofError> {
+        self.check_path_length(path_length(leaf_count))?;
+        ensure!(
+            self.compute_root(leaf, leaf_index)? == *root,
+            MerkleProofError::RootMismatch
+        );
+        Ok(())
     }
+
+    /// Checks that the proof's path length is not larger than the maximum path length.
+    fn check_path_length(&self, max_path_length: usize) -> Result<(), MerkleProofError>;
 
     /// Recomputes the Merkle root from the proof and the provided leaf data.
     ///
     /// Returns `None` if the provided index is too large.
-    fn compute_root(&self, leaf: &[u8], leaf_index: usize) -> Option<Node>;
+    fn compute_root(&self, leaf: &[u8], leaf_index: usize) -> Result<Node, MerkleProofError>;
 }
 
 /// A proof that some data is at index `leaf_index` in a [`MerkleTree`].
@@ -122,9 +147,9 @@ impl<T> MerkleAuth for MerkleProof<T>
 where
     T: HashFunction<DIGEST_LEN>,
 {
-    fn compute_root(&self, leaf: &[u8], leaf_index: usize) -> Option<Node> {
+    fn compute_root(&self, leaf: &[u8], leaf_index: usize) -> Result<Node, MerkleProofError> {
         if leaf_index >> self.path.len() != 0 {
-            return None;
+            return Err(MerkleProofError::LeafIndexOutOfBounds(leaf_index));
         }
         let mut current_hash = leaf_hash::<T>(leaf);
         let mut level_index = leaf_index;
@@ -140,7 +165,15 @@ where
             // Update to the level index one level up in the tree
             level_index /= 2;
         }
-        Some(current_hash)
+        Ok(current_hash)
+    }
+
+    fn check_path_length(&self, max_path_length: usize) -> Result<(), MerkleProofError> {
+        if self.path.len() > max_path_length {
+            Err(MerkleProofError::PathLengthTooLarge)
+        } else {
+            Ok(())
+        }
     }
 }
 
@@ -245,15 +278,13 @@ where
     /// Get the [`MerkleProof`] for the leaf at `leaf_index` consisting
     /// of all sibling hashes on the path from the leaf to the root.
     #[tracing::instrument(skip_all, level = Level::DEBUG, fields(n_leaves = self.n_leaves))]
-    pub fn get_proof(&self, leaf_index: usize) -> Result<MerkleProof<T>, LeafIndexOutOfBounds> {
+    pub fn get_proof(&self, leaf_index: usize) -> Result<MerkleProof<T>, MerkleProofError> {
         tracing::trace!("computing Merkle proof");
         if leaf_index >= self.n_leaves {
             tracing::warn!("leaf index out of bounds");
-            return Err(LeafIndexOutOfBounds(leaf_index));
+            return Err(MerkleProofError::LeafIndexOutOfBounds(leaf_index));
         }
-        let mut path = Vec::with_capacity(
-            usize::try_from(self.n_leaves.ilog2()).expect("this is smaller than `n_leaves`") + 1,
-        );
+        let mut path = Vec::with_capacity(path_length(self.n_leaves));
         let mut level_index = leaf_index;
         let mut n_level = self.n_leaves;
         let mut level_base_index = 0;
@@ -311,6 +342,14 @@ fn n_nodes(n_leaves: usize) -> usize {
     tot_nodes + lvl_nodes
 }
 
+/// Returns the path length of a Merkle tree with `n_leaves` leaves.
+fn path_length(n_leaves: usize) -> usize {
+    if n_leaves <= 1 {
+        return 0;
+    }
+    usize::try_from((n_leaves - 1).ilog2()).expect("this is smaller than `n_leaves`") + 1
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -360,15 +399,15 @@ mod test {
 
     #[test]
     fn test_get_path_out_of_bounds() {
-        let test_inp: Vec<_> = [
+        let test_input: Vec<_> = [
             "foo", "bar", "fizz", "baz", "buzz", "fizz", "foobar", "walrus", "fizz",
         ]
         .iter()
         .map(|x| x.as_bytes())
         .collect();
-        for i in 0..test_inp.len() {
-            let mt: MerkleTree = MerkleTree::build(&test_inp[..i]);
-            match mt.get_proof(i.next_power_of_two()) {
+        for leaf_count in 0..test_input.len() {
+            let mt: MerkleTree = MerkleTree::build(&test_input[..leaf_count]);
+            match mt.get_proof(leaf_count.next_power_of_two()) {
                 Err(_) => {}
                 Ok(_) => panic!("Expected an error"),
             }
@@ -377,22 +416,30 @@ mod test {
 
     #[test]
     fn test_merkle_path_verify() {
-        for i in 0..TEST_INPUT.len() {
-            let mt: MerkleTree = MerkleTree::build(&TEST_INPUT[..i]);
-            for (index, leaf_data) in TEST_INPUT[..i].iter().enumerate() {
+        for leaf_count in 0..TEST_INPUT.len() {
+            let mt: MerkleTree = MerkleTree::build(&TEST_INPUT[..leaf_count]);
+            for (index, leaf_data) in TEST_INPUT[..leaf_count].iter().enumerate() {
                 let proof = mt.get_proof(index).unwrap();
-                assert!(proof.verify_proof(&mt.root(), leaf_data, index));
+                assert!(
+                    proof
+                        .verify_proof(&mt.root(), leaf_count, leaf_data, index)
+                        .is_ok()
+                );
             }
         }
     }
 
     #[test]
     fn test_merkle_path_verify_fails_for_wrong_index() {
-        for i in 0..TEST_INPUT.len() {
-            let mt: MerkleTree = MerkleTree::build(&TEST_INPUT[..i]);
-            for (index, leaf_data) in TEST_INPUT[..i].iter().enumerate() {
+        for leaf_count in 0..TEST_INPUT.len() {
+            let mt: MerkleTree = MerkleTree::build(&TEST_INPUT[..leaf_count]);
+            for (index, leaf_data) in TEST_INPUT[..leaf_count].iter().enumerate() {
                 let proof = mt.get_proof(index).unwrap();
-                assert!(!proof.verify_proof(&mt.root(), leaf_data, index + 1));
+                assert!(
+                    proof
+                        .verify_proof(&mt.root(), leaf_count, leaf_data, index + 1)
+                        .is_err()
+                );
             }
         }
     }

--- a/crates/walrus-core/src/test_utils.rs
+++ b/crates/walrus-core/src/test_utils.rs
@@ -30,6 +30,7 @@ use crate::{
         self,
         EncodingConfig,
         EncodingConfigTrait as _,
+        Primary,
         PrimaryRecoverySymbol,
         PrimarySliver,
         QuiltError,
@@ -337,7 +338,7 @@ pub fn generate_config_metadata_and_valid_recovery_symbols()
                 )
                 .unwrap()
         }),
-        config_enum.n_secondary_source_symbols().get().into(),
+        config_enum.n_symbols_for_recovery::<Primary>(),
     )
     .collect();
     Ok((

--- a/crates/walrus-core/src/test_utils.rs
+++ b/crates/walrus-core/src/test_utils.rs
@@ -34,6 +34,7 @@ use crate::{
         PrimaryRecoverySymbol,
         PrimarySliver,
         QuiltError,
+        RequiredSymbolsCount,
         SecondarySliver,
         quilt_encoding::QuiltStoreBlob,
     },
@@ -328,6 +329,8 @@ pub fn generate_config_metadata_and_valid_recovery_symbols()
     let config_enum = encoding_config.get_for_type(DEFAULT_ENCODING);
     let (sliver_pairs, metadata) = config_enum.encode_with_metadata(&blob)?;
     let target_sliver_index = SliverIndex(0);
+    let RequiredSymbolsCount::Exact(n_symbols_required) =
+        config_enum.n_symbols_for_recovery::<Primary>();
     let recovery_symbols = walrus_test_utils::random_subset(
         (1..encoding_config.n_shards.get()).map(|i| {
             sliver_pairs[i as usize]
@@ -338,7 +341,7 @@ pub fn generate_config_metadata_and_valid_recovery_symbols()
                 )
                 .unwrap()
         }),
-        config_enum.n_symbols_for_recovery::<Primary>(),
+        n_symbols_required,
     )
     .collect();
     Ok((

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -2879,7 +2879,7 @@ impl ServiceState for StorageNodeInner {
         ensure!(
             self.is_stored_at_all_shards_at_latest_epoch(blob_id)
                 .await
-                .context("database error when checkingstorage status")?,
+                .context("database error when checking storage status")?,
             ComputeStorageConfirmationError::NotFullyStored,
         );
 
@@ -3717,7 +3717,8 @@ mod tests {
             let attestation = node
                 .as_ref()
                 .verify_inconsistency_proof(&blob_id, inconsistency_proof)
-                .await?;
+                .await
+                .context("failed to verify inconsistency proof")?;
 
             // The proof should be valid and we should receive a valid signature
             node.as_ref()

--- a/crates/walrus-service/src/node/committee/request_futures.rs
+++ b/crates/walrus-service/src/node/committee/request_futures.rs
@@ -38,6 +38,7 @@ use walrus_core::{
         GeneralRecoverySymbol,
         Primary,
         RecoverySymbol as RecoverySymbolData,
+        RequiredSymbolsCount,
         Secondary,
         SliverData,
         SliverRecoveryOrVerificationError,
@@ -296,39 +297,24 @@ where
             "starting recovery for sliver"
         );
 
-        // Since recovery currently consumes the symbols, rather than copy the symbols in every case
-        // to handle the rare cases when we fail to *decode* the sliver despite collecting the
-        // required number of symbols, we instead retry the entire process with an increased amount.
-        //
-        // Remark: With the current RS2 encoding, we know the exact number of symbols required to
-        // decode the sliver, so this loop would not be necessary. However, future encodings may
-        // require a variable number of symbols to decode the sliver, in which case this loop is
-        // actually needed.
-        let mut additional_symbols = 0;
         loop {
-            if let Some(result) = self
-                .recover_with_additional_symbols(additional_symbols)
-                .await
-            {
+            if let Some(result) = self.recover().await {
                 return result;
             }
-            additional_symbols += 1;
+            tracing::error!("unable to recover sliver from sufficient number of symbols; retrying");
         }
     }
 
     #[tracing::instrument(skip(self))]
-    async fn recover_with_additional_symbols(
-        &mut self,
-        additional_symbols: usize,
-    ) -> Option<Result<Sliver, InconsistencyProofEnum>> {
+    async fn recover(&mut self) -> Option<Result<Sliver, InconsistencyProofEnum>> {
         let mut committee_listener = self.shared.subscribe_to_committee_changes();
 
-        // Total symbols required to decode the sliver.
-        let total_symbols_required = self.total_symbols_required(additional_symbols);
+        // The number of symbols required to decode the sliver.
+        let n_symbols_required = self.n_symbols_required();
 
-        // Total symbols to request from other storage nodes initially.
-        let total_symbols_to_request = std::cmp::min(
-            total_symbols_required
+        // The number of symbols to request from other storage nodes initially.
+        let n_symbols_to_request = std::cmp::min(
+            n_symbols_required
                 + self
                     .shared
                     .config
@@ -338,8 +324,8 @@ where
 
         // Track the collection of recovery symbols.
         let mut symbol_tracker = SymbolTracker::new(
-            total_symbols_required,
-            total_symbols_to_request,
+            n_symbols_required,
+            n_symbols_to_request,
             self.target_index,
             self.target_sliver_type,
         );
@@ -372,6 +358,7 @@ where
                                 %n_symbols,
                                 "successfully collected the desired number of recovery symbols"
                             );
+                            assert!(n_symbols >= n_symbols_required);
                             self.stats.metrics.recovery_future_backoffs
                                 .observe(self.stats.total_backoffs as f64);
                             self.stats.metrics.recovery_future_failed_requests
@@ -407,17 +394,18 @@ where
         }
     }
 
-    fn total_symbols_required(&self, additional_symbols: usize) -> usize {
+    fn n_symbols_required(&self) -> usize {
         let encoding_config = self
             .shared
             .encoding_config
             .get_for_type(self.metadata.metadata().encoding_type());
-        let min_symbols_for_recovery = if self.target_sliver_type == SliverType::Primary {
-            encoding_config.n_symbols_for_recovery::<Primary>()
-        } else {
-            encoding_config.n_symbols_for_recovery::<Secondary>()
-        };
-        min_symbols_for_recovery + additional_symbols
+        let RequiredSymbolsCount::Exact(n_symbols_required) =
+            if self.target_sliver_type == SliverType::Primary {
+                encoding_config.n_symbols_for_recovery::<Primary>()
+            } else {
+                encoding_config.n_symbols_for_recovery::<Secondary>()
+            };
+        n_symbols_required
     }
 
     #[tracing::instrument(skip_all)]
@@ -439,6 +427,10 @@ where
     /// The function *does not* verify the recovery symbols. It is the caller's responsibility to
     /// ensure that the recovery symbols have been verified to be useable to recover the identified
     /// symbol.
+    ///
+    /// It is also the caller's responsibility to ensure that the number of recovery symbols is
+    /// sufficient to recover the sliver. The function returns `None` if this is not the case or
+    /// decoding fails for other reasons.
     ///
     /// Returns an inconsistency proof if the sliver turns out to be inconsistent.
     async fn decode_sliver_by_axis<A, I>(

--- a/crates/walrus-service/src/node/committee/test_committee_service.rs
+++ b/crates/walrus-service/src/node/committee/test_committee_service.rs
@@ -27,7 +27,6 @@ use walrus_core::{
     SliverType,
     bft,
     encoding::{
-        self,
         EncodingConfig,
         EncodingConfigTrait as _,
         GeneralRecoverySymbol,
@@ -452,25 +451,21 @@ fn recovery_symbols_by_shard(
     let target_sliver_pair_index = target_sliver_index.to_pair_index::<Primary>(n_shards);
 
     let encoding_config = EncodingConfig::new(n_shards);
-    let (sliver_pairs, metadata) = encoding_config
-        .get_for_type(DEFAULT_ENCODING)
-        .encode_with_metadata(&blob)?;
+    let encoding_config_enum = encoding_config.get_for_type(DEFAULT_ENCODING);
+    let (sliver_pairs, metadata) = encoding_config_enum.encode_with_metadata(&blob)?;
 
     let recovery_symbols = sliver_pairs
         .iter()
         .map(|pair| {
             let symbol = pair
                 .secondary
-                .recovery_symbol_for_sliver(
-                    target_sliver_pair_index,
-                    &encoding_config.get_for_type(metadata.metadata().encoding_type()),
-                )
+                .recovery_symbol_for_sliver(target_sliver_pair_index, &encoding_config_enum)
                 .unwrap();
             (pair.index(), symbol)
         })
         .choose_multiple(
             rng,
-            encoding::min_symbols_for_recovery::<Primary>(n_shards).into(),
+            encoding_config_enum.n_symbols_for_recovery::<Primary>(),
         );
 
     Ok((

--- a/crates/walrus-service/src/node/committee/test_committee_service.rs
+++ b/crates/walrus-service/src/node/committee/test_committee_service.rs
@@ -32,6 +32,7 @@ use walrus_core::{
         GeneralRecoverySymbol,
         Primary,
         PrimaryRecoverySymbol,
+        RequiredSymbolsCount,
     },
     inconsistency::PrimaryInconsistencyProof,
     keys::ProtocolKeyPair,
@@ -454,6 +455,8 @@ fn recovery_symbols_by_shard(
     let encoding_config_enum = encoding_config.get_for_type(DEFAULT_ENCODING);
     let (sliver_pairs, metadata) = encoding_config_enum.encode_with_metadata(&blob)?;
 
+    let RequiredSymbolsCount::Exact(n_symbols_for_recovery) =
+        encoding_config_enum.n_symbols_for_recovery::<Primary>();
     let recovery_symbols = sliver_pairs
         .iter()
         .map(|pair| {
@@ -463,10 +466,7 @@ fn recovery_symbols_by_shard(
                 .unwrap();
             (pair.index(), symbol)
         })
-        .choose_multiple(
-            rng,
-            encoding_config_enum.n_symbols_for_recovery::<Primary>(),
-        );
+        .choose_multiple(rng, n_symbols_for_recovery);
 
     Ok((
         metadata,

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -490,6 +490,8 @@ impl Storage {
     }
 
     /// Store the verified metadata.
+    ///
+    /// This must *not* be called for a blob that is not tracked in the blob-info table.
     #[tracing::instrument(skip_all)]
     pub async fn put_verified_metadata(
         &self,
@@ -499,6 +501,7 @@ impl Storage {
             .await
     }
 
+    // Important: This must *not* be called for a blob that is not tracked in the blob-info table.
     async fn put_metadata(
         &self,
         blob_id: &BlobId,

--- a/crates/walrus-storage-node-client/src/client.rs
+++ b/crates/walrus-storage-node-client/src/client.rs
@@ -3,7 +3,7 @@
 
 //! Client for interacting with the StorageNode API.
 
-use std::sync::Arc;
+use std::{num::NonZeroU16, sync::Arc};
 
 use fastcrypto::traits::{EncodeDecodeBase64, KeyPair};
 use futures::TryFutureExt as _;
@@ -703,8 +703,9 @@ impl StorageNodeClient {
     )]
     pub async fn get_and_verify_recovery_symbol<A: EncodingAxis>(
         &self,
+        n_shards: NonZeroU16,
+        expected_symbol_size: usize,
         metadata: &VerifiedBlobMetadataWithId,
-        encoding_config: &EncodingConfig,
         remote_sliver_pair: SliverPairIndex,
         local_sliver_pair: SliverPairIndex,
     ) -> Result<RecoverySymbol<A, MerkleProof>, NodeError> {
@@ -715,12 +716,12 @@ impl StorageNodeClient {
                 local_sliver_pair,
             )
             .await?;
-
         symbol
             .verify(
+                n_shards,
+                expected_symbol_size,
                 metadata.as_ref(),
-                encoding_config,
-                local_sliver_pair.to_sliver_index::<A>(encoding_config.n_shards()),
+                local_sliver_pair.to_sliver_index::<A>(n_shards),
             )
             .map_err(NodeError::other)?;
 

--- a/crates/walrus-sui/benches/gas_cost_bench.rs
+++ b/crates/walrus-sui/benches/gas_cost_bench.rs
@@ -238,11 +238,12 @@ async fn gas_cost_for_contract_calls(args: Args) -> anyhow::Result<()> {
 
             if args.extend {
                 let epochs_extended = Some(epochs_ahead);
+                let attribute = Default::default();
                 let certify_and_extend_params: Vec<CertifyAndExtendBlobParams> = blob_objs
                     .iter()
                     .map(|blob| CertifyAndExtendBlobParams {
                         blob,
-                        attribute: None,
+                        attribute: &attribute,
                         certificate: None,
                         epochs_extended,
                     })


### PR DESCRIPTION
## Description

This PR ensures that we only perform cryptographic validation of inconsistency proofs and recovery symbols after performing some checks on the size of them and their proofs.

Also adds some clarifying comments and docstrings and cleans up no-longer-used functions.

## Test plan

Existing/adapted tests.
