### PR TITLE
ci: make sure we catch inconsistent example files

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -9,7 +9,7 @@ filter = 'package(walrus-e2e-tests)'
 threads-required = 4
 
 [profile.ci]
-retries = 2 # retry twice for a total of 3 attempts
+retries = 1 # retry once for a total of 2 attempts
 slow-timeout = { period = "1m", terminate-after = 10 } # Timeout tests after 10 minutes
 
 [[profile.ci.overrides]]
@@ -18,7 +18,9 @@ slow-timeout = { period = "2m", terminate-after = 5 } # Mark E2E tests as slow o
 threads-required = 4
 
 [[profile.ci.overrides]]
-filter = 'test(check_and_update_example_config) or test(check_and_update_openapi)'
+# We have some tests that keep example files in sync with the code. If the files are not in sync,
+# the test fails and overwrites these example files. If we retry them, they always succeed.
+filter = 'test(~check_and_update)'
 retries = 0 # Do not retry these tests as they always succeed on the second run
 
 [profile.simtest]

--- a/crates/walrus-upload-relay/src/controller.rs
+++ b/crates/walrus-upload-relay/src/controller.rs
@@ -599,7 +599,7 @@ mod tests {
     const EXAMPLE_CONFIG_PATH: &str = "walrus_upload_relay_config_example.yaml";
 
     #[test]
-    fn keep_example_config_in_sync() {
+    fn check_and_update_example_config() {
         let config = WalrusUploadRelayConfig {
             tip_config: TipConfig::SendTip {
                 address: SuiAddress::from_bytes([42; 32]).expect("valid bytes"),
@@ -621,7 +621,7 @@ mod tests {
     /// This test ensures that the files `upload_relay_openapi.yaml` and
     /// `upload_relay_openapi.html` are kept in sync with changes to the spec.
     #[test]
-    fn upload_relay_check_and_update_openapi_spec() {
+    fn check_and_update_openapi_spec() {
         let label = "upload_relay";
         let spec_path = format!("{label}_openapi.yaml");
         let html_path = format!("{label}_openapi.html");


### PR DESCRIPTION
## Description

Make sure we catch inconsistent example files in CI by turning off retries for the corresponding tests.

Also reduce the default number of retries to 1 to catch excessively flaky tests.

## Test plan

Run the CI with an inconsistency introduced by a test commit 62f4b04b7568aabaa3d8f6aab276be901097b840: https://github.com/MystenLabs/walrus/actions/runs/17297627090/job/49099781547?pr=2478