### PR TITLE
chore: bump Rust to 1.89 and fix new lint warnings

### DIFF
--- a/crates/walrus-core/src/encoding/blob_encoding.rs
+++ b/crates/walrus-core/src/encoding/blob_encoding.rs
@@ -216,7 +216,7 @@ impl<'a> BlobEncoder<'a> {
         })
     }
 
-    fn rows(&self) -> Chunks<u8> {
+    fn rows(&self) -> Chunks<'_, u8> {
         self.blob.chunks(self.n_columns * self.symbol_usize())
     }
 
@@ -241,7 +241,7 @@ impl<'a> BlobEncoder<'a> {
     }
 
     /// Computes the fully expanded message matrix by encoding rows and columns.
-    fn get_expanded_matrix(&self) -> ExpandedMessageMatrix {
+    fn get_expanded_matrix(&self) -> ExpandedMessageMatrix<'_> {
         self.span
             .in_scope(|| ExpandedMessageMatrix::new(&self.config, self.symbol_size, self.blob))
     }

--- a/crates/walrus-core/src/encoding/config.rs
+++ b/crates/walrus-core/src/encoding/config.rs
@@ -299,7 +299,7 @@ impl EncodingConfig {
 
     /// Returns the encoding config for the given encoding type wrapped as an
     /// [`EncodingConfigEnum`].
-    pub fn get_for_type(&self, encoding_type: EncodingType) -> EncodingConfigEnum {
+    pub fn get_for_type(&self, encoding_type: EncodingType) -> EncodingConfigEnum<'_> {
         match encoding_type {
             EncodingType::RS2 => EncodingConfigEnum::ReedSolomon(&self.reed_solomon),
             _ => panic!("unsupported encoding type: {:?}", encoding_type),
@@ -463,7 +463,7 @@ impl ReedSolomonEncodingConfig {
     pub fn get_blob_decoder<E: EncodingAxis>(
         &self,
         blob_size: u64,
-    ) -> Result<BlobDecoder<ReedSolomonDecoder, E>, DataTooLargeError> {
+    ) -> Result<BlobDecoder<'_, ReedSolomonDecoder, E>, DataTooLargeError> {
         BlobDecoder::new(self, blob_size)
     }
 }

--- a/crates/walrus-sdk/src/client.rs
+++ b/crates/walrus-sdk/src/client.rs
@@ -1421,7 +1421,7 @@ impl WalrusNodeClient<SuiContractClient> {
     }
 
     /// Creates a resource manager for the client.
-    pub async fn resource_manager(&self, committees: &ActiveCommittees) -> ResourceManager {
+    pub async fn resource_manager(&self, committees: &ActiveCommittees) -> ResourceManager<'_> {
         ResourceManager::new(&self.sui_client, committees.write_committee().epoch)
     }
 

--- a/crates/walrus-sdk/src/client/client_types.rs
+++ b/crates/walrus-sdk/src/client/client_types.rs
@@ -102,7 +102,7 @@ pub trait WalrusStoreBlobApi<'a, T: Debug + Clone + Send + Sync> {
     fn ready_to_extend(&self) -> bool;
 
     /// Returns the parameters for certifying and extending the blob.
-    fn get_certify_and_extend_params(&self) -> Result<CertifyAndExtendBlobParams, ClientError>;
+    fn get_certify_and_extend_params(&self) -> Result<CertifyAndExtendBlobParams<'_>, ClientError>;
 
     /// Transitions the blob to the next state based on the encoding result.
     ///
@@ -356,7 +356,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for Unencoded
         false
     }
 
-    fn get_certify_and_extend_params(&self) -> ClientResult<CertifyAndExtendBlobParams> {
+    fn get_certify_and_extend_params(&self) -> ClientResult<CertifyAndExtendBlobParams<'_>> {
         Err(ClientError::store_blob_internal(format!(
             "Invalid operation for blob {self:?}",
         )))
@@ -547,7 +547,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for EncodedBl
         false
     }
 
-    fn get_certify_and_extend_params(&self) -> Result<CertifyAndExtendBlobParams, ClientError> {
+    fn get_certify_and_extend_params(&self) -> Result<CertifyAndExtendBlobParams<'_>, ClientError> {
         Err(invalid_operation_for_blob(
             &self,
             "get_certify_and_extend_params".to_string(),
@@ -738,7 +738,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for BlobWithS
         false
     }
 
-    fn get_certify_and_extend_params(&self) -> Result<CertifyAndExtendBlobParams, ClientError> {
+    fn get_certify_and_extend_params(&self) -> Result<CertifyAndExtendBlobParams<'_>, ClientError> {
         Err(ClientError::store_blob_internal(format!(
             "Invalid operation for blob {self:?}",
         )))
@@ -1002,7 +1002,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for Registere
         matches!(operation, RegisterBlobOp::ReuseAndExtend { .. })
     }
 
-    fn get_certify_and_extend_params(&self) -> ClientResult<CertifyAndExtendBlobParams> {
+    fn get_certify_and_extend_params(&self) -> ClientResult<CertifyAndExtendBlobParams<'_>> {
         if let StoreOp::RegisterNew {
             operation:
                 RegisterBlobOp::ReuseAndExtend {
@@ -1259,7 +1259,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for BlobWithC
         false
     }
 
-    fn get_certify_and_extend_params(&self) -> ClientResult<CertifyAndExtendBlobParams> {
+    fn get_certify_and_extend_params(&self) -> ClientResult<CertifyAndExtendBlobParams<'_>> {
         let StoreOp::RegisterNew { operation, blob } = &self.operation else {
             return Err(invalid_operation_for_blob(
                 &self,
@@ -1482,7 +1482,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for Completed
         false
     }
 
-    fn get_certify_and_extend_params(&self) -> ClientResult<CertifyAndExtendBlobParams> {
+    fn get_certify_and_extend_params(&self) -> ClientResult<CertifyAndExtendBlobParams<'_>> {
         Err(invalid_operation_for_blob(
             &self,
             "get_certify_and_extend_params".to_string(),
@@ -1650,7 +1650,7 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlobApi<'a, T> for FailedBlo
         false
     }
 
-    fn get_certify_and_extend_params(&self) -> Result<CertifyAndExtendBlobParams, ClientError> {
+    fn get_certify_and_extend_params(&self) -> Result<CertifyAndExtendBlobParams<'_>, ClientError> {
         Err(ClientError::store_blob_internal(format!(
             "Invalid operation for blob {self:?}",
         )))

--- a/crates/walrus-service/src/event/event_processor/checkpoint.rs
+++ b/crates/walrus-service/src/event/event_processor/checkpoint.rs
@@ -122,10 +122,9 @@ impl CheckpointProcessor {
                 .effects
                 .events_digest()
                 .zip(transaction.events.as_ref())
+                && *events_digest != events.digest()
             {
-                if *events_digest != events.digest() {
-                    anyhow::bail!("Events digest does not match");
-                }
+                anyhow::bail!("Events digest does not match");
             }
         }
 

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -880,7 +880,7 @@ impl StorageNode {
         event_blob_writer_cursor: EventStreamCursor,
         storage_node_cursor: EventStreamCursor,
         event_blob_writer: &mut Option<EventBlobWriter>,
-    ) -> anyhow::Result<EventStreamWithStartingIndices> {
+    ) -> anyhow::Result<EventStreamWithStartingIndices<'_>> {
         let event_cursor = storage_node_cursor.min(event_blob_writer_cursor);
         let lowest_needed_event_index = event_cursor.element_index;
         let processing_starting_index = storage_node_cursor.element_index;
@@ -1195,13 +1195,12 @@ impl StorageNode {
             if let EventStreamElement::ContractEvent(ContractEvent::EpochChangeEvent(
                 EpochChangeEvent::EpochChangeStart(EpochChangeStart { epoch, .. }),
             )) = &stream_element.element
+                && *epoch >= first_complete_epoch
             {
-                if *epoch >= first_complete_epoch {
-                    // Processing the `EpochChangeStart` event for the first complete epoch will set
-                    // the `current_event_epoch` to `epoch`, such that we will take the previous
-                    // if-statement and return `false` for all future events.
-                    return Ok(false);
-                }
+                // Processing the `EpochChangeStart` event for the first complete epoch will set
+                // the `current_event_epoch` to `epoch`, such that we will take the previous
+                // if-statement and return `false` for all future events.
+                return Ok(false);
             }
         }
 
@@ -1547,20 +1546,18 @@ impl StorageNode {
             self.inner.storage.get_latest_handled_event_index()? >= event_handle.index();
         if self.inner.consistency_check_config.enable_consistency_check
             && !node_is_reprocessing_events
-        {
-            if let Err(err) = consistency_check::schedule_background_consistency_check(
+            && let Err(err) = consistency_check::schedule_background_consistency_check(
                 self.inner.clone(),
                 self.blob_sync_handler.clone(),
                 event.epoch,
             )
             .await
-            {
-                tracing::warn!(
-                    ?err,
-                    epoch = %event.epoch,
-                    "failed to schedule background blob info consistency check"
-                );
-            }
+        {
+            tracing::warn!(
+                ?err,
+                epoch = %event.epoch,
+                "failed to schedule background blob info consistency check"
+            );
         }
 
         // During epoch change, we need to lock the read access to shard map until all the new

--- a/crates/walrus-service/src/node/blob_retirement_notifier.rs
+++ b/crates/walrus-service/src/node/blob_retirement_notifier.rs
@@ -146,7 +146,7 @@ impl BlobRetirementNotify {
     /// Wait for notification.
     /// Note that in order to be awakened, notified must be called before any future possible
     /// notify_waiters.
-    pub fn notified(&self) -> Notified {
+    pub fn notified(&self) -> Notified<'_> {
         self.notify.notified()
     }
 

--- a/crates/walrus-service/src/node/epoch_change_driver.rs
+++ b/crates/walrus-service/src/node/epoch_change_driver.rs
@@ -375,11 +375,11 @@ impl Future for EpochChangeDriverInner<'_> {
         });
 
         tracing::info_span!("scheduled_process_subsidies").in_scope(|| {
-            if let Some(subsidies) = this.subsidies_future.as_mut() {
-                if let Poll::Ready(()) = subsidies.poll_unpin(cx) {
-                    tracing::trace!("subsidies future completed");
-                    this.subsidies_future = None;
-                }
+            if let Some(subsidies) = this.subsidies_future.as_mut()
+                && let Poll::Ready(()) = subsidies.poll_unpin(cx)
+            {
+                tracing::trace!("subsidies future completed");
+                this.subsidies_future = None;
             }
         });
 

--- a/crates/walrus-service/src/node/server/openapi.rs
+++ b/crates/walrus-service/src/node/server/openapi.rs
@@ -18,6 +18,7 @@ pub(super) const GROUP_STORING_BLOBS: &str = "Writing Blobs";
 pub(super) const GROUP_READING_BLOBS: &str = "Reading Blobs";
 pub(super) const GROUP_RECOVERY: &str = "Recovery";
 pub(super) const GROUP_STATUS: &str = "Status";
+#[allow(dead_code)] // False positive; this is actually used in the generated OpenAPI spec.
 pub(super) const GROUP_SYNC_SHARD: &str = "Sync Shard";
 
 #[derive(utoipa::OpenApi)]

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -776,7 +776,10 @@ impl Storage {
     }
 
     /// Returns an iterator over the certified blob info before the specified epoch.
-    pub(crate) fn certified_blob_info_iter_before_epoch(&self, epoch: Epoch) -> BlobInfoIterator {
+    pub(crate) fn certified_blob_info_iter_before_epoch(
+        &self,
+        epoch: Epoch,
+    ) -> BlobInfoIterator<'_> {
         self.blob_info
             .certified_blob_info_iter_before_epoch(epoch, std::ops::Bound::Unbounded)
     }
@@ -785,7 +788,7 @@ impl Storage {
     pub(crate) fn certified_per_object_blob_info_iter_before_epoch(
         &self,
         epoch: Epoch,
-    ) -> PerObjectBlobInfoIterator {
+    ) -> PerObjectBlobInfoIterator<'_> {
         self.blob_info
             .certified_per_object_blob_info_iter_before_epoch(epoch, std::ops::Bound::Unbounded)
     }

--- a/crates/walrus-service/src/node/storage/blob_info.rs
+++ b/crates/walrus-service/src/node/storage/blob_info.rs
@@ -307,7 +307,7 @@ impl BlobInfoTable {
         &self,
         before_epoch: Epoch,
         starting_blob_id_bound: Bound<BlobId>,
-    ) -> BlobInfoIterator {
+    ) -> BlobInfoIterator<'_> {
         BlobInfoIter::new(
             Box::new(
                 self.aggregate_blob_info
@@ -325,7 +325,7 @@ impl BlobInfoTable {
         &self,
         before_epoch: Epoch,
         starting_object_id_bound: Bound<ObjectID>,
-    ) -> PerObjectBlobInfoIterator {
+    ) -> PerObjectBlobInfoIterator<'_> {
         BlobInfoIter::new(
             Box::new(
                 self.per_object_blob_info
@@ -767,30 +767,28 @@ impl ValidBlobInfoV1 {
         if let Some(PermanentBlobInfoV1 {
             end_epoch, event, ..
         }) = self.permanent_certified.as_ref()
+            && *end_epoch > current_epoch
         {
-            if *end_epoch > current_epoch {
-                return BlobStatus::Permanent {
-                    end_epoch: *end_epoch,
-                    is_certified: true,
-                    status_event: *event,
-                    deletable_counts,
-                    initial_certified_epoch,
-                };
-            }
+            return BlobStatus::Permanent {
+                end_epoch: *end_epoch,
+                is_certified: true,
+                status_event: *event,
+                deletable_counts,
+                initial_certified_epoch,
+            };
         }
         if let Some(PermanentBlobInfoV1 {
             end_epoch, event, ..
         }) = self.permanent_total.as_ref()
+            && *end_epoch > current_epoch
         {
-            if *end_epoch > current_epoch {
-                return BlobStatus::Permanent {
-                    end_epoch: *end_epoch,
-                    is_certified: false,
-                    status_event: *event,
-                    deletable_counts,
-                    initial_certified_epoch,
-                };
-            }
+            return BlobStatus::Permanent {
+                end_epoch: *end_epoch,
+                is_certified: false,
+                status_event: *event,
+                deletable_counts,
+                initial_certified_epoch,
+            };
         }
 
         if deletable_counts != Default::default() {

--- a/crates/walrus-sui/src/client/read_client.rs
+++ b/crates/walrus-sui/src/client/read_client.rs
@@ -531,37 +531,37 @@ impl SuiReadClient {
         self.sui_client.get_sui_object(node_id).await
     }
 
-    fn walrus_package_id(&self) -> RwLockReadGuard<ObjectID> {
+    fn walrus_package_id(&self) -> RwLockReadGuard<'_, ObjectID> {
         self.walrus_package_id
             .read()
             .expect("mutex should not be poisoned")
     }
 
-    fn walrus_package_id_mut(&self) -> RwLockWriteGuard<ObjectID> {
+    fn walrus_package_id_mut(&self) -> RwLockWriteGuard<'_, ObjectID> {
         self.walrus_package_id
             .write()
             .expect("mutex should not be poisoned")
     }
 
     /// Returns a mutable reference to the credits object.
-    fn credits_mut(&self) -> RwLockWriteGuard<Option<SharedObjectWithPkgConfig>> {
+    fn credits_mut(&self) -> RwLockWriteGuard<'_, Option<SharedObjectWithPkgConfig>> {
         self.credits.write().expect("mutex should not be poisoned")
     }
 
     /// Returns a mutable reference to the walrus subsidies object.
-    fn walrus_subsidies_mut(&self) -> RwLockWriteGuard<Option<SharedObjectWithPkgConfig>> {
+    fn walrus_subsidies_mut(&self) -> RwLockWriteGuard<'_, Option<SharedObjectWithPkgConfig>> {
         self.walrus_subsidies
             .write()
             .expect("mutex should not be poisoned")
     }
 
-    pub(crate) fn type_origin_map(&self) -> RwLockReadGuard<TypeOriginMap> {
+    pub(crate) fn type_origin_map(&self) -> RwLockReadGuard<'_, TypeOriginMap> {
         self.type_origin_map
             .read()
             .expect("mutex should not be poisoned")
     }
 
-    fn type_origin_map_mut(&self) -> RwLockWriteGuard<TypeOriginMap> {
+    fn type_origin_map_mut(&self) -> RwLockWriteGuard<'_, TypeOriginMap> {
         self.type_origin_map
             .write()
             .expect("mutex should not be poisoned")

--- a/crates/walrus-sui/src/types/move_structs.rs
+++ b/crates/walrus-sui/src/types/move_structs.rs
@@ -167,7 +167,7 @@ impl BlobAttribute {
     }
 
     /// Returns an iterator over the key-value pairs in the metadata.
-    pub fn iter(&self) -> MetadataIter {
+    pub fn iter(&self) -> MetadataIter<'_> {
         MetadataIter {
             inner: self.metadata.contents.iter(),
         }

--- a/crates/walrus-utils/src/metrics/monitored_scope.rs
+++ b/crates/walrus-utils/src/metrics/monitored_scope.rs
@@ -23,21 +23,21 @@ impl MonitoredScopeMetrics {
                 &["scope_name"],
                 registry,
             )
-            .unwrap(),
+            .expect("this is a valid metrics registration"),
             scope_iterations: register_int_gauge_vec_with_registry!(
                 "walrus_monitored_scope_iterations",
                 "Total number of times where the monitored scope runs",
                 &["scope_name"],
                 registry,
             )
-            .unwrap(),
+            .expect("this is a valid metrics registration"),
             scope_duration_ns: register_int_gauge_vec_with_registry!(
                 "walrus_monitored_scope_duration_ns",
                 "Total duration in nanosecs where the monitored scope is running",
                 &["scope_name"],
                 registry,
             )
-            .unwrap(),
+            .expect("this is a valid metrics registration"),
         }
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.88"
+channel = "1.89"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Description

Bumps Rust to the latest stable toolchain and fixes all new lint warnings (some with `cargo clippy --fix`, some manually). 

## Test plan

CI.
