### PR TITLE
chore: [docs] update portal configuration and add new portals list

### DIFF
--- a/.github/actions/build-mdbook/action.yaml
+++ b/.github/actions/build-mdbook/action.yaml
@@ -37,10 +37,10 @@ runs:
         url="https://github.com/lzanini/mdbook-katex/releases/download/0.9.0-binaries/mdbook-katex-v0.9.0-x86_64-unknown-linux-gnu.tar.gz"
         curl -sSL "$url" | tar -xz --directory=bin
       shell: bash
-    - name: Install mdbook-templates from crates.io
-      uses: taiki-e/install-action@970d55e3ce02a46d60ffae7b4fab3dedace6e769 # pin@v2.49.13
-      with:
-        tool: mdbook-templates@0.2.0
+    - name: Install mdbook-template from GitHub
+      run: |
+        cargo install --git https://github.com/MystenLabs/mdbook-template --locked
+      shell: bash
     - name: Install mdbook-tabs
       run: |
         url="https://github.com/RustForWeb/mdbook-plugins/releases/download/v0.2.1/mdbook-tabs-v0.2.1-x86_64-unknown-linux-gnu.tar.gz"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ directory.
 You can also build the documentation locally (assuming you have Rust installed):
 
 ```sh
-cargo install mdbook mdbook-admonish mdbook-katex mdbook-linkcheck mdbook-tabs mdbook-templates --locked
+cargo install mdbook mdbook-admonish mdbook-katex mdbook-linkcheck mdbook-tabs --locked
+cargo install --git https://github.com/MystenLabs/mdbook-template --locked
 mdbook serve
 ```
 

--- a/book.toml
+++ b/book.toml
@@ -42,6 +42,6 @@ after = ["links"]
 
 [preprocessor.templates]
 command = "mdbook-templates"
-path = "docs/book/assets/operators.json"
+path = ["docs/book/assets/operators.json", "docs/book/portals/list.json"]
 
 [preprocessor.tabs]

--- a/book.toml
+++ b/book.toml
@@ -40,8 +40,8 @@ inline-delimiter = { left = "\\(", right = "\\)" }
 [preprocessor.gettext]
 after = ["links"]
 
-[preprocessor.templates]
-command = "mdbook-templates"
-path = ["docs/book/assets/operators.json", "docs/book/portals/list.json"]
+[preprocessor.template]
+command = "mdbook-template"
+paths = ["docs/book/assets/operators.json", "docs/book/assets/portals.json"]
 
 [preprocessor.tabs]

--- a/docs/book/assets/portals.json
+++ b/docs/book/assets/portals.json
@@ -1,0 +1,7 @@
+{
+  "portals": {
+    "https://wal.app": {
+      "operator": "Mysten Labs"
+    }
+  }
+}

--- a/docs/book/portals/list.json
+++ b/docs/book/portals/list.json
@@ -1,7 +1,0 @@
-{
-  "portals": {
-    "https://wal.app": {
-      "operator": "Mysten Labs"
-    }
-  }
-}

--- a/docs/book/portals/list.json
+++ b/docs/book/portals/list.json
@@ -1,0 +1,7 @@
+{
+  "portals": {
+    "https://wal.app": {
+      "operator": "Mysten Labs"
+    }
+  }
+}

--- a/docs/book/usage/web-api.md
+++ b/docs/book/usage/web-api.md
@@ -319,8 +319,10 @@ once per week.
 The following is a list of known public aggregators on Walrus Mainnet; they are checked
 periodically, but each of them may still be temporarily unavailable:
 
-{{ #mainnet.aggregators }}
-{{ /mainnet.aggregators }}
+{{#each mainnet.aggregators as |info url|}}
+
+- `{{url}}`
+  {{/each}}
 
 ### Testnet
 
@@ -329,16 +331,21 @@ periodically, but each of them may still be temporarily unavailable:
 The following is a list of known public aggregators on Walrus Testnet; they are checked
 periodically, but each of them may still be temporarily unavailable:
 
-{{ #testnet.aggregators }}
-{{ /testnet.aggregators }}
+{{#each testnet.aggregators as |info url|}}
+
+- `{{url}}`
+  {{/each}}
 
 #### Publishers {#publishers-testnet}
 
 The following is a list of known public publishers on Walrus Testnet; they are checked
 periodically, but each of them may still be temporarily unavailable:
 
-{{ #testnet.publishers }}
-{{ /testnet.publishers }}
+{{#each testnet.publishers as |info url|}}
+
+- `{{url}}`
+  {{/each}}
+
 <!-- markdownlint-enable proper-names -->
 
 Most of these limit requests to 10 MiB by default. If you want to upload larger files, you need to

--- a/docs/book/walrus-sites/portal.md
+++ b/docs/book/walrus-sites/portal.md
@@ -13,7 +13,7 @@ Currently, only a server-side portal is served at <https://wal.app>.
 We maintain a list of known portals. New portals can self-identify by opening a PR to add themselves
 to the list.
 
-### Known portals
+## Known portals
 
 {{ #portals }}
 {{ /portals }}

--- a/docs/book/walrus-sites/portal.md
+++ b/docs/book/walrus-sites/portal.md
@@ -15,8 +15,14 @@ to the list.
 
 ## Known portals
 
-{{ #portals }}
-{{ /portals }}
+{{#if portals}}
+{{#each portals}}
+
+- `{{@key}}{{#if this.operator}} ({{this.operator}}){{/if}}`
+  {{/each}}
+  {{else}}
+- `https://wal.app (operated by Mysten Labs)`
+  {{/if}}
 
 ```admonish warning
 We are sunsetting the testnet portal! From now on, you can only access the mainnet portal

--- a/docs/book/walrus-sites/portal.md
+++ b/docs/book/walrus-sites/portal.md
@@ -10,6 +10,14 @@ portals:
 
 Currently, only a server-side portal is served at <https://wal.app>.
 
+We maintain a list of known portals. New portals can self-identify by opening a PR to add themselves
+to the list.
+
+### Known portals
+
+{{ #portals }}
+{{ /portals }}
+
 ```admonish warning
 We are sunsetting the testnet portal! From now on, you can only access the mainnet portal
 at <https://wal.app>.
@@ -39,7 +47,7 @@ cd walrus-sites
 
 Make sure you are on the stable branch:
 
-``` sh
+```sh
 git checkout mainnet
 ```
 
@@ -100,13 +108,13 @@ serving sites that are not published by you.
 - `AGGREGATOR_URL`: The url to a Walrus aggregator that will fetch the site resources from Walrus.
 
 - `AMPLITUDE_API_KEY`: Provide it if you want to enable [Amplitude](https://amplitude.com/) for your
-server analytics.
+  server analytics.
 
 - `EDGE_CONFIG`: If you host your portal on Vercel, you can use the [Edge Config][edge-config] to
-blocklist certain SuiNS subdomains or b36 object ids.
+  blocklist certain SuiNS subdomains or b36 object ids.
 
 - `EDGE_CONFIG_ALLOWLIST`: Similar to blocklist, but allows certain subdomains to use the premium
-rpc url list.
+  rpc url list.
 
 - `ENABLE_ALLOWLIST`: Enable the allowlist feature.
 
@@ -117,10 +125,10 @@ rpc url list.
 - `ENABLE_VERCEL_WEB_ANALYTICS`: Enable Vercel web analytics.
 
 - `LANDING_PAGE_OID_B36`: The b36 object id of the landing page Walrus Site. i.e. the page you get
-when you visit `localhost:3000`.
+  when you visit `localhost:3000`.
 
 - `PORTAL_DOMAIN_NAME_LENGTH`: If you connect your portal with a domain name, specify the length of
-the domain name. e.g. `example.com` has a length of 11.
+  the domain name. e.g. `example.com` has a length of 11.
 
 - `PREMIUM_RPC_URL_LIST`: A list of rpc urls that are used when a site belongs to the allowlist.
 
@@ -131,15 +139,15 @@ the domain name. e.g. `example.com` has a length of 11.
 - `SENTRY_DSN`: If you enable Sentry error tracking, provide your Sentry DSN.
 
 - `SENTRY_TRACES_SAMPLE_RATE`: If you enable Sentry error tracking, provide the sample rate for
-traces.
+  traces.
 
 - `SITE_PACKAGE`: The Walrus Site package id. Depending on the network you are using, you will
-have to specify the correct package id.
+  have to specify the correct package id.
 
 - `SUINS_CLIENT_NETWORK`: The network of the SuiNS client.
 
 - `B36_DOMAIN_RESOLUTION_SUPPORT`: Define if b36 domain resolution is supported. Otherwise the
-site will not be served.
+  site will not be served.
 
 #### Constants
 
@@ -153,7 +161,7 @@ here are the explanations for each parameter:
   only. Use this at your own risk, may render some sites with legitimate SuiNS names unusable.
 
 - `FALLBACK_PORTAL`: This is related only to the service worker portal. The fallback portal should
-be a server-side portal that is used in cases where some browsers do not support service workers.
+  be a server-side portal that is used in cases where some browsers do not support service workers.
 
 ### Deploying the Portal
 
@@ -192,7 +200,7 @@ This requires having the [`bun`](https://bun.sh/) tool installed:
 
 Check if bun is installed with:
 
-``` sh
+```sh
 bun --version
 ```
 

--- a/docs/book/walrus-sites/portal.md
+++ b/docs/book/walrus-sites/portal.md
@@ -15,6 +15,8 @@ to the list.
 
 ## Known portals
 
+Portals can self-identify by opening a PR that adds an entry to `docs/book/portals/list.json`.
+
 {{#if portals}}
 {{#each portals}}
 


### PR DESCRIPTION
## Description
This pull request updates the documentation to introduce and display a list of known portals for the project. It adds a new JSON data file for portals, updates the configuration to include this data, and enhances the documentation to show the list and explain how new portals can be added.

**Documentation updates for portals:**

* Added a new file, `docs/book/portals/list.json`, which contains the list of known portals and their operators.
* Updated `book.toml` to include `docs/book/portals/list.json` as a data source for the templates preprocessor, allowing portal data to be used in documentation.
* Enhanced `docs/book/walrus-sites/portal.md` to explain how new portals can be added and to display the list of known portals using a template block.

