### PR TITLE
feat: Allow event blob catchup at runtime

### DIFF
--- a/crates/walrus-service/node_config_example.yaml
+++ b/crates/walrus-service/node_config_example.yaml
@@ -166,6 +166,11 @@ event_processor_config:
     max_consecutive_pool_monitor_failures: 10
   event_stream_catchup_min_checkpoint_lag: 20000
   sampled_tracing_interval_secs: 3600
+  enable_runtime_catchup: true
+  runtime_catchup_lag_threshold: 20000
+  runtime_lag_check_interval_secs: 300
+  catchup_coordination_timeout_secs: 3000
+  catchup_processing_timeout_secs: 3000
 use_legacy_event_provider: false
 disable_event_blob_writer: false
 commission_rate: 6000

--- a/crates/walrus-service/src/event/event_processor.rs
+++ b/crates/walrus-service/src/event/event_processor.rs
@@ -8,6 +8,7 @@ pub mod catchup;
 pub mod checkpoint;
 pub mod client;
 pub mod config;
+pub mod coordination;
 pub mod db;
 pub mod metrics;
 pub mod package_store;

--- a/crates/walrus-service/src/event/event_processor/config.rs
+++ b/crates/walrus-service/src/event/event_processor/config.rs
@@ -106,6 +106,25 @@ pub struct EventProcessorConfig {
     #[serde_as(as = "DurationSeconds")]
     #[serde(rename = "sampled_tracing_interval_secs")]
     pub sampled_tracing_interval: Duration,
+    /// Enable runtime catchup functionality.
+    pub enable_runtime_catchup: bool,
+    /// Runtime catchup lag threshold for triggering catchup at runtime.
+    /// When the lag exceeds this threshold during runtime, the catchup manager
+    /// will be invoked in parallel with the checkpoint downloader to accelerate
+    /// recovery. Should typically be the same as event_stream_catchup_min_checkpoint_lag.
+    pub runtime_catchup_lag_threshold: u64,
+    /// Interval for checking lag during runtime to trigger catchup if needed.
+    #[serde_as(as = "DurationSeconds")]
+    #[serde(rename = "runtime_lag_check_interval_secs")]
+    pub runtime_lag_check_interval: Duration,
+    /// Timeout for catchup operations to prevent indefinite blocking.
+    #[serde_as(as = "DurationSeconds")]
+    #[serde(rename = "catchup_coordination_timeout_secs")]
+    pub catchup_coordination_timeout: Duration,
+    /// Timeout for catchup processing to prevent indefinite blocking.
+    #[serde_as(as = "DurationSeconds")]
+    #[serde(rename = "catchup_processing_timeout_secs")]
+    pub catchup_processing_timeout: Duration,
 }
 
 impl Default for EventProcessorConfig {
@@ -116,6 +135,11 @@ impl Default for EventProcessorConfig {
             adaptive_downloader_config: Default::default(),
             event_stream_catchup_min_checkpoint_lag: 20_000,
             sampled_tracing_interval: Duration::from_secs(3600),
+            runtime_catchup_lag_threshold: 20_000,
+            runtime_lag_check_interval: Duration::from_secs(300),
+            enable_runtime_catchup: true,
+            catchup_coordination_timeout: Duration::from_secs(3000),
+            catchup_processing_timeout: Duration::from_secs(3000),
         }
     }
 }

--- a/crates/walrus-service/src/event/event_processor/coordination.rs
+++ b/crates/walrus-service/src/event/event_processor/coordination.rs
@@ -1,0 +1,267 @@
+// Copyright (c) Walrus Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Coordination module for managing operation between checkpoint downloader and catchup manager.
+
+use std::{sync::Arc, time::Instant};
+
+use tokio::sync::{Mutex, Notify, mpsc};
+
+/// Messages for coordinating between catchup manager and checkpoint tailing
+#[derive(Debug, Clone)]
+pub enum CoordinationMessage {
+    /// Stop checkpoint tailing for catchup processing
+    StopCheckpointTailing,
+    /// Restart checkpoint tailing after catchup completion
+    RestartCheckpointTailing,
+    /// Catchup operation failed, resume normal operation
+    CatchupFailed,
+}
+
+/// Coordination state between checkpoint downloader and catchup manager.
+///
+/// This struct manages the synchronization between the checkpoint downloader and
+/// catchup manager during runtime catchup operations using message-passing.
+/// The coordination works in phases:
+/// 1. Download phase: Event blobs are downloaded in parallel with checkpoint tailing
+/// 2. Processing phase: Send StopCheckpointTailing message, process event blobs
+/// 3. Resume phase: Send RestartCheckpointTailing message (picks up from new latest checkpoint)
+#[derive(Debug)]
+pub struct CatchupCoordinationState {
+    /// Channel for sending coordination messages to checkpoint tailing task
+    pub coordination_tx: mpsc::UnboundedSender<CoordinationMessage>,
+    /// Whether catchup is currently active
+    pub catchup_active: Arc<std::sync::atomic::AtomicBool>,
+    /// Timestamp when catchup was last started
+    pub last_catchup_start: Arc<Mutex<Option<Instant>>>,
+    /// Notifier signaled when checkpoint tailing has fully stopped
+    tailing_stopped_notify: Arc<Notify>,
+    /// Flag indicating whether checkpoint tailing is currently stopped
+    is_tailing_stopped: Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl CatchupCoordinationState {
+    /// Attempt to mark catchup as active. Returns true if we successfully
+    /// transitioned from inactive to active, false if another catchup is already running.
+    pub async fn try_start_catchup(&self) -> bool {
+        match self.catchup_active.compare_exchange(
+            false,
+            true,
+            std::sync::atomic::Ordering::AcqRel,
+            std::sync::atomic::Ordering::Acquire,
+        ) {
+            Ok(_) => {
+                *self.last_catchup_start.lock().await = Some(Instant::now());
+                true
+            }
+            Err(_) => false,
+        }
+    }
+
+    /// Explicitly mark catchup as inactive.
+    pub fn mark_catchup_inactive(&self) {
+        self.catchup_active
+            .store(false, std::sync::atomic::Ordering::Release);
+    }
+
+    /// Creates a new coordination state instance and returns it with a receiver.
+    pub fn new() -> (Self, mpsc::UnboundedReceiver<CoordinationMessage>) {
+        let (coordination_tx, coordination_rx) = mpsc::unbounded_channel();
+
+        (
+            Self {
+                coordination_tx,
+                catchup_active: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                last_catchup_start: Arc::new(Mutex::new(None)),
+                tailing_stopped_notify: Arc::new(Notify::new()),
+                is_tailing_stopped: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            },
+            coordination_rx,
+        )
+    }
+
+    /// Mark that checkpoint tailing has started.
+    pub fn mark_tailing_started(&self) {
+        self.is_tailing_stopped
+            .store(false, std::sync::atomic::Ordering::Release);
+    }
+
+    /// Notify that checkpoint tailing has fully stopped and wake any waiters.
+    pub fn notify_tailing_stopped(&self) {
+        self.is_tailing_stopped
+            .store(true, std::sync::atomic::Ordering::Release);
+        self.tailing_stopped_notify.notify_one();
+    }
+
+    /// Wait until checkpoint tailing is stopped, with timeout.
+    /// Returns true if stopped, false on timeout.
+    pub async fn wait_for_tailing_stopped(&self, timeout: std::time::Duration) -> bool {
+        if self
+            .is_tailing_stopped
+            .load(std::sync::atomic::Ordering::Acquire)
+        {
+            return true;
+        }
+        match tokio::time::timeout(timeout, self.tailing_stopped_notify.notified()).await {
+            Ok(()) => true,
+            Err(_) => false,
+        }
+    }
+
+    /// Start the download phase of catchup.
+    /// During this phase, event blobs are downloaded in parallel with checkpoint tailing.
+    #[cfg(test)]
+    pub async fn start_catchup_download_phase(&self) {
+        tracing::info!(
+            "starting catchup download phase - checkpoint tailing continues in parallel"
+        );
+
+        self.catchup_active
+            .store(true, std::sync::atomic::Ordering::Release);
+        *self.last_catchup_start.lock().await = Some(Instant::now());
+    }
+
+    /// Transition from download phase to processing phase.
+    /// This sends a message to stop checkpoint tailing.
+    pub async fn start_catchup_processing_phase(
+        &self,
+    ) -> Result<(), mpsc::error::SendError<CoordinationMessage>> {
+        tracing::info!(
+            "starting catchup processing phase - sending stop message to checkpoint tailing"
+        );
+
+        self.coordination_tx
+            .send(CoordinationMessage::StopCheckpointTailing)?;
+        Ok(())
+    }
+
+    /// Complete catchup processing and signal for checkpoint tailing restart.
+    /// This sends a message to restart checkpoint tailing from the new latest checkpoint.
+    pub async fn complete_catchup(
+        &self,
+    ) -> Result<(), mpsc::error::SendError<CoordinationMessage>> {
+        tracing::info!("completing catchup - sending restart message to checkpoint tailing");
+
+        self.catchup_active
+            .store(false, std::sync::atomic::Ordering::Release);
+        self.coordination_tx
+            .send(CoordinationMessage::RestartCheckpointTailing)?;
+        Ok(())
+    }
+
+    /// Signal catchup failure and resume normal operation.
+    pub async fn catchup_failed(&self) -> Result<(), mpsc::error::SendError<CoordinationMessage>> {
+        tracing::warn!("catchup failed - sending failure message to checkpoint tailing");
+
+        self.catchup_active
+            .store(false, std::sync::atomic::Ordering::Release);
+        self.coordination_tx
+            .send(CoordinationMessage::CatchupFailed)?;
+        Ok(())
+    }
+
+    /// Check if catchup is currently active.
+    pub fn is_catchup_active(&self) -> bool {
+        self.catchup_active
+            .load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    /// Get statistics about the current coordination state.
+    pub async fn get_stats(&self) -> CoordinationStats {
+        let last_start = *self.last_catchup_start.lock().await;
+
+        CoordinationStats {
+            catchup_active: self.is_catchup_active(),
+            time_since_last_catchup: last_start.map(|t| t.elapsed()),
+        }
+    }
+}
+
+impl Default for CatchupCoordinationState {
+    fn default() -> Self {
+        Self::new().0
+    }
+}
+
+/// Statistics about the current coordination state.
+#[derive(Debug, Clone)]
+pub struct CoordinationStats {
+    /// Whether catchup is currently active
+    pub catchup_active: bool,
+    /// Time elapsed since last catchup started
+    pub time_since_last_catchup: Option<std::time::Duration>,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tokio::time::sleep;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_coordination_message_passing() {
+        let (state, mut rx) = CatchupCoordinationState::new();
+
+        // Test sending stop message
+        state.start_catchup_processing_phase().await.unwrap();
+
+        match rx.recv().await {
+            Some(CoordinationMessage::StopCheckpointTailing) => {
+                // Expected
+            }
+            other => panic!("Expected StopCheckpointTailing, got {:?}", other),
+        }
+
+        // Test sending restart message
+        state.complete_catchup().await.unwrap();
+
+        match rx.recv().await {
+            Some(CoordinationMessage::RestartCheckpointTailing) => {
+                // Expected
+            }
+            other => panic!("Expected RestartCheckpointTailing, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_cooldown_management_like_behavior() {
+        let (state, _rx) = CatchupCoordinationState::new();
+        let short_wait = Duration::from_millis(10);
+
+        // Initially no catchup and no timestamp
+        let stats = state.get_stats().await;
+        assert!(!stats.catchup_active);
+        assert!(stats.time_since_last_catchup.is_none());
+
+        // Start catchup download phase should set active and timestamp
+        state.start_catchup_download_phase().await;
+        let stats = state.get_stats().await;
+        assert!(stats.catchup_active);
+        assert!(stats.time_since_last_catchup.is_some());
+
+        // After a short wait, elapsed should still be some (monotonic increase implied)
+        sleep(short_wait + Duration::from_millis(5)).await;
+        let stats = state.get_stats().await;
+        assert!(stats.catchup_active);
+        assert!(stats.time_since_last_catchup.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_coordination_stats() {
+        let (state, _rx) = CatchupCoordinationState::new();
+
+        // Initial stats
+        let stats = state.get_stats().await;
+        assert!(!stats.catchup_active);
+        assert_eq!(stats.time_since_last_catchup, None);
+
+        // After starting catchup
+        state.start_catchup_download_phase().await;
+
+        let stats = state.get_stats().await;
+        assert!(stats.catchup_active);
+        assert!(stats.time_since_last_catchup.is_some());
+    }
+}

--- a/crates/walrus-service/src/event/event_processor/metrics.rs
+++ b/crates/walrus-service/src/event/event_processor/metrics.rs
@@ -13,6 +13,8 @@ walrus_utils::metrics::define_metric_set! {
         event_processor_latest_downloaded_checkpoint: IntGauge[],
         #[help = "The number of checkpoints downloaded. Useful for computing the download rate"]
         event_processor_total_downloaded_checkpoints: IntCounter[],
+        #[help = "Current lag in checkpoints detected during runtime monitoring"]
+        runtime_lag_current: IntGauge[],
     }
 }
 

--- a/crates/walrus-service/src/event/event_processor/processor.rs
+++ b/crates/walrus-service/src/event/event_processor/processor.rs
@@ -12,13 +12,26 @@ use sui_types::{
     full_checkpoint_content::CheckpointData,
     messages_checkpoint::VerifiedCheckpoint,
 };
-use tokio::{select, sync::Mutex, time::sleep};
+use tokio::{
+    select,
+    sync::{Mutex, mpsc},
+    task::JoinHandle,
+    time::sleep,
+};
 use tokio_util::sync::CancellationToken;
 use typed_store::{Map, TypedStoreError};
 use walrus_core::ensure;
-use walrus_utils::{metrics::Registry, tracing_sampled};
+use walrus_utils::{
+    metrics::{Registry, monitored_scope},
+    tracing_sampled,
+};
 
-use super::{metrics::EventProcessorMetrics, package_store::LocalDBPackageStore};
+use super::{
+    catchup,
+    coordination::CatchupCoordinationState,
+    metrics::EventProcessorMetrics,
+    package_store::LocalDBPackageStore,
+};
 use crate::event::{
     event_processor::{
         bootstrap::get_bootstrap_committee_and_checkpoint,
@@ -26,6 +39,7 @@ use crate::event::{
         checkpoint::CheckpointProcessor,
         client::ClientManager,
         config::{EventProcessorConfig, EventProcessorRuntimeConfig, SystemConfig},
+        coordination::CoordinationMessage,
         db::EventProcessorStores,
     },
     events::{IndexedStreamEvent, InitState, StreamEventWithInitState},
@@ -33,6 +47,11 @@ use crate::event::{
 
 /// The maximum number of events to poll per poll.
 const MAX_EVENTS_PER_POLL: usize = 1000;
+/// Startup catchup timeout (seconds) used during initial catchup in EventProcessor::new
+const STARTUP_CATCHUP_TIMEOUT_SECS: u64 = 5 * 60;
+/// Runtime catchup processing timeout (seconds) used during runtime catchup in
+/// EventProcessor::start_runtime_catchup_monitoring
+const RUNTIME_CATCHUP_PROCESSING_TIMEOUT_SECS: u64 = 5 * 60 * 60;
 
 /// The event processor.
 #[derive(Clone)]
@@ -59,6 +78,14 @@ pub struct EventProcessor {
     pub checkpoint_processor: CheckpointProcessor,
     /// The interval at which to sample high-frequency tracing logs.
     pub sampled_tracing_interval: Duration,
+    /// Configuration for event processing.
+    pub config: EventProcessorConfig,
+    /// System configuration.
+    pub system_config: SystemConfig,
+    /// Recovery path for catchup operations.
+    pub recovery_path: std::path::PathBuf,
+    /// Metrics registry for creating new metric instances.
+    pub metrics_registry: Registry,
 }
 
 impl fmt::Debug for EventProcessor {
@@ -70,6 +97,10 @@ impl fmt::Debug for EventProcessor {
             .field("committee_store", &self.stores.committee_store)
             .field("event_store", &self.stores.event_store)
             .field("sampled_tracing_interval", &self.sampled_tracing_interval)
+            .field(
+                "runtime_catchup_enabled",
+                &self.config.enable_runtime_catchup,
+            )
             .finish()
     }
 }
@@ -128,6 +159,10 @@ impl EventProcessor {
             package_store,
             checkpoint_processor,
             sampled_tracing_interval: config.sampled_tracing_interval,
+            config: config.clone(),
+            system_config: system_config.clone(),
+            recovery_path: runtime_config.db_path.join("recovery"),
+            metrics_registry: metrics_registry.clone(),
         };
 
         if event_processor.stores.checkpoint_store.is_empty() {
@@ -145,43 +180,7 @@ impl EventProcessor {
             .checkpoint_processor
             .update_cached_latest_checkpoint_seq_number(current_checkpoint);
 
-        let clients = client_manager.into_client_set();
-
-        let catchup_manager = EventBlobCatchupManager::new(
-            event_processor.stores.clone(),
-            clients,
-            system_config,
-            runtime_config.db_path.join("recovery"),
-            metrics_registry,
-        );
-        if let Err(e) = catchup_manager
-            .catchup(config.event_stream_catchup_min_checkpoint_lag)
-            .await
-        {
-            tracing::error!("failed to catchup using event blobs: {e}");
-        }
-
-        if event_processor.stores.checkpoint_store.is_empty() {
-            let (committee, verified_checkpoint) = get_bootstrap_committee_and_checkpoint(
-                client_manager.get_sui_client().clone(),
-                client_manager.get_client().clone(),
-                event_processor.original_system_pkg_id,
-            )
-            .await?;
-            event_processor
-                .stores
-                .committee_store
-                .insert(&(), &committee)?;
-            event_processor
-                .stores
-                .checkpoint_store
-                .insert(&(), verified_checkpoint.serializable_ref())?;
-
-            // Also update the cache with the bootstrap checkpoint sequence number.
-            event_processor
-                .checkpoint_processor
-                .update_cached_latest_checkpoint_seq_number(*verified_checkpoint.sequence_number());
-        }
+        let _clients = client_manager.into_client_set();
 
         Ok(event_processor)
     }
@@ -244,17 +243,89 @@ impl EventProcessor {
 
     /// Starts the event processor. This method will run until the cancellation token is cancelled.
     pub async fn start(&self, cancellation_token: CancellationToken) -> Result<(), anyhow::Error> {
-        tracing::info!("starting event processor");
+        if self.config.enable_runtime_catchup {
+            tracing::info!("starting event processor with runtime catchup enabled");
+        } else {
+            tracing::info!("starting event processor with runtime catchup disabled");
+        }
+
+        let (coordination_state, coordination_rx) = CatchupCoordinationState::new();
+        let coordination_state = Arc::new(coordination_state);
+
+        let catchup_manager = EventBlobCatchupManager::new(
+            self.stores.clone(),
+            self.client_manager.clone().into_client_set(),
+            self.system_config.clone(),
+            self.recovery_path.clone(),
+            &self.metrics_registry,
+            catchup::CatchupRuntimeConfig {
+                coordination_state: coordination_state.clone(),
+                coordination_timeout: Duration::from_secs(STARTUP_CATCHUP_TIMEOUT_SECS),
+                processing_timeout: Duration::from_secs(RUNTIME_CATCHUP_PROCESSING_TIMEOUT_SECS),
+            },
+        );
+        // Notify tailing stopped to unblock the catchup task
+        coordination_state.notify_tailing_stopped();
+
+        if let Err(e) = catchup_manager
+            .catchup(self.config.event_stream_catchup_min_checkpoint_lag)
+            .await
+        {
+            tracing::error!("failed to catchup using event blobs: {e}");
+        }
+
+        if self.stores.checkpoint_store.is_empty() {
+            let (committee, verified_checkpoint) = get_bootstrap_committee_and_checkpoint(
+                self.client_manager.get_sui_client().clone(),
+                self.client_manager.get_client().clone(),
+                self.original_system_pkg_id,
+            )
+            .await?;
+
+            self.stores.committee_store.insert(&(), &committee)?;
+            self.stores
+                .checkpoint_store
+                .insert(&(), verified_checkpoint.serializable_ref())?;
+
+            self.checkpoint_processor
+                .update_cached_latest_checkpoint_seq_number(*verified_checkpoint.sequence_number());
+        }
+
         let pruning_task = self.start_pruning_events(cancellation_token.clone());
-        let tailing_task = self.start_tailing_checkpoints(cancellation_token.clone());
-        select! {
-            pruning_result = pruning_task => {
-                cancellation_token.cancel();
-                pruning_result
+        let tailing_task = self.start_tailing_checkpoints_with_restart_support(
+            cancellation_token.clone(),
+            coordination_state.clone(),
+            coordination_rx,
+        );
+        if self.config.enable_runtime_catchup {
+            let catchup_task = self.start_runtime_catchup_monitoring(
+                cancellation_token.clone(),
+                coordination_state.clone(),
+            );
+            select! {
+                pruning_result = pruning_task => {
+                    cancellation_token.cancel();
+                    pruning_result
+                }
+                tailing_result = tailing_task => {
+                    cancellation_token.cancel();
+                    tailing_result
+                }
+                catchup_result = catchup_task => {
+                    cancellation_token.cancel();
+                    catchup_result
+                }
             }
-            tailing_result = tailing_task => {
-                cancellation_token.cancel();
-                tailing_result
+        } else {
+            select! {
+                pruning_result = pruning_task => {
+                    cancellation_token.cancel();
+                    pruning_result
+                }
+                tailing_result = tailing_task => {
+                    cancellation_token.cancel();
+                    tailing_result
+                }
             }
         }
     }
@@ -290,6 +361,9 @@ impl EventProcessor {
             self.sampled_tracing_interval,
         );
 
+        #[cfg(msim)]
+        sui_macros::fail_point_async!("pause_checkpoint_tailing_entry");
+
         while let Some(entry) = rx.recv().await {
             let Ok(checkpoint) = entry.result else {
                 let error = entry.result.err().unwrap_or(anyhow!("unknown error"));
@@ -323,6 +397,75 @@ impl EventProcessor {
                 .process_checkpoint(checkpoint, prev_verified_checkpoint, next_event_index)
                 .await?;
             next_checkpoint += 1;
+        }
+        Ok(())
+    }
+
+    fn start_tailing_task(
+        &self,
+        cancel_token: CancellationToken,
+        coordination_state: Arc<CatchupCoordinationState>,
+    ) -> JoinHandle<Result<()>> {
+        let processor = self.clone();
+        coordination_state.mark_tailing_started();
+        let coordination_state = coordination_state.clone();
+        tokio::spawn(async move {
+            tracing::info!("Starting tailing task");
+            let result = processor.start_tailing_checkpoints(cancel_token).await;
+            tracing::info!("Tailing task exited");
+            coordination_state.notify_tailing_stopped();
+            result
+        })
+    }
+
+    /// Checkpoint tailing with message-based coordination for catchup
+    async fn start_tailing_checkpoints_with_restart_support(
+        &self,
+        cancel_token: CancellationToken,
+        coordination_state: Arc<CatchupCoordinationState>,
+        mut coordination_rx: mpsc::UnboundedReceiver<CoordinationMessage>,
+    ) -> Result<()> {
+        let mut child_cancel_token = cancel_token.child_token();
+
+        let mut tailing_task: Option<JoinHandle<Result<()>>> =
+            Some(self.start_tailing_task(child_cancel_token.clone(), coordination_state.clone()));
+        loop {
+            tokio::select! {
+                msg = coordination_rx.recv() => {
+                    match msg {
+                        Some(CoordinationMessage::StopCheckpointTailing) => {
+                            child_cancel_token.cancel();
+                            if let Some(handle) = tailing_task.take() {
+                                match handle.await {
+                                    Ok(Ok(_)) => tracing::info!("tailing task exited"),
+                                    Ok(Err(error)) => tracing::error!(?error, "tailing task error"),
+                                    Err(error) => tracing::error!(?error, "tailing task panicked"),
+                                }
+                            } else {
+                                tracing::error!("stop requested but tailing task was not running");
+                                coordination_state.notify_tailing_stopped();
+                            }
+                            continue;
+                        }
+                        Some(CoordinationMessage::RestartCheckpointTailing |
+                            CoordinationMessage::CatchupFailed) => {
+                            tracing::info!("restarting checkpoint tailing");
+                            child_cancel_token = cancel_token.child_token();
+                            tailing_task = Some(self.start_tailing_task(
+                                child_cancel_token.clone(), coordination_state.clone()));
+                            continue;
+                        }
+                        None => {
+                            tracing::info!("tailing task exited");
+                            break;
+                        }
+                    }
+                }
+                _ = cancel_token.cancelled() => {
+                    tracing::info!("tailing task cancelled");
+                    break;
+                }
+            }
         }
         Ok(())
     }
@@ -367,5 +510,88 @@ impl EventProcessor {
                 },
             }
         }
+    }
+
+    /// Runtime catchup monitoring task
+    async fn start_runtime_catchup_monitoring(
+        &self,
+        cancel_token: CancellationToken,
+        coordination_state: Arc<CatchupCoordinationState>,
+    ) -> Result<()> {
+        let mut lag_check_interval = tokio::time::interval(self.config.runtime_lag_check_interval);
+        lag_check_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        tracing::info!(
+            check_interval_secs = self.config.runtime_lag_check_interval.as_secs(),
+            lag_threshold = self.config.runtime_catchup_lag_threshold,
+            "starting runtime catchup monitoring"
+        );
+
+        let coordination_state_clone = coordination_state.clone();
+        let catchup_manager = EventBlobCatchupManager::new(
+            self.stores.clone(),
+            self.client_manager.clone().into_client_set(),
+            self.system_config.clone(),
+            self.recovery_path.clone(),
+            &self.metrics_registry,
+            catchup::CatchupRuntimeConfig {
+                coordination_state: coordination_state_clone,
+                coordination_timeout: self.config.catchup_coordination_timeout,
+                processing_timeout: self.config.catchup_processing_timeout,
+            },
+        );
+
+        loop {
+            let _scope = monitored_scope::monitored_scope("RuntimeCatchupMonitoring");
+            select! {
+                _ = lag_check_interval.tick() => {
+                    if coordination_state.is_catchup_active() {
+                        continue;
+                    }
+
+                    match catchup_manager.get_current_lag().await {
+                        Ok(lag) => {
+                            self.metrics
+                                .runtime_lag_current
+                                .set(i64::try_from(lag).unwrap_or(i64::MAX));
+
+                            if lag > self.config.runtime_catchup_lag_threshold {
+                                tracing::info!(
+                                    lag = lag,
+                                    threshold = self.config.runtime_catchup_lag_threshold,
+                                    "triggering runtime catchup due to high lag"
+                                );
+                                match catchup_manager.perform_catchup().await {
+                                    Ok(()) => {}
+                                    Err(catchup::CatchupError::Recoverable(error)) => {
+                                        tracing::warn!(?error, "recoverable error in catchup");
+                                    }
+                                    Err(catchup::CatchupError::NonRecoverable(error)) => {
+                                        return Err(error);
+                                    }
+                                }
+                            } else {
+                                tracing::debug!(
+                                    lag = lag,
+                                    threshold = self.config.runtime_catchup_lag_threshold,
+                                    "lag below threshold, no catchup needed"
+                                );
+                            }
+                        }
+                        Err(error) => {
+                            tracing::warn!(
+                                error = ?error,
+                                "failed to calculate current lag for runtime catchup monitoring"
+                            );
+                        }
+                    }
+                }
+                _ = cancel_token.cancelled() => {
+                    tracing::info!("runtime catchup monitoring shutting down");
+                    break;
+                }
+            }
+        }
+        Ok(())
     }
 }

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -1150,6 +1150,7 @@ impl StorageNodeHandleBuilder {
                     // in simtest.
                     200
                 },
+                runtime_catchup_lag_threshold: 200,
                 ..Default::default()
             },
             use_legacy_event_provider: false,

--- a/crates/walrus-sui/src/client/retry_client/failover.rs
+++ b/crates/walrus-sui/src/client/retry_client/failover.rs
@@ -211,7 +211,7 @@ impl<ClientT, BuilderT: LazyClientBuilder<ClientT> + std::fmt::Debug>
                 Ok(client) => client,
                 Err(error) => {
                     // Log the error and failover to the next client.
-                    tracing::warn!(
+                    tracing::info!(
                         "failed to get client from url {}, error: {}, failover to next client",
                         self.lazy_client_builders[next_index]
                             .get_rpc_url()
@@ -344,7 +344,7 @@ impl<ClientT, BuilderT: LazyClientBuilder<ClientT> + std::fmt::Debug>
                         .get_current_rpc_url()
                         .await
                         .unwrap_or_else(|error| error.to_string());
-                    tracing::warn!(
+                    tracing::info!(
                         "RPC to endpoint {:?} failed with error: {:?}, fetching next client",
                         failed_rpc_url,
                         error

--- a/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
@@ -196,7 +196,14 @@ impl LazyClientBuilder<SuiClient> for LazySuiClientBuilder {
                     "build_sui_client",
                 )
                 .await
-                .map_err(|e| FailoverError::FailedToGetClient(e.to_string()))?;
+                .map_err(|e| {
+                    tracing::info!(
+                        "failed to get sui client from url {}, error: {}",
+                        rpc_url,
+                        e
+                    );
+                    FailoverError::FailedToGetClient(e.to_string())
+                })?;
                 Ok(Arc::new(sui_client))
             }
         }


### PR DESCRIPTION
## Description

This PR adds runtime catchup support to the walrus-service event processor so a node that falls behind at runtime can catch up using event blobs, while the checkpoint downloader continues to run safely.

1. Runtime lag monitoring and catchup trigger periodically computes lag between local and network checkpoints which triggers EventBlobCatchupManager when lag exceeds threshold at runtime (not only at startup).
2. New CatchupCoordinationState handles Stop/Restart/CatchupFailed with an unbounded channel.
3. Tailing uses start_tailing_checkpoints_with_restart_support to listen for coordination messages.
4. Processing phase sends a stop message, waits for acks, then restarts tailing afterwards.
5. Added an ack using Notify to signal when checkpoint tailing has fully stopped.
6. Tailing task uses a child CancellationToken

Process:
Monitor task checks lag at runtime_lag_check_interval. If lag > runtime_catchup_lag_threshold, it triggers catchup:
Phase 1: Download blobs (parallel to normal tailing).
Phase 2: Send Stop to tailing; wait for ack with timeout.
Phase 3: Process blobs; update stores and metrics.
Phase 4: Send Restart to tailing.


## Test plan

Added simtest