### PR TITLE
fix: do not send trasnaction if blob already certified, tidy publisher traces

### DIFF
--- a/crates/walrus-core/src/encoding/basic_encoding.rs
+++ b/crates/walrus-core/src/encoding/basic_encoding.rs
@@ -88,7 +88,7 @@ impl<'a> ReedSolomonEncoder<'a> {
     /// Returns an [`EncodeError`] if the `data` is empty, not a multiple of `n_source_symbols`, or
     /// too large to be encoded with the provided `n_source_symbols`.
     #[tracing::instrument(
-        level = Level::ERROR,
+        level = Level::TRACE,
         err(level = Level::WARN),
         skip(data)
     )]

--- a/crates/walrus-sdk/src/client/resource.rs
+++ b/crates/walrus-sdk/src/client/resource.rs
@@ -238,6 +238,7 @@ impl<'a> ResourceManager<'a> {
     /// The function considers the requirements given to the store operation (epochs ahead,
     /// persistence, force store), the status of the blob on chain, and the available resources in
     /// the wallet.
+    #[tracing::instrument(level = Level::DEBUG, skip_all)]
     pub async fn register_walrus_store_blobs<T: Debug + Clone + Send + Sync>(
         &self,
         encoded_blobs_with_status: Vec<WalrusStoreBlob<'a, T>>,

--- a/crates/walrus-sdk/src/config/committees_refresh_config.rs
+++ b/crates/walrus-sdk/src/config/committees_refresh_config.rs
@@ -57,6 +57,7 @@ impl CommitteesRefreshConfig {
     }
 }
 
+#[tracing::instrument(skip_all)]
 async fn build_refresher_and_handle(
     sui_client: impl ReadClient,
     committees_refresh_config: CommitteesRefreshConfig,

--- a/crates/walrus-service/src/client/daemon.rs
+++ b/crates/walrus-service/src/client/daemon.rs
@@ -243,6 +243,7 @@ impl<T: ReadClient> WalrusReadClient for WalrusNodeClient<T> {
 }
 
 impl WalrusWriteClient for WalrusNodeClient<SuiContractClient> {
+    #[tracing::instrument(skip_all)]
     async fn write_blob(
         &self,
         blob: &[u8],

--- a/crates/walrus-sui/src/client.rs
+++ b/crates/walrus-sui/src/client.rs
@@ -1321,6 +1321,7 @@ impl SuiContractClient {
     ///
     /// Returns the shared blob object ID if the post store action is Share.
     /// See [`CertifyAndExtendBlobParams`] for the details of the parameters.
+    #[tracing::instrument(level = Level::DEBUG, skip_all)]
     pub async fn certify_and_extend_blobs(
         &self,
         blobs_with_certificates: &[CertifyAndExtendBlobParams<'_>],
@@ -2714,7 +2715,12 @@ impl SuiContractClientInner {
         post_store: PostStoreAction,
         with_credits: bool,
     ) -> SuiClientResult<Vec<CertifyAndExtendBlobResult>> {
+        if blobs_with_certificates.is_empty() {
+            return Ok(vec![]);
+        }
+
         let mut pt_builder = self.transaction_builder()?;
+
         for blob_params in blobs_with_certificates {
             let blob = blob_params.blob;
 

--- a/crates/walrus-sui/src/client/read_client.rs
+++ b/crates/walrus-sui/src/client/read_client.rs
@@ -408,6 +408,7 @@ impl SuiReadClient {
     }
 
     /// Fetches the system and staking objects and the fixed system parameters and caches them.
+    #[tracing::instrument(skip_all)]
     pub async fn init_cache(&self) -> SuiClientResult<()> {
         let _ = self.get_and_cache_system_and_staking_objects().await?;
         let _ = self.fixed_system_parameters().await?;

--- a/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
@@ -443,7 +443,7 @@ impl RetriableSuiClient {
     /// Returns the balance for the given coin type owned by address.
     ///
     /// Calls [`sui_sdk::apis::CoinReadApi::get_balance`] internally.
-    #[tracing::instrument(level = Level::DEBUG, skip_all)]
+    #[tracing::instrument(level = Level::TRACE, skip_all)]
     pub async fn get_balance(
         &self,
         owner: SuiAddress,
@@ -1074,7 +1074,7 @@ impl RetriableSuiClient {
     }
 
     /// Executes a transaction.
-    #[tracing::instrument(err, skip(self))]
+    #[tracing::instrument(level = Level::DEBUG, err, skip(self, transaction))]
     pub(crate) async fn execute_transaction(
         &self,
         transaction: Transaction,


### PR DESCRIPTION
## Description

When sending a request to the publisher to store a blob that was already stored, certification would be skipped but a transaction would be sent to Sui regardless due to not checking if there were no blobs to put into the PTB. This fixes that skips several code paths when the list on which they would be operating is empty.

Additionally, this tidies some of the tracing export to reduce noise in trace exports.

## Test plan

Existing tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
