### PR TITLE
fix(daemon): use client multiplexer in daemon

### DIFF
--- a/crates/walrus-service/src/client/cli/runner.rs
+++ b/crates/walrus-service/src/client/cli/runner.rs
@@ -1212,15 +1212,16 @@ impl ClientCommandRunner {
         aggregator_args: AggregatorArgs,
     ) -> Result<()> {
         args.print_debug_message("attempting to run the Walrus daemon");
-        let auth_config = args.generate_auth_config()?;
-
-        let client = get_contract_client(
-            self.config?,
-            self.wallet,
+        let client = ClientMultiplexer::new(
+            self.wallet?,
+            &self.config?,
             self.gas_budget,
-            &args.daemon_args.blocklist,
+            registry,
+            &args,
         )
         .await?;
+        let auth_config = args.generate_auth_config()?;
+
         ClientDaemon::new_daemon(client, auth_config, registry, &args, &aggregator_args)
             .run()
             .await?;


### PR DESCRIPTION
## Description

Fixes a bug whereby the `publisher` uses the `ClientMutliplexer`, but the `daemon` does not.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
