### PR TITLE
chore: reduce test failures of upload relay due to port conflicts

### DIFF
--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -2458,8 +2458,10 @@ async fn test_store_with_upload_relay_no_tip() {
         ],
         ..cluster_config.clone()
     };
-    let server_address = unused_socket_address(UnusedSocketAddressIp::AllInterfaces, false)
-        .expect("get unused socket address");
+    let server_address = unused_socket_address(UnusedSocketAddressIp::AllInterfaces {
+        force_time_wait: false,
+    })
+    .expect("get unused socket address");
 
     let registry = Registry::default();
 
@@ -2577,8 +2579,10 @@ async fn test_store_with_upload_relay_with_tip() {
         ..cluster_client.inner.config().clone()
     };
 
-    let server_address = unused_socket_address(UnusedSocketAddressIp::AllInterfaces, false)
-        .expect("get unused socket address");
+    let server_address = unused_socket_address(UnusedSocketAddressIp::AllInterfaces {
+        force_time_wait: false,
+    })
+    .expect("get unused socket address");
 
     const TIP_BASE: u64 = 1000;
     const TIP_MULTIPLIER: u64 = 100;

--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -72,7 +72,9 @@ use walrus_sdk::{
 use walrus_service::test_utils::{
     StorageNodeHandleTrait,
     TestNodesConfig,
+    UnusedSocketAddressIp,
     test_cluster::{self, FROST_PER_NODE_WEIGHT},
+    unused_socket_address,
 };
 use walrus_storage_node_client::api::BlobStatus;
 use walrus_sui::{
@@ -97,7 +99,6 @@ use walrus_sui::{
 };
 use walrus_test_utils::{Result as TestResult, WithTempDir, assert_unordered_eq, async_param_test};
 use walrus_upload_relay::{
-    DEFAULT_SERVER_ADDRESS,
     UploadRelayHandle,
     controller::{WalrusUploadRelayConfig, get_client_with_config},
 };
@@ -2457,9 +2458,8 @@ async fn test_store_with_upload_relay_no_tip() {
         ],
         ..cluster_config.clone()
     };
-    let server_address: SocketAddr = DEFAULT_SERVER_ADDRESS
-        .parse()
-        .expect("valid server address");
+    let server_address = unused_socket_address(UnusedSocketAddressIp::AllInterfaces, false)
+        .expect("get unused socket address");
 
     let registry = Registry::default();
 
@@ -2577,9 +2577,8 @@ async fn test_store_with_upload_relay_with_tip() {
         ..cluster_client.inner.config().clone()
     };
 
-    let server_address: SocketAddr = DEFAULT_SERVER_ADDRESS
-        .parse()
-        .expect("valid server address");
+    let server_address = unused_socket_address(UnusedSocketAddressIp::AllInterfaces, false)
+        .expect("get unused socket address");
 
     const TIP_BASE: u64 = 1000;
     const TIP_MULTIPLIER: u64 = 100;

--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -72,9 +72,8 @@ use walrus_sdk::{
 use walrus_service::test_utils::{
     StorageNodeHandleTrait,
     TestNodesConfig,
-    UnusedSocketAddressIp,
+    UnusedSocketAddress,
     test_cluster::{self, FROST_PER_NODE_WEIGHT},
-    unused_socket_address,
 };
 use walrus_storage_node_client::api::BlobStatus;
 use walrus_sui::{
@@ -2458,9 +2457,10 @@ async fn test_store_with_upload_relay_no_tip() {
         ],
         ..cluster_config.clone()
     };
-    let server_address = unused_socket_address(UnusedSocketAddressIp::AllInterfaces {
+    let server_address = UnusedSocketAddress::AllInterfaces {
         force_time_wait: false,
-    })
+    }
+    .try_into()
     .expect("get unused socket address");
 
     let registry = Registry::default();
@@ -2579,9 +2579,10 @@ async fn test_store_with_upload_relay_with_tip() {
         ..cluster_client.inner.config().clone()
     };
 
-    let server_address = unused_socket_address(UnusedSocketAddressIp::AllInterfaces {
+    let server_address = UnusedSocketAddress::AllInterfaces {
         force_time_wait: false,
-    })
+    }
+    .try_into()
     .expect("get unused socket address");
 
     const TIP_BASE: u64 = 1000;

--- a/crates/walrus-service/src/node/event_blob_writer.rs
+++ b/crates/walrus-service/src/node/event_blob_writer.rs
@@ -2119,7 +2119,7 @@ mod tests {
         stub_contract_service: std::sync::Arc<StubContractService>,
     ) -> anyhow::Result<StorageNodeHandle> {
         let test_config =
-            crate::test_utils::StorageNodeTestConfig::new_with_keypair(vec![], false, keypair);
+            crate::test_utils::StorageNodeTestConfig::new_with_keypair(vec![], keypair);
 
         StorageNodeHandle::builder()
             .with_storage(crate::test_utils::empty_storage_with_shards(&[]).await)

--- a/crates/walrus-simtest/tests/simtest.rs
+++ b/crates/walrus-simtest/tests/simtest.rs
@@ -53,7 +53,7 @@ mod tests {
         },
     };
     use walrus_sui::{
-        client::{BlobPersistence, PostStoreAction, ReadClient, SuiContractClient, UpgradeType},
+        client::{PostStoreAction, ReadClient, SuiContractClient, UpgradeType},
         system_setup::copy_recursively,
         test_utils::system_setup::{development_contract_dir, testnet_contract_dir},
         types::move_structs::EventBlob,

--- a/crates/walrus-simtest/tests/simtest_param_sync.rs
+++ b/crates/walrus-simtest/tests/simtest_param_sync.rs
@@ -236,11 +236,9 @@ mod tests {
         assert!(walrus_cluster.nodes[5].node_id.is_none());
         let client_arc = Arc::new(client);
 
-        let new_address = walrus_service::test_utils::unused_socket_address(
-            UnusedSocketAddressIp::DistinctIp,
-            true,
-        )
-        .expect("should get unused socket address");
+        let new_address =
+            walrus_service::test_utils::unused_socket_address(UnusedSocketAddressIp::DistinctIp)
+                .expect("should get unused socket address");
         let network_key_pair = walrus_core::keys::NetworkKeyPair::generate();
         // Generate random voting params
         let voting_params = VotingParams {

--- a/crates/walrus-simtest/tests/simtest_param_sync.rs
+++ b/crates/walrus-simtest/tests/simtest_param_sync.rs
@@ -17,7 +17,7 @@ mod tests {
     use walrus_service::{
         client::ClientCommunicationConfig,
         node::config::{CommissionRateData, PathOrInPlace, StorageNodeConfig, SyncedNodeConfigSet},
-        test_utils::{SimStorageNodeHandle, TestNodesConfig, UnusedSocketAddressIp, test_cluster},
+        test_utils::{SimStorageNodeHandle, TestNodesConfig, UnusedSocketAddress, test_cluster},
     };
     use walrus_simtest::test_utils::simtest_utils::{self, BlobInfoConsistencyCheck};
     use walrus_sui::{
@@ -236,9 +236,9 @@ mod tests {
         assert!(walrus_cluster.nodes[5].node_id.is_none());
         let client_arc = Arc::new(client);
 
-        let new_address =
-            walrus_service::test_utils::unused_socket_address(UnusedSocketAddressIp::DistinctIp)
-                .expect("should get unused socket address");
+        let new_address = UnusedSocketAddressIp::DistinctIp
+            .try_into()
+            .expect("should get unused socket address");
         let network_key_pair = walrus_core::keys::NetworkKeyPair::generate();
         // Generate random voting params
         let voting_params = VotingParams {

--- a/crates/walrus-simtest/tests/simtest_param_sync.rs
+++ b/crates/walrus-simtest/tests/simtest_param_sync.rs
@@ -17,7 +17,7 @@ mod tests {
     use walrus_service::{
         client::ClientCommunicationConfig,
         node::config::{CommissionRateData, PathOrInPlace, StorageNodeConfig, SyncedNodeConfigSet},
-        test_utils::{SimStorageNodeHandle, TestNodesConfig, test_cluster},
+        test_utils::{SimStorageNodeHandle, TestNodesConfig, UnusedSocketAddressIp, test_cluster},
     };
     use walrus_simtest::test_utils::simtest_utils::{self, BlobInfoConsistencyCheck};
     use walrus_sui::{
@@ -236,7 +236,11 @@ mod tests {
         assert!(walrus_cluster.nodes[5].node_id.is_none());
         let client_arc = Arc::new(client);
 
-        let new_address = walrus_service::test_utils::unused_socket_address(true);
+        let new_address = walrus_service::test_utils::unused_socket_address(
+            UnusedSocketAddressIp::DistinctIp,
+            true,
+        )
+        .expect("should get unused socket address");
         let network_key_pair = walrus_core::keys::NetworkKeyPair::generate();
         // Generate random voting params
         let voting_params = VotingParams {

--- a/crates/walrus-simtest/tests/simtest_param_sync.rs
+++ b/crates/walrus-simtest/tests/simtest_param_sync.rs
@@ -7,7 +7,7 @@
 
 #[cfg(msim)]
 mod tests {
-    use std::{sync::Arc, time::Duration};
+    use std::{net::SocketAddr, sync::Arc, time::Duration};
 
     use rand::Rng;
     use sui_types::base_types::ObjectID;
@@ -236,7 +236,7 @@ mod tests {
         assert!(walrus_cluster.nodes[5].node_id.is_none());
         let client_arc = Arc::new(client);
 
-        let new_address = UnusedSocketAddress::DistinctIp
+        let new_address: SocketAddr = UnusedSocketAddress::DistinctIp
             .try_into()
             .expect("should get unused socket address");
         let network_key_pair = walrus_core::keys::NetworkKeyPair::generate();

--- a/crates/walrus-simtest/tests/simtest_param_sync.rs
+++ b/crates/walrus-simtest/tests/simtest_param_sync.rs
@@ -236,7 +236,7 @@ mod tests {
         assert!(walrus_cluster.nodes[5].node_id.is_none());
         let client_arc = Arc::new(client);
 
-        let new_address = UnusedSocketAddressIp::DistinctIp
+        let new_address = UnusedSocketAddress::DistinctIp
             .try_into()
             .expect("should get unused socket address");
         let network_key_pair = walrus_core::keys::NetworkKeyPair::generate();


### PR DESCRIPTION
## Description

There were some instances where ports were not being released in time for retries. This change unifies the unused_socket_address code paths and leverages them in the upload relay tests.

## Test plan

CI Pipeline.