### PR TITLE
fix: extending blob at the latest epoch

### DIFF
--- a/crates/walrus-service/src/node/blob_event_processor.rs
+++ b/crates/walrus-service/src/node/blob_event_processor.rs
@@ -203,22 +203,41 @@ impl BackgroundEventProcessor {
 
         let histogram_set = self.node.metrics.recover_blob_duration_seconds.clone();
 
-        if !self.node.is_blob_certified(&event.blob_id)?
+        // Get the current event epoch to check if the blob is fully stored up to the shard
+        // assignment in this epoch. If the current event epoch is not set (the node may just
+        // started), we always start the blob sync.
+        let current_event_epoch = self.node.try_get_current_event_epoch();
+
+        #[allow(unused_mut)]
+        let mut skip_blob_sync_in_test = false;
+        // No op when not in simtest mode.
+        sui_macros::fail_point_if!(
+            "skip_non_extension_certified_event_triggered_blob_sync",
+            || {
+                skip_blob_sync_in_test = !event.is_extension;
+            }
+        );
+
+        if skip_blob_sync_in_test
+            || !self.node.is_blob_certified(&event.blob_id)?
             || self.node.storage.node_status()?.is_catching_up()
-            || self
-                .node
-                .is_stored_at_all_shards_at_epoch(
-                    &event.blob_id,
-                    self.node.current_event_epoch().await?,
-                )
-                .await?
+            || (current_event_epoch.is_some()
+                && self
+                    .node
+                    .is_stored_at_all_shards_at_epoch(
+                        &event.blob_id,
+                        current_event_epoch.expect("just checked that current event epoch is set"),
+                    )
+                    .await?)
         {
             event_handle.mark_as_complete();
 
             tracing::debug!(
-                "skipping blob certified event for blob id: {}, epoch: {}",
+                "skipping syncing blob during certified event processing for blob id: {}, \
+                epoch: {}, is_extension: {}",
                 event.blob_id,
-                event.epoch
+                event.epoch,
+                event.is_extension
             );
 
             walrus_utils::with_label!(histogram_set, metrics::STATUS_SKIPPED)

--- a/crates/walrus-service/src/node/blob_event_processor.rs
+++ b/crates/walrus-service/src/node/blob_event_processor.rs
@@ -233,11 +233,10 @@ impl BackgroundEventProcessor {
             event_handle.mark_as_complete();
 
             tracing::debug!(
-                "skipping syncing blob during certified event processing for blob id: {}, \
-                epoch: {}, is_extension: {}",
-                event.blob_id,
-                event.epoch,
-                event.is_extension
+                %event.blob_id,
+                %event.epoch,
+                %event.is_extension,
+                "skipping syncing blob during certified event processing",
             );
 
             walrus_utils::with_label!(histogram_set, metrics::STATUS_SKIPPED)

--- a/crates/walrus-service/src/node/blob_sync.rs
+++ b/crates/walrus-service/src/node/blob_sync.rs
@@ -285,6 +285,10 @@ impl BlobSyncHandler {
     }
 
     /// Starts a blob sync for the given `blob_id` and `certified_epoch`.
+    /// The `certified_epoch` is only used to find the proper committee to read the slivers, and
+    /// may not be the same as the current epoch.
+    /// To find the shard assignment the blob is stored at, we uses `current_event_epoch()` instead.
+    /// See `recover_blob_slivers()` for more details.
     ///
     /// Returns a `Notify` that is notified when the sync task is finished.
     #[tracing::instrument(skip_all, fields(otel.kind = "PRODUCER"))]

--- a/crates/walrus-service/src/node/blob_sync.rs
+++ b/crates/walrus-service/src/node/blob_sync.rs
@@ -286,9 +286,13 @@ impl BlobSyncHandler {
 
     /// Starts a blob sync for the given `blob_id` and `certified_epoch`.
     /// The `certified_epoch` is only used to find the proper committee to read the slivers, and
-    /// may not be the same as the current epoch.
-    /// To find the shard assignment the blob is stored at, we uses `current_event_epoch()` instead.
-    /// See `recover_blob_slivers()` for more details.
+    ///
+    /// The `certified_epoch` is only used to find the proper committee to read the metadata and
+    /// recovery symbols during epoch change, and may differ from the current epoch.
+    ///
+    /// To find the shard assignment the blob is stored at, we use
+    /// [`StorageNodeInner::current_event_epoch`] instead. See
+    /// [`BlobSynchronizer::recover_blob_slivers`] for more details.
     ///
     /// Returns a `Notify` that is notified when the sync task is finished.
     #[tracing::instrument(skip_all, fields(otel.kind = "PRODUCER"))]

--- a/crates/walrus-simtest/tests/simtest_failure.rs
+++ b/crates/walrus-simtest/tests/simtest_failure.rs
@@ -338,7 +338,6 @@ mod tests {
 
     // This integration test simulates a scenario where a node is repeatedly crashing and
     // recovering.
-    #[ignore = "ignore integration simtests by default"]
     #[walrus_simtest]
     async fn test_repeated_node_crash() {
         // We use a very short epoch duration of 10 seconds so that we can exercise more epoch

--- a/crates/walrus-simtest/tests/simtest_failure.rs
+++ b/crates/walrus-simtest/tests/simtest_failure.rs
@@ -338,6 +338,7 @@ mod tests {
 
     // This integration test simulates a scenario where a node is repeatedly crashing and
     // recovering.
+    #[ignore = "ignore integration simtests by default"]
     #[walrus_simtest]
     async fn test_repeated_node_crash() {
         // We use a very short epoch duration of 10 seconds so that we can exercise more epoch


### PR DESCRIPTION
## Description

test_repeated_node_crash exposes a bug where the first blob certified event may not trigger blob sync due to that
the blob may have been expired based on the current committee epoch. However, in the same epoch where
the blob was expired based the first certified event, the blob may be extended. Currently, blob extension does not
trigger blob sync, which may leave the node to miss the data.

To fix this issue, we need to allow blob extension event to also trigger blob sync if the blob misses some shard data.
There is another complication associated with this method because `current_event_epoch()` may not be available
to use to check blob data integrity. In this case, we just need to blindly start the blob sync: if the blob is fully stored,
blob sync still won't do any work.

## Test plan

200 test_repeated_node_crash
new unit test added to test blob extension triggered blob sync.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
