### PR TITLE
chore: bump Sui version to testnet-v1.55.0

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -155,7 +155,9 @@ jobs:
     if: ${{ needs.diff.outputs.isRelevantForRustTests == 'true' }}
     runs-on: ubuntu-ghcloud
     env:
-      MSIM_TEST_NUM: 5
+      # TODO(zhewu): set this back to 5 after proper walrus cluster cleanup is implemented after
+      # each test run.
+      MSIM_TEST_NUM: 1
       # Turn off Sui logging since it can be very distractive in CI
       RUST_LOG: simtest=info,error,sui_=off,consensus_core=off
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1364,8 +1364,8 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bin-version"
-version = "1.54.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+version = "1.55.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "const-str 0.5.7",
  "git-version",
@@ -2087,7 +2087,7 @@ dependencies = [
 [[package]]
 name = "consensus-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "fastcrypto",
  "mysten-network",
@@ -2099,7 +2099,7 @@ dependencies = [
 [[package]]
 name = "consensus-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -2156,7 +2156,7 @@ dependencies = [
 [[package]]
 name = "consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "base64 0.21.7",
  "consensus-config",
@@ -3232,7 +3232,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -4746,6 +4746,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpc"
+version = "0.1.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "jsonrpsee"
 version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5484,12 +5496,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 
 [[package]]
 name = "move-abstract-interpreter-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "move-binary-format",
 ]
@@ -5497,12 +5509,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "enum-compat-util",
@@ -5518,12 +5530,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5539,7 +5551,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "indexmap 2.11.0",
@@ -5552,7 +5564,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -5567,7 +5579,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -5577,7 +5589,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
@@ -5592,7 +5604,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
@@ -5607,7 +5619,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
@@ -5622,7 +5634,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5643,7 +5655,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5679,7 +5691,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5704,7 +5716,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5729,7 +5741,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5750,7 +5762,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "clap",
@@ -5773,7 +5785,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -5791,7 +5803,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "hex",
@@ -5804,7 +5816,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -5817,7 +5829,7 @@ dependencies = [
 [[package]]
 name = "move-model-2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5840,7 +5852,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "clap",
@@ -5876,7 +5888,7 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "enum-compat-util",
  "quote",
@@ -5886,7 +5898,7 @@ dependencies = [
 [[package]]
 name = "move-regex-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "itertools 0.10.5",
  "move-binary-format",
@@ -5897,7 +5909,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -5912,7 +5924,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v0"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -5927,7 +5939,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v1"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -5942,7 +5954,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v2"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -5957,7 +5969,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "once_cell",
  "phf",
@@ -5967,7 +5979,7 @@ dependencies = [
 [[package]]
 name = "move-trace-format"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -5979,7 +5991,7 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "move-binary-format",
  "once_cell",
@@ -5988,7 +6000,7 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "move-vm-config",
  "once_cell",
@@ -6000,7 +6012,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "better_any",
  "fail",
@@ -6020,7 +6032,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "better_any",
  "fail",
@@ -6039,7 +6051,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "better_any",
  "fail",
@@ -6058,7 +6070,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "better_any",
  "fail",
@@ -6077,7 +6089,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6091,7 +6103,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -6104,7 +6116,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -6117,7 +6129,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -6130,7 +6142,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -6143,7 +6155,7 @@ dependencies = [
 [[package]]
 name = "msim"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=192bd9590f8552d5a1c5debf66c4ff2672af037e#192bd9590f8552d5a1c5debf66c4ff2672af037e"
+source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=45b88cffa3f50d6f2022d0b422ca4a077ac96a98#45b88cffa3f50d6f2022d0b422ca4a077ac96a98"
 dependencies = [
  "ahash 0.7.8",
  "async-task",
@@ -6163,7 +6175,7 @@ dependencies = [
  "serde",
  "socket2 0.4.10",
  "tap",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.15",
  "toml 0.5.11",
  "tracing",
  "tracing-subscriber",
@@ -6172,7 +6184,7 @@ dependencies = [
 [[package]]
 name = "msim-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=192bd9590f8552d5a1c5debf66c4ff2672af037e#192bd9590f8552d5a1c5debf66c4ff2672af037e"
+source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=45b88cffa3f50d6f2022d0b422ca4a077ac96a98#45b88cffa3f50d6f2022d0b422ca4a077ac96a98"
 dependencies = [
  "darling 0.14.4",
  "proc-macro2",
@@ -6261,7 +6273,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "mysten-common"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "antithesis_sdk",
  "anyhow",
@@ -6284,7 +6296,7 @@ dependencies = [
 [[package]]
 name = "mysten-metrics"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "async-trait",
  "axum 0.8.4",
@@ -6305,7 +6317,7 @@ dependencies = [
 [[package]]
 name = "mysten-network"
 version = "0.2.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -6341,7 +6353,7 @@ dependencies = [
 [[package]]
 name = "mysten-service"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7535,7 +7547,7 @@ dependencies = [
 [[package]]
 name = "prometheus-closure-metric"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -8000,19 +8012,21 @@ dependencies = [
 
 [[package]]
 name = "real_tokio"
-version = "1.43.0"
-source = "git+https://github.com/MystenLabs/tokio-msim-fork.git?rev=7329bff6ee996d8df6cf810a9c2e59631ad5a2fb#7329bff6ee996d8df6cf810a9c2e59631ad5a2fb"
+version = "1.47.1"
+source = "git+https://github.com/MystenLabs/tokio-msim-fork.git?rev=c59702c3177a31405d42ec12e01fa4a445728326#c59702c3177a31405d42ec12e01fa4a445728326"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio 1.0.4",
  "parking_lot 0.12.4",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.10",
- "tokio-macros 2.5.0 (git+https://github.com/MystenLabs/tokio-msim-fork.git?rev=7329bff6ee996d8df6cf810a9c2e59631ad5a2fb)",
- "windows-sys 0.52.0",
+ "slab",
+ "socket2 0.6.0",
+ "tokio-macros 2.5.0 (git+https://github.com/MystenLabs/tokio-msim-fork.git?rev=c59702c3177a31405d42ec12e01fa4a445728326)",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9013,7 +9027,7 @@ dependencies = [
 [[package]]
 name = "shared-crypto"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "bcs",
  "eyre",
@@ -9115,7 +9129,7 @@ dependencies = [
 [[package]]
 name = "simulacrum"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9508,7 +9522,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 [[package]]
 name = "sui-adapter-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9541,7 +9555,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9569,7 +9583,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9596,7 +9610,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9623,7 +9637,7 @@ dependencies = [
 [[package]]
 name = "sui-authority-aggregation"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "futures",
  "mysten-metrics",
@@ -9635,7 +9649,7 @@ dependencies = [
 [[package]]
 name = "sui-config"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anemo",
  "anyhow",
@@ -9668,7 +9682,7 @@ dependencies = [
 [[package]]
 name = "sui-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anemo",
  "antithesis_sdk",
@@ -9758,8 +9772,8 @@ dependencies = [
 
 [[package]]
 name = "sui-crypto"
-version = "0.0.5"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=d3334e5a8b1127f2e197d85750f1fb78c7084ae1#d3334e5a8b1127f2e197d85750f1fb78c7084ae1"
+version = "0.0.6"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=8bc0ff524a3a60561f1ba6315399f6f09e2b85b3#8bc0ff524a3a60561f1ba6315399f6f09e2b85b3"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -9784,7 +9798,7 @@ dependencies = [
 [[package]]
 name = "sui-data-ingestion-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9812,8 +9826,8 @@ dependencies = [
 
 [[package]]
 name = "sui-display"
-version = "1.54.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+version = "1.55.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -9825,7 +9839,7 @@ dependencies = [
 [[package]]
 name = "sui-enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -9833,7 +9847,7 @@ dependencies = [
 [[package]]
 name = "sui-execution"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-interpreter-v2",
@@ -9871,16 +9885,16 @@ dependencies = [
 
 [[package]]
 name = "sui-field-count"
-version = "1.54.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+version = "1.55.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "sui-field-count-derive",
 ]
 
 [[package]]
 name = "sui-field-count-derive"
-version = "1.54.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+version = "1.55.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -9889,7 +9903,7 @@ dependencies = [
 [[package]]
 name = "sui-framework"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -9902,8 +9916,8 @@ dependencies = [
 
 [[package]]
 name = "sui-framework-snapshot"
-version = "1.54.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+version = "1.55.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9918,7 +9932,7 @@ dependencies = [
 [[package]]
 name = "sui-genesis-builder"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9946,7 +9960,7 @@ dependencies = [
 [[package]]
 name = "sui-http"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "bytes",
  "http 1.3.1",
@@ -9965,8 +9979,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer"
-version = "1.54.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+version = "1.55.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10036,8 +10050,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-framework"
-version = "1.54.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+version = "1.55.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10073,8 +10087,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-framework-store-traits"
-version = "1.54.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+version = "1.55.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10084,8 +10098,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-metrics"
-version = "1.54.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+version = "1.55.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -10101,7 +10115,7 @@ dependencies = [
 [[package]]
 name = "sui-json"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "bcs",
@@ -10118,7 +10132,7 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -10177,7 +10191,7 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc-api"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -10197,7 +10211,7 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc-types"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "bcs",
@@ -10230,11 +10244,17 @@ dependencies = [
 [[package]]
 name = "sui-keys"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
+ "async-trait",
+ "base64 0.21.7",
+ "bcs",
  "bip32",
+ "colored",
  "fastcrypto",
+ "jsonrpc",
+ "mockall 0.11.4",
  "rand 0.8.5",
  "regex",
  "serde",
@@ -10244,12 +10264,13 @@ dependencies = [
  "slip10_ed25519",
  "sui-types",
  "tiny-bip39",
+ "tokio",
 ]
 
 [[package]]
 name = "sui-macros"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "futures",
  "once_cell",
@@ -10260,7 +10281,7 @@ dependencies = [
 [[package]]
 name = "sui-metrics-push-client"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -10277,8 +10298,8 @@ dependencies = [
 
 [[package]]
 name = "sui-move-build"
-version = "1.54.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+version = "1.55.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -10303,7 +10324,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "bcs",
  "better_any",
@@ -10326,7 +10347,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "bcs",
  "better_any",
@@ -10347,7 +10368,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "bcs",
  "better_any",
@@ -10368,7 +10389,7 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "bcs",
  "better_any",
@@ -10388,8 +10409,8 @@ dependencies = [
 
 [[package]]
 name = "sui-name-service"
-version = "1.54.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+version = "1.55.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "bcs",
  "move-core-types",
@@ -10401,7 +10422,7 @@ dependencies = [
 [[package]]
 name = "sui-network"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -10440,8 +10461,8 @@ dependencies = [
 
 [[package]]
 name = "sui-node"
-version = "1.54.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+version = "1.55.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -10498,8 +10519,8 @@ dependencies = [
 
 [[package]]
 name = "sui-open-rpc"
-version = "1.54.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+version = "1.55.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "bcs",
  "schemars 0.8.22",
@@ -10511,7 +10532,7 @@ dependencies = [
 [[package]]
 name = "sui-open-rpc-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -10523,8 +10544,8 @@ dependencies = [
 
 [[package]]
 name = "sui-package-management"
-version = "1.54.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+version = "1.55.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -10542,7 +10563,7 @@ dependencies = [
 [[package]]
 name = "sui-package-resolver"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "async-trait",
  "bcs",
@@ -10559,8 +10580,8 @@ dependencies = [
 
 [[package]]
 name = "sui-pg-db"
-version = "1.54.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+version = "1.55.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10589,7 +10610,7 @@ dependencies = [
 [[package]]
 name = "sui-proc-macros"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -10601,7 +10622,7 @@ dependencies = [
 [[package]]
 name = "sui-protocol-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "clap",
  "fastcrypto",
@@ -10618,7 +10639,7 @@ dependencies = [
 [[package]]
 name = "sui-protocol-config-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10627,8 +10648,8 @@ dependencies = [
 
 [[package]]
 name = "sui-rpc"
-version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=d3334e5a8b1127f2e197d85750f1fb78c7084ae1#d3334e5a8b1127f2e197d85750f1fb78c7084ae1"
+version = "0.0.6"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=8bc0ff524a3a60561f1ba6315399f6f09e2b85b3#8bc0ff524a3a60561f1ba6315399f6f09e2b85b3"
 dependencies = [
  "base64 0.22.1",
  "bcs",
@@ -10647,7 +10668,7 @@ dependencies = [
 [[package]]
 name = "sui-rpc-api"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -10693,8 +10714,8 @@ dependencies = [
 
 [[package]]
 name = "sui-sdk"
-version = "1.54.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+version = "1.55.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10726,8 +10747,8 @@ dependencies = [
 
 [[package]]
 name = "sui-sdk-types"
-version = "0.0.5"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=d3334e5a8b1127f2e197d85750f1fb78c7084ae1#d3334e5a8b1127f2e197d85750f1fb78c7084ae1"
+version = "0.0.6"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=8bc0ff524a3a60561f1ba6315399f6f09e2b85b3#8bc0ff524a3a60561f1ba6315399f6f09e2b85b3"
 dependencies = [
  "base64ct",
  "bcs",
@@ -10747,7 +10768,7 @@ dependencies = [
 [[package]]
 name = "sui-simulator"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -10771,7 +10792,7 @@ dependencies = [
 [[package]]
 name = "sui-snapshot"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "bcs",
@@ -10799,8 +10820,8 @@ dependencies = [
 
 [[package]]
 name = "sui-sql-macro"
-version = "1.54.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+version = "1.55.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -10810,7 +10831,7 @@ dependencies = [
 [[package]]
 name = "sui-storage"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10860,7 +10881,7 @@ dependencies = [
 [[package]]
 name = "sui-swarm"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "futures",
@@ -10887,7 +10908,7 @@ dependencies = [
 [[package]]
 name = "sui-swarm-config"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anemo",
  "anyhow",
@@ -10914,7 +10935,7 @@ dependencies = [
 [[package]]
 name = "sui-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "reqwest",
  "serde",
@@ -10925,7 +10946,7 @@ dependencies = [
 [[package]]
 name = "sui-test-transaction-builder"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "bcs",
  "move-core-types",
@@ -10939,7 +10960,7 @@ dependencies = [
 [[package]]
 name = "sui-tls"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -10961,7 +10982,7 @@ dependencies = [
 [[package]]
 name = "sui-transaction-builder"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10978,7 +10999,7 @@ dependencies = [
 [[package]]
 name = "sui-transaction-checks"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "fastcrypto-zkp",
  "once_cell",
@@ -10993,7 +11014,7 @@ dependencies = [
 [[package]]
 name = "sui-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anemo",
  "anyhow",
@@ -11069,7 +11090,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -11085,7 +11106,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -11101,7 +11122,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -11116,7 +11137,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -11236,7 +11257,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "telemetry-subscribers"
 version = "0.2.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -11312,7 +11333,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 [[package]]
 name = "test-cluster"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "anyhow",
  "bcs",
@@ -11551,9 +11572,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.46.1"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
@@ -11564,10 +11585,10 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tokio-macros 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11584,7 +11605,7 @@ dependencies = [
 [[package]]
 name = "tokio-macros"
 version = "2.5.0"
-source = "git+https://github.com/MystenLabs/tokio-msim-fork.git?rev=7329bff6ee996d8df6cf810a9c2e59631ad5a2fb#7329bff6ee996d8df6cf810a9c2e59631ad5a2fb"
+source = "git+https://github.com/MystenLabs/tokio-msim-fork.git?rev=c59702c3177a31405d42ec12e01fa4a445728326#c59702c3177a31405d42ec12e01fa4a445728326"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11689,15 +11710,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
-source = "git+https://github.com/MystenLabs/tokio-msim-fork.git?rev=7329bff6ee996d8df6cf810a9c2e59631ad5a2fb#7329bff6ee996d8df6cf810a9c2e59631ad5a2fb"
+version = "0.7.15"
+source = "git+https://github.com/MystenLabs/tokio-msim-fork.git?rev=c59702c3177a31405d42ec12e01fa4a445728326#c59702c3177a31405d42ec12e01fa4a445728326"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-io",
  "futures-sink",
  "futures-util",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.5",
  "pin-project-lite",
  "real_tokio",
  "slab",
@@ -12230,7 +12251,7 @@ dependencies = [
 [[package]]
 name = "typed-store"
 version = "0.4.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "async-trait",
  "backoff",
@@ -12291,7 +12312,7 @@ dependencies = [
 [[package]]
 name = "typed-store-derive"
 version = "0.3.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -12302,7 +12323,7 @@ dependencies = [
 [[package]]
 name = "typed-store-error"
 version = "0.4.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "serde",
  "thiserror 1.0.69",
@@ -12311,7 +12332,7 @@ dependencies = [
 [[package]]
 name = "typed-store-workspace-hack"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.54.0#037c533b2cdce536b95b626aaf1230358b6cdf05"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.55.0#53c8eb3b93dc3c97325a4922edf78e3fa00e4089"
 dependencies = [
  "cc",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,9 +76,9 @@ jsonwebtoken = "9.3.1"
 md5 = "0.7.0"
 mime = "0.3.17"
 mockall = "0.12.1"
-move-core-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
-move-package = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
-mysten-metrics = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
+move-core-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.55.0" }
+move-package = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.55.0" }
+mysten-metrics = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.55.0" }
 num-bigint = { version = "0.4.5", default-features = false }
 object_store = { version = "0.11.2", features = ["gcp"] }
 once_cell = { version = "1.21.3" }
@@ -109,25 +109,25 @@ serde_with = { version = "3.14", features = ["base64"] }
 serde_yaml = "0.9"
 sha2 = "0.10.9"
 snap = "1.1.0"
-sui-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
-sui-json-rpc-api = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
-sui-json-rpc-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
-sui-keys = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
-sui-macros = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
-sui-move-build = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
-sui-package-management = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
-sui-package-resolver = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
-sui-protocol-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
-sui-rpc-api = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
-sui-sdk = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
-sui-simulator = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
-sui-storage = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
-sui-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
+sui-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.55.0" }
+sui-json-rpc-api = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.55.0" }
+sui-json-rpc-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.55.0" }
+sui-keys = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.55.0" }
+sui-macros = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.55.0" }
+sui-move-build = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.55.0" }
+sui-package-management = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.55.0" }
+sui-package-resolver = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.55.0" }
+sui-protocol-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.55.0" }
+sui-rpc-api = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.55.0" }
+sui-sdk = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.55.0" }
+sui-simulator = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.55.0" }
+sui-storage = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.55.0" }
+sui-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.55.0" }
 syn = "2.0"
 tap = "1.0.1"
-telemetry-subscribers = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
+telemetry-subscribers = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.55.0" }
 tempfile = "3.21.0"
-test-cluster = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
+test-cluster = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.55.0" }
 thiserror = "2.0.16"
 tokio = { version = "=1.47.1", features = ["macros", "rt-multi-thread", "signal"] }
 tokio-metrics = { version = "0.4.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ telemetry-subscribers = { git = "https://github.com/MystenLabs/sui", tag = "test
 tempfile = "3.21.0"
 test-cluster = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.54.0" }
 thiserror = "2.0.16"
-tokio = { version = "=1.46.1", features = ["macros", "rt-multi-thread", "signal"] }
+tokio = { version = "=1.47.1", features = ["macros", "rt-multi-thread", "signal"] }
 tokio-metrics = { version = "0.4.2", default-features = false }
 tokio-stream = "0.1.17"
 tokio-util = "0.7.13"

--- a/contracts/subsidies/Move.lock
+++ b/contracts/subsidies/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "8D196BDCF541F37BD0D2BD1F49853E26A2269F160B70701E09DC9318985D4242"
+manifest_digest = "91580DCD159680CF6FE7630CBD6663DDD3A1D0FA31A6951D4FB3974D72E9DDEC"
 deps_digest = "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -12,11 +12,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.55.0", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.55.0", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -40,7 +40,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.53.2"
+compiler-version = "1.55.0"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/contracts/subsidies/Move.toml
+++ b/contracts/subsidies/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.54.0" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.55.0" }
 WAL = { local = "../wal" }
 Walrus = { local = "../walrus" }
 

--- a/contracts/wal/Move.lock
+++ b/contracts/wal/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "B5BFA891E818F99DD32A6AF2C206E007F75628C71E1C7128BE1D5A75C65BD499"
+manifest_digest = "F7B5A27B90D65DED3AECB07E0B255F24822E32937C132CB2D09A08876F534E79"
 deps_digest = "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -10,18 +10,18 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.55.0", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.55.0", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
 ]
 
 [move.toolchain-version]
-compiler-version = "1.53.2"
+compiler-version = "1.55.0"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/contracts/wal/Move.toml
+++ b/contracts/wal/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.54.0" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.55.0" }
 
 [addresses]
 wal = "0x0"

--- a/contracts/wal_exchange/Move.lock
+++ b/contracts/wal_exchange/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "4FD21C5A8774FADDD0CDB4ADB485B4A9AB22A3B7D7AB0C25F250FE9AF9379355"
+manifest_digest = "C21E45DA3D9D36C92C37B645C1CE1D6F67AAC2A2508FCC7458D6A18A8C5BE296"
 deps_digest = "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -11,11 +11,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.55.0", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.55.0", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -30,6 +30,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.53.2"
+compiler-version = "1.55.0"
 edition = "2024.beta"
 flavor = "sui"

--- a/contracts/wal_exchange/Move.toml
+++ b/contracts/wal_exchange/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.54.0" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.55.0" }
 WAL = { local = "../wal" }
 
 [addresses]

--- a/contracts/walrus/Move.lock
+++ b/contracts/walrus/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "7A23640DBBFC0616F6CA858C13F192A7C6173722E516EB1C21179E31FFCFF1D0"
+manifest_digest = "88642A3DBAA663BA40D52FB0497949FC5BCEA95B452B79D41F380E3499253B3D"
 deps_digest = "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -11,11 +11,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.55.0", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.55.0", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -30,7 +30,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.53.2"
+compiler-version = "1.55.0"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/contracts/walrus/Move.toml
+++ b/contracts/walrus/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.54.0" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.55.0" }
 WAL = { local = "../wal" }
 
 [addresses]

--- a/contracts/walrus_subsidies/Move.lock
+++ b/contracts/walrus_subsidies/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "EC1ECD06577F8AA5B66DF6C0D8D5BCC0CE4C74EEBC58FBF82293D9A3828C0DF4"
+manifest_digest = "000E2675FD7A59A45168CD8CD914103964480AE9B38A33F0BF3210ECB7A941C2"
 deps_digest = "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -12,11 +12,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.55.0", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.55.0", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -40,6 +40,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.53.2"
+compiler-version = "1.55.0"
 edition = "2024.beta"
 flavor = "sui"

--- a/contracts/walrus_subsidies/Move.toml
+++ b/contracts/walrus_subsidies/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.54.0" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.55.0" }
 WAL = { local = "../wal" }
 Walrus = { local = "../walrus" }
 

--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -2319,7 +2319,7 @@ pub async fn test_select_coins_max_objects() -> TestResult {
         None,
     )?;
     let env = cluster_wallet.get_active_env()?.to_owned();
-    let mut wallet = test_utils::temp_dir_wallet(None, env)?;
+    let mut wallet = test_utils::temp_dir_wallet(None, env).await?;
 
     let sui = |sui: u64| (sui * 1_000_000_000);
 

--- a/crates/walrus-service/src/client/multiplexer.rs
+++ b/crates/walrus-service/src/client/multiplexer.rs
@@ -371,7 +371,7 @@ impl<'a> SubClientLoader<'a> {
         sub_wallet_idx: usize,
         refresh_handle: CommitteesRefresherHandle,
     ) -> anyhow::Result<WalrusNodeClient<SuiContractClient>> {
-        let mut wallet = self.create_or_load_sub_wallet(sub_wallet_idx)?;
+        let mut wallet = self.create_or_load_sub_wallet(sub_wallet_idx).await?;
         self.top_up_if_necessary(&mut wallet, self.min_balance)
             .await?;
 
@@ -395,7 +395,7 @@ impl<'a> SubClientLoader<'a> {
     /// file. Otherwise, it creates a new wallet and saves it to the file.
     ///
     /// The corresponding keystore files are named `sui_<sub_wallet_idx>.keystore`.
-    fn create_or_load_sub_wallet(&self, sub_wallet_idx: usize) -> anyhow::Result<Wallet> {
+    async fn create_or_load_sub_wallet(&self, sub_wallet_idx: usize) -> anyhow::Result<Wallet> {
         let wallet_config_path = self
             .sub_wallets_dir
             .join(format!("sui_client_{sub_wallet_idx}.yaml"));
@@ -415,6 +415,7 @@ impl<'a> SubClientLoader<'a> {
                 Some(&keystore_filename),
                 self.config.communication_config.sui_client_request_timeout,
             )
+            .await
         }
     }
 

--- a/crates/walrus-service/src/common/utils.rs
+++ b/crates/walrus-service/src/common/utils.rs
@@ -497,7 +497,7 @@ pub async fn generate_sui_wallet(
         "generating Sui wallet for {sui_network} at '{}'",
         path.display()
     );
-    let mut wallet = walrus_sui::utils::create_wallet(path, sui_network.env(), None, None)?;
+    let mut wallet = walrus_sui::utils::create_wallet(path, sui_network.env(), None, None).await?;
     let rpc_urls = &[wallet.get_rpc_url()?];
     let client = RetriableSuiClient::new_for_rpc_urls(rpc_urls, Default::default(), None).await?;
 

--- a/crates/walrus-stress/src/generator/write_client.rs
+++ b/crates/walrus-stress/src/generator/write_client.rs
@@ -288,7 +288,8 @@ pub async fn wallet_for_testing_from_refill(
     let mut wallet = temp_dir_wallet(
         config.communication_config.sui_client_request_timeout,
         network.env(),
-    )?;
+    )
+    .await?;
     let address = wallet.as_mut().active_address()?;
     refiller.send_gas_request(address).await?;
     refiller.send_wal_request(address).await?;

--- a/crates/walrus-sui/src/client.rs
+++ b/crates/walrus-sui/src/client.rs
@@ -20,12 +20,7 @@ use retry_client::{RetriableSuiClient, retriable_sui_client::MAX_GAS_PAYMENT_OBJ
 use serde::{Deserialize, Serialize};
 use sui_package_management::LockCommand;
 use sui_sdk::{
-    rpc_types::{
-        SuiExecutionStatus,
-        SuiTransactionBlockEffectsAPI,
-        SuiTransactionBlockResponse,
-        get_new_package_obj_from_response,
-    },
+    rpc_types::{SuiExecutionStatus, SuiTransactionBlockEffectsAPI, SuiTransactionBlockResponse},
     types::base_types::ObjectID,
 };
 use sui_types::{TypeTag, base_types::SuiAddress, event::EventID, transaction::TransactionData};
@@ -2341,7 +2336,7 @@ impl SuiContractClientInner {
         method: &'static str,
     ) -> SuiClientResult<SuiTransactionBlockResponse> {
         // Sign the transaction with the wallet's keys
-        let signed_transaction = self.wallet.sign_transaction(&transaction);
+        let signed_transaction = self.wallet.sign_transaction(&transaction).await;
 
         // Execute the transaction and wait for response
         let response = self
@@ -2936,7 +2931,8 @@ impl SuiContractClientInner {
         response: &SuiTransactionBlockResponse,
         build_config: MoveBuildConfig,
     ) -> SuiClientResult<ObjectID> {
-        let new_package_id = get_new_package_obj_from_response(response)
+        let new_package_id = response
+            .get_new_package_obj()
             .ok_or_else(|| {
                 anyhow!(
                     "no new package ID found in the transaction response: {:?}",

--- a/crates/walrus-sui/src/system_setup.rs
+++ b/crates/walrus-sui/src/system_setup.rs
@@ -226,7 +226,7 @@ pub(crate) async fn publish_package(
 
     #[allow(deprecated)]
     let response = wallet
-        .execute_transaction_may_fail(wallet.sign_transaction(&tx_data))
+        .execute_transaction_may_fail(wallet.sign_transaction(&tx_data).await)
         .await?;
 
     // Update the lock file with the new package ID.
@@ -516,7 +516,7 @@ pub async fn create_system_and_staking_objects(
         TransactionData::new_programmable(address, gas_coins, ptb, gas_budget, gas_price);
 
     // sign and send transaction
-    let signed_transaction = wallet.sign_transaction(&transaction);
+    let signed_transaction = wallet.sign_transaction(&transaction).await;
     #[allow(deprecated)]
     let response = wallet
         .execute_transaction_may_fail(signed_transaction)

--- a/crates/walrus-sui/src/test_utils.rs
+++ b/crates/walrus-sui/src/test_utils.rs
@@ -384,7 +384,7 @@ pub mod using_tokio {
 }
 
 /// Creates a wallet for testing in a temporary directory.
-pub fn temp_dir_wallet(
+pub async fn temp_dir_wallet(
     request_timeout: Option<Duration>,
     env: SuiEnv,
 ) -> anyhow::Result<WithTempDir<Wallet>> {
@@ -394,7 +394,8 @@ pub fn temp_dir_wallet(
         env,
         None,
         request_timeout,
-    )?;
+    )
+    .await?;
 
     Ok(WithTempDir {
         inner: wallet,
@@ -526,7 +527,8 @@ pub async fn wallet_for_testing(
         funding_wallet.get_active_env()?.to_owned(),
         None,
         None,
-    )?;
+    )
+    .await?;
 
     if funded {
         fund_addresses(funding_wallet, vec![wallet.active_address()?], None).await?;
@@ -572,7 +574,7 @@ pub async fn fund_addresses(
     );
     #[allow(deprecated)]
     funding_wallet
-        .execute_transaction_may_fail(funding_wallet.sign_transaction(&transaction))
+        .execute_transaction_may_fail(funding_wallet.sign_transaction(&transaction).await)
         .await?;
 
     Ok(())

--- a/crates/walrus-sui/src/wallet.rs
+++ b/crates/walrus-sui/src/wallet.rs
@@ -49,8 +49,8 @@ impl Wallet {
     }
 
     /// Passes through to the `WalletContext` to sign a transaction.
-    pub fn sign_transaction(&self, transaction_data: &TransactionData) -> Transaction {
-        self.wallet_context.sign_transaction(transaction_data)
+    pub async fn sign_transaction(&self, transaction_data: &TransactionData) -> Transaction {
+        self.wallet_context.sign_transaction(transaction_data).await
     }
 
     // TODO: WAL-820 move callsites to the RetriableSuiClient.

--- a/docker/walrus-antithesis/sui_version.toml
+++ b/docker/walrus-antithesis/sui_version.toml
@@ -1,1 +1,1 @@
-SUI_VERSION = "testnet-v1.54.0"
+SUI_VERSION = "testnet-v1.55.0"

--- a/scripts/simtest/cargo-simtest
+++ b/scripts/simtest/cargo-simtest
@@ -54,9 +54,9 @@ if [[ -n "$LOCAL_MSIM_PATH" ]]; then
 else
   cargo_patch_args=(
     --config 'patch.crates-io.tokio.git = "https://github.com/MystenLabs/mysten-sim.git"'
-    --config 'patch.crates-io.tokio.rev = "192bd9590f8552d5a1c5debf66c4ff2672af037e"'
+    --config 'patch.crates-io.tokio.rev = "45b88cffa3f50d6f2022d0b422ca4a077ac96a98"'
     --config 'patch.crates-io.futures-timer.git = "https://github.com/MystenLabs/mysten-sim.git"'
-    --config 'patch.crates-io.futures-timer.rev = "192bd9590f8552d5a1c5debf66c4ff2672af037e"'
+    --config 'patch.crates-io.futures-timer.rev = "45b88cffa3f50d6f2022d0b422ca4a077ac96a98"'
   )
 fi
 

--- a/testnet-contracts/subsidies/Move.lock
+++ b/testnet-contracts/subsidies/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "8D196BDCF541F37BD0D2BD1F49853E26A2269F160B70701E09DC9318985D4242"
+manifest_digest = "91580DCD159680CF6FE7630CBD6663DDD3A1D0FA31A6951D4FB3974D72E9DDEC"
 deps_digest = "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -12,11 +12,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.55.0", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.55.0", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -40,7 +40,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.53.2"
+compiler-version = "1.55.0"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/testnet-contracts/subsidies/Move.toml
+++ b/testnet-contracts/subsidies/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.54.0" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.55.0" }
 WAL = { local = "../wal" }
 Walrus = { local = "../walrus" }
 

--- a/testnet-contracts/wal/Move.lock
+++ b/testnet-contracts/wal/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "B5BFA891E818F99DD32A6AF2C206E007F75628C71E1C7128BE1D5A75C65BD499"
+manifest_digest = "F7B5A27B90D65DED3AECB07E0B255F24822E32937C132CB2D09A08876F534E79"
 deps_digest = "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -10,18 +10,18 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.55.0", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.55.0", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
 ]
 
 [move.toolchain-version]
-compiler-version = "1.53.2"
+compiler-version = "1.55.0"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/testnet-contracts/wal/Move.toml
+++ b/testnet-contracts/wal/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.54.0" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.55.0" }
 
 [addresses]
 wal = "0x0"

--- a/testnet-contracts/wal_exchange/Move.lock
+++ b/testnet-contracts/wal_exchange/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "4FD21C5A8774FADDD0CDB4ADB485B4A9AB22A3B7D7AB0C25F250FE9AF9379355"
+manifest_digest = "C21E45DA3D9D36C92C37B645C1CE1D6F67AAC2A2508FCC7458D6A18A8C5BE296"
 deps_digest = "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -11,11 +11,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.55.0", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.55.0", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -30,7 +30,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.53.2"
+compiler-version = "1.55.0"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/testnet-contracts/wal_exchange/Move.toml
+++ b/testnet-contracts/wal_exchange/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.54.0" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.55.0" }
 WAL = { local = "../wal" }
 
 [addresses]

--- a/testnet-contracts/walrus/Move.lock
+++ b/testnet-contracts/walrus/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "7A23640DBBFC0616F6CA858C13F192A7C6173722E516EB1C21179E31FFCFF1D0"
+manifest_digest = "88642A3DBAA663BA40D52FB0497949FC5BCEA95B452B79D41F380E3499253B3D"
 deps_digest = "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -11,11 +11,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.55.0", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.55.0", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -30,7 +30,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.53.2"
+compiler-version = "1.55.0"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/testnet-contracts/walrus/Move.toml
+++ b/testnet-contracts/walrus/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.54.0" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.55.0" }
 WAL = { local = "../wal" }
 
 [addresses]

--- a/testnet-contracts/walrus_subsidies/Move.lock
+++ b/testnet-contracts/walrus_subsidies/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "EC1ECD06577F8AA5B66DF6C0D8D5BCC0CE4C74EEBC58FBF82293D9A3828C0DF4"
+manifest_digest = "000E2675FD7A59A45168CD8CD914103964480AE9B38A33F0BF3210ECB7A941C2"
 deps_digest = "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -12,11 +12,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.55.0", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.54.0", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.55.0", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -40,7 +40,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.53.2"
+compiler-version = "1.55.0"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/testnet-contracts/walrus_subsidies/Move.toml
+++ b/testnet-contracts/walrus_subsidies/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.54.0" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.55.0" }
 WAL = { local = "../wal" }
 Walrus = { local = "../walrus" }
 


### PR DESCRIPTION
## Description

Update sui version to testnet-v1.55.0

- addressed a number of breaking changes
- new version revealed a simtest setup issue that the walrus cluster is not properly cleaned. Will address in a followup PR.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
