### PR TITLE
fix: minor improvements to config files

### DIFF
--- a/crates/walrus-sdk/client_config_example.yaml
+++ b/crates/walrus-sdk/client_config_example.yaml
@@ -11,7 +11,7 @@ communication_config:
   max_concurrent_sliver_reads: null
   max_concurrent_metadata_reads: 3
   max_concurrent_status_reads: null
-  max_data_in_flight: null
+  max_data_in_flight: 12500000
   reqwest_config:
     total_timeout_millis: 30000
     pool_idle_timeout_millis: null

--- a/crates/walrus-service/node_config_example.yaml
+++ b/crates/walrus-service/node_config_example.yaml
@@ -115,6 +115,7 @@ sui:
     max_retries: 5
   gas_budget: null
   rpc_fallback_config: null
+  additional_rpc_endpoints: []
   request_timeout: null
 blob_recovery:
   max_concurrent_blob_syncs: 100

--- a/crates/walrus-service/src/common/config.rs
+++ b/crates/walrus-service/src/common/config.rs
@@ -51,7 +51,7 @@ pub struct SuiConfig {
     #[serde(default, skip_serializing_if = "defaults::is_none")]
     pub rpc_fallback_config: Option<RpcFallbackConfig>,
     /// Additional RPC endpoints to use for the event processor.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "defaults::is_default")]
     pub additional_rpc_endpoints: Vec<String>,
     /// The request timeout for communicating with Sui network.
     #[serde(default, skip_serializing_if = "defaults::is_none")]

--- a/docs/book/usage/setup.md
+++ b/docs/book/usage/setup.md
@@ -217,6 +217,11 @@ The configuration file currently supports the following parameters for each of t
 system_object: 0x2134d52768ea07e8c43570ef975eb3e4c27a39fa6396bef985b5abc58d03ddd2
 staking_object: 0x10b9d30c28448939ce6c4d6c6e0ffce4a7f8a4ada8248bdad09ef8b70e4a3904
 
+# You can specify a list of Sui RPC URLs for reads. If none is provided, the RPC URL in the Sui
+# wallet is used.
+rpc_urls:
+  - https://fullnode.mainnet.sui.io:443
+
 # You can define a custom path to your Sui wallet configuration here. If this is unset or `null`
 # (default), the wallet is configured from `./sui_config.yaml` (relative to your current working
 # directory), or the system-wide wallet at `~/.sui/sui_config/client.yaml` in this order. Both
@@ -232,8 +237,11 @@ wallet_config:
   # configuration file.
   active_address: 0x...
 
-# The following parameters can be used to tune the networking behavior of the client. There is no
-# risk in playing around with these values. In the worst case, you may not be able to store/read
-# blob due to timeouts or other networking errors.
-{{ #include ../setup/client_config_example.yaml:8: }}
+# [...]
 ```
+
+There are some additional parameters that can be used to tune the networking behavior of the client,
+see the [full example client configuration](../setup/client_config_example.yaml). If you experience
+excessively slow uploads, it may be worth experimenting with these values. There is no risk in
+playing around with these values; in the worst case, you may not be able to store/read blob due to
+timeouts or other networking errors.


### PR DESCRIPTION
## Description

- Remove the `Option` for the `max_data_in_flight` parameter.
- Include the `additional_rpc_endpoints` in the autogenerated example config.
- Print a more useful error if the client configuration cannot be parsed.
- Improve documentation around the client configuration.

## Test plan

Modified unit test, manual inspection.
