### PR TITLE
docs: add section on avoiding duplicate-content SEO in custom portals

### DIFF
--- a/docs/book/SUMMARY.md
+++ b/docs/book/SUMMARY.md
@@ -66,6 +66,7 @@
   - [The Walrus Sites portal](./walrus-sites/portal.md)
   - [Bring your own domain](./walrus-sites/bring-your-own-domain.md)
   - [Site data authentication](./walrus-sites/authentication.md)
+  - [Avoiding Duplicate-Content SEO in Custom Portals](./walrus-sites/avoid-duplicate-content-seo.md)
   - [Known restrictions](./walrus-sites/restrictions.md)
 
 ---

--- a/docs/book/walrus-sites/avoid-duplicate-content-seo.md
+++ b/docs/book/walrus-sites/avoid-duplicate-content-seo.md
@@ -43,8 +43,8 @@ In the HTML `<head>`:
 
 ## Recommended Practices
 
-- **Canonical host policy**  
-  Choose one hostname type per site (custom domain > SuiNS > base36 is a good priority).  
+- **Canonical host policy**
+  Choose one hostname type per site (custom domain > SuiNS > base36 is a good priority).
   All other hosts should include canonical hints pointing to that choice.
 
 - **Base36 subdomains**
@@ -52,6 +52,7 @@ In the HTML `<head>`:
   - Disable if not needed: `B36_DOMAIN_RESOLUTION_SUPPORT=false`.
   - If enabled, add canonical hints (`<link rel="canonical">` or `Link: rel="canonical"`).
   - Optionally, block them from indexing with:
+
     ```http
     X-Robots-Tag: noindex
     ```
@@ -63,6 +64,6 @@ In the HTML `<head>`:
   - It’s always a good practice to add canonical hints in your HTML or headers pointing to your chosen custom domain,
     to avoid duplicate indexing across different hosts.
 
-- **Multiple SuiNS names → one site**  
+- **Multiple SuiNS names → one site**
   This can happen permissionlessly. If you own the extra names, add canonical hints in your site HTML
   to point to your preferred domain.

--- a/docs/book/walrus-sites/avoid-duplicate-content-seo.md
+++ b/docs/book/walrus-sites/avoid-duplicate-content-seo.md
@@ -1,14 +1,14 @@
 # Avoiding Duplicate-Content SEO in Custom Portals
 
-When you deploy your own Walrus Sites portal, you may expose the same site under multiple hostnames:
-
 > **Note:** This guidance does not require any changes to the Walrus Sites portal itself.
 > It is focused on **site-level fixes** (HTML tags or HTTP headers) that developers can
 > add when hosting their own portals.
 
+When you deploy your own Walrus Sites portal, you may expose the same site under multiple hostnames:
+
 - **[SuiNS](https://suins.io/)** – human-readable names registered on-chain, e.g. `snowreads.wal.app`.
 - **Base36** – subdomains derived directly from the site object ID, e.g. `1myb…xd.portal.com`.
-- **[BYOD](https://docs.wal.app/walrus-sites/bring-your-own-domain.html)** – Bring Your Own Domain,
+- **[Custom domains](https://docs.wal.app/walrus-sites/bring-your-own-domain.html)** – Bring Your Own Domain,
   e.g. `example.com`.
 
 Search engines treat the same content served at multiple hosts as duplicates,
@@ -20,48 +20,13 @@ If you run your own portal and enable base36 or BYOD, you must take steps to sig
 
 ---
 
-## Recommended Practices
-
-- **Canonical host policy**
-  Choose one hostname type per site (BYOD > SuiNS > base36 is a good priority).
-  All other hosts should include canonical hints pointing to that choice.
-
-- **Base36 subdomains**
-
-  - Disable if not needed: `B36_DOMAIN_RESOLUTION_SUPPORT=false`.
-  - If enabled, add either:
-
-    - An HTML `<link rel="canonical">` in your pages, or
-    - An HTTP header:
-
-      ```http
-      Link: <https://example.com/page>; rel="canonical"
-      ```
-
-  - Alternatively, block them from indexing with:
-
-    ```http
-    X-Robots-Tag: noindex
-    ```
-
-- **BYOD domains**
-
-  - Enable with care: `BRING_YOUR_OWN_DOMAIN=true`.
-  - Decide if BYOD or SuiNS is canonical, and ensure non-canonical hosts send canonical hints or `noindex`.
-
-- **Multiple SuiNS names → one site**
-  This can happen permissionlessly. If you own the extra names, add canonical hints to consolidate them.
-  Otherwise, add a `<link rel="canonical">` in the HTML to indicate your preferred host.
-
----
-
 ## Example Scenario
 
 **Problem:**
 You run a site that is reachable at both:
 
 - `https://example.wal.app/math` (SuiNS)
-- `https://example.com/math` (BYOD)
+- `https://example.com/math` (Custom domain)
 
 A web crawler will see identical content at two different URLs and may treat them as duplicates.
 
@@ -73,3 +38,28 @@ In the HTML `<head>`:
 ```html
 <link rel="canonical" href="https://example.com/math" />
 ```
+
+---
+
+## Recommended Practices
+
+- **Canonical host policy**  
+  Choose one hostname type per site (custom domain > SuiNS > base36 is a good priority).  
+  All other hosts should include canonical hints pointing to that choice.
+
+- **Base36 subdomains**
+
+  - Disable if not needed: `B36_DOMAIN_RESOLUTION_SUPPORT=false`.
+  - If enabled, add canonical hints (`<link rel="canonical">` or `Link: rel="canonical"`).
+  - Optionally, block them from indexing with:
+    ```http
+    X-Robots-Tag: noindex
+    ```
+
+- **Custom domains**
+
+  - Setting `BRING_YOUR_OWN_DOMAIN=true` makes the portal serve only your configured custom domain (single-site mode). Other domains, including SuiNS and base36, are not resolved by that portal.
+  - It’s always a good practice to add canonical hints in your HTML or headers pointing to your chosen custom domain, to avoid duplicate indexing across different hosts.
+
+- **Multiple SuiNS names → one site**  
+  This can happen permissionlessly. If you own the extra names, add canonical hints in your site HTML to point to your preferred domain.

--- a/docs/book/walrus-sites/avoid-duplicate-content-seo.md
+++ b/docs/book/walrus-sites/avoid-duplicate-content-seo.md
@@ -59,11 +59,13 @@ In the HTML `<head>`:
 
 - **Custom domains**
 
-  - Setting `BRING_YOUR_OWN_DOMAIN=true` makes the portal serve only your configured custom domain (single-site mode).
+  - Setting `BRING_YOUR_OWN_DOMAIN=true` makes the portal serve only your configured
+    custom domain (single-site mode).
     Other domains, including SuiNS and base36, are not resolved by that portal.
-  - It’s always a good practice to add canonical hints in your HTML or headers pointing to your chosen custom domain,
+  - It’s always a good practice to add canonical hints in your HTML or headers pointing
+    to your chosen custom domain,
     to avoid duplicate indexing across different hosts.
 
 - **Multiple SuiNS names → one site**
-  This can happen permissionlessly. If you own the extra names, add canonical hints in your site HTML
-  to point to your preferred domain.
+  This can happen permissionlessly. If you own the extra names, add canonical hints
+  in your site HTML to point to your preferred domain.

--- a/docs/book/walrus-sites/avoid-duplicate-content-seo.md
+++ b/docs/book/walrus-sites/avoid-duplicate-content-seo.md
@@ -1,0 +1,49 @@
+# Avoiding Duplicate-Content SEO in Custom Portals
+
+When you deploy your own Walrus Sites portal, you may expose the same site under multiple hostnames (e.g., **SuiNS**, **base36**, or **BYOD**). Search engines treat this as duplicate content, which can dilute ranking signals.
+
+The official `wal.app` portal avoids this by serving only **SuiNS domains** with base36 and BYOD disabled. If you enable base36 or BYOD on your own portal, you should enforce canonicalization.
+
+## Recommended Practices
+
+- **Canonical host policy**
+
+  - Choose one canonical type per site (e.g., BYOD > SuiNS > base36).
+  - Redirect all other hosts to the canonical one.
+
+- **Base36 subdomains**
+
+  - Disable if not needed: `B36_DOMAIN_RESOLUTION_SUPPORT=false`.
+  - If enabled, redirect (`301`) base36 → canonical host, or add `X-Robots-Tag: noindex` to base36 responses.
+
+- **BYOD domains**
+
+  - Enable with care: `BRING_YOUR_OWN_DOMAIN=true`.
+  - Decide if BYOD or SuiNS is canonical and redirect the rest.
+  - If redirect is not possible, inject canonical hints (headers or `<link rel="canonical">`).
+
+- **Implementation points**
+
+  - Add redirects or headers in `portal/server/src/main.ts` after host parsing.
+  - Example redirect:
+
+    ```ts
+    return new Response(null, {
+      status: 301,
+      headers: { Location: canonicalUrl },
+    });
+    ```
+
+  - Example noindex header:
+
+    ```ts
+    return new Response(body, {
+      headers: {
+        ...existingHeaders,
+        "X-Robots-Tag": "noindex",
+      },
+    });
+    ```
+
+- **Multiple SuiNS names → one site**
+  - This can happen permissionlessly. If you control the extra names, redirect them to your canonical. Otherwise, add a `<link rel="canonical">` in the site HTML as a best-effort signal.

--- a/docs/book/walrus-sites/avoid-duplicate-content-seo.md
+++ b/docs/book/walrus-sites/avoid-duplicate-content-seo.md
@@ -1,8 +1,11 @@
 # Avoiding Duplicate-Content SEO in Custom Portals
 
-When you deploy your own Walrus Sites portal, you may expose the same site under multiple hostnames (e.g., **SuiNS**, **base36**, or **BYOD**). Search engines treat this as duplicate content, which can dilute ranking signals.
+When you deploy your own Walrus Sites portal, you may expose the same site under multiple hostnames
+(e.g., **SuiNS**, **base36**, or **BYOD**). Search engines treat this as duplicate content,
+which can dilute ranking signals.
 
-The official `wal.app` portal avoids this by serving only **SuiNS domains** with base36 and BYOD disabled. If you enable base36 or BYOD on your own portal, you should enforce canonicalization.
+The official `wal.app` portal avoids this by serving only **SuiNS domains** with base36 and BYOD disabled.
+If you enable base36 or BYOD on your own portal, you should enforce canonicalization.
 
 ## Recommended Practices
 
@@ -46,4 +49,5 @@ The official `wal.app` portal avoids this by serving only **SuiNS domains** with
     ```
 
 - **Multiple SuiNS names → one site**
-  - This can happen permissionlessly. If you control the extra names, redirect them to your canonical. Otherwise, add a `<link rel="canonical">` in the site HTML as a best-effort signal.
+  - This can happen permissionlessly. If you control the extra names, redirect them to your canonical.
+    Otherwise, add a `<link rel="canonical">` in the site HTML as a best-effort signal.

--- a/docs/book/walrus-sites/avoid-duplicate-content-seo.md
+++ b/docs/book/walrus-sites/avoid-duplicate-content-seo.md
@@ -1,53 +1,75 @@
 # Avoiding Duplicate-Content SEO in Custom Portals
 
-When you deploy your own Walrus Sites portal, you may expose the same site under multiple hostnames
-(e.g., **SuiNS**, **base36**, or **BYOD**). Search engines treat this as duplicate content,
+When you deploy your own Walrus Sites portal, you may expose the same site under multiple hostnames:
+
+> **Note:** This guidance does not require any changes to the Walrus Sites portal itself.
+> It is focused on **site-level fixes** (HTML tags or HTTP headers) that developers can
+> add when hosting their own portals.
+
+- **[SuiNS](https://suins.io/)** – human-readable names registered on-chain, e.g. `snowreads.wal.app`.
+- **Base36** – subdomains derived directly from the site object ID, e.g. `1myb…xd.portal.com`.
+- **[BYOD](https://docs.wal.app/walrus-sites/bring-your-own-domain.html)** – Bring Your Own Domain,
+  e.g. `example.com`.
+
+Search engines treat the same content served at multiple hosts as duplicates,
 which can dilute ranking signals.
 
-The official `wal.app` portal avoids this by serving only **SuiNS domains** with base36 and BYOD disabled.
-If you enable base36 or BYOD on your own portal, you should enforce canonicalization.
+The official [`wal.app`](https://wal.app) portal avoids this issue by **only serving SuiNS domains**,
+with base36 and BYOD disabled.
+If you run your own portal and enable base36 or BYOD, you must take steps to signal a canonical host.
+
+---
 
 ## Recommended Practices
 
 - **Canonical host policy**
-
-  - Choose one canonical type per site (e.g., BYOD > SuiNS > base36).
-  - Redirect all other hosts to the canonical one.
+  Choose one hostname type per site (BYOD > SuiNS > base36 is a good priority).
+  All other hosts should include canonical hints pointing to that choice.
 
 - **Base36 subdomains**
 
   - Disable if not needed: `B36_DOMAIN_RESOLUTION_SUPPORT=false`.
-  - If enabled, redirect (`301`) base36 → canonical host, or add `X-Robots-Tag: noindex` to base36 responses.
+  - If enabled, add either:
+
+    - An HTML `<link rel="canonical">` in your pages, or
+    - An HTTP header:
+
+      ```http
+      Link: <https://example.com/page>; rel="canonical"
+      ```
+
+  - Alternatively, block them from indexing with:
+
+    ```http
+    X-Robots-Tag: noindex
+    ```
 
 - **BYOD domains**
 
   - Enable with care: `BRING_YOUR_OWN_DOMAIN=true`.
-  - Decide if BYOD or SuiNS is canonical and redirect the rest.
-  - If redirect is not possible, inject canonical hints (headers or `<link rel="canonical">`).
-
-- **Implementation points**
-
-  - Add redirects or headers in `portal/server/src/main.ts` after host parsing.
-  - Example redirect:
-
-    ```ts
-    return new Response(null, {
-      status: 301,
-      headers: { Location: canonicalUrl },
-    });
-    ```
-
-  - Example noindex header:
-
-    ```ts
-    return new Response(body, {
-      headers: {
-        ...existingHeaders,
-        "X-Robots-Tag": "noindex",
-      },
-    });
-    ```
+  - Decide if BYOD or SuiNS is canonical, and ensure non-canonical hosts send canonical hints or `noindex`.
 
 - **Multiple SuiNS names → one site**
-  - This can happen permissionlessly. If you control the extra names, redirect them to your canonical.
-    Otherwise, add a `<link rel="canonical">` in the site HTML as a best-effort signal.
+  This can happen permissionlessly. If you own the extra names, add canonical hints to consolidate them.
+  Otherwise, add a `<link rel="canonical">` in the HTML to indicate your preferred host.
+
+---
+
+## Example Scenario
+
+**Problem:**
+You run a site that is reachable at both:
+
+- `https://example.wal.app/math` (SuiNS)
+- `https://example.com/math` (BYOD)
+
+A web crawler will see identical content at two different URLs and may treat them as duplicates.
+
+**Solution:**
+Add a canonical hint so crawlers know which host to index:
+
+In the HTML `<head>`:
+
+```html
+<link rel="canonical" href="https://example.com/math" />
+```

--- a/docs/book/walrus-sites/avoid-duplicate-content-seo.md
+++ b/docs/book/walrus-sites/avoid-duplicate-content-seo.md
@@ -8,7 +8,7 @@ When you deploy your own Walrus Sites portal, you may expose the same site under
 
 - **[SuiNS](https://suins.io/)** – human-readable names registered on-chain, e.g. `snowreads.wal.app`.
 - **Base36** – subdomains derived directly from the site object ID, e.g. `1myb…xd.portal.com`.
-- **[Custom domains](https://docs.wal.app/walrus-sites/bring-your-own-domain.html)** – Bring Your Own Domain,
+- **[Custom domains](https://docs.wal.app/walrus-sites/bring-your-own-domain.html)** – BYOD,
   e.g. `example.com`.
 
 Search engines treat the same content served at multiple hosts as duplicates,
@@ -58,8 +58,11 @@ In the HTML `<head>`:
 
 - **Custom domains**
 
-  - Setting `BRING_YOUR_OWN_DOMAIN=true` makes the portal serve only your configured custom domain (single-site mode). Other domains, including SuiNS and base36, are not resolved by that portal.
-  - It’s always a good practice to add canonical hints in your HTML or headers pointing to your chosen custom domain, to avoid duplicate indexing across different hosts.
+  - Setting `BRING_YOUR_OWN_DOMAIN=true` makes the portal serve only your configured custom domain (single-site mode).
+    Other domains, including SuiNS and base36, are not resolved by that portal.
+  - It’s always a good practice to add canonical hints in your HTML or headers pointing to your chosen custom domain,
+    to avoid duplicate indexing across different hosts.
 
 - **Multiple SuiNS names → one site**  
-  This can happen permissionlessly. If you own the extra names, add canonical hints in your site HTML to point to your preferred domain.
+  This can happen permissionlessly. If you own the extra names, add canonical hints in your site HTML
+  to point to your preferred domain.


### PR DESCRIPTION
## Description

This pull request adds new documentation to help users avoid duplicate-content SEO issues when deploying custom Walrus Sites portals. The main focus is on providing guidance for canonicalization and best practices to ensure search engines do not penalize sites for duplicate content.

Documentation updates:

* Added a new section to the table of contents in `SUMMARY.md` for avoiding duplicate-content SEO in custom portals.
* Created a new page, `avoid-duplicate-content-seo.md`, with detailed recommendations on canonical host policies, handling of base36 and BYOD domains, implementation examples for redirects and headers, and advice for managing multiple SuiNS names for a single site.