### PR TITLE
test: make unit tests work with `cargo test` and `cargo tarpaulin`

### DIFF
--- a/.github/actions/run_tarpaulin/action.yml
+++ b/.github/actions/run_tarpaulin/action.yml
@@ -1,6 +1,12 @@
 name: Test coverage
 description: Run all tests and report coverage
 
+inputs:
+  RUST_LOG:
+    description: Controls the logging level for the tests
+    required: false
+    default: "warn,walrus=info,checkpoint-downloader=info"
+
 runs:
   using: "composite"
   steps:
@@ -9,6 +15,8 @@ runs:
 
     - name: Run tests (including integration E2E tests) and record coverage
       run: cargo tarpaulin
+      env:
+        RUST_LOG: ${{ inputs.RUST_LOG }}
       shell: bash
 
     - name: Upload coverage report

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
       - uses: taiki-e/install-action@970d55e3ce02a46d60ffae7b4fab3dedace6e769 # pin@v2.49.13
         with:
-          tool: cargo-deny@0.17.0
+          tool: cargo-deny@0.18.4
       - name: Check dependencies
         run: cargo deny check bans licenses sources
 

--- a/.github/workflows/scheduled_reports.yml
+++ b/.github/workflows/scheduled_reports.yml
@@ -42,19 +42,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
       - uses: ./.github/actions/run_tarpaulin
 
-  simtests:
-    name: Run all simtests
-    runs-on: ubuntu-ghcloud
-    env:
-      MSIM_TEST_NUM: 30
-    steps:
-      - uses: taiki-e/install-action@970d55e3ce02a46d60ffae7b4fab3dedace6e769 # pin@v2.49.13
-        with:
-          tool: cargo-nextest
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
-      - run: ./scripts/simtest/install.sh
-      - run: cargo simtest simtest --profile simtest
-
   dependencies:
     name: Check dependencies (including vulnerabilities)
     runs-on: ubuntu-latest
@@ -62,6 +49,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
       - uses: taiki-e/install-action@970d55e3ce02a46d60ffae7b4fab3dedace6e769 # pin@v2.49.13
         with:
-          tool: cargo-deny@0.17.0
+          tool: cargo-deny@0.18.4
       - name: Check dependencies
         run: cargo deny check bans licenses sources

--- a/.tarpaulin.toml
+++ b/.tarpaulin.toml
@@ -3,9 +3,11 @@ out = ["Html", "Xml"]
 packages = [
   "walrus-core",
   "walrus-e2e-tests",
-  "walrus-rest-client",
+  "walrus-sdk",
   "walrus-service",
+  "walrus-storage-node-client",
   "walrus-sui",
+  "walrus-upload-relay",
   "walrus-utils",
 ]
 run-types = ["Lib", "Tests"]
@@ -26,5 +28,5 @@ exclude-files = [
   "crates/walrus-stress/**/*",
   "crates/walrus-test-utils/**/*",
 ]
-# Include all tests, even longer integration tests.
-args = ["--include-ignored"]
+# TODO(WAL-986): Add the following after end-to-end tests work with `cargo tarpaulin`.
+# args = ["--include-ignored"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1929,13 +1929,13 @@ dependencies = [
  "sui-macros",
  "sui-rpc-api",
  "sui-types",
- "telemetry-subscribers",
  "tempfile",
  "tokio",
  "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
  "typed-store 1.31.0",
  "walrus-sui",
+ "walrus-test-utils",
  "walrus-utils",
 ]
 
@@ -12832,7 +12832,6 @@ dependencies = [
  "sui-protocol-config",
  "sui-simulator",
  "sui-types",
- "telemetry-subscribers",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -13232,9 +13231,12 @@ name = "walrus-test-utils"
 version = "1.31.0"
 dependencies = [
  "anyhow",
+ "once_cell",
  "rand 0.8.5",
  "tempfile",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/checkpoint-downloader/Cargo.toml
+++ b/crates/checkpoint-downloader/Cargo.toml
@@ -17,7 +17,6 @@ serde_with.workspace = true
 sui-macros.workspace = true
 sui-rpc-api.workspace = true
 sui-types.workspace = true
-telemetry-subscribers.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tokio-util.workspace = true
 tracing.workspace = true
@@ -31,3 +30,4 @@ workspace = true
 [dev-dependencies]
 rocksdb.workspace = true
 tempfile.workspace = true
+walrus-test-utils.workspace = true

--- a/crates/checkpoint-downloader/src/downloader.rs
+++ b/crates/checkpoint-downloader/src/downloader.rs
@@ -578,7 +578,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn test_parallel_fetcher() -> Result<()> {
-        telemetry_subscribers::init_for_testing();
+        walrus_test_utils::init_tracing();
         let rest_url = "http://localhost:9000";
         let retriable_client = RetriableRpcClient::new(
             vec![LazyFallibleRpcClientBuilder::Url {

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
 use rstest::rstest;
 
 use super::*;
@@ -13,6 +15,12 @@ fn temp_dir() -> std::path::PathBuf {
     tempfile::tempdir()
         .expect("Failed to open temporary directory")
         .keep()
+}
+
+// Prevent tests running simultaneously to avoid interferences with metric registration.
+fn global_test_lock() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(Mutex::default).lock().unwrap()
 }
 
 enum TestIteratorWrapper<'a, K, V> {
@@ -407,14 +415,17 @@ async fn test_insert_batch_across_different_db() {
 
 #[tokio::test]
 async fn test_delete_batch() {
-    let db = DBMap::<i32, String>::open(
-        temp_dir(),
-        MetricConf::default(),
-        None,
-        None,
-        &ReadWriteOptions::default(),
-    )
-    .expect("Failed to open storage");
+    let db = {
+        let _lock = global_test_lock();
+        DBMap::<i32, String>::open(
+            temp_dir(),
+            MetricConf::default(),
+            None,
+            None,
+            &ReadWriteOptions::default(),
+        )
+        .expect("Failed to open storage")
+    };
 
     let keys_vals = (1..100).map(|i| (i, i.to_string()));
     let mut batch = db.batch();
@@ -437,14 +448,17 @@ async fn test_delete_batch() {
 
 #[tokio::test]
 async fn test_delete_range() {
-    let db: DBMap<i32, String> = DBMap::open(
-        temp_dir(),
-        MetricConf::default(),
-        None,
-        None,
-        &ReadWriteOptions::default().set_ignore_range_deletions(false),
-    )
-    .expect("Failed to open storage");
+    let db: DBMap<i32, String> = {
+        let _lock = global_test_lock();
+        DBMap::open(
+            temp_dir(),
+            MetricConf::default(),
+            None,
+            None,
+            &ReadWriteOptions::default().set_ignore_range_deletions(false),
+        )
+        .expect("Failed to open storage")
+    };
 
     // Note that the last element is (100, "100".to_owned()) here
     let keys_vals = (0..101).map(|i| (i, i.to_string()));
@@ -472,14 +486,17 @@ async fn test_delete_range() {
 
 #[tokio::test]
 async fn test_clear() {
-    let db = DBMap::<i32, String>::open(
-        temp_dir(),
-        MetricConf::default(),
-        None,
-        Some("table"),
-        &ReadWriteOptions::default(),
-    )
-    .expect("Failed to open storage");
+    let db = {
+        let _lock = global_test_lock();
+        DBMap::<i32, String>::open(
+            temp_dir(),
+            MetricConf::default(),
+            None,
+            Some("table"),
+            &ReadWriteOptions::default(),
+        )
+        .expect("Failed to open storage")
+    };
     // Test clear of empty map
     let _ = db.unsafe_clear();
 
@@ -613,14 +630,17 @@ async fn test_range_iter() {
 
 #[tokio::test]
 async fn test_is_empty() {
-    let db = DBMap::<i32, String>::open(
-        temp_dir(),
-        MetricConf::default(),
-        None,
-        Some("table"),
-        &ReadWriteOptions::default(),
-    )
-    .expect("Failed to open storage");
+    let db = {
+        let _lock = global_test_lock();
+        DBMap::<i32, String>::open(
+            temp_dir(),
+            MetricConf::default(),
+            None,
+            Some("table"),
+            &ReadWriteOptions::default(),
+        )
+        .expect("Failed to open storage")
+    };
 
     // Test empty map is truly empty
     assert!(db.is_empty());
@@ -731,6 +751,8 @@ async fn test_multi_remove() {
 }
 
 fn open_map<P: AsRef<Path>, K, V>(path: P, opt_cf: Option<&str>) -> DBMap<K, V> {
+    let _lock = global_test_lock();
+
     DBMap::<K, V>::open(
         path,
         MetricConf::default(),
@@ -861,16 +883,19 @@ async fn test_dbmap_ticker_statistics() {
     let metric_conf = MetricConf::new("test_db");
 
     // Open the database with multiple column families
-    let rocks = open_cf_opts(
-        &path,
-        Some(db_options),
-        metric_conf,
-        &[
-            ("cf1", default_db_options().options),
-            ("cf2", default_db_options().options),
-        ],
-    )
-    .expect("Failed to open database");
+    let rocks = {
+        let _lock = global_test_lock();
+        open_cf_opts(
+            &path,
+            Some(db_options),
+            metric_conf,
+            &[
+                ("cf1", default_db_options().options),
+                ("cf2", default_db_options().options),
+            ],
+        )
+        .expect("Failed to open database")
+    };
 
     // Create DBMaps for different column families
     let db_cf1: DBMap<i32, String> =

--- a/crates/walrus-core/src/encoding/quilt_encoding.rs
+++ b/crates/walrus-core/src/encoding/quilt_encoding.rs
@@ -1934,7 +1934,7 @@ mod tests {
         max_num_slivers_for_quilt_index: usize,
         expected: Result<usize, QuiltError>,
     ) {
-        let _ = tracing_subscriber::fmt().try_init();
+        walrus_test_utils::init_tracing();
         let res = utils::compute_symbol_size(
             blobs,
             n_columns,
@@ -2082,7 +2082,7 @@ mod tests {
     }
 
     fn construct_quilt(quilt_store_blobs: &[QuiltStoreBlob<'_>], config: EncodingConfigEnum) {
-        let _ = tracing_subscriber::fmt().try_init();
+        walrus_test_utils::init_tracing();
 
         let encoder = QuiltConfigV1::get_encoder(config.clone(), quilt_store_blobs);
 
@@ -2168,7 +2168,7 @@ mod tests {
         max_blob_size: usize,
         n_shards: u16,
     ) {
-        let _ = tracing_subscriber::fmt().try_init();
+        walrus_test_utils::init_tracing();
 
         const MAX_NUM_TAGS: usize = 10;
         const MAX_VALUE_LENGTH: usize = 100;
@@ -2191,7 +2191,7 @@ mod tests {
     }
 
     fn encode_decode_quilt(mut test_data: QuiltTestData<'_>, config: EncodingConfigEnum) {
-        let _ = tracing_subscriber::fmt().try_init();
+        walrus_test_utils::init_tracing();
 
         let quilt_store_blobs = test_data.take_blobs();
 
@@ -2232,7 +2232,7 @@ mod tests {
         let decode_index_result = quilt_decoder.get_or_decode_quilt_index();
         let missing_slivers =
             if let Err(QuiltError::MissingSlivers(missing_indices)) = decode_index_result {
-                tracing::info!("missing_indices: {:?}", missing_indices);
+                tracing::debug!("missing_indices: {:?}", missing_indices);
                 slivers
                     .iter()
                     .filter(|sliver| missing_indices.contains(&sliver.index))

--- a/crates/walrus-e2e-tests/Cargo.toml
+++ b/crates/walrus-e2e-tests/Cargo.toml
@@ -20,7 +20,6 @@ sui-macros.workspace = true
 sui-protocol-config.workspace = true
 sui-simulator.workspace = true
 sui-types.workspace = true
-telemetry-subscribers.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true

--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -113,7 +113,7 @@ async_param_test! {
     ]
 }
 async fn test_store_and_read_blob_without_failures(blob_size: usize) {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
     assert!(matches!(
         run_store_and_read_with_crash_failures(&[], &[], blob_size, None).await,
         Ok(()),
@@ -216,7 +216,7 @@ async fn test_store_and_read_blob_with_crash_failures(
     failed_shards_read: &[usize],
     expected_errors: &[ClientErrorKind],
 ) {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
     let result = run_store_and_read_with_crash_failures(
         failed_shards_write,
         failed_shards_read,
@@ -252,7 +252,7 @@ async fn run_store_and_read_with_crash_failures(
     data_length: usize,
     upload_relay_client: Option<UploadRelayClient>,
 ) -> TestResult {
-    let _ = tracing_subscriber::fmt::try_init();
+    walrus_test_utils::init_tracing();
 
     let (_sui_cluster_handle, mut cluster, client, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
@@ -288,7 +288,7 @@ async_param_test! {
 }
 /// Stores a blob that is inconsistent in 1 shard.
 async fn test_inconsistency(failed_nodes: &[usize]) -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
 
     let (_sui_cluster_handle, mut cluster, mut client, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
@@ -439,7 +439,7 @@ async fn test_store_with_existing_blob_resource(
     epochs_ahead_required: EpochCount,
     should_match: bool,
 ) -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
 
     let (_sui_cluster_handle, _cluster, client, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
@@ -575,7 +575,7 @@ async fn store_blob(
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 pub async fn test_store_and_read_duplicate_blobs() -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
 
     let (_sui_cluster_handle, _cluster, client, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
@@ -632,7 +632,7 @@ pub async fn test_store_and_read_duplicate_blobs() -> TestResult {
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_store_with_existing_blobs() -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
 
     let (_sui_cluster_handle, _cluster, client, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
@@ -747,7 +747,7 @@ async fn test_store_with_existing_storage_resource(
     epochs_ahead_required: EpochCount,
     should_match: bool,
 ) -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
 
     let (_sui_cluster_handle, _cluster, client, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
@@ -819,7 +819,7 @@ async_param_test! {
 }
 /// Tests blob object deletion.
 async fn test_delete_blob(blobs_to_create: u32) -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
     let (_sui_cluster_handle, _cluster, client, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
     let blob = walrus_test_utils::random_data(314);
@@ -877,7 +877,7 @@ async fn test_delete_blob(blobs_to_create: u32) -> TestResult {
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_storage_nodes_do_not_serve_data_for_deleted_blobs() -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
     let (_sui_cluster_handle, _cluster, client, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
     let client = client.as_ref();
@@ -947,7 +947,7 @@ async_param_test! {
 }
 /// Tests that a quilt can be stored.
 async fn test_store_quilt(blobs_to_create: u32) -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
 
     let test_nodes_config = TestNodesConfig {
         node_weights: vec![7, 7, 7, 7, 7],
@@ -1080,7 +1080,7 @@ async fn test_store_quilt(blobs_to_create: u32) -> TestResult {
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_blocklist() -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
     let blocklist_dir = tempfile::tempdir().expect("temporary directory creation must succeed");
     let (_sui_cluster_handle, _cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
         .with_test_nodes_config(TestNodesConfig {
@@ -1171,7 +1171,7 @@ async fn test_blocklist() -> TestResult {
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_blob_operations_with_credits() -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
     let (_sui_cluster_handle, _cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
         .with_credits()
         .build()
@@ -1237,7 +1237,7 @@ async fn test_blob_operations_with_credits() -> TestResult {
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_walrus_subsidies_get_called_by_node() -> TestResult {
-    let _ = tracing_subscriber::fmt::try_init();
+    walrus_test_utils::init_tracing();
 
     let (_sui_cluster_handle, cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
         .with_epoch_duration(Duration::from_secs(20))
@@ -1282,7 +1282,7 @@ async fn test_walrus_subsidies_get_called_by_node() -> TestResult {
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_multiple_stores_same_blob() -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
     let (_sui_cluster_handle, _cluster, client, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
     let client = client.as_ref();
@@ -1422,7 +1422,7 @@ async fn test_multiple_stores_same_blob() -> TestResult {
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_repeated_shard_move() -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
     let (_sui_cluster_handle, walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
         .with_epoch_duration(Duration::from_secs(20))
         .with_test_nodes_config(TestNodesConfig {
@@ -1500,7 +1500,7 @@ async fn test_repeated_shard_move() -> TestResult {
 async fn test_burn_blobs() -> TestResult {
     const N_BLOBS: usize = 3;
     const N_TO_DELETE: usize = 2;
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
 
     let (_sui_cluster_handle, _cluster, client, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
@@ -1551,7 +1551,7 @@ async fn test_burn_blobs() -> TestResult {
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_extend_owned_blobs() -> TestResult {
-    let _ = tracing_subscriber::fmt::try_init();
+    walrus_test_utils::init_tracing();
     let (_sui_cluster_handle, _cluster, client, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
 
@@ -1614,7 +1614,7 @@ async fn test_extend_owned_blobs() -> TestResult {
 async fn test_share_blobs() -> TestResult {
     const EXTEND_EPOCHS: EpochCount = 10;
     const INITIAL_FUNDS: u64 = 1000000000;
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
 
     let (_sui_cluster_handle, _cluster, client, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
@@ -1712,7 +1712,7 @@ async fn test_post_store_action(
     n_owned_blobs: usize,
     n_target_blobs: usize,
 ) -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
     let (_sui_cluster_handle, _cluster, client, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
     let target_address: SuiAddress = SuiAddress::from_bytes(TARGET_ADDRESS).expect("valid address");
@@ -1782,7 +1782,7 @@ async fn test_post_store_action(
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_store_blob_with_random_attributes() -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
 
     let (_sui_cluster_handle, _cluster, client, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
@@ -2013,7 +2013,7 @@ impl<'a> BlobAttributeTestContext<'a> {
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_blob_attribute_add_and_remove() -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
 
     let (_sui_cluster_handle, _cluster, mut client, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
@@ -2069,7 +2069,7 @@ async fn test_blob_attribute_add_and_remove() -> TestResult {
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_blob_attribute_fields_operations() -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
 
     let (_sui_cluster_handle, _cluster, mut client, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
@@ -2168,7 +2168,7 @@ async fn test_blob_attribute_fields_operations() -> TestResult {
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_shard_move_out_and_back_in_immediately() -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
     let (_sui_cluster_handle, walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
         .with_epoch_duration(Duration::from_secs(20))
         .with_test_nodes_config(TestNodesConfig {
@@ -2312,7 +2312,7 @@ async fn test_ptb_retriable_error() -> TestResult {
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 pub async fn test_select_coins_max_objects() -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
     let (sui_cluster_handle, _, _, _) = test_cluster::E2eTestSetupBuilder::new().build().await?;
 
     // Create a new wallet on the cluster.
@@ -2390,8 +2390,8 @@ pub async fn test_select_coins_max_objects() -> TestResult {
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_store_with_upload_relay_no_tip() {
-    telemetry_subscribers::init_for_testing();
-    let _ = tracing_subscriber::fmt::try_init();
+    walrus_test_utils::init_tracing();
+    walrus_test_utils::init_tracing();
 
     // Start the Sui and Walrus clusters.
     let (sui_cluster_handle, _cluster, cluster_client, _) =
@@ -2517,8 +2517,8 @@ fn get_upload_relay_url(server_address: &SocketAddr) -> Url {
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_store_with_upload_relay_with_tip() {
-    telemetry_subscribers::init_for_testing();
-    let _ = tracing_subscriber::fmt::try_init();
+    walrus_test_utils::init_tracing();
+    walrus_test_utils::init_tracing();
 
     // Start the Sui and Walrus clusters.
     let (sui_cluster_handle, _cluster, cluster_client, _system_context) =

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -4184,7 +4184,7 @@ mod tests {
 
     #[walrus_simtest]
     async fn cancel_expired_blob_sync_upon_epoch_change() -> TestResult {
-        telemetry_subscribers::init_for_testing();
+        walrus_test_utils::init_tracing();
 
         let shards: &[&[u16]] = &[&[1], &[0, 2, 3, 4]];
 
@@ -4954,9 +4954,14 @@ mod tests {
         Ok(())
     }
 
+    /// Waits for the shard to be synced.
     async fn wait_for_shard_in_active_state(shard_storage: &ShardStorage) -> TestResult {
-        // Waits for the shard to be synced.
-        tokio::time::timeout(Duration::from_secs(15), async {
+        let timeout = if cfg!(tarpaulin) {
+            Duration::from_secs(30)
+        } else {
+            Duration::from_secs(15)
+        };
+        tokio::time::timeout(timeout, async {
             loop {
                 let status = shard_storage.status().unwrap();
                 if status == ShardStatus::Active {
@@ -5903,7 +5908,7 @@ mod tests {
 
         #[walrus_simtest]
         async fn finish_epoch_change_start_should_not_block_event_processing() -> TestResult {
-            telemetry_subscribers::init_for_testing();
+            walrus_test_utils::init_tracing();
 
             // It is important to only use one node in this test, so that no other node would
             // drive epoch change on chain, and send events to the nodes.
@@ -6021,7 +6026,7 @@ mod tests {
         // Tests that storage node lag check is not affected by the blob writer cursor.
         #[walrus_simtest]
         async fn event_blob_cursor_should_not_affect_node_state() -> TestResult {
-            telemetry_subscribers::init_for_testing();
+            walrus_test_utils::init_tracing();
 
             // Set the initial cursor to a high value to simulate a severe lag to
             // blob writer cursor.
@@ -6553,7 +6558,7 @@ mod tests {
         ]
     }
     async fn process_epoch_change_start_idempotent(wait_for_shard_active: bool) -> TestResult {
-        let _ = tracing_subscriber::fmt::try_init();
+        walrus_test_utils::init_tracing();
 
         let (cluster, events, _blob_detail) =
             cluster_with_initial_epoch_and_certified_blob(&[&[0, 1], &[2, 3]], &[BLOB], 2, None)
@@ -6646,7 +6651,7 @@ mod tests {
         ]
     }
     async fn test_extend_blob_also_extends_registration(deletable: bool) -> TestResult {
-        let _ = tracing_subscriber::fmt::try_init();
+        walrus_test_utils::init_tracing();
 
         let (cluster, events, _blob_detail) =
             cluster_with_initial_epoch_and_certified_blob(&[&[0, 1, 2, 3]], &[], 1, None).await?;
@@ -6702,7 +6707,7 @@ mod tests {
     // Tests that blob extension is correctly handled after multiple epochs.
     #[tokio::test]
     async fn extend_blob_after_multiple_epochs() -> TestResult {
-        let _ = tracing_subscriber::fmt::try_init();
+        walrus_test_utils::init_tracing();
 
         let (cluster, events, _blob_detail) =
             cluster_with_initial_epoch_and_certified_blob(&[&[0, 1, 2, 3]], &[], 1, None).await?;

--- a/crates/walrus-service/src/node/config_synchronizer.rs
+++ b/crates/walrus-service/src/node/config_synchronizer.rs
@@ -448,9 +448,7 @@ mod tests {
         new_cert_subject: &str,
         expect_restart: bool,
     ) -> anyhow::Result<()> {
-        let _ = tracing_subscriber::fmt()
-            .with_max_level(tracing::Level::DEBUG)
-            .try_init();
+        walrus_test_utils::init_tracing();
 
         // Set up test environment with temporary directory and certificate.
         let temp_dir = TempDir::new()?;

--- a/crates/walrus-service/tests/epoch_change.rs
+++ b/crates/walrus-service/tests/epoch_change.rs
@@ -13,7 +13,7 @@ async fn nodes_drive_epoch_change() -> walrus_test_utils::Result {
     use walrus_core::Epoch;
     use walrus_service::test_utils::{StorageNodeHandleTrait, TestNodesConfig, test_cluster};
 
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
     let epoch_duration = Duration::from_secs(5);
     let (_sui, storage_nodes, _, _) = test_cluster::E2eTestSetupBuilder::new()
         .with_epoch_duration(epoch_duration)

--- a/crates/walrus-sui/tests/test_walrus_sui.rs
+++ b/crates/walrus-sui/tests/test_walrus_sui.rs
@@ -67,7 +67,7 @@ async fn initialize_contract_and_wallet_with_credits_with_single_node() -> anyho
 #[tokio::test]
 #[ignore = "ignore E2E tests by default"]
 async fn test_initialize_contract() -> anyhow::Result<()> {
-    _ = tracing_subscriber::fmt::try_init();
+    walrus_test_utils::init_tracing();
     initialize_contract_and_wallet_with_single_node().await?;
     Ok(())
 }
@@ -75,7 +75,7 @@ async fn test_initialize_contract() -> anyhow::Result<()> {
 #[tokio::test]
 #[ignore = "ignore integration tests by default"]
 async fn test_register_certify_blob_100_percent_buyer_credits() -> anyhow::Result<()> {
-    _ = tracing_subscriber::fmt::try_init();
+    walrus_test_utils::init_tracing();
     let encoding_type = EncodingType::RS2;
 
     let (_sui_cluster_handle, walrus_client, _, _) =
@@ -120,7 +120,7 @@ async fn test_register_certify_blob_100_percent_buyer_credits() -> anyhow::Resul
 #[tokio::test]
 #[ignore = "ignore integration tests by default"]
 async fn test_register_certify_blob() -> anyhow::Result<()> {
-    _ = tracing_subscriber::fmt::try_init();
+    walrus_test_utils::init_tracing();
     let encoding_type = EncodingType::RS2;
 
     let (_sui_cluster_handle, walrus_client, _, test_node_keys) =
@@ -306,7 +306,7 @@ async fn test_register_certify_blob() -> anyhow::Result<()> {
 #[tokio::test]
 #[ignore = "ignore integration tests by default"]
 async fn test_invalidate_blob() -> anyhow::Result<()> {
-    _ = tracing_subscriber::fmt::try_init();
+    walrus_test_utils::init_tracing();
 
     let (_sui_cluster_handle, walrus_client, _, test_node_keys) =
         initialize_contract_and_wallet_with_single_node().await?;
@@ -358,7 +358,7 @@ async fn test_invalidate_blob() -> anyhow::Result<()> {
 #[tokio::test]
 #[ignore = "ignore integration tests by default"]
 async fn test_get_committee() -> anyhow::Result<()> {
-    _ = tracing_subscriber::fmt::try_init();
+    walrus_test_utils::init_tracing();
     let (_sui_cluster_handle, walrus_client, _, test_node_keys) =
         initialize_contract_and_wallet_with_single_node().await?;
     let committee = walrus_client
@@ -386,7 +386,7 @@ async fn test_set_authorized() -> anyhow::Result<()> {
     use sui_types::base_types::ObjectID;
     use walrus_sui::types::move_structs::Authorized;
 
-    _ = tracing_subscriber::fmt::try_init();
+    walrus_test_utils::init_tracing();
     let (_sui_cluster_handle, walrus_client, _, _) =
         initialize_contract_and_wallet_with_single_node().await?;
     let protocol_key_pair = ProtocolKeyPair::generate();
@@ -456,7 +456,7 @@ async fn test_set_authorized() -> anyhow::Result<()> {
 #[tokio::test]
 #[ignore = "ignore integration tests by default"]
 async fn test_exchange_sui_for_wal() -> anyhow::Result<()> {
-    _ = tracing_subscriber::fmt::try_init();
+    walrus_test_utils::init_tracing();
     let (_sui_cluster_handle, walrus_client, system_context, _) =
         initialize_contract_and_wallet_with_single_node().await?;
     let exchange_id = walrus_client
@@ -485,7 +485,7 @@ async fn test_exchange_sui_for_wal() -> anyhow::Result<()> {
 #[tokio::test]
 #[ignore = "ignore integration tests by default"]
 async fn test_collect_commission() -> anyhow::Result<()> {
-    _ = tracing_subscriber::fmt::try_init();
+    walrus_test_utils::init_tracing();
 
     // Set zero duration, s.t. we can change the epoch whenever we need to.
     let (_sui_cluster_handle, walrus_client, _, _) =
@@ -544,7 +544,7 @@ async fn test_automatic_wal_coin_squashing(
     n_source_coins: u64,
     n_target_coins: u64,
 ) -> anyhow::Result<()> {
-    _ = tracing_subscriber::fmt::try_init();
+    walrus_test_utils::init_tracing();
     // Use a source_amount that is cleanly divisible by `n_target_coins` to make sure that we send
     // the full amount back in `n_target_coins` coins payments.
     let source_amount = 10_000 * n_target_coins;

--- a/crates/walrus-test-utils/Cargo.toml
+++ b/crates/walrus-test-utils/Cargo.toml
@@ -8,8 +8,11 @@ version.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+once_cell.workspace = true
 rand.workspace = true
 tempfile.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
 
 [lints]
 workspace = true

--- a/crates/walrus-utils/src/tracing_sampled.rs
+++ b/crates/walrus-utils/src/tracing_sampled.rs
@@ -152,7 +152,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn test_sampled_logging_new_macro() {
         #![allow(clippy::cast_possible_truncation)]
-        let _ = tracing_subscriber::fmt::try_init();
+        walrus_test_utils::init_tracing();
 
         let start = Instant::now();
         let mut actual_log_count = 0;


### PR DESCRIPTION
## Description

We normally run tests with `cargo nextest`, which has some additional isolation mechanisms compared to `cargo test` and `cargo tarpaulin`. This resulted in some tests not running successfully with `cargo test` and `cargo tarpaulin`.

This adds some locks for some unit tests to prevent them from running simultaneously in the same process. It also updates the tarpaulin config and unifies how tracing subscribers are initialized in tests.

Unfortunately, some end-to-end tests still fail after this change. A follow-up issue was created for this.

## Test plan

Ran the tests locally. Check that the tarpaulin job succeeds for this PR.
