### PR TITLE
feat: Enable transactions in storage db

### DIFF
--- a/crates/typed-store/src/rocks/errors.rs
+++ b/crates/typed-store/src/rocks/errors.rs
@@ -92,6 +92,13 @@ pub fn typed_store_err_from_bcs_err(err: bcs::Error) -> TypedStoreError {
 /// Convert the rocksdb error to the typed store error
 pub fn typed_store_err_from_rocks_err(err: RocksError) -> TypedStoreError {
     match err.kind() {
+        // Busy: transaction conflict (pessimistic lock conflict or optimistic commit conflict).
+        // TryAgain: insufficient memtable history to validate conflicts; retry is recommended.
+        // References:
+        // - Transactions overview: https://github.com/facebook/rocksdb/wiki/Transactions
+        // - Optimistic txns (Busy/TryAgain, history tuning):
+        //   https://github.com/facebook/rocksdb/wiki/Optimistic-Transactions
+        // - Status codes: https://github.com/facebook/rocksdb/blob/main/include/rocksdb/status.h
         rocksdb::ErrorKind::Busy | rocksdb::ErrorKind::TryAgain => {
             TypedStoreError::RetryableTransactionError
         }

--- a/crates/walrus-service/node_config_example.yaml
+++ b/crates/walrus-service/node_config_example.yaml
@@ -9,6 +9,7 @@ db_config:
     wal_ttl_seconds: 172800
     wal_size_limit_mb: 10240
     enable_statistics: false
+    experimental_use_optimistic_transaction_db: false
   standard:
     enable_blob_files: false
     min_blob_size: 0

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -263,12 +263,21 @@ impl Storage {
             .chain(blob_info_column_families)
             .collect::<Vec<_>>();
 
-        let database = rocks::open_cf_opts(
-            path,
-            Some(db_opts),
-            metrics_config,
-            &expected_column_families,
-        )?;
+        let database = if db_config.experimental_use_optimistic_transaction_db() {
+            rocks::open_cf_opts_optimistic(
+                path,
+                Some(db_opts),
+                metrics_config,
+                &expected_column_families,
+            )?
+        } else {
+            rocks::open_cf_opts(
+                path,
+                Some(db_opts),
+                metrics_config,
+                &expected_column_families,
+            )?
+        };
 
         let node_status = DBMap::reopen(
             &database,

--- a/crates/walrus-service/src/node/storage/database_config.rs
+++ b/crates/walrus-service/src/node/storage/database_config.rs
@@ -227,6 +227,12 @@ pub struct GlobalDatabaseOptions {
     pub wal_size_limit_mb: Option<u64>,
     /// Whether to enable statistics.
     pub enable_statistics: bool,
+    /// Temporary/experimental: if true, open databases using OptimisticTransactionDB instead of
+    /// the standard DB. This enables optimistic transactions for write paths that need
+    /// transactional semantics. Once transactions are fully adopted, this flag should be removed
+    /// and the behavior made unconditional.
+    #[serde(alias = "use_optimistic_transaction_db")]
+    pub experimental_use_optimistic_transaction_db: bool,
 }
 
 impl Default for GlobalDatabaseOptions {
@@ -238,6 +244,18 @@ impl Default for GlobalDatabaseOptions {
             wal_ttl_seconds: Some(60 * 60 * 24 * 2), // 2 days,
             wal_size_limit_mb: Some(10 * 1024),      // 10 GB,
             enable_statistics: false,
+            experimental_use_optimistic_transaction_db: false,
+        }
+    }
+}
+
+impl GlobalDatabaseOptions {
+    /// Provides a config tailored for tests. In particular, enables optimistic transactions.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn default_for_test() -> Self {
+        Self {
+            experimental_use_optimistic_transaction_db: true,
+            ..Default::default()
         }
     }
 }
@@ -357,6 +375,11 @@ impl DatabaseConfig {
     /// Returns the global database options.
     pub fn global(&self) -> GlobalDatabaseOptions {
         self.global.clone()
+    }
+
+    /// Returns true if the storage node should use OptimisticTransactionDB.
+    pub fn experimental_use_optimistic_transaction_db(&self) -> bool {
+        self.global.experimental_use_optimistic_transaction_db
     }
 
     fn standard(&self) -> DatabaseTableOptions {
@@ -508,6 +531,17 @@ impl Default for DatabaseConfig {
             event_store: None,
             init_state: None,
             shared_shard_storage_block_cache_config: None,
+        }
+    }
+}
+
+impl DatabaseConfig {
+    /// Provides a config tailored for tests.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn default_for_test() -> Self {
+        Self {
+            global: GlobalDatabaseOptions::default_for_test(),
+            ..Default::default()
         }
     }
 }

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -3037,7 +3037,7 @@ pub fn storage_node_config() -> WithTempDir<StorageNodeConfig> {
             .try_into()
             .expect("should be able to find an unused socket address"),
             storage_path: temp_dir.path().to_path_buf(),
-            db_config: Default::default(),
+            db_config: DatabaseConfig::default_for_test(),
             rest_server: Default::default(),
             blocklist_path: None,
             sui: None,


### PR DESCRIPTION
## Description

Enable optimistic transaction through a config. Rollout plan would be to enable it on selective (mysten) nodes and monitor performance before rolling out widely.

## Test plan

Existing tests