### PR TITLE
fix: fix walrus-backup garbage collection statistics

### DIFF
--- a/crates/walrus-service/src/backup/config.rs
+++ b/crates/walrus-service/src/backup/config.rs
@@ -105,6 +105,10 @@ pub struct BackupConfig {
         default = "defaults::idle_garbage_collector_sleep_time"
     )]
     pub idle_garbage_collector_sleep_time: Duration,
+    /// After how many epochs beyond a blob's end_epoch does it become eligible for garbage
+    /// collection?
+    #[serde(default = "defaults::garbage_collection_epoch_offset")]
+    pub garbage_collection_epoch_offset: u64,
 }
 
 impl BackupConfig {
@@ -132,6 +136,7 @@ impl BackupConfig {
             retry_fetch_after_interval: defaults::retry_fetch_after_interval(),
             idle_fetcher_sleep_time: defaults::idle_fetcher_sleep_time(),
             idle_garbage_collector_sleep_time: defaults::idle_garbage_collector_sleep_time(),
+            garbage_collection_epoch_offset: defaults::garbage_collection_epoch_offset(),
         }
     }
 }
@@ -211,5 +216,8 @@ pub mod defaults {
     }
     pub fn blob_job_chunk_size() -> u32 {
         10
+    }
+    pub fn garbage_collection_epoch_offset() -> u64 {
+        2
     }
 }

--- a/crates/walrus-service/src/backup/garbage_collector.rs
+++ b/crates/walrus-service/src/backup/garbage_collector.rs
@@ -65,6 +65,30 @@ async fn collect_garbage(
         .await
         .expect("failed to connect to postgres for collect_garbage");
 
+    let garbage_query = format!(
+        "
+            WITH expired_blob_ids AS (
+                SELECT blob_id
+                FROM blob_state
+                WHERE
+                    state = 'archived' AND
+                    (initiate_gc_after IS NULL OR initiate_gc_after < NOW()) AND
+                    COALESCE(
+                        end_epoch + {} <= (
+                            SELECT MAX(epoch) FROM epoch_change_start_event),
+                        FALSE)
+                LIMIT 15
+            ),
+            _updated_count AS (
+                UPDATE blob_state
+                SET initiate_gc_after = NOW() + INTERVAL '1 day'
+                WHERE blob_id IN (SELECT blob_id FROM expired_blob_ids)
+            )
+            SELECT blob_id from expired_blob_ids
+        ",
+        config.garbage_collection_epoch_offset,
+    );
+
     // Start an infinite loop polling the database for blob state statistics and updating the
     // metrics.
     loop {
@@ -79,39 +103,18 @@ async fn collect_garbage(
             |conn| {
                 {
                     async move {
-                        diesel::sql_query(
-                            "
-                            WITH expired_blob_ids AS (
-                                SELECT blob_id
-                                FROM blob_state
-                                WHERE
-                                    state = 'archived' AND
-                                    (initiate_gc_after IS NULL OR initiate_gc_after < NOW()) AND
-                                    COALESCE(
-                                        end_epoch + 2 <= (
-                                            SELECT MAX(epoch) FROM epoch_change_start_event),
-                                        FALSE)
-                                LIMIT 15
-                            ),
-                            _updated_count AS (
-                                UPDATE blob_state
-                                SET initiate_gc_after = NOW() + INTERVAL '1 day'
-                                WHERE blob_id IN (SELECT blob_id FROM expired_blob_ids)
-                            )
-                            SELECT blob_id from expired_blob_ids
-                            ",
-                        )
-                        .get_results(conn)
-                        .await
-                        .inspect_err(|error| {
-                            tracing::warn!(
-                                ?error,
-                                "failed to query blob_state table for expired blobs"
-                            );
-                        })
-                        .inspect(|blobs| {
-                            tracing::info!(?blobs, "fetched expired blobs");
-                        })
+                        diesel::sql_query(&garbage_query)
+                            .get_results(conn)
+                            .await
+                            .inspect_err(|error| {
+                                tracing::warn!(
+                                    ?error,
+                                    "failed to query blob_state table for expired blobs"
+                                );
+                            })
+                            .inspect(|blobs| {
+                                tracing::info!(?blobs, "fetched expired blobs");
+                            })
                     }
                 }
                 .scope_boxed()

--- a/crates/walrus-service/src/backup/garbage_collector.rs
+++ b/crates/walrus-service/src/backup/garbage_collector.rs
@@ -88,6 +88,7 @@ async fn collect_garbage(
         ",
         config.garbage_collection_epoch_offset,
     );
+    let garbage_query = garbage_query.as_str();
 
     // Start an infinite loop polling the database for blob state statistics and updating the
     // metrics.
@@ -103,7 +104,7 @@ async fn collect_garbage(
             |conn| {
                 {
                     async move {
-                        diesel::sql_query(&garbage_query)
+                        diesel::sql_query(garbage_query)
                             .get_results(conn)
                             .await
                             .inspect_err(|error| {


### PR DESCRIPTION
## Description

Fix a regression in garbage collection statistics in walrus-backup. The regression was introduced recently in 7321bdf9431841f75afc97e6927be35c548cbbb3 wherein I delayed the garbage collection mechanism until 2 epochs later than expiry, but failed to update the related stats collection.

## Test plan

CI Pipeline.

