### PR TITLE
fix(client): fix JSON parsing of storeQuilt options

### DIFF
--- a/crates/walrus-service/src/client/cli/args.rs
+++ b/crates/walrus-service/src/client/cli/args.rs
@@ -227,7 +227,10 @@ pub enum CliCommands {
         /// Custom identifiers and tags are NOT supported for quilt patches.
         /// Use `--blobs` to specify custom identifiers and tags.
         #[arg(long, num_args = 0..)]
-        #[serde(deserialize_with = "walrus_utils::config::resolve_home_dir_vec")]
+        #[serde(
+            default,
+            deserialize_with = "walrus_utils::config::resolve_home_dir_vec"
+        )]
         paths: Vec<PathBuf>,
         /// Blobs to include in the quilt, each blob is specified as a JSON string.
         ///


### PR DESCRIPTION
## Description

The missing `serde(default)` meant that the `paths` argument always had to be included when using the JSON mode.

## Test plan

Manual test.
