### PR TITLE
chore: empty quilt blob protection

### DIFF
--- a/crates/walrus-core/src/encoding/quilt_encoding.rs
+++ b/crates/walrus-core/src/encoding/quilt_encoding.rs
@@ -1096,7 +1096,7 @@ impl QuiltV1 {
                 .as_ref()
                 .expect("quilt index should be set"));
         }
-        
+
         let columns_size = self.data.len() / self.row_size * self.symbol_size;
         let quilt_index = QuiltVersionV1::decode_quilt_index(self, columns_size)?;
         self.quilt_index = Some(quilt_index);
@@ -2495,9 +2495,6 @@ mod tests {
     fn test_new_from_quilt_blob_panics_on_empty_input() {
         use core::num::NonZeroU16;
         let config = ReedSolomonEncodingConfig::new(NonZeroU16::new(7).unwrap());
-        let _ = QuiltV1::new_from_quilt_blob(
-            Vec::new(),
-            &EncodingConfigEnum::ReedSolomon(&config),
-        );
+        let _ = QuiltV1::new_from_quilt_blob(Vec::new(), &EncodingConfigEnum::ReedSolomon(&config));
     }
 }


### PR DESCRIPTION
## Description

According to the https://github.com/MystenLabs/walrus/issues/2534

This PR fixes a denial-of-service panic when constructing a QuiltV1 directly from an empty quilt blob. This change adds explicit input validation and defensive guards to return a proper error instead of panicking.


## Test plan
How did you test the new or updated feature?

unit test

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
