### PR TITLE
feat: Enable Rocksdb statistics at runtime through config

### DIFF
--- a/crates/typed-store/src/metrics.rs
+++ b/crates/typed-store/src/metrics.rs
@@ -411,6 +411,14 @@ pub struct OperationMetrics {
     pub rocksdb_bloom_filter_prefix_useful_total: IntGaugeVec,
     /// Number of times prefix filter found a key matching the point query
     pub rocksdb_bloom_filter_prefix_true_positive_total: IntGaugeVec,
+    /// Number of bytes the compaction algorithm copied
+    pub rocksdb_compaction_num_bytes_written: IntGaugeVec,
+    /// Number of bytes read by the compaction algorithm
+    pub rocksdb_compaction_num_bytes_read: IntGaugeVec,
+    /// Number of bytes read
+    pub rocksdb_num_bytes_read: IntGaugeVec,
+    /// Number of bytes written
+    pub rocksdb_num_bytes_written: IntGaugeVec,
 }
 
 impl OperationMetrics {
@@ -690,6 +698,34 @@ impl OperationMetrics {
             rocksdb_bloom_filter_prefix_true_positive_total: register_int_gauge_vec_with_registry!(
                 "rocksdb_bloom_filter_prefix_true_positive_total",
                 "Number of times prefix filter found a key matching the point query",
+                &["db_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_compaction_num_bytes_written: register_int_gauge_vec_with_registry!(
+                "rocksdb_compaction_num_bytes_written",
+                "Number of bytes the compaction algorithm copied",
+                &["db_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_compaction_num_bytes_read: register_int_gauge_vec_with_registry!(
+                "rocksdb_compaction_num_bytes_read",
+                "Number of bytes read by the compaction algorithm",
+                &["db_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_num_bytes_read: register_int_gauge_vec_with_registry!(
+                "rocksdb_num_bytes_read",
+                "Number of bytes read by the db",
+                &["db_name"],
+                registry,
+            )
+            .unwrap(),
+            rocksdb_num_bytes_written: register_int_gauge_vec_with_registry!(
+                "rocksdb_num_bytes_written",
+                "Number of bytes written by the db",
                 &["db_name"],
                 registry,
             )

--- a/crates/typed-store/src/rocks.rs
+++ b/crates/typed-store/src/rocks.rs
@@ -954,6 +954,34 @@ impl<K, V> DBMap<K, V> {
                     .db_options
                     .get_ticker_count(Ticker::BloomFilterPrefixTruePositive) as i64,
             );
+        db_metrics
+            .op_metrics
+            .rocksdb_compaction_num_bytes_written
+            .with_label_values(&[&rocksdb.db_name()])
+            .set(
+                rocksdb
+                    .db_options
+                    .get_ticker_count(Ticker::CompactWriteBytes) as i64,
+            );
+        db_metrics
+            .op_metrics
+            .rocksdb_compaction_num_bytes_read
+            .with_label_values(&[&rocksdb.db_name()])
+            .set(
+                rocksdb
+                    .db_options
+                    .get_ticker_count(Ticker::CompactReadBytes) as i64,
+            );
+        db_metrics
+            .op_metrics
+            .rocksdb_num_bytes_read
+            .with_label_values(&[&rocksdb.db_name()])
+            .set(rocksdb.db_options.get_ticker_count(Ticker::BytesRead) as i64);
+        db_metrics
+            .op_metrics
+            .rocksdb_num_bytes_written
+            .with_label_values(&[&rocksdb.db_name()])
+            .set(rocksdb.db_options.get_ticker_count(Ticker::BytesWritten) as i64);
     }
 
     /// Create a checkpoint of the database

--- a/crates/walrus-service/src/node/storage/database_config.rs
+++ b/crates/walrus-service/src/node/storage/database_config.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use rocksdb::{DBCompressionType, Options};
+use rocksdb::{DBCompressionType, Options, statistics::StatsLevel};
 use serde::{Deserialize, Serialize};
 use typed_store::rocks::get_block_options;
 
@@ -282,6 +282,8 @@ pub struct GlobalDatabaseOptions {
     pub wal_ttl_seconds: Option<u64>,
     /// The size limit for the WAL in MB.
     pub wal_size_limit_mb: Option<u64>,
+    /// Whether to enable statistics.
+    pub enable_statistics: bool,
 }
 
 impl Default for GlobalDatabaseOptions {
@@ -292,6 +294,7 @@ impl Default for GlobalDatabaseOptions {
             keep_log_file_num: Some(50),
             wal_ttl_seconds: Some(60 * 60 * 24 * 2), // 2 days,
             wal_size_limit_mb: Some(10 * 1024),      // 10 GB,
+            enable_statistics: false,
         }
     }
 }
@@ -318,6 +321,11 @@ impl From<&GlobalDatabaseOptions> for Options {
 
         if let Some(wal_size_limit_mb) = value.wal_size_limit_mb {
             options.set_wal_size_limit_mb(wal_size_limit_mb);
+        }
+
+        if value.enable_statistics {
+            options.enable_statistics();
+            options.set_statistics_level(StatsLevel::ExceptHistogramOrTimers);
         }
 
         options


### PR DESCRIPTION
## Description

This PR allows us to enable RocksDB statistics at runtime through database config change. Also adds some db compaction related statistics  to be tracked.