### PR TITLE
chore: rename Client to WalrusNodeClient

### DIFF
--- a/crates/walrus-sdk/src/client.rs
+++ b/crates/walrus-sdk/src/client.rs
@@ -154,7 +154,7 @@ impl<E: EncodingAxis> SliverSelector<E> {
 
 /// A client to communicate with Walrus shards and storage nodes.
 #[derive(Debug, Clone)]
-pub struct Client<T> {
+pub struct WalrusNodeClient<T> {
     config: ClientConfig,
     sui_client: T,
     communication_limits: CommunicationLimits,
@@ -166,7 +166,7 @@ pub struct Client<T> {
     communication_factory: NodeCommunicationFactory,
 }
 
-impl Client<()> {
+impl WalrusNodeClient<()> {
     /// Creates a new Walrus client without a Sui client.
     pub async fn new(
         config: ClientConfig,
@@ -219,8 +219,8 @@ impl Client<()> {
         })
     }
 
-    /// Converts `self` to a [`Client<C>`] by adding the `sui_client`.
-    pub async fn with_client<C>(self, sui_client: C) -> Client<C> {
+    /// Converts `self` to a [`WalrusNodeClient<C>`] by adding the `sui_client`.
+    pub async fn with_client<C>(self, sui_client: C) -> WalrusNodeClient<C> {
         let Self {
             config,
             sui_client: _,
@@ -230,7 +230,7 @@ impl Client<()> {
             blocklist,
             communication_factory: node_client_factory,
         } = self;
-        Client::<C> {
+        WalrusNodeClient::<C> {
             config,
             sui_client,
             committees_handle,
@@ -242,14 +242,14 @@ impl Client<()> {
     }
 }
 
-impl<T: ReadClient> Client<T> {
+impl<T: ReadClient> WalrusNodeClient<T> {
     /// Creates a new read client starting from a config file.
     pub async fn new_read_client(
         config: ClientConfig,
         committees_handle: CommitteesRefresherHandle,
         sui_read_client: T,
     ) -> ClientResult<Self> {
-        Ok(Client::new(config, committees_handle)
+        Ok(WalrusNodeClient::new(config, committees_handle)
             .await?
             .with_client(sui_read_client)
             .await)
@@ -270,7 +270,7 @@ impl<T: ReadClient> Client<T> {
             .build_refresher_and_run(sui_read_client.clone())
             .await
             .map_err(|e| ClientError::from(ClientErrorKind::Other(e.into())))?;
-        Ok(Client::new(config, committees_handle)
+        Ok(WalrusNodeClient::new(config, committees_handle)
             .await?
             .with_client(sui_read_client)
             .await)
@@ -823,14 +823,14 @@ impl<T: ReadClient> Client<T> {
     }
 }
 
-impl Client<SuiContractClient> {
+impl WalrusNodeClient<SuiContractClient> {
     /// Creates a new client starting from a config file.
     pub async fn new_contract_client(
         config: ClientConfig,
         committees_handle: CommitteesRefresherHandle,
         sui_client: SuiContractClient,
     ) -> ClientResult<Self> {
-        Ok(Client::new(config, committees_handle)
+        Ok(WalrusNodeClient::new(config, committees_handle)
             .await?
             .with_client(sui_client)
             .await)
@@ -848,7 +848,7 @@ impl Client<SuiContractClient> {
             .build_refresher_and_run(sui_client.read_client().clone())
             .await
             .map_err(|e| ClientError::from(ClientErrorKind::Other(e.into())))?;
-        Ok(Client::new(config, committees_handle)
+        Ok(WalrusNodeClient::new(config, committees_handle)
             .await?
             .with_client(sui_client)
             .await)
@@ -1502,7 +1502,7 @@ impl Client<SuiContractClient> {
     }
 }
 
-impl<T> Client<T> {
+impl<T> WalrusNodeClient<T> {
     /// Adds a [`Blocklist`] to the client that will be checked when storing or reading blobs.
     ///
     /// This can be called again to replace the blocklist.

--- a/crates/walrus-sdk/src/client/quilt_client.rs
+++ b/crates/walrus-sdk/src/client/quilt_client.rs
@@ -37,7 +37,12 @@ use walrus_sui::{
 use walrus_utils::read_blob_from_file;
 
 use crate::{
-    client::{Client, StoreArgs, client_types::StoredQuiltPatch, responses::QuiltStoreResult},
+    client::{
+        StoreArgs,
+        WalrusNodeClient,
+        client_types::StoredQuiltPatch,
+        responses::QuiltStoreResult,
+    },
     error::{ClientError, ClientErrorKind, ClientResult},
 };
 
@@ -372,13 +377,13 @@ impl Default for QuiltClientConfig {
 /// A facade for interacting with Walrus quilt.
 #[derive(Debug, Clone)]
 pub struct QuiltClient<'a, T> {
-    client: &'a Client<T>,
+    client: &'a WalrusNodeClient<T>,
     config: QuiltClientConfig,
 }
 
 impl<'a, T> QuiltClient<'a, T> {
     /// Creates a new QuiltClient.
-    pub fn new(client: &'a Client<T>, config: QuiltClientConfig) -> Self {
+    pub fn new(client: &'a WalrusNodeClient<T>, config: QuiltClientConfig) -> Self {
         Self { client, config }
     }
 

--- a/crates/walrus-sdk/src/client/upload_relay_client.rs
+++ b/crates/walrus-sdk/src/client/upload_relay_client.rs
@@ -31,7 +31,7 @@ use walrus_utils::backoff::{self, BackoffStrategy, ExponentialBackoff, Exponenti
 use super::{WalrusStoreBlob, WalrusStoreBlobApi};
 use crate::{
     ObjectID,
-    client::Client as WalrusClient,
+    client::WalrusNodeClient,
     config::{ClientConfig as WalrusConfig, load_configuration},
     core::{
         BlobId,

--- a/crates/walrus-service/bin/deploy.rs
+++ b/crates/walrus-service/bin/deploy.rs
@@ -637,7 +637,7 @@ mod commands {
         if serialize_unsigned {
             // Compile package
             let chain_id = contract_client
-                .sui_client()
+                .retriable_sui_client()
                 .get_chain_identifier()
                 .await
                 .ok();

--- a/crates/walrus-service/src/backup/service.rs
+++ b/crates/walrus-service/src/backup/service.rs
@@ -26,7 +26,7 @@ use sui_types::event::EventID;
 use tokio_util::sync::CancellationToken;
 use walrus_core::{BlobId, encoding::Primary};
 use walrus_sdk::{
-    client::Client,
+    client::WalrusNodeClient,
     config::{ClientConfig, combine_rpc_urls},
 };
 use walrus_sui::{
@@ -604,9 +604,11 @@ async fn backup_fetcher(
     let walrus_client_config =
         ClientConfig::new_from_contract_config(backup_config.sui.contract_config.clone());
 
-    let read_client =
-        Client::new_read_client_with_refresher(walrus_client_config, sui_read_client.clone())
-            .await?;
+    let read_client = WalrusNodeClient::new_read_client_with_refresher(
+        walrus_client_config,
+        sui_read_client.clone(),
+    )
+    .await?;
 
     let mut consecutive_fetch_errors = 0;
     loop {

--- a/crates/walrus-service/src/backup/service.rs
+++ b/crates/walrus-service/src/backup/service.rs
@@ -661,7 +661,7 @@ async fn backup_fetch_inner_core(
     conn: &mut AsyncPgConnection,
     backup_config: &BackupConfig,
     backup_metric_set: &BackupFetcherMetricSet,
-    read_client: &Client<SuiReadClient>,
+    read_client: &WalrusNodeClient<SuiReadClient>,
     blob_id: BlobId,
 ) -> Result<()> {
     tracing::info!(blob_id = %blob_id, "[backup_fetcher] received work item");

--- a/crates/walrus-service/src/client/cli.rs
+++ b/crates/walrus-service/src/client/cli.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 use walrus_core::{BlobId, QuiltPatchId, encoding::QuiltError};
 use walrus_sdk::{
     blocklist::Blocklist,
-    client::Client,
+    client::WalrusNodeClient,
     config::ClientConfig,
     sui::client::{SuiContractClient, SuiReadClient, retry_client::RetriableSuiClient},
 };
@@ -48,7 +48,8 @@ pub use args::{
 pub use cli_output::CliOutput;
 pub use runner::ClientCommandRunner;
 
-/// Creates a [`Client`] based on the provided [`ClientConfig`] with read-only access to Sui.
+/// Creates a [`WalrusNodeClient`] based on the provided [`ClientConfig`] with read-only access to
+/// Sui.
 ///
 /// The RPC URL is set based on the `rpc_url` parameter (if `Some`), the `rpc_url` field in the
 /// `config` (if `Some`), or the `wallet` (if `Ok`). An error is returned if it cannot be set
@@ -58,7 +59,7 @@ pub async fn get_read_client(
     rpc_url: Option<String>,
     wallet: Result<Wallet>,
     blocklist_path: &Option<PathBuf>,
-) -> Result<Client<SuiReadClient>> {
+) -> Result<WalrusNodeClient<SuiReadClient>> {
     let sui_read_client =
         get_sui_read_client_from_rpc_node_or_wallet(&config, rpc_url, wallet).await?;
 
@@ -66,7 +67,7 @@ pub async fn get_read_client(
         .refresh_config
         .build_refresher_and_run(sui_read_client.clone())
         .await?;
-    let client = Client::new_read_client(config, refresh_handle, sui_read_client).await?;
+    let client = WalrusNodeClient::new_read_client(config, refresh_handle, sui_read_client).await?;
 
     if blocklist_path.is_some() {
         Ok(client.with_blocklist(Blocklist::new(blocklist_path)?))
@@ -75,21 +76,21 @@ pub async fn get_read_client(
     }
 }
 
-/// Creates a [`Client<SuiContractClient>`] based on the provided [`ClientConfig`] with
+/// Creates a [`WalrusNodeClient<SuiContractClient>`] based on the provided [`ClientConfig`] with
 /// write access to Sui.
 pub async fn get_contract_client(
     config: ClientConfig,
     wallet: Result<Wallet>,
     gas_budget: Option<u64>,
     blocklist_path: &Option<PathBuf>,
-) -> Result<Client<SuiContractClient>> {
+) -> Result<WalrusNodeClient<SuiContractClient>> {
     let sui_client = config.new_contract_client(wallet?, gas_budget).await?;
 
     let refresh_handle = config
         .refresh_config
         .build_refresher_and_run(sui_client.read_client().clone())
         .await?;
-    let client = Client::new_contract_client(config, refresh_handle, sui_client).await?;
+    let client = WalrusNodeClient::new_contract_client(config, refresh_handle, sui_client).await?;
 
     if blocklist_path.is_some() {
         Ok(client.with_blocklist(Blocklist::new(blocklist_path)?))

--- a/crates/walrus-service/src/client/cli/runner.rs
+++ b/crates/walrus-service/src/client/cli/runner.rs
@@ -39,9 +39,9 @@ use walrus_core::{
 };
 use walrus_sdk::{
     client::{
-        Client,
         NodeCommunicationFactory,
         StoreArgs,
+        WalrusNodeClient,
         quilt_client::{
             assign_identifiers_with_paths,
             generate_identifier_from_path,
@@ -597,7 +597,8 @@ impl ClientCommandRunner {
         let config = self.config?;
         let sui_read_client =
             get_sui_read_client_from_rpc_node_or_wallet(&config, rpc_url, self.wallet).await?;
-        let read_client = Client::new_read_client_with_refresher(config, sui_read_client).await?;
+        let read_client =
+            WalrusNodeClient::new_read_client_with_refresher(config, sui_read_client).await?;
 
         let quilt_read_client = read_client.quilt_client();
 
@@ -643,7 +644,8 @@ impl ClientCommandRunner {
         let config = self.config?;
         let sui_read_client =
             get_sui_read_client_from_rpc_node_or_wallet(&config, rpc_url, self.wallet).await?;
-        let read_client = Client::new_read_client_with_refresher(config, sui_read_client).await?;
+        let read_client =
+            WalrusNodeClient::new_read_client_with_refresher(config, sui_read_client).await?;
 
         let quilt_read_client = read_client.quilt_client();
         let quilt_metadata = quilt_read_client.get_quilt_metadata(&quilt_id).await?;
@@ -758,7 +760,7 @@ impl ClientCommandRunner {
     }
 
     async fn store_dry_run(
-        client: Client<SuiContractClient>,
+        client: WalrusNodeClient<SuiContractClient>,
         files: Vec<PathBuf>,
         encoding_type: EncodingType,
         epochs_ahead: EpochCount,
@@ -933,7 +935,7 @@ impl ClientCommandRunner {
 
     /// Performs a dry run of storing a quilt.
     async fn store_quilt_dry_run(
-        client: Client<SuiContractClient>,
+        client: WalrusNodeClient<SuiContractClient>,
         blobs: &[QuiltStoreBlob<'static>],
         encoding_type: EncodingType,
         epochs_ahead: EpochCount,
@@ -995,7 +997,7 @@ impl ClientCommandRunner {
             .refresh_config
             .build_refresher_and_run(sui_read_client.clone())
             .await?;
-        let client = Client::new(config, refresher_handle).await?;
+        let client = WalrusNodeClient::new(config, refresher_handle).await?;
 
         let file = file_or_blob_id.file.clone();
         let blob_id =
@@ -1532,7 +1534,7 @@ impl ClientCommandRunner {
 }
 
 async fn delete_blob(
-    client: &Client<SuiContractClient>,
+    client: &WalrusNodeClient<SuiContractClient>,
     target: BlobIdentity,
     confirmation: UserConfirmation,
     no_status_check: bool,
@@ -1635,7 +1637,7 @@ async fn delete_blob(
 async fn get_epochs_ahead(
     epoch_arg: EpochArg,
     max_epochs_ahead: EpochCount,
-    client: &Client<SuiContractClient>,
+    client: &WalrusNodeClient<SuiContractClient>,
 ) -> Result<u32, anyhow::Error> {
     let epochs_ahead = match epoch_arg {
         EpochArg {

--- a/crates/walrus-service/src/client/daemon.rs
+++ b/crates/walrus-service/src/client/daemon.rs
@@ -55,8 +55,8 @@ use walrus_core::{
 };
 use walrus_sdk::{
     client::{
-        Client,
         StoreArgs,
+        WalrusNodeClient,
         responses::{BlobStoreResult, QuiltStoreResult},
     },
     error::{ClientError, ClientResult},
@@ -162,7 +162,7 @@ pub trait WalrusWriteClient: WalrusReadClient {
     fn default_post_store_action(&self) -> PostStoreAction;
 }
 
-impl<T: ReadClient> WalrusReadClient for Client<T> {
+impl<T: ReadClient> WalrusReadClient for WalrusNodeClient<T> {
     async fn read_blob(&self, blob_id: &BlobId) -> ClientResult<Vec<u8>> {
         self.read_blob_retry_committees::<Primary>(blob_id).await
     }
@@ -200,7 +200,7 @@ impl<T: ReadClient> WalrusReadClient for Client<T> {
     }
 }
 
-impl WalrusWriteClient for Client<SuiContractClient> {
+impl WalrusWriteClient for WalrusNodeClient<SuiContractClient> {
     async fn write_blob(
         &self,
         blob: &[u8],

--- a/crates/walrus-service/src/common/utils.rs
+++ b/crates/walrus-service/src/common/utils.rs
@@ -757,11 +757,14 @@ pub(crate) fn unwrap_or_resume_unwind<T, E: std::convert::From<tokio::task::Join
 pub async fn create_walrus_client_with_refresher(
     contract_config: ContractConfig,
     sui_read_client: walrus_sui::client::SuiReadClient,
-) -> anyhow::Result<walrus_sdk::client::Client<walrus_sui::client::SuiReadClient>> {
+) -> anyhow::Result<walrus_sdk::client::WalrusNodeClient<walrus_sui::client::SuiReadClient>> {
     let client_config = crate::client::ClientConfig::new_from_contract_config(contract_config);
-    walrus_sdk::client::Client::new_read_client_with_refresher(client_config, sui_read_client)
-        .await
-        .map_err(anyhow::Error::from)
+    walrus_sdk::client::WalrusNodeClient::new_read_client_with_refresher(
+        client_config,
+        sui_read_client,
+    )
+    .await
+    .map_err(anyhow::Error::from)
 }
 
 #[cfg(test)]

--- a/crates/walrus-service/src/event/event_blob_downloader.rs
+++ b/crates/walrus-service/src/event/event_blob_downloader.rs
@@ -10,7 +10,7 @@ use std::{
 
 use anyhow::Result;
 use walrus_core::{BlobId, Epoch};
-use walrus_sdk::{client::Client as WalrusClient, error::ClientResult};
+use walrus_sdk::{client::WalrusNodeClient, error::ClientResult};
 use walrus_sui::{
     client::{ReadClient, SuiReadClient},
     types::move_structs::EventBlob,
@@ -62,13 +62,16 @@ pub enum LastCertifiedEventBlob {
 /// Responsible for downloading and managing event blobs
 #[derive(Debug)]
 pub struct EventBlobDownloader {
-    walrus_client: WalrusClient<SuiReadClient>,
+    walrus_client: WalrusNodeClient<SuiReadClient>,
     sui_read_client: SuiReadClient,
 }
 
 impl EventBlobDownloader {
     /// Creates a new instance of the event blob downloader.
-    pub fn new(walrus_client: WalrusClient<SuiReadClient>, sui_read_client: SuiReadClient) -> Self {
+    pub fn new(
+        walrus_client: WalrusNodeClient<SuiReadClient>,
+        sui_read_client: SuiReadClient,
+    ) -> Self {
         Self {
             walrus_client,
             sui_read_client,

--- a/crates/walrus-service/src/event/event_processor/catchup.rs
+++ b/crates/walrus-service/src/event/event_processor/catchup.rs
@@ -294,7 +294,7 @@ impl EventBlobCatchupManager {
         let sui_read_client =
             SuiReadClient::new(self.clients.sui_client.clone(), &contract_config).await?;
         let config = crate::client::ClientConfig::new_from_contract_config(contract_config);
-        let walrus_client = walrus_sdk::client::Client::new_read_client_with_refresher(
+        let walrus_client = walrus_sdk::client::WalrusNodeClient::new_read_client_with_refresher(
             config,
             sui_read_client.clone(),
         )

--- a/crates/walrus-service/src/node/contract_service.rs
+++ b/crates/walrus-service/src/node/contract_service.rs
@@ -626,7 +626,7 @@ impl SystemContractService for SuiSystemContractService {
     ) -> Result<StorageNodeCap, SuiClientError> {
         let node_capability = if let Some(node_cap) = node_capability_object_id {
             self.read_client
-                .sui_client()
+                .retriable_sui_client()
                 .get_sui_object(node_cap)
                 .await?
         } else {

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -2548,7 +2548,7 @@ pub mod test_cluster {
         ) -> anyhow::Result<(
             Arc<TokioMutex<TestClusterHandle>>,
             TestCluster<StorageNodeHandle>,
-            WithTempDir<client::Client<SuiContractClient>>,
+            WithTempDir<client::WalrusNodeClient<SuiContractClient>>,
             SystemContext,
         )> {
             self.build_generic().await
@@ -2563,7 +2563,7 @@ pub mod test_cluster {
         ) -> anyhow::Result<(
             Arc<TokioMutex<TestClusterHandle>>,
             TestCluster<T>,
-            WithTempDir<client::Client<SuiContractClient>>,
+            WithTempDir<client::WalrusNodeClient<SuiContractClient>>,
             SystemContext,
         )> {
             #[cfg(not(msim))]
@@ -2784,7 +2784,10 @@ pub mod test_cluster {
 
             let client = admin_contract_client
                 .and_then_async(|contract_client| {
-                    client::Client::new_contract_client_with_refresher(config, contract_client)
+                    client::WalrusNodeClient::new_contract_client_with_refresher(
+                        config,
+                        contract_client,
+                    )
                 })
                 .await?;
 

--- a/crates/walrus-simtest/src/test_utils.rs
+++ b/crates/walrus-simtest/src/test_utils.rs
@@ -21,7 +21,7 @@ pub mod simtest_utils {
         EpochCount,
         encoding::{Primary, Secondary},
     };
-    use walrus_sdk::client::{Client, StoreArgs, responses::BlobStoreResult};
+    use walrus_sdk::client::{StoreArgs, WalrusNodeClient, responses::BlobStoreResult};
     use walrus_service::test_utils::{SimStorageNodeHandle, TestCluster};
     use walrus_storage_node_client::api::ServiceHealthInfo;
     use walrus_sui::{
@@ -73,7 +73,7 @@ pub mod simtest_utils {
     /// Gets the last certified event blob from the client.
     /// Returns the last certified event blob if it exists, otherwise panics.
     pub async fn get_last_certified_event_blob_must_succeed(
-        client: &Arc<WithTempDir<Client<SuiContractClient>>>,
+        client: &Arc<WithTempDir<WalrusNodeClient<SuiContractClient>>>,
     ) -> EventBlob {
         const TIMEOUT: Duration = Duration::from_secs(10);
         let start = Instant::now();
@@ -99,7 +99,7 @@ pub mod simtest_utils {
     ///
     // TODO(zhewu): restructure this to a test client.
     pub async fn write_read_and_check_random_blob(
-        client: &WithTempDir<Client<SuiContractClient>>,
+        client: &WithTempDir<WalrusNodeClient<SuiContractClient>>,
         data_length: usize,
         write_only: bool,
         deletable: bool,
@@ -240,7 +240,7 @@ pub mod simtest_utils {
 
     /// Probabilistically extend one of the blobs from blobs_written.
     async fn maybe_extend_blob(
-        client: &WithTempDir<Client<SuiContractClient>>,
+        client: &WithTempDir<WalrusNodeClient<SuiContractClient>>,
         blobs_written: &HashSet<ObjectID>,
     ) {
         // Probabilistically extend one of the blobs from blobs_written.
@@ -261,7 +261,7 @@ pub mod simtest_utils {
 
     /// Probabilistically delete one of the blobs from blobs_written.
     async fn maybe_delete_blob(
-        client: &WithTempDir<Client<SuiContractClient>>,
+        client: &WithTempDir<WalrusNodeClient<SuiContractClient>>,
         blobs_written: &HashSet<ObjectID>,
     ) {
         if rand::thread_rng().gen_bool(0.1) {
@@ -276,7 +276,7 @@ pub mod simtest_utils {
 
     /// Starts a background workload that writes and reads random blobs.
     pub fn start_background_workload(
-        client_clone: Arc<WithTempDir<Client<SuiContractClient>>>,
+        client_clone: Arc<WithTempDir<WalrusNodeClient<SuiContractClient>>>,
         write_only: bool,
         max_retry_count: Option<usize>,
         epochs_max: Option<EpochCount>,

--- a/crates/walrus-simtest/tests/simtest.rs
+++ b/crates/walrus-simtest/tests/simtest.rs
@@ -29,7 +29,7 @@ mod tests {
     use tokio::sync::RwLock;
     use walrus_core::EpochCount;
     use walrus_proc_macros::walrus_simtest;
-    use walrus_sdk::client::{Client, StoreArgs, metrics::ClientMetrics};
+    use walrus_sdk::client::{StoreArgs, WalrusNodeClient, metrics::ClientMetrics};
     use walrus_service::{
         client::ClientCommunicationConfig,
         event::event_processor::config::EventProcessorConfig,
@@ -1109,7 +1109,7 @@ mod tests {
     }
 
     async fn wait_for_event_blob_writer_to_make_progress(
-        client: &Arc<WithTempDir<Client<SuiContractClient>>>,
+        client: &Arc<WithTempDir<WalrusNodeClient<SuiContractClient>>>,
         last_certified_event_blob: EventBlob,
     ) {
         loop {

--- a/crates/walrus-simtest/tests/simtest_event_blob.rs
+++ b/crates/walrus-simtest/tests/simtest_event_blob.rs
@@ -17,7 +17,7 @@ mod tests {
     use typed_store::rocks::be_fix_int_ser;
     use walrus_core::{BlobId, test_utils};
     use walrus_proc_macros::walrus_simtest;
-    use walrus_sdk::{client::Client, config::ClientCommunicationConfig};
+    use walrus_sdk::{client::WalrusNodeClient, config::ClientCommunicationConfig};
     use walrus_service::{
         node::{DatabaseConfig, event_blob_writer::CertifiedEventBlobMetadata},
         test_utils::{SimStorageNodeHandle, TestCluster, TestNodesConfig, test_cluster},
@@ -27,7 +27,7 @@ mod tests {
     use walrus_test_utils::WithTempDir;
 
     async fn wait_for_certification_stuck(
-        client: &Arc<WithTempDir<Client<SuiContractClient>>>,
+        client: &Arc<WithTempDir<WalrusNodeClient<SuiContractClient>>>,
     ) -> EventBlob {
         let start = Instant::now();
         let mut last_blob_time = Instant::now();
@@ -63,7 +63,7 @@ mod tests {
 
     async fn wait_for_event_blob_writer_to_fork(
         walrus_cluster: &mut TestCluster<SimStorageNodeHandle>,
-        client: &Arc<WithTempDir<Client<SuiContractClient>>>,
+        client: &Arc<WithTempDir<WalrusNodeClient<SuiContractClient>>>,
         node_index: usize,
     ) -> Result<(), anyhow::Error> {
         let node = &walrus_cluster.nodes[node_index];

--- a/crates/walrus-stress/src/generator.rs
+++ b/crates/walrus-stress/src/generator.rs
@@ -19,7 +19,7 @@ use tokio::{
 use walrus_core::{BlobId, EpochCount, encoding::Primary};
 use walrus_sdk::{
     client::{
-        Client,
+        WalrusNodeClient,
         metrics::{self, ClientMetrics},
     },
     config::ClientConfig,
@@ -49,8 +49,8 @@ use write_client::WriteClient;
 pub struct LoadGenerator {
     write_client_pool: Receiver<WriteClient>,
     write_client_pool_tx: Sender<WriteClient>,
-    read_client_pool: Receiver<Client<SuiReadClient>>,
-    read_client_pool_tx: Sender<Client<SuiReadClient>>,
+    read_client_pool: Receiver<WalrusNodeClient<SuiReadClient>>,
+    read_client_pool_tx: Sender<WalrusNodeClient<SuiReadClient>>,
     metrics: Arc<ClientMetrics>,
     _refill_handles: RefillHandles,
 }
@@ -86,7 +86,7 @@ impl LoadGenerator {
             .build_refresher_and_run(sui_read_client.clone())
             .await?;
         for read_client in try_join_all((0..n_clients).map(|_| {
-            Client::new_read_client(
+            WalrusNodeClient::new_read_client(
                 client_config.clone(),
                 refresher_handle.clone(),
                 sui_read_client.clone(),

--- a/crates/walrus-stress/src/generator/write_client.rs
+++ b/crates/walrus-stress/src/generator/write_client.rs
@@ -19,7 +19,12 @@ use walrus_core::{
     metadata::VerifiedBlobMetadataWithId,
 };
 use walrus_sdk::{
-    client::{Client, StoreArgs, metrics::ClientMetrics, refresh::CommitteesRefresherHandle},
+    client::{
+        StoreArgs,
+        WalrusNodeClient,
+        metrics::ClientMetrics,
+        refresh::CommitteesRefresherHandle,
+    },
     error::ClientError,
     store_optimizations::StoreOptimizations,
 };
@@ -44,7 +49,7 @@ use super::blob::{BlobData, WriteBlobConfig};
 /// Client for writing test blobs to storage nodes
 #[derive(Debug)]
 pub(crate) struct WriteClient {
-    client: WithTempDir<Client<SuiContractClient>>,
+    client: WithTempDir<WalrusNodeClient<SuiContractClient>>,
     blob: BlobData,
     metrics: Arc<ClientMetrics>,
 }
@@ -244,7 +249,7 @@ async fn new_client(
     gas_budget: Option<u64>,
     refresher_handle: CommitteesRefresherHandle,
     refiller: Refiller,
-) -> anyhow::Result<WithTempDir<Client<SuiContractClient>>> {
+) -> anyhow::Result<WithTempDir<WalrusNodeClient<SuiContractClient>>> {
     // Create the client with a separate wallet
     let wallet = wallet_for_testing_from_refill(config, network, refiller).await?;
     let rpc_urls = &[wallet.as_ref().get_rpc_url()?];
@@ -268,7 +273,7 @@ async fn new_client(
 
     let client = sui_contract_client
         .and_then_async(|contract_client| {
-            Client::new_contract_client(config.clone(), refresher_handle, contract_client)
+            WalrusNodeClient::new_contract_client(config.clone(), refresher_handle, contract_client)
         })
         .await?;
     Ok(client)

--- a/crates/walrus-stress/src/main.rs
+++ b/crates/walrus-stress/src/main.rs
@@ -17,7 +17,7 @@ use clap::{Parser, Subcommand};
 use generator::blob::WriteBlobConfig;
 use rand::{RngCore, seq::SliceRandom};
 use sui_types::base_types::ObjectID;
-use walrus_sdk::client::{Client, metrics::ClientMetrics};
+use walrus_sdk::client::{WalrusNodeClient, metrics::ClientMetrics};
 use walrus_service::client::{ClientConfig, Refiller};
 use walrus_stress::single_client_workload::{
     SingleClientWorkload,
@@ -367,7 +367,9 @@ async fn run_single_client_workload(
     )
     .context("Failed to load wallet context")?;
     let contract_client = client_config.new_contract_client(wallet, None).await?;
-    let client = Client::new_contract_client_with_refresher(client_config, contract_client).await?;
+    let client =
+        WalrusNodeClient::new_contract_client_with_refresher(client_config, contract_client)
+            .await?;
 
     let single_client_workload = SingleClientWorkload::new(
         client,

--- a/crates/walrus-stress/src/single_client_workload/blob_pool.rs
+++ b/crates/walrus-stress/src/single_client_workload/blob_pool.rs
@@ -9,7 +9,7 @@ use rand::{Rng, seq::IteratorRandom};
 use walrus_core::{BlobId, Epoch, EpochCount};
 use walrus_sdk::ObjectID;
 
-use super::client_op_generator::WalrusClientOp;
+use super::client_op_generator::WalrusNodeClientOp;
 
 /// Data and info of a blob.
 pub(crate) struct BlobDataAndInfo {
@@ -58,10 +58,10 @@ impl BlobPool {
         &mut self,
         blob_id: BlobId,
         blob_object_id: Option<ObjectID>,
-        op: WalrusClientOp,
+        op: WalrusNodeClientOp,
     ) {
         match op {
-            WalrusClientOp::Write {
+            WalrusNodeClientOp::Write {
                 blob,
                 deletable,
                 store_epoch_ahead,
@@ -74,23 +74,23 @@ impl BlobPool {
                     store_epoch_ahead,
                 );
             }
-            WalrusClientOp::Delete { blob_id } => {
+            WalrusNodeClientOp::Delete { blob_id } => {
                 self.delete_blob(blob_id);
             }
-            WalrusClientOp::Extend {
+            WalrusNodeClientOp::Extend {
                 blob_id,
                 object_id: _object_id,
                 store_epoch_ahead,
             } => {
                 self.extend_blob(blob_id, store_epoch_ahead);
             }
-            WalrusClientOp::Read {
+            WalrusNodeClientOp::Read {
                 blob_id: _blob_id,
                 sliver_type: _sliver_type,
             } => {
                 // Do nothing.
             }
-            WalrusClientOp::None => {
+            WalrusNodeClientOp::None => {
                 // Do nothing.
             }
         }
@@ -197,7 +197,7 @@ mod tests {
         let object_id = create_test_object_id();
         let blob_data = create_test_blob_data();
 
-        let write_op = WalrusClientOp::Write {
+        let write_op = WalrusNodeClientOp::Write {
             blob: blob_data.clone(),
             deletable: true,
             store_epoch_ahead: 10,
@@ -223,7 +223,7 @@ mod tests {
         let object_id = create_test_object_id();
 
         // First add a blob
-        let write_op = WalrusClientOp::Write {
+        let write_op = WalrusNodeClientOp::Write {
             blob: create_test_blob_data(),
             deletable: true,
             store_epoch_ahead: 10,
@@ -232,7 +232,7 @@ mod tests {
         assert!(!pool.is_empty());
 
         // Then delete it
-        let delete_op = WalrusClientOp::Delete { blob_id };
+        let delete_op = WalrusNodeClientOp::Delete { blob_id };
         pool.update_blob_pool(blob_id, None, delete_op);
 
         assert!(pool.is_empty());
@@ -246,7 +246,7 @@ mod tests {
         let object_id = create_test_object_id();
 
         // First add a blob
-        let write_op = WalrusClientOp::Write {
+        let write_op = WalrusNodeClientOp::Write {
             blob: create_test_blob_data(),
             deletable: true,
             store_epoch_ahead: 10,
@@ -254,7 +254,7 @@ mod tests {
         pool.update_blob_pool(blob_id, Some(object_id), write_op);
 
         // Then extend it
-        let extend_op = WalrusClientOp::Extend {
+        let extend_op = WalrusNodeClientOp::Extend {
             blob_id,
             object_id,
             store_epoch_ahead: 5,
@@ -272,7 +272,7 @@ mod tests {
         let object_id = create_test_object_id();
 
         // First add a blob
-        let write_op = WalrusClientOp::Write {
+        let write_op = WalrusNodeClientOp::Write {
             blob: create_test_blob_data(),
             deletable: true,
             store_epoch_ahead: 10,
@@ -280,7 +280,7 @@ mod tests {
         pool.update_blob_pool(blob_id, Some(object_id), write_op);
 
         // Read operation should not change anything
-        let read_op = WalrusClientOp::Read {
+        let read_op = WalrusNodeClientOp::Read {
             blob_id,
             sliver_type: SliverType::Primary,
         };
@@ -298,7 +298,7 @@ mod tests {
         let object_id = create_test_object_id();
         let blob_data = create_test_blob_data();
 
-        let write_op = WalrusClientOp::Write {
+        let write_op = WalrusNodeClientOp::Write {
             blob: blob_data.clone(),
             deletable: true,
             store_epoch_ahead: 10,
@@ -316,7 +316,7 @@ mod tests {
         let blob_id = create_test_blob_id();
         let object_id = create_test_object_id();
 
-        let write_op = WalrusClientOp::Write {
+        let write_op = WalrusNodeClientOp::Write {
             blob: create_test_blob_data(),
             deletable: true,
             store_epoch_ahead: 10,
@@ -337,17 +337,17 @@ mod tests {
         let blob_id3 = BlobId([3; 32]);
         let object_id = create_test_object_id();
 
-        let write_op1 = WalrusClientOp::Write {
+        let write_op1 = WalrusNodeClientOp::Write {
             blob: vec![1],
             deletable: true,
             store_epoch_ahead: 5,
         };
-        let write_op2 = WalrusClientOp::Write {
+        let write_op2 = WalrusNodeClientOp::Write {
             blob: vec![2],
             deletable: true,
             store_epoch_ahead: 10,
         };
-        let write_op3 = WalrusClientOp::Write {
+        let write_op3 = WalrusNodeClientOp::Write {
             blob: vec![3],
             deletable: true,
             store_epoch_ahead: 15,
@@ -376,7 +376,7 @@ mod tests {
 
         // Add deletable blob
         let deletable_blob_id = BlobId([1; 32]);
-        let write_op1 = WalrusClientOp::Write {
+        let write_op1 = WalrusNodeClientOp::Write {
             blob: vec![1],
             deletable: true,
             store_epoch_ahead: 10,
@@ -385,7 +385,7 @@ mod tests {
 
         // Add non-deletable blob
         let permanent_blob_id = BlobId([2; 32]);
-        let write_op2 = WalrusClientOp::Write {
+        let write_op2 = WalrusNodeClientOp::Write {
             blob: vec![2],
             deletable: false,
             store_epoch_ahead: 10,

--- a/crates/walrus-sui/benches/gas_cost_bench.rs
+++ b/crates/walrus-sui/benches/gas_cost_bench.rs
@@ -328,7 +328,7 @@ async fn gas_cost_summary_for_last_tx(
         ),
     );
     let transaction = walrus_client
-        .sui_client()
+        .retriable_sui_client()
         .query_transaction_blocks(query.clone(), None, None, true)
         .await?
         .data

--- a/crates/walrus-sui/src/client.rs
+++ b/crates/walrus-sui/src/client.rs
@@ -561,8 +561,8 @@ impl SuiContractClient {
     }
 
     /// Gets the [`RetriableSuiClient`] from the associated read client.
-    pub fn sui_client(&self) -> &RetriableSuiClient {
-        self.read_client.sui_client()
+    pub fn retriable_sui_client(&self) -> &RetriableSuiClient {
+        self.read_client.retriable_sui_client()
     }
 
     /// Returns the active address of the client.
@@ -1491,8 +1491,8 @@ impl SuiContractClientInner {
     }
 
     /// Gets the [`RetriableSuiClient`] from the associated read client.
-    pub fn sui_client(&self) -> &RetriableSuiClient {
-        self.read_client.sui_client()
+    pub fn retriable_sui_client(&self) -> &RetriableSuiClient {
+        self.read_client.retriable_sui_client()
     }
 
     /// Purchases blob storage for the next `epochs_ahead` Walrus epochs and an encoded
@@ -1550,7 +1550,9 @@ impl SuiContractClientInner {
             storage_id.len()
         );
 
-        self.sui_client().get_sui_object(storage_id[0]).await
+        self.retriable_sui_client()
+            .get_sui_object(storage_id[0])
+            .await
     }
 
     /// Registers a blob with the specified [`BlobId`] using the provided [`StorageResource`],
@@ -1578,7 +1580,9 @@ impl SuiContractClientInner {
             storage_id.len()
         );
 
-        self.sui_client().get_sui_object(storage_id[0]).await
+        self.retriable_sui_client()
+            .get_sui_object(storage_id[0])
+            .await
     }
 
     /// Registers a blob with the specified [`BlobId`] using the provided [`StorageResource`],
@@ -1630,7 +1634,9 @@ impl SuiContractClientInner {
             expected_num_blobs
         );
 
-        self.sui_client().get_sui_objects(&blob_obj_ids).await
+        self.retriable_sui_client()
+            .get_sui_objects(&blob_obj_ids)
+            .await
     }
 
     /// Purchases blob storage for the next `epochs_ahead` Walrus epochs and uses the resulting
@@ -1747,7 +1753,9 @@ impl SuiContractClientInner {
             expected_num_blobs
         );
 
-        self.sui_client().get_sui_objects(&blob_obj_ids).await
+        self.retriable_sui_client()
+            .get_sui_objects(&blob_obj_ids)
+            .await
     }
 
     /// Certifies the specified blob on Sui, given a certificate that confirms its storage and
@@ -1872,7 +1880,7 @@ impl SuiContractClientInner {
             cap_id.len()
         );
 
-        self.sui_client().get_sui_object(cap_id[0]).await
+        self.retriable_sui_client().get_sui_object(cap_id[0]).await
     }
 
     /// Registers candidate nodes, sending the resulting capability objects to the specified
@@ -1918,7 +1926,7 @@ impl SuiContractClientInner {
             cap_ids.len(),
         );
 
-        self.sui_client().get_sui_objects(&cap_ids).await
+        self.retriable_sui_client().get_sui_objects(&cap_ids).await
     }
 
     /// For each entry in `node_ids_with_amounts`, stakes the amount of WAL specified by the second
@@ -1958,7 +1966,9 @@ impl SuiContractClientInner {
             count
         );
 
-        self.sui_client().get_sui_objects(&staked_wal).await
+        self.retriable_sui_client()
+            .get_sui_objects(&staked_wal)
+            .await
     }
 
     /// Call to request withdrawal of stake from StakedWal object.
@@ -2031,7 +2041,7 @@ impl SuiContractClientInner {
         node_capability_object_id: ObjectID,
     ) -> SuiClientResult<()> {
         let node_capability: StorageNodeCap = self
-            .sui_client()
+            .retriable_sui_client()
             .get_sui_object(node_capability_object_id)
             .await?;
 
@@ -2087,7 +2097,11 @@ impl SuiContractClientInner {
         upgrade_type: UpgradeType,
     ) -> SuiClientResult<ObjectID> {
         // Compile package
-        let chain_id = self.sui_client().get_chain_identifier().await.ok();
+        let chain_id = self
+            .retriable_sui_client()
+            .get_chain_identifier()
+            .await
+            .ok();
         let (compiled_package, build_config) =
             compile_package(package_path, Default::default(), chain_id).await?;
 
@@ -2331,7 +2345,7 @@ impl SuiContractClientInner {
 
         // Execute the transaction and wait for response
         let response = self
-            .sui_client()
+            .retriable_sui_client()
             .execute_transaction(signed_transaction, method)
             .await?;
 
@@ -2359,9 +2373,12 @@ impl SuiContractClientInner {
     pub async fn merge_coins(&mut self) -> SuiClientResult<()> {
         let mut tx_builder = self.transaction_builder()?;
         let address = self.wallet.active_address()?;
-        let sui_balance = self.sui_client().get_balance(address, None).await?;
+        let sui_balance = self
+            .retriable_sui_client()
+            .get_balance(address, None)
+            .await?;
         let wal_balance = self
-            .sui_client()
+            .retriable_sui_client()
             .get_balance(address, Some(self.read_client().wal_coin_type().to_owned()))
             .await?;
 
@@ -2478,7 +2495,7 @@ impl SuiContractClientInner {
     ) -> SuiClientResult<ObjectID> {
         let blob: Blob = self
             .read_client
-            .sui_client()
+            .retriable_sui_client()
             .get_sui_object(blob_obj_id)
             .await?;
         let mut pt_builder = self.transaction_builder()?;
@@ -2517,7 +2534,7 @@ impl SuiContractClientInner {
     ) -> SuiClientResult<()> {
         let blob: Blob = self
             .read_client
-            .sui_client()
+            .retriable_sui_client()
             .get_sui_object(blob_obj_id)
             .await?;
         let mut pt_builder = self.transaction_builder()?;
@@ -2542,7 +2559,7 @@ impl SuiContractClientInner {
     ) -> SuiClientResult<()> {
         let blob: Blob = self
             .read_client
-            .sui_client()
+            .retriable_sui_client()
             .get_sui_object(blob_obj_id)
             .await?;
         let mut pt_builder = self.transaction_builder()?;
@@ -2845,7 +2862,7 @@ impl SuiContractClientInner {
         );
 
         let shared_blobs = self
-            .sui_client()
+            .retriable_sui_client()
             .get_sui_objects::<SharedBlob>(&object_ids)
             .await?;
 
@@ -2880,7 +2897,7 @@ impl SuiContractClientInner {
             // Fetch all SharedBlob objects and collect them as a mapping from blob object ID
             // to shared blob object ID.
             let shared_blobs = self
-                .sui_client()
+                .retriable_sui_client()
                 .get_sui_objects::<SharedBlob>(&object_ids)
                 .await?;
             Ok(shared_blobs

--- a/crates/walrus-sui/src/client/read_client.rs
+++ b/crates/walrus-sui/src/client/read_client.rs
@@ -354,7 +354,7 @@ impl SuiReadClient {
     }
 
     /// Gets the [`RetriableSuiClient`] from the associated read client.
-    pub fn sui_client(&self) -> &RetriableSuiClient {
+    pub fn retriable_sui_client(&self) -> &RetriableSuiClient {
         &self.sui_client
     }
 
@@ -620,7 +620,11 @@ impl SuiReadClient {
     /// Returns the digest of the package at `package_path` for the currently active sui network.
     pub async fn compute_package_digest(&self, package_path: PathBuf) -> SuiClientResult<[u8; 32]> {
         // Compile package to get the digest.
-        let chain_id = self.sui_client().get_chain_identifier().await.ok();
+        let chain_id = self
+            .retriable_sui_client()
+            .get_chain_identifier()
+            .await
+            .ok();
         tracing::info!(?chain_id, "chain identifier");
         let (compiled_package, _build_config) =
             compile_package(package_path, Default::default(), chain_id).await?;

--- a/crates/walrus-sui/src/client/transaction_builder.rs
+++ b/crates/walrus-sui/src/client/transaction_builder.rs
@@ -761,14 +761,14 @@ impl WalrusPtbBuilder {
     ) -> SuiClientResult<()> {
         let exchange: WalExchange = self
             .read_client
-            .sui_client()
+            .retriable_sui_client()
             .get_sui_object(exchange_id)
             .await?;
         // We can get the package ID from the exchange object because we only use it in testnet
         // and the exchange is currently not designed for upgrades.
         let exchange_package = self
             .read_client
-            .sui_client()
+            .retriable_sui_client()
             .get_package_id_from_object(exchange_id)
             .await?;
         let exchange_arg = self.pt_builder.obj(
@@ -1130,7 +1130,7 @@ impl WalrusPtbBuilder {
     ) -> SuiClientResult<Argument> {
         let object_data = self
             .read_client
-            .sui_client()
+            .retriable_sui_client()
             .get_object_with_options(object, SuiObjectDataOptions::new().with_type())
             .await?
             .data
@@ -1633,7 +1633,7 @@ impl WalrusPtbBuilder {
             Authorized::Object(receiver) => {
                 let object = self
                     .read_client
-                    .sui_client()
+                    .retriable_sui_client()
                     .get_object_with_options(receiver, SuiObjectDataOptions::default().with_owner())
                     .await?;
                 ensure!(
@@ -1664,7 +1664,7 @@ impl WalrusPtbBuilder {
             Some(credits_object_id) if with_credits => {
                 let credits_object = self
                     .read_client
-                    .sui_client()
+                    .retriable_sui_client()
                     .get_credits_object(credits_object_id)
                     .await?;
                 let subsidy = full_price * u64::from(credits_object.buyer_subsidy_rate)
@@ -1691,7 +1691,7 @@ impl WalrusPtbBuilder {
             Some(credits_object_id) if with_credits => {
                 let buyer_subsidy_rate = self
                     .read_client
-                    .sui_client()
+                    .retriable_sui_client()
                     .get_credits_object(credits_object_id)
                     .await?
                     .buyer_subsidy_rate;
@@ -1800,7 +1800,7 @@ pub async fn build_transaction_data_with_min_gas_balance(
     } else {
         let tx_kind = TransactionKind::ProgrammableTransaction(programmable_transaction.clone());
         read_client
-            .sui_client()
+            .retriable_sui_client()
             .estimate_gas_budget(sender_address, tx_kind, gas_price)
             .await?
     };

--- a/crates/walrus-sui/tests/test_walrus_sui.rs
+++ b/crates/walrus-sui/tests/test_walrus_sui.rs
@@ -572,7 +572,7 @@ async fn test_automatic_wal_coin_squashing(
     // `n_target_coins` coins.
     let n_coins = client_1
         .as_ref()
-        .sui_client()
+        .retriable_sui_client()
         .get_balance(
             client_1_address,
             Some(client_2.as_ref().read_client().wal_coin_type().to_owned()),
@@ -622,7 +622,7 @@ async fn test_automatic_wal_coin_squashing(
     assert_eq!(
         client_1
             .as_ref()
-            .sui_client()
+            .retriable_sui_client()
             .get_balance(
                 client_1_address,
                 Some(client_2.as_ref().read_client().wal_coin_type().to_owned()),

--- a/docs/book/walrus-sites/ci-cd-gh-workflow.md
+++ b/docs/book/walrus-sites/ci-cd-gh-workflow.md
@@ -20,7 +20,7 @@ This means:
 The action (`MystenLabs/walrus-sites/.github/actions/deploy`) requires these inputs:
 
 - **`SUI_ADDRESS`**: Your Sui address (GitHub variable)
-- **`SUI_KEYSTORE`**: Your private key in base64 format (GitHub secret)  
+- **`SUI_KEYSTORE`**: Your private key in base64 format (GitHub secret)
 - **`DIST`**: Path to your **built** site directory
 
 Optional inputs include:


### PR DESCRIPTION
## Description

The intent of this change is to reduce the mental overhead of reading Walrus code. Currently there are too many things called "client". This should alleviate this burden a tiny bit.

Rename `walrus_sdk::client::Client` to `walrus_sdk::client::WalrusNodeClient`.
Rename `walrus_sui::client::SuiContractClient::sui_client` to `walrus_sui::client::SuiContractClient::retriable_sui_client`.
Rename `walrus_sui::client::SuiContractClientInner::sui_client` to `walrus_sui::client::SuiContractClientInner::retriable_sui_client`.
Rename `walrus_sui::client::read_client::SuiReadClient::sui_client` to `walrus_sui::client::read_client::SuiReadClient::retriable_sui_client`.

## Test plan

CI Pipeline.