### PR TITLE
chore: bump sui dep version to testnet-v1.54.0 (#2432)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,6 +1381,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bcder"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ffdaa8c6398acd07176317eb6c1f9082869dd1cc3fee7c72c6354866b928cc"
+dependencies = [
+ "bytes",
+ "smallvec",
+]
+
+[[package]]
 name = "bcs"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1454,8 +1464,8 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bin-version"
-version = "1.53.2"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+version = "1.54.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "const-str 0.5.7",
  "git-version",
@@ -2159,7 +2169,7 @@ dependencies = [
 [[package]]
 name = "consensus-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "fastcrypto",
  "mysten-network",
@@ -2171,7 +2181,7 @@ dependencies = [
 [[package]]
 name = "consensus-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -2228,7 +2238,7 @@ dependencies = [
 [[package]]
 name = "consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "base64 0.21.7",
  "consensus-config",
@@ -3314,7 +3324,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -5645,12 +5655,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 
 [[package]]
 name = "move-abstract-interpreter-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "move-binary-format",
 ]
@@ -5658,12 +5668,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "enum-compat-util",
@@ -5679,12 +5689,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5700,7 +5710,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "indexmap 2.10.0",
@@ -5713,7 +5723,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -5728,7 +5738,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -5738,7 +5748,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
@@ -5753,7 +5763,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
@@ -5768,7 +5778,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
@@ -5783,7 +5793,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5804,7 +5814,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5840,7 +5850,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5865,7 +5875,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5890,7 +5900,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5911,7 +5921,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "clap",
@@ -5934,7 +5944,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -5952,7 +5962,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "hex",
@@ -5965,7 +5975,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -5978,7 +5988,7 @@ dependencies = [
 [[package]]
 name = "move-model-2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6001,7 +6011,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "clap",
@@ -6037,7 +6047,7 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "enum-compat-util",
  "quote",
@@ -6047,7 +6057,7 @@ dependencies = [
 [[package]]
 name = "move-regex-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "itertools 0.10.5",
  "move-binary-format",
@@ -6058,7 +6068,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -6073,7 +6083,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v0"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -6088,7 +6098,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v1"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -6103,7 +6113,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v2"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -6118,7 +6128,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "once_cell",
  "phf",
@@ -6128,7 +6138,7 @@ dependencies = [
 [[package]]
 name = "move-trace-format"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -6140,7 +6150,7 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "move-binary-format",
  "once_cell",
@@ -6149,7 +6159,7 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "move-vm-config",
  "once_cell",
@@ -6161,7 +6171,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "better_any",
  "fail",
@@ -6181,7 +6191,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "better_any",
  "fail",
@@ -6200,7 +6210,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "better_any",
  "fail",
@@ -6219,7 +6229,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "better_any",
  "fail",
@@ -6238,7 +6248,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6252,7 +6262,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -6265,7 +6275,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -6278,7 +6288,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -6291,7 +6301,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -6422,7 +6432,7 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 [[package]]
 name = "mysten-common"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "antithesis_sdk",
  "anyhow",
@@ -6434,6 +6444,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "rand 0.8.5",
  "reqwest",
+ "serde_json",
  "snap",
  "sui-macros",
  "tempfile",
@@ -6444,7 +6455,7 @@ dependencies = [
 [[package]]
 name = "mysten-metrics"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "async-trait",
  "axum 0.8.1",
@@ -6465,7 +6476,7 @@ dependencies = [
 [[package]]
 name = "mysten-network"
 version = "0.2.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -6501,7 +6512,7 @@ dependencies = [
 [[package]]
 name = "mysten-service"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "axum 0.8.1",
@@ -7669,7 +7680,7 @@ dependencies = [
 [[package]]
 name = "prometheus-closure-metric"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -9191,7 +9202,7 @@ dependencies = [
 [[package]]
 name = "shared-crypto"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "bcs",
  "eyre",
@@ -9293,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "simulacrum"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9680,7 +9691,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 [[package]]
 name = "sui-adapter-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9713,7 +9724,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9741,7 +9752,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9768,7 +9779,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9795,7 +9806,7 @@ dependencies = [
 [[package]]
 name = "sui-authority-aggregation"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "futures",
  "mysten-metrics",
@@ -9807,7 +9818,7 @@ dependencies = [
 [[package]]
 name = "sui-config"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anemo",
  "anyhow",
@@ -9840,7 +9851,7 @@ dependencies = [
 [[package]]
 name = "sui-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anemo",
  "antithesis_sdk",
@@ -9956,7 +9967,7 @@ dependencies = [
 [[package]]
 name = "sui-data-ingestion-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9984,8 +9995,8 @@ dependencies = [
 
 [[package]]
 name = "sui-display"
-version = "1.53.2"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+version = "1.54.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -9997,7 +10008,7 @@ dependencies = [
 [[package]]
 name = "sui-enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -10005,7 +10016,7 @@ dependencies = [
 [[package]]
 name = "sui-execution"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-interpreter-v2",
@@ -10043,16 +10054,16 @@ dependencies = [
 
 [[package]]
 name = "sui-field-count"
-version = "1.53.2"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+version = "1.54.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "sui-field-count-derive",
 ]
 
 [[package]]
 name = "sui-field-count-derive"
-version = "1.53.2"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+version = "1.54.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -10061,7 +10072,7 @@ dependencies = [
 [[package]]
 name = "sui-framework"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -10074,8 +10085,8 @@ dependencies = [
 
 [[package]]
 name = "sui-framework-snapshot"
-version = "1.53.2"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+version = "1.54.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "bcs",
@@ -10090,7 +10101,7 @@ dependencies = [
 [[package]]
 name = "sui-genesis-builder"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "bcs",
@@ -10118,7 +10129,7 @@ dependencies = [
 [[package]]
 name = "sui-http"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "bytes",
  "http 1.3.1",
@@ -10137,8 +10148,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer"
-version = "1.53.2"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+version = "1.54.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10208,8 +10219,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-framework"
-version = "1.53.2"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+version = "1.54.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10245,8 +10256,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-framework-store-traits"
-version = "1.53.2"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+version = "1.54.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10256,8 +10267,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-metrics"
-version = "1.53.2"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+version = "1.54.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "axum 0.8.1",
@@ -10273,7 +10284,7 @@ dependencies = [
 [[package]]
 name = "sui-json"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "bcs",
@@ -10290,7 +10301,7 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -10349,7 +10360,7 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc-api"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -10369,7 +10380,7 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc-types"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "bcs",
@@ -10402,7 +10413,7 @@ dependencies = [
 [[package]]
 name = "sui-keys"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "bip32",
@@ -10421,7 +10432,7 @@ dependencies = [
 [[package]]
 name = "sui-macros"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "futures",
  "once_cell",
@@ -10432,7 +10443,7 @@ dependencies = [
 [[package]]
 name = "sui-metrics-push-client"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -10449,8 +10460,8 @@ dependencies = [
 
 [[package]]
 name = "sui-move-build"
-version = "1.53.2"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+version = "1.54.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -10475,7 +10486,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "bcs",
  "better_any",
@@ -10498,7 +10509,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "bcs",
  "better_any",
@@ -10519,7 +10530,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "bcs",
  "better_any",
@@ -10540,7 +10551,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "bcs",
  "better_any",
@@ -10560,8 +10571,8 @@ dependencies = [
 
 [[package]]
 name = "sui-name-service"
-version = "1.53.2"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+version = "1.54.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "bcs",
  "move-core-types",
@@ -10573,7 +10584,7 @@ dependencies = [
 [[package]]
 name = "sui-network"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -10612,8 +10623,8 @@ dependencies = [
 
 [[package]]
 name = "sui-node"
-version = "1.53.2"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+version = "1.54.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -10670,8 +10681,8 @@ dependencies = [
 
 [[package]]
 name = "sui-open-rpc"
-version = "1.53.2"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+version = "1.54.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "bcs",
  "schemars 0.8.21",
@@ -10683,7 +10694,7 @@ dependencies = [
 [[package]]
 name = "sui-open-rpc-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -10695,8 +10706,8 @@ dependencies = [
 
 [[package]]
 name = "sui-package-management"
-version = "1.53.2"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+version = "1.54.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -10714,7 +10725,7 @@ dependencies = [
 [[package]]
 name = "sui-package-resolver"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "async-trait",
  "bcs",
@@ -10731,8 +10742,8 @@ dependencies = [
 
 [[package]]
 name = "sui-pg-db"
-version = "1.53.2"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+version = "1.54.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10743,20 +10754,25 @@ dependencies = [
  "diesel-async",
  "diesel_migrations",
  "futures",
+ "rustls 0.23.30",
+ "rustls-pemfile 2.2.0",
  "scoped-futures",
  "sui-field-count",
  "sui-indexer-alt-framework-store-traits",
  "sui-sql-macro",
  "tempfile",
  "tokio",
+ "tokio-postgres",
+ "tokio-postgres-rustls",
  "tracing",
  "url",
+ "webpki-roots",
 ]
 
 [[package]]
 name = "sui-proc-macros"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -10768,7 +10784,7 @@ dependencies = [
 [[package]]
 name = "sui-protocol-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "clap",
  "fastcrypto",
@@ -10785,7 +10801,7 @@ dependencies = [
 [[package]]
 name = "sui-protocol-config-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10814,7 +10830,7 @@ dependencies = [
 [[package]]
 name = "sui-rpc-api"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -10860,8 +10876,8 @@ dependencies = [
 
 [[package]]
 name = "sui-sdk"
-version = "1.53.2"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+version = "1.54.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10914,7 +10930,7 @@ dependencies = [
 [[package]]
 name = "sui-simulator"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -10938,7 +10954,7 @@ dependencies = [
 [[package]]
 name = "sui-snapshot"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "bcs",
@@ -10966,8 +10982,8 @@ dependencies = [
 
 [[package]]
 name = "sui-sql-macro"
-version = "1.53.2"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+version = "1.54.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -10977,7 +10993,7 @@ dependencies = [
 [[package]]
 name = "sui-storage"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11027,7 +11043,7 @@ dependencies = [
 [[package]]
 name = "sui-swarm"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "futures",
@@ -11054,7 +11070,7 @@ dependencies = [
 [[package]]
 name = "sui-swarm-config"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anemo",
  "anyhow",
@@ -11081,7 +11097,7 @@ dependencies = [
 [[package]]
 name = "sui-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "reqwest",
  "serde",
@@ -11092,7 +11108,7 @@ dependencies = [
 [[package]]
 name = "sui-test-transaction-builder"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "bcs",
  "move-core-types",
@@ -11106,7 +11122,7 @@ dependencies = [
 [[package]]
 name = "sui-tls"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -11128,7 +11144,7 @@ dependencies = [
 [[package]]
 name = "sui-transaction-builder"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11145,7 +11161,7 @@ dependencies = [
 [[package]]
 name = "sui-transaction-checks"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "fastcrypto-zkp",
  "once_cell",
@@ -11160,7 +11176,7 @@ dependencies = [
 [[package]]
 name = "sui-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anemo",
  "anyhow",
@@ -11236,7 +11252,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -11252,7 +11268,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -11268,7 +11284,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -11283,7 +11299,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -11403,7 +11419,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "telemetry-subscribers"
 version = "0.2.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -11479,7 +11495,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 [[package]]
 name = "test-cluster"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "anyhow",
  "bcs",
@@ -11795,6 +11811,20 @@ dependencies = [
  "tokio",
  "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "whoami",
+]
+
+[[package]]
+name = "tokio-postgres-rustls"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04fb792ccd6bbcd4bba408eb8a292f70fc4a3589e5d793626f45190e6454b6ab"
+dependencies = [
+ "ring",
+ "rustls 0.23.30",
+ "tokio",
+ "tokio-postgres",
+ "tokio-rustls 0.26.1",
+ "x509-certificate",
 ]
 
 [[package]]
@@ -12362,7 +12392,7 @@ dependencies = [
 [[package]]
 name = "typed-store"
 version = "0.4.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "async-trait",
  "backoff",
@@ -12423,7 +12453,7 @@ dependencies = [
 [[package]]
 name = "typed-store-derive"
 version = "0.3.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -12434,7 +12464,7 @@ dependencies = [
 [[package]]
 name = "typed-store-error"
 version = "0.4.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "serde",
  "thiserror 1.0.69",
@@ -12443,7 +12473,7 @@ dependencies = [
 [[package]]
 name = "typed-store-workspace-hack"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.53.2#0cfc71d63baec89b4b380eb7c5a65590460afabc"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
 dependencies = [
  "cc",
  "lazy_static",
@@ -13984,6 +14014,25 @@ dependencies = [
  "der 0.7.9",
  "spki 0.7.3",
  "tls_codec",
+]
+
+[[package]]
+name = "x509-certificate"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66534846dec7a11d7c50a74b7cdb208b9a581cad890b7866430d438455847c85"
+dependencies = [
+ "bcder",
+ "bytes",
+ "chrono",
+ "der 0.7.9",
+ "hex",
+ "pem",
+ "ring",
+ "signature 2.2.0",
+ "spki 0.7.3",
+ "thiserror 1.0.69",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,9 +76,9 @@ jsonwebtoken = "9.3.1"
 md5 = "0.7.0"
 mime = "0.3.17"
 mockall = "0.12.1"
-move-core-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.2" }
-move-package = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.2" }
-mysten-metrics = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.2" }
+move-core-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
+move-package = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
+mysten-metrics = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
 num-bigint = { version = "0.4.5", default-features = false }
 object_store = { version = "0.11.2", features = ["gcp"] }
 once_cell = { version = "1.21.3" }
@@ -109,25 +109,25 @@ serde_with = { version = "3.14", features = ["base64"] }
 serde_yaml = "0.9"
 sha2 = "0.10.9"
 snap = "1.1.0"
-sui-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.2" }
-sui-json-rpc-api = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.2" }
-sui-json-rpc-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.2" }
-sui-keys = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.2" }
-sui-macros = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.2" }
-sui-move-build = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.2" }
-sui-package-management = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.2" }
-sui-package-resolver = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.2" }
-sui-protocol-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.2" }
-sui-rpc-api = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.2" }
-sui-sdk = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.2" }
-sui-simulator = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.2" }
-sui-storage = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.2" }
-sui-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.2" }
+sui-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
+sui-json-rpc-api = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
+sui-json-rpc-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
+sui-keys = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
+sui-macros = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
+sui-move-build = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
+sui-package-management = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
+sui-package-resolver = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
+sui-protocol-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
+sui-rpc-api = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
+sui-sdk = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
+sui-simulator = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
+sui-storage = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
+sui-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
 syn = "2.0"
 tap = "1.0.1"
-telemetry-subscribers = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.2" }
+telemetry-subscribers = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
 tempfile = "3.20.0"
-test-cluster = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.53.2" }
+test-cluster = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
 thiserror = "2.0.12"
 tokio = { version = "=1.46.1", features = ["macros", "rt-multi-thread", "signal"] }
 tokio-stream = "0.1.17"

--- a/contracts/subsidies/Move.lock
+++ b/contracts/subsidies/Move.lock
@@ -12,11 +12,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.2", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.2", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },

--- a/contracts/subsidies/Move.toml
+++ b/contracts/subsidies/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.53.2" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.54.0" }
 WAL = { local = "../wal" }
 Walrus = { local = "../walrus" }
 

--- a/contracts/wal/Move.lock
+++ b/contracts/wal/Move.lock
@@ -10,11 +10,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.2", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.2", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },

--- a/contracts/wal/Move.toml
+++ b/contracts/wal/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.53.2" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.54.0" }
 
 [addresses]
 wal = "0x0"

--- a/contracts/wal_exchange/Move.lock
+++ b/contracts/wal_exchange/Move.lock
@@ -11,11 +11,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.2", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.2", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },

--- a/contracts/wal_exchange/Move.toml
+++ b/contracts/wal_exchange/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.53.2" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.54.0" }
 WAL = { local = "../wal" }
 
 [addresses]

--- a/contracts/walrus/Move.lock
+++ b/contracts/walrus/Move.lock
@@ -11,11 +11,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.2", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.2", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },

--- a/contracts/walrus/Move.toml
+++ b/contracts/walrus/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.53.2" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.54.0" }
 WAL = { local = "../wal" }
 
 [addresses]

--- a/contracts/walrus_subsidies/Move.lock
+++ b/contracts/walrus_subsidies/Move.lock
@@ -12,11 +12,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.2", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.2", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },

--- a/contracts/walrus_subsidies/Move.toml
+++ b/contracts/walrus_subsidies/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.53.2" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.54.0" }
 WAL = { local = "../wal" }
 Walrus = { local = "../walrus" }
 

--- a/crates/walrus-service/daemon_openapi.yaml
+++ b/crates/walrus-service/daemon_openapi.yaml
@@ -663,8 +663,7 @@ components:
             minimum: 0
       examples:
       - txDigest: EhtoQF9UpPyg5PsPUs69LdkcRrjQ3R4cTsHnwxZVTNrC
-        eventSeq:
-          $serde_json::private::Number: '0'
+        eventSeq: 0
     EventOrObjectId:
       oneOf:
       - type: object

--- a/crates/walrus-service/publisher_openapi.yaml
+++ b/crates/walrus-service/publisher_openapi.yaml
@@ -480,8 +480,7 @@ components:
             minimum: 0
       examples:
       - txDigest: EhtoQF9UpPyg5PsPUs69LdkcRrjQ3R4cTsHnwxZVTNrC
-        eventSeq:
-          $serde_json::private::Number: '0'
+        eventSeq: 0
     EventOrObjectId:
       oneOf:
       - type: object

--- a/crates/walrus-service/storage_openapi.yaml
+++ b/crates/walrus-service/storage_openapi.yaml
@@ -1020,8 +1020,7 @@ components:
             minimum: 0
       examples:
       - txDigest: EhtoQF9UpPyg5PsPUs69LdkcRrjQ3R4cTsHnwxZVTNrC
-        eventSeq:
-          $serde_json::private::Number: '0'
+        eventSeq: 0
     ObjectID:
       type: string
       title: Sui object ID

--- a/crates/walrus-upload-relay/upload_relay_openapi.yaml
+++ b/crates/walrus-upload-relay/upload_relay_openapi.yaml
@@ -198,13 +198,10 @@ components:
                 minimum: 0
       description: The kinds of tip that the proxy can choose to configure.
       examples:
-      - const:
-          $serde_json::private::Number: '31415'
+      - const: 31415
       - linear:
-          base:
-            $serde_json::private::Number: '101'
-          encoded_size_mul_per_kib:
-            $serde_json::private::Number: '42'
+          base: 101
+          encoded_size_mul_per_kib: 42
     TransactionDigest:
       type: string
       title: Sui transaction digest

--- a/docker/walrus-antithesis/sui_version.toml
+++ b/docker/walrus-antithesis/sui_version.toml
@@ -1,1 +1,1 @@
-SUI_VERSION = "testnet-v1.53.2"
+SUI_VERSION = "testnet-v1.54.0"

--- a/testnet-contracts/subsidies/Move.lock
+++ b/testnet-contracts/subsidies/Move.lock
@@ -12,11 +12,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.2", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.2", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },

--- a/testnet-contracts/subsidies/Move.toml
+++ b/testnet-contracts/subsidies/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.53.2" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.54.0" }
 WAL = { local = "../wal" }
 Walrus = { local = "../walrus" }
 

--- a/testnet-contracts/wal/Move.lock
+++ b/testnet-contracts/wal/Move.lock
@@ -10,11 +10,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.2", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.2", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },

--- a/testnet-contracts/wal/Move.toml
+++ b/testnet-contracts/wal/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.53.2" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.54.0" }
 
 [addresses]
 wal = "0x0"

--- a/testnet-contracts/wal_exchange/Move.lock
+++ b/testnet-contracts/wal_exchange/Move.lock
@@ -11,11 +11,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.2", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.2", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },

--- a/testnet-contracts/wal_exchange/Move.toml
+++ b/testnet-contracts/wal_exchange/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.53.2" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.54.0" }
 WAL = { local = "../wal" }
 
 [addresses]

--- a/testnet-contracts/walrus/Move.lock
+++ b/testnet-contracts/walrus/Move.lock
@@ -11,11 +11,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.2", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.2", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },

--- a/testnet-contracts/walrus/Move.toml
+++ b/testnet-contracts/walrus/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.53.2" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.54.0" }
 WAL = { local = "../wal" }
 
 [addresses]

--- a/testnet-contracts/walrus_subsidies/Move.lock
+++ b/testnet-contracts/walrus_subsidies/Move.lock
@@ -12,11 +12,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.2", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.53.2", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },

--- a/testnet-contracts/walrus_subsidies/Move.toml
+++ b/testnet-contracts/walrus_subsidies/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.53.2" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.54.0" }
 WAL = { local = "../wal" }
 Walrus = { local = "../walrus" }
 


### PR DESCRIPTION
* chore: bump sui dep version to testnet-v1.54.0

Keep Walrus sui deps in sync.