### PR TITLE
test: make unit tests work with `cargo test`

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
       - uses: taiki-e/install-action@970d55e3ce02a46d60ffae7b4fab3dedace6e769 # pin@v2.49.13
         with:
-          tool: cargo-deny@0.17.0
+          tool: cargo-deny@0.18.4
       - name: Check dependencies
         run: cargo deny check bans licenses sources
 
@@ -128,8 +128,8 @@ jobs:
           sudo apt-get install -y libssl-dev pkg-config zlib1g-dev libpq-dev build-essential cmake
       - name: Run tests
         run: cargo nextest run --workspace --features "walrus-service/backup" --profile ci --run-ignored all
-      - name: Run doctests
-        run: cargo test --doc
+      - name: Run all unit tests and doctests with `cargo test`
+        run: cargo test
 
   test-coverage:
     name: Run all Rust tests and report coverage

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1860,13 +1860,13 @@ dependencies = [
  "sui-macros",
  "sui-rpc-api",
  "sui-types",
- "telemetry-subscribers",
  "tempfile",
  "tokio",
  "tokio-util 0.7.16",
  "tracing",
  "typed-store 1.34.0",
  "walrus-sui",
+ "walrus-test-utils",
  "walrus-utils",
 ]
 
@@ -12726,7 +12726,6 @@ dependencies = [
  "sui-protocol-config",
  "sui-simulator",
  "sui-types",
- "telemetry-subscribers",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -13127,9 +13126,12 @@ name = "walrus-test-utils"
 version = "1.34.0"
 dependencies = [
  "anyhow",
+ "once_cell",
  "rand 0.8.5",
  "tempfile",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/checkpoint-downloader/Cargo.toml
+++ b/crates/checkpoint-downloader/Cargo.toml
@@ -18,7 +18,6 @@ serde_with.workspace = true
 sui-macros.workspace = true
 sui-rpc-api.workspace = true
 sui-types.workspace = true
-telemetry-subscribers.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tokio-util.workspace = true
 tracing.workspace = true
@@ -32,3 +31,4 @@ workspace = true
 [dev-dependencies]
 rocksdb.workspace = true
 tempfile.workspace = true
+walrus-test-utils.workspace = true

--- a/crates/checkpoint-downloader/src/downloader.rs
+++ b/crates/checkpoint-downloader/src/downloader.rs
@@ -595,7 +595,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn test_parallel_fetcher() -> Result<()> {
-        telemetry_subscribers::init_for_testing();
+        walrus_test_utils::init_tracing();
         let rest_url = "http://localhost:9000";
         let retriable_client = RetriableRpcClient::new(
             vec![LazyFallibleRpcClientBuilder::Url {

--- a/crates/walrus-core/src/encoding/quilt_encoding.rs
+++ b/crates/walrus-core/src/encoding/quilt_encoding.rs
@@ -1961,7 +1961,7 @@ mod tests {
         max_num_slivers_for_quilt_index: usize,
         expected: Result<usize, QuiltError>,
     ) {
-        let _ = tracing_subscriber::fmt().try_init();
+        walrus_test_utils::init_tracing();
         let res = utils::compute_symbol_size(
             blobs,
             n_columns,
@@ -2109,7 +2109,7 @@ mod tests {
     }
 
     fn construct_quilt(quilt_store_blobs: &[QuiltStoreBlob<'_>], config: EncodingConfigEnum) {
-        let _ = tracing_subscriber::fmt().try_init();
+        walrus_test_utils::init_tracing();
 
         let encoder = QuiltConfigV1::get_encoder(config.clone(), quilt_store_blobs);
 
@@ -2195,7 +2195,7 @@ mod tests {
         max_blob_size: usize,
         n_shards: u16,
     ) {
-        let _ = tracing_subscriber::fmt().try_init();
+        walrus_test_utils::init_tracing();
 
         const MAX_NUM_TAGS: usize = 10;
         const MAX_VALUE_LENGTH: usize = 100;
@@ -2218,7 +2218,7 @@ mod tests {
     }
 
     fn encode_decode_quilt(mut test_data: QuiltTestData<'_>, config: EncodingConfigEnum) {
-        let _ = tracing_subscriber::fmt().try_init();
+        walrus_test_utils::init_tracing();
 
         let quilt_store_blobs = test_data.take_blobs();
 
@@ -2259,7 +2259,7 @@ mod tests {
         let decode_index_result = quilt_decoder.get_or_decode_quilt_index();
         let missing_slivers =
             if let Err(QuiltError::MissingSlivers(missing_indices)) = decode_index_result {
-                tracing::info!("missing_indices: {:?}", missing_indices);
+                tracing::debug!("missing_indices: {:?}", missing_indices);
                 slivers
                     .iter()
                     .filter(|sliver| missing_indices.contains(&sliver.index))

--- a/crates/walrus-e2e-tests/Cargo.toml
+++ b/crates/walrus-e2e-tests/Cargo.toml
@@ -20,7 +20,6 @@ sui-macros.workspace = true
 sui-protocol-config.workspace = true
 sui-simulator.workspace = true
 sui-types.workspace = true
-telemetry-subscribers.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true

--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -113,7 +113,7 @@ async_param_test! {
     ]
 }
 async fn test_store_and_read_blob_without_failures(blob_size: usize) {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
     assert!(matches!(
         run_store_and_read_with_crash_failures(&[], &[], blob_size, None).await,
         Ok(()),
@@ -216,7 +216,7 @@ async fn test_store_and_read_blob_with_crash_failures(
     failed_shards_read: &[usize],
     expected_errors: &[ClientErrorKind],
 ) {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
     let result = run_store_and_read_with_crash_failures(
         failed_shards_write,
         failed_shards_read,
@@ -252,7 +252,7 @@ async fn run_store_and_read_with_crash_failures(
     data_length: usize,
     upload_relay_client: Option<UploadRelayClient>,
 ) -> TestResult {
-    let _ = tracing_subscriber::fmt::try_init();
+    walrus_test_utils::init_tracing();
 
     let (_sui_cluster_handle, mut cluster, client, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
@@ -288,7 +288,7 @@ async_param_test! {
 }
 /// Stores a blob that is inconsistent in 1 shard.
 async fn test_inconsistency(failed_nodes: &[usize]) -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
 
     let (_sui_cluster_handle, mut cluster, mut client, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
@@ -465,7 +465,7 @@ async fn test_store_with_existing_blob_resource(
     persistence_required: BlobPersistence,
     should_match: bool,
 ) -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
 
     let (_sui_cluster_handle, _cluster, client, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
@@ -606,7 +606,7 @@ async fn store_blob(
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 pub async fn test_store_and_read_duplicate_blobs() -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
 
     let (_sui_cluster_handle, _cluster, client, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
@@ -669,7 +669,7 @@ async_param_test! {
 }
 /// Tests that blobs can be extended when possible.
 async fn test_store_with_existing_blobs(persistence: BlobPersistence) -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
 
     let (_sui_cluster_handle, _cluster, client, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
@@ -764,7 +764,7 @@ async fn test_store_with_existing_storage_resource(
     epochs_ahead_required: EpochCount,
     should_match: bool,
 ) -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
 
     let (_sui_cluster_handle, _cluster, client, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
@@ -836,7 +836,7 @@ async_param_test! {
 }
 /// Tests blob object deletion.
 async fn test_delete_blob(blobs_to_create: u32) -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
     let (_sui_cluster_handle, _cluster, client, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
     let blob = walrus_test_utils::random_data(314);
@@ -895,7 +895,7 @@ async fn test_delete_blob(blobs_to_create: u32) -> TestResult {
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_storage_nodes_do_not_serve_data_for_deleted_blobs() -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
     let (_sui_cluster_handle, _cluster, client, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
     let client = client.as_ref();
@@ -966,7 +966,7 @@ async_param_test! {
 }
 /// Tests that a quilt can be stored.
 async fn test_store_quilt(blobs_to_create: u32) -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
 
     let test_nodes_config = TestNodesConfig {
         node_weights: vec![7, 7, 7, 7, 7],
@@ -1099,7 +1099,7 @@ async fn test_store_quilt(blobs_to_create: u32) -> TestResult {
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_blocklist() -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
     let blocklist_dir = tempfile::tempdir().expect("temporary directory creation must succeed");
     let (_sui_cluster_handle, _cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
         .with_test_nodes_config(TestNodesConfig {
@@ -1190,7 +1190,7 @@ async fn test_blocklist() -> TestResult {
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_blob_operations_with_credits() -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
     let (_sui_cluster_handle, _cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
         .with_credits()
         .build()
@@ -1256,7 +1256,7 @@ async fn test_blob_operations_with_credits() -> TestResult {
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_walrus_subsidies_get_called_by_node() -> TestResult {
-    let _ = tracing_subscriber::fmt::try_init();
+    walrus_test_utils::init_tracing();
 
     let (_sui_cluster_handle, cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
         .with_epoch_duration(Duration::from_secs(20))
@@ -1301,7 +1301,7 @@ async fn test_walrus_subsidies_get_called_by_node() -> TestResult {
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_multiple_stores_same_blob() -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
     let (_sui_cluster_handle, _cluster, client, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
     let client = client.as_ref();
@@ -1441,7 +1441,7 @@ async fn test_multiple_stores_same_blob() -> TestResult {
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_repeated_shard_move() -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
     let (_sui_cluster_handle, walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
         .with_epoch_duration(Duration::from_secs(20))
         .with_test_nodes_config(TestNodesConfig {
@@ -1519,7 +1519,7 @@ async fn test_repeated_shard_move() -> TestResult {
 async fn test_burn_blobs() -> TestResult {
     const N_BLOBS: usize = 3;
     const N_TO_DELETE: usize = 2;
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
 
     let (_sui_cluster_handle, _cluster, client, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
@@ -1570,7 +1570,7 @@ async fn test_burn_blobs() -> TestResult {
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_extend_owned_blobs() -> TestResult {
-    let _ = tracing_subscriber::fmt::try_init();
+    walrus_test_utils::init_tracing();
     let (_sui_cluster_handle, _cluster, client, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
 
@@ -1633,7 +1633,7 @@ async fn test_extend_owned_blobs() -> TestResult {
 async fn test_share_blobs() -> TestResult {
     const EXTEND_EPOCHS: EpochCount = 10;
     const INITIAL_FUNDS: u64 = 1000000000;
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
 
     let (_sui_cluster_handle, _cluster, client, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
@@ -1731,7 +1731,7 @@ async fn test_post_store_action(
     n_owned_blobs: usize,
     n_target_blobs: usize,
 ) -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
     let (_sui_cluster_handle, _cluster, client, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
     let target_address: SuiAddress = SuiAddress::from_bytes(TARGET_ADDRESS).expect("valid address");
@@ -1801,7 +1801,7 @@ async fn test_post_store_action(
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_store_blob_with_random_attributes() -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
 
     let (_sui_cluster_handle, _cluster, client, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
@@ -2032,7 +2032,7 @@ impl<'a> BlobAttributeTestContext<'a> {
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_blob_attribute_add_and_remove() -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
 
     let (_sui_cluster_handle, _cluster, mut client, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
@@ -2088,7 +2088,7 @@ async fn test_blob_attribute_add_and_remove() -> TestResult {
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_blob_attribute_fields_operations() -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
 
     let (_sui_cluster_handle, _cluster, mut client, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
@@ -2187,7 +2187,7 @@ async fn test_blob_attribute_fields_operations() -> TestResult {
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_shard_move_out_and_back_in_immediately() -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
     let (_sui_cluster_handle, walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
         .with_epoch_duration(Duration::from_secs(20))
         .with_test_nodes_config(TestNodesConfig {
@@ -2331,7 +2331,7 @@ async fn test_ptb_retriable_error() -> TestResult {
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 pub async fn test_select_coins_max_objects() -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
     let (sui_cluster_handle, _, _, _) = test_cluster::E2eTestSetupBuilder::new().build().await?;
 
     // Create a new wallet on the cluster.
@@ -2409,8 +2409,8 @@ pub async fn test_select_coins_max_objects() -> TestResult {
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_store_with_upload_relay_no_tip() {
-    telemetry_subscribers::init_for_testing();
-    let _ = tracing_subscriber::fmt::try_init();
+    walrus_test_utils::init_tracing();
+    walrus_test_utils::init_tracing();
 
     // Start the Sui and Walrus clusters.
     let (sui_cluster_handle, _cluster, cluster_client, _) =
@@ -2538,8 +2538,8 @@ fn get_upload_relay_url(server_address: &SocketAddr) -> Url {
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_store_with_upload_relay_with_tip() {
-    telemetry_subscribers::init_for_testing();
-    let _ = tracing_subscriber::fmt::try_init();
+    walrus_test_utils::init_tracing();
+    walrus_test_utils::init_tracing();
 
     // Start the Sui and Walrus clusters.
     let (sui_cluster_handle, _cluster, cluster_client, _system_context) =

--- a/crates/walrus-service/src/node/config_synchronizer.rs
+++ b/crates/walrus-service/src/node/config_synchronizer.rs
@@ -448,9 +448,7 @@ mod tests {
         new_cert_subject: &str,
         expect_restart: bool,
     ) -> anyhow::Result<()> {
-        let _ = tracing_subscriber::fmt()
-            .with_max_level(tracing::Level::DEBUG)
-            .try_init();
+        walrus_test_utils::init_tracing();
 
         // Set up test environment with temporary directory and certificate.
         let temp_dir = TempDir::new()?;

--- a/crates/walrus-service/tests/epoch_change.rs
+++ b/crates/walrus-service/tests/epoch_change.rs
@@ -13,7 +13,7 @@ async fn nodes_drive_epoch_change() -> walrus_test_utils::Result {
     use walrus_core::Epoch;
     use walrus_service::test_utils::{StorageNodeHandleTrait, TestNodesConfig, test_cluster};
 
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
     let epoch_duration = Duration::from_secs(5);
     let (_sui, storage_nodes, _, _) = test_cluster::E2eTestSetupBuilder::new()
         .with_epoch_duration(epoch_duration)

--- a/crates/walrus-sui/tests/test_walrus_sui.rs
+++ b/crates/walrus-sui/tests/test_walrus_sui.rs
@@ -67,7 +67,7 @@ async fn initialize_contract_and_wallet_with_credits_with_single_node() -> anyho
 #[tokio::test]
 #[ignore = "ignore E2E tests by default"]
 async fn test_initialize_contract() -> anyhow::Result<()> {
-    _ = tracing_subscriber::fmt::try_init();
+    walrus_test_utils::init_tracing();
     initialize_contract_and_wallet_with_single_node().await?;
     Ok(())
 }
@@ -75,7 +75,7 @@ async fn test_initialize_contract() -> anyhow::Result<()> {
 #[tokio::test]
 #[ignore = "ignore integration tests by default"]
 async fn test_register_certify_blob_100_percent_buyer_credits() -> anyhow::Result<()> {
-    _ = tracing_subscriber::fmt::try_init();
+    walrus_test_utils::init_tracing();
     let encoding_type = EncodingType::RS2;
 
     let (_sui_cluster_handle, walrus_client, _, _) =
@@ -120,7 +120,7 @@ async fn test_register_certify_blob_100_percent_buyer_credits() -> anyhow::Resul
 #[tokio::test]
 #[ignore = "ignore integration tests by default"]
 async fn test_register_certify_blob() -> anyhow::Result<()> {
-    _ = tracing_subscriber::fmt::try_init();
+    walrus_test_utils::init_tracing();
     let encoding_type = EncodingType::RS2;
 
     let (_sui_cluster_handle, walrus_client, _, test_node_keys) =
@@ -306,7 +306,7 @@ async fn test_register_certify_blob() -> anyhow::Result<()> {
 #[tokio::test]
 #[ignore = "ignore integration tests by default"]
 async fn test_invalidate_blob() -> anyhow::Result<()> {
-    _ = tracing_subscriber::fmt::try_init();
+    walrus_test_utils::init_tracing();
 
     let (_sui_cluster_handle, walrus_client, _, test_node_keys) =
         initialize_contract_and_wallet_with_single_node().await?;
@@ -358,7 +358,7 @@ async fn test_invalidate_blob() -> anyhow::Result<()> {
 #[tokio::test]
 #[ignore = "ignore integration tests by default"]
 async fn test_get_committee() -> anyhow::Result<()> {
-    _ = tracing_subscriber::fmt::try_init();
+    walrus_test_utils::init_tracing();
     let (_sui_cluster_handle, walrus_client, _, test_node_keys) =
         initialize_contract_and_wallet_with_single_node().await?;
     let committee = walrus_client
@@ -386,7 +386,7 @@ async fn test_set_authorized() -> anyhow::Result<()> {
     use sui_types::base_types::ObjectID;
     use walrus_sui::types::move_structs::Authorized;
 
-    _ = tracing_subscriber::fmt::try_init();
+    walrus_test_utils::init_tracing();
     let (_sui_cluster_handle, walrus_client, _, _) =
         initialize_contract_and_wallet_with_single_node().await?;
     let protocol_key_pair = ProtocolKeyPair::generate();
@@ -456,7 +456,7 @@ async fn test_set_authorized() -> anyhow::Result<()> {
 #[tokio::test]
 #[ignore = "ignore integration tests by default"]
 async fn test_exchange_sui_for_wal() -> anyhow::Result<()> {
-    _ = tracing_subscriber::fmt::try_init();
+    walrus_test_utils::init_tracing();
     let (_sui_cluster_handle, walrus_client, system_context, _) =
         initialize_contract_and_wallet_with_single_node().await?;
     let exchange_id = walrus_client
@@ -485,7 +485,7 @@ async fn test_exchange_sui_for_wal() -> anyhow::Result<()> {
 #[tokio::test]
 #[ignore = "ignore integration tests by default"]
 async fn test_collect_commission() -> anyhow::Result<()> {
-    _ = tracing_subscriber::fmt::try_init();
+    walrus_test_utils::init_tracing();
 
     // Set zero duration, s.t. we can change the epoch whenever we need to.
     let (_sui_cluster_handle, walrus_client, _, _) =
@@ -544,7 +544,7 @@ async fn test_automatic_wal_coin_squashing(
     n_source_coins: u64,
     n_target_coins: u64,
 ) -> anyhow::Result<()> {
-    _ = tracing_subscriber::fmt::try_init();
+    walrus_test_utils::init_tracing();
     // Use a source_amount that is cleanly divisible by `n_target_coins` to make sure that we send
     // the full amount back in `n_target_coins` coins payments.
     let source_amount = 10_000 * n_target_coins;

--- a/crates/walrus-test-utils/Cargo.toml
+++ b/crates/walrus-test-utils/Cargo.toml
@@ -8,8 +8,11 @@ version.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+once_cell.workspace = true
 rand.workspace = true
 tempfile.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
 
 [lints]
 workspace = true

--- a/crates/walrus-utils/src/tracing_sampled.rs
+++ b/crates/walrus-utils/src/tracing_sampled.rs
@@ -153,7 +153,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn test_sampled_logging_new_macro() {
         #![allow(clippy::cast_possible_truncation)]
-        let _ = tracing_subscriber::fmt::try_init();
+        walrus_test_utils::init_tracing();
 
         let start = Instant::now();
         let mut actual_log_count = 0;


### PR DESCRIPTION
## Description

We normally run tests with `cargo nextest`, which has some additional isolation mechanisms compared to `cargo test`.
This resulted in some tests not running successfully with `cargo test`.

This adds locks for some unit tests to prevent them from running simultaneously in the same process. It also unifies how tracing subscribers are initialized in tests.

Finally, this runs unit tests in the standard CI workflow to ensure that we don't accidentally break them again.

Unfortunately, integration tests are still a bit flaky with `cargo test` and need to be fixed separately.

## Test plan

Added `cargo test` to the CI workflow + ran it locally.
