### PR TITLE
feat: Make shard sync directly ingest data in sst files

### DIFF
--- a/crates/walrus-core/src/lib.rs
+++ b/crates/walrus-core/src/lib.rs
@@ -124,6 +124,9 @@ impl BlobId {
     /// A blob ID with all zeros.
     pub const ZERO: Self = Self([0u8; Self::LENGTH]);
 
+    /// A blob ID with all ones.
+    pub const MAX: Self = Self([u8::MAX; Self::LENGTH]);
+
     /// Returns the blob ID as a hash over the Merkle root, encoding type,
     /// and unencoded_length of the blob.
     pub fn from_metadata(merkle_root: Node, encoding: EncodingType, unencoded_length: u64) -> Self {

--- a/crates/walrus-service/node_config_example.yaml
+++ b/crates/walrus-service/node_config_example.yaml
@@ -145,6 +145,9 @@ shard_sync_config:
   shard_sync_concurrency: 10
   shard_sync_retry_switch_to_recovery_interval_secs: 43200
   restart_shard_sync_always_retry_transfer_first: true
+  sst_ingestion_config:
+    max_entries: null
+    compact_after_sync: true
 event_processor_config:
   pruning_interval_secs: 3600
   checkpoint_request_timeout_secs: 60

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -5565,6 +5565,16 @@ mod tests {
         ) -> TestResult {
             let shard_sync_config = ShardSyncConfig {
                 sliver_count_per_sync_request: 2,
+                // Align SST flush threshold with the request size for this test.
+                // For this test, we need one flush (and thus one progress persist) per request
+                // to preserve the original progress semantics being asserted (whether shard sync
+                // "makes progress" between retriable failures). Setting `sst_max_entries` equal
+                // or less to the request size ensures each request triggers a flush and records
+                // `last_synced_blob_id` deterministically.
+                sst_ingestion_config: Some(crate::node::config::SstIngestionConfig {
+                    max_entries: Some(2),
+                    compact_after_sync: true,
+                }),
                 shard_sync_retry_min_backoff: Duration::from_secs(1),
                 shard_sync_retry_max_backoff: Duration::from_secs(5),
                 shard_sync_retry_switch_to_recovery_interval: Duration::from_secs(10),

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -675,6 +675,9 @@ pub struct ShardSyncConfig {
     /// transfer. This is the preferred option since it's always cheaper to scan the blob info
     /// table without transferring the shards.
     pub restart_shard_sync_always_retry_transfer_first: bool,
+    /// Configuration for using SST ingestion during shard sync. None disables this feature.
+    #[serde(default, skip_serializing_if = "defaults::is_none")]
+    pub sst_ingestion_config: Option<SstIngestionConfig>,
 }
 
 impl Default for ShardSyncConfig {
@@ -689,6 +692,26 @@ impl Default for ShardSyncConfig {
             shard_sync_concurrency: 10,
             shard_sync_retry_switch_to_recovery_interval: Duration::from_secs(12 * 60 * 60), // 12hr
             restart_shard_sync_always_retry_transfer_first: true,
+            sst_ingestion_config: Some(SstIngestionConfig::default()),
+        }
+    }
+}
+
+/// Configuration for SST ingestion during shard sync.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct SstIngestionConfig {
+    /// SST flush thresholds for shard sync (per SST file).
+    pub max_entries: Option<usize>,
+    /// Compact SST after shard sync completes.
+    pub compact_after_sync: bool,
+}
+
+impl Default for SstIngestionConfig {
+    fn default() -> Self {
+        Self {
+            max_entries: None,
+            compact_after_sync: true,
         }
     }
 }

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -85,6 +85,8 @@ use crate::common::config::SuiConfig;
 use crate::event::event_processor::config::{EventProcessorRuntimeConfig, SystemConfig};
 #[cfg(msim)]
 use crate::node::ConfigLoader;
+#[cfg(msim)]
+use crate::node::config::SstIngestionConfig;
 use crate::{
     event::{
         event_processor::{config::EventProcessorConfig, processor::EventProcessor},
@@ -1175,6 +1177,18 @@ impl StorageNodeHandleBuilder {
             blob_recovery: BlobRecoveryConfig::default_for_test(),
             ..storage_node_config().inner
         };
+
+        if rand::random::<bool>() {
+            storage_node_config.shard_sync_config.sst_ingestion_config =
+                Some(SstIngestionConfig::default());
+            storage_node_config
+                .shard_sync_config
+                .sst_ingestion_config
+                .as_mut()
+                .unwrap()
+                .max_entries = Some(1);
+            tracing::info!("SST based ingestion is enabled on the node");
+        }
 
         randomize_sliver_recovery_additional_symbols(&mut storage_node_config);
 


### PR DESCRIPTION
## Description

This PR introduces an optional, high-throughput write path for shard sync that ingests sliver data via RocksDB SST files instead of per-key batched writes. It also adds typed-store utilities to build and ingest SSTs safely. The feature is disabled by default and can be toggled per node via config.

The primary motivation for doing this work is during shard sync, the node downloading the shard does writes to shard column family at a high rate which causes compaction to back up and slow down (or potentially stall) *writes to the entire db* which is not great. Writing data through sst files is also the recommended way of bulk ingesting data according to RocksDB wiki.


## Test plan

Added unit tests, and the rollout will be done initially only on testnet.