### PR TITLE
docs(walrus-sites): slight improvement on the testnet portal warning

### DIFF
--- a/docs/book/walrus-sites/portal.md
+++ b/docs/book/walrus-sites/portal.md
@@ -11,10 +11,11 @@ portals:
 Currently, only a server-side portal is served at <https://wal.app>.
 
 ```admonish warning title="Important: Testnet Portal Access"
-<https://wal.app> only supports sites deployed on mainnet.
-If you published your site on testnet, you **must** run your own portal to access it:
-- **For development**: Run a portal locally (see instructions below)
-- **For sharing publicly**: Self-host your own portal with a custom domain
+<https://wal.app> only serves sites deployed on mainnet, linked with SuiNS names.
+You can run a portal to access mainnet sites as well.
+Walrus Foundation does not maintain a Portal that serves testnet Walrus Sites.
+To access Sites deployed on testnet you can either use a thirdparty testnet portal,
+self-host one or run one locally.
 ```
 
 We maintain a list of known portals. New portals can self-identify by opening a PR to add themselves

--- a/docs/book/walrus-sites/tutorial-publish.md
+++ b/docs/book/walrus-sites/tutorial-publish.md
@@ -37,8 +37,10 @@ duration of an epoch is one day. On Mainnet, the duration of an epoch is two wee
 ```admonish warning title="Important: Testnet vs Mainnet Access"
 **After publishing, how you access your site depends on which network you used:**
 
-- **Mainnet sites**: Can be accessed through <https://wal.app> once you set up a SuiNS name
-- **Testnet sites**: Require you to [run a portal locally](./portal.md) since wal.app only supports mainnet
+- **Mainnet sites**: Can be accessed through any mainnet portal.
+<https://wal.app> serves Walrus Sites on mainnet by resolving SuiNS names that point to them.
+- **Testnet sites**: Can be accessed through any testnet portal.
+Walrus Foundation does not operate a testnet portal. You can [self-host or run one locally](./portal.md)
 ```
 
 The end of the output should look like the following:


### PR DESCRIPTION
## Description

This PR brings a small improvement to the warning about the testnet portal availability.

*meant to accompany a similar [walrus-sites pr](https://github.com/MystenLabs/walrus-sites/pull/557)
