### PR TITLE
feat: Add success metric of checkpoint download source

### DIFF
--- a/crates/walrus-sui/Cargo.toml
+++ b/crates/walrus-sui/Cargo.toml
@@ -62,7 +62,7 @@ utoipa = { workspace = true, optional = true, features = ["axum_extras", "macros
 walkdir = "2.5.0"
 walrus-core = { workspace = true, features = ["sui-types", "utoipa"] }
 walrus-test-utils = { workspace = true, optional = true }
-walrus-utils = { workspace = true, features = ["backoff", "config", "metrics"] }
+walrus-utils = { workspace = true, features = ["backoff", "config", "log", "metrics"] }
 
 [dev-dependencies]
 clap.workspace = true

--- a/crates/walrus-sui/src/client/metrics.rs
+++ b/crates/walrus-sui/src/client/metrics.rs
@@ -30,6 +30,9 @@ walrus_utils::metrics::define_metric_set! {
 
         #[help = "The source of a checkpoint download"]
         checkpoint_download_source: IntCounterVec["download_source"],
+
+        #[help = "The source of a successful checkpoint download"]
+        checkpoint_download_success_source: IntCounterVec["download_source"],
     }
 }
 
@@ -81,6 +84,13 @@ impl SuiClientMetricSet {
     /// Records the source of a checkpoint download.
     pub fn record_checkpoint_download_source(&self, source: &str) {
         self.checkpoint_download_source
+            .with_label_values(&[source])
+            .inc();
+    }
+
+    /// Records the source of a successful checkpoint download.
+    pub fn record_checkpoint_download_success_source(&self, source: &str) {
+        self.checkpoint_download_success_source
             .with_label_values(&[source])
             .inc();
     }

--- a/crates/walrus-sui/src/client/retry_client/download_handler.rs
+++ b/crates/walrus-sui/src/client/retry_client/download_handler.rs
@@ -105,6 +105,10 @@ impl CheckpointDownloadHandler {
             .lock()
             .expect("mutex should not be poisoned");
         failures.remove(&sequence_number);
+
+        if let Some(metrics) = &self.metrics {
+            metrics.record_checkpoint_download_success_source("primary");
+        }
     }
 
     /// Called on fallback success for a specific sequence_number.
@@ -115,6 +119,10 @@ impl CheckpointDownloadHandler {
             .lock()
             .expect("mutex should not be poisoned");
         failures.remove(&sequence_number);
+
+        if let Some(metrics) = &self.metrics {
+            metrics.record_checkpoint_download_success_source("fallback");
+        }
     }
 
     /// Determines the initial action for fetching a checkpoint.


### PR DESCRIPTION
## Description

We observed “direct_fallback” download rates roughly 2x higher than “primary.” This is not duplicate downloads: “direct_fallback” is incremented per attempt during skip windows, and the outer downloader retries on failure. As a result, “direct_fallback” counts can reflect multiple attempts for the same checkpoint. We’re adding explicit success counters to provide apples-to-apples visibility into successful downloads by source.
