### PR TITLE
fix(client): correct output when storing already certified deletable blob

### DIFF
--- a/crates/walrus-sdk/src/client/resource.rs
+++ b/crates/walrus-sdk/src/client/resource.rs
@@ -197,9 +197,7 @@ impl StoreOp {
                     StoreOp::NoOp(BlobStoreResult::AlreadyCertified {
                         blob_id: blob.blob_id,
                         event_or_object: EventOrObjectId::Object(blob.id),
-                        end_epoch: blob
-                            .certified_epoch
-                            .expect("certified blob must have a certified epoch"),
+                        end_epoch: blob.storage.end_epoch,
                     })
                 } else {
                     StoreOp::RegisterNew {


### PR DESCRIPTION
## Description

This fixes the incorrect store output when storing a deletable blob if the wallet already owned a certified deletable blob with a sufficient lifetime.

**Before:**
```console
$ walrus store --epochs 10 --context testnet empty --deletable
Success: Deletable blob stored successfully.
Path: empty
Blob ID: 3GPQL3HZNnFhN_F7l5Aa-X1VOtAKwIsg9zuWk8R81v4
Sui object ID: 0xb72624e898b2e2bfe038d125710fc7c81c4f0c3e958b12129cf9728e4cda1f98
Unencoded size: 0 B
Encoded size (including replicated metadata): 63.0 MiB
Cost (excluding gas): 0.096 WAL (storage was purchased, and a new blob object was registered)
Expiry epoch (exclusive): 149
Encoding type: RedStuff/Reed-Solomon

Summary for Modified or Created Blobs (1 newly certified)
Total encoded size: 63.0 MiB
Total cost: 0.096 WAL

$ walrus store --epochs 10 --context testnet empty --deletable
Success: Blob was already available and certified within Walrus, for a sufficient number of epochs.
Path: empty
Blob ID: 3GPQL3HZNnFhN_F7l5Aa-X1VOtAKwIsg9zuWk8R81v4
Owned Blob registration object ID: 0xb72624e898b2e2bfe038d125710fc7c81c4f0c3e958b12129cf9728e4cda1f98
Expiry epoch (exclusive): 139

No blobs were modified or created
```

**After:**
```console
$ walrus store --epochs 10 --context testnet empty --deletable
Success: Blob was already available and certified within Walrus, for a sufficient number of epochs.
Path: empty
Blob ID: 3GPQL3HZNnFhN_F7l5Aa-X1VOtAKwIsg9zuWk8R81v4
Owned Blob registration object ID: 0xb72624e898b2e2bfe038d125710fc7c81c4f0c3e958b12129cf9728e4cda1f98
Expiry epoch (exclusive): 149

No blobs were modified or created
```

Also adds a test for this case and refactors the related test code.

## Test plan

Added+modified test + manual test (see above).
