### PR TITLE
fix: skip setting latest event epoch when the first event is an epoch change event after node restart

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -1309,7 +1309,12 @@ impl StorageNode {
             return Ok(());
         };
 
-        tracing::debug!("checking the first contract event if we're severely lagging");
+        tracing::debug!(
+            "checking the first contract event if we're severely lagging, \
+            first new event epoch: {}, epoch at start: {}",
+            first_new_event_epoch,
+            epoch_at_start
+        );
 
         // Clear the starting epoch, so that we won't make this check again in the current run.
         *maybe_epoch_at_start = None;
@@ -1326,18 +1331,19 @@ impl StorageNode {
         }
 
         // Set the initial current event epoch. Note that if the first event is an epoch change
-        // start event, the current event epoch is the previous epoch, since the epoch change has
-        // not been executed yet.
-        let current_event_epoch = match event {
+        // start event, we don't set it here since the epoch change execution will set it to the
+        // new epoch. This helps prevent a race condition where the node enters recovery mode
+        // before the epoch change execution, and the node may be recovering to an epoch that is
+        // 2 or more epochs behind the latest epoch.
+        match event {
             ContractEvent::EpochChangeEvent(EpochChangeEvent::EpochChangeStart(
                 EpochChangeStart { .. },
-            )) => first_new_event_epoch - 1,
-            _ => first_new_event_epoch,
+            )) => {}
+            _ => self
+                .inner
+                .latest_event_epoch_sender
+                .send(Some(first_new_event_epoch))?,
         };
-
-        self.inner
-            .latest_event_epoch_sender
-            .send(Some(current_event_epoch))?;
 
         Ok(())
     }

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -1310,10 +1310,9 @@ impl StorageNode {
         };
 
         tracing::debug!(
-            "checking the first contract event if we're severely lagging, \
-            first new event epoch: {}, epoch at start: {}",
             first_new_event_epoch,
-            epoch_at_start
+            epoch_at_start,
+            "checking the first contract event if we're severely lagging"
         );
 
         // Clear the starting epoch, so that we won't make this check again in the current run.
@@ -1335,15 +1334,14 @@ impl StorageNode {
         // new epoch. This helps prevent a race condition where the node enters recovery mode
         // before the epoch change execution, and the node may be recovering to an epoch that is
         // 2 or more epochs behind the latest epoch.
-        match event {
-            ContractEvent::EpochChangeEvent(EpochChangeEvent::EpochChangeStart(
-                EpochChangeStart { .. },
-            )) => {}
-            _ => self
-                .inner
+        if !matches!(
+            event,
+            ContractEvent::EpochChangeEvent(EpochChangeEvent::EpochChangeStart(_))
+        ) {
+            self.inner
                 .latest_event_epoch_sender
-                .send(Some(first_new_event_epoch))?,
-        };
+                .send(Some(first_new_event_epoch))?;
+        }
 
         Ok(())
     }

--- a/crates/walrus-service/src/node/blob_sync.rs
+++ b/crates/walrus-service/src/node/blob_sync.rs
@@ -585,9 +585,9 @@ impl BlobSynchronizer {
             .owned_shards_at_epoch(latest_event_epoch)
             .unwrap_or_else(|error| {
                 tracing::error!(
-                    "shard assignment must be found at the certified epoch {}, error: {:?}",
-                    latest_event_epoch,
-                    error
+                    certified_epoch = latest_event_epoch,
+                    ?error,
+                    "shard assignment must be found at the certified epoch",
                 );
                 panic!(
                     "shard assignment must be found at the certified epoch {latest_event_epoch}, \

--- a/crates/walrus-service/src/node/blob_sync.rs
+++ b/crates/walrus-service/src/node/blob_sync.rs
@@ -583,12 +583,16 @@ impl BlobSynchronizer {
         let futures_iter = self
             .node
             .owned_shards_at_epoch(latest_event_epoch)
-            .unwrap_or_else(|_| {
+            .unwrap_or_else(|error| {
                 tracing::error!(
-                    "shard assignment must be found at the certified epoch {}",
-                    latest_event_epoch
+                    "shard assignment must be found at the certified epoch {}, error: {:?}",
+                    latest_event_epoch,
+                    error
                 );
-                panic!("shard assignment must be found at the certified epoch {latest_event_epoch}")
+                panic!(
+                    "shard assignment must be found at the certified epoch {latest_event_epoch}, \
+                    error: {error}",
+                )
             })
             .into_iter()
             .map(|shard| {


### PR DESCRIPTION
## Description

Previously in #2326 , we found that when the first event after a node restart is an epoch change event, we need to
set the latest event epoch to the previous epoch, since the epoch change hasn't been executed yet. What can happen
now is that after setting the epoch to the previous epoch, the `latest event epoch` may be 2 epochs earlier than the
latest epoch on chain. This can cause blob sync initiated by node recovery task to fail since we try to recover
blobs that are from 2 epochs ago.

The fix for this issue is that instead of setting the epoch to the previous epoch, we don't set `latest event epoch`
when the first event is an epoch change event. This is because after the epoch change event is executed, it will
set it to the latest one. In this case, blob recovery will always uses the epoch of the current event the node is processing.

## Test plan

Originally manifested in test_repeated_node_crash. 100 tests passed.

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
