### PR TITLE
feat(node): update blob info when deletable blobs expire

### DIFF
--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -918,6 +918,88 @@ async fn test_storage_nodes_do_not_serve_data_for_deleted_blobs() -> TestResult 
     assert_eq!(count_deleted, 1, "should have deleted one blob");
     tokio::time::sleep(Duration::from_millis(50)).await;
 
+    check_that_blob_is_not_available(client, blob_id).await
+}
+
+/// Tests that nodes correctly update the blob info for expired deletable blobs and no longer serve
+/// data for them.
+#[ignore = "ignore E2E tests by default"]
+#[walrus_simtest]
+async fn test_storage_nodes_do_not_serve_data_for_expired_deletable_blobs() -> TestResult {
+    telemetry_subscribers::init_for_testing();
+    let epoch_duration = Duration::from_secs(15);
+    let (_sui_cluster_handle, cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
+        .with_epoch_duration(epoch_duration)
+        .build()
+        .await?;
+    let client = client.as_ref();
+    let blob = walrus_test_utils::random_data(314);
+    let blobs = vec![blob.as_slice()];
+
+    // Store the blob for 42 epochs.
+    let [
+        BlobStoreResult::NewlyCreated {
+            blob_object:
+                Blob {
+                    blob_id,
+                    id: object_id,
+                    ..
+                },
+            ..
+        },
+    ] = client
+        .reserve_and_store_blobs(
+            &blobs,
+            &StoreArgs::default_with_epochs(42)
+                .no_store_optimizations()
+                .deletable(),
+        )
+        .await?[..]
+    else {
+        panic!("should have exactly one newly created blob");
+    };
+
+    // Store the blob again for a single epoch.
+    let [
+        BlobStoreResult::NewlyCreated {
+            ref blob_object, ..
+        },
+    ] = client
+        .reserve_and_store_blobs(
+            &blobs,
+            &StoreArgs::default_with_epochs(1)
+                .no_store_optimizations()
+                .deletable(),
+        )
+        .await?[..]
+    else {
+        panic!("should have exactly one newly created blob");
+    };
+    assert_eq!(blob_object.blob_id, blob_id);
+    let early_end_epoch = blob_object.storage.end_epoch;
+
+    // Make sure we can read the blob.
+    assert_eq!(client.read_blob::<Primary>(&blob_id).await?, blob);
+
+    // Delete the blob with the later end epoch.
+    client.delete_owned_blob_by_object(object_id).await?;
+
+    // Wait until the end epoch of the early blob is reached, at which point it should no longer be
+    // available.
+    tokio::time::timeout(
+        epoch_duration * 3,
+        cluster.wait_for_nodes_to_reach_epoch(early_end_epoch),
+    )
+    .await
+    .expect("timed out waiting for nodes to reach end epoch of first blob");
+
+    check_that_blob_is_not_available(client, blob_id).await
+}
+
+async fn check_that_blob_is_not_available(
+    client: &WalrusNodeClient<SuiContractClient>,
+    blob_id: BlobId,
+) -> TestResult {
     let status_result = client
         .get_verified_blob_status(
             &blob_id,

--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -926,7 +926,7 @@ async fn test_storage_nodes_do_not_serve_data_for_deleted_blobs() -> TestResult 
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_storage_nodes_do_not_serve_data_for_expired_deletable_blobs() -> TestResult {
-    telemetry_subscribers::init_for_testing();
+    walrus_test_utils::init_tracing();
     let epoch_duration = Duration::from_secs(15);
     let (_sui_cluster_handle, cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
         .with_epoch_duration(epoch_duration)

--- a/crates/walrus-sdk/src/client.rs
+++ b/crates/walrus-sdk/src/client.rs
@@ -14,7 +14,7 @@ use std::{
     time::Instant,
 };
 
-use anyhow::anyhow;
+use anyhow::{anyhow, bail};
 use bimap::BiMap;
 pub use client_types::{UnencodedBlob, WalrusStoreBlob, WalrusStoreBlobApi};
 pub use communication::NodeCommunicationFactory;
@@ -2257,7 +2257,10 @@ async fn verify_blob_status_event(
     let event = match status {
         BlobStatus::Invalid { event } => event,
         BlobStatus::Permanent { status_event, .. } => status_event,
-        BlobStatus::Nonexistent | BlobStatus::Deletable { .. } => return Ok(()),
+        BlobStatus::Deletable { .. } => {
+            bail!("deletable status cannot be verified with an on-chain event")
+        }
+        BlobStatus::Nonexistent => return Ok(()),
     };
     tracing::debug!(?event, "verifying blob status with on-chain event");
 

--- a/crates/walrus-service/node_config_example.yaml
+++ b/crates/walrus-service/node_config_example.yaml
@@ -205,3 +205,5 @@ node_recovery_config:
   max_concurrent_blob_syncs_during_recovery: 1000
 blob_event_processor_config:
   num_workers: 10
+garbage_collection:
+  enable_blob_info_cleanup: false

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -192,6 +192,9 @@ pub struct StorageNodeConfig {
     /// Configuration for the blob event processor.
     #[serde(default, skip_serializing_if = "defaults::is_default")]
     pub blob_event_processor_config: BlobEventProcessorConfig,
+    /// Configuration for garbage collection and related tasks.
+    #[serde(default, skip_serializing_if = "defaults::is_default")]
+    pub garbage_collection: GarbageCollectionConfig,
 }
 
 impl Default for StorageNodeConfig {
@@ -235,6 +238,7 @@ impl Default for StorageNodeConfig {
             admin_socket_path: None,
             node_recovery_config: Default::default(),
             blob_event_processor_config: Default::default(),
+            garbage_collection: Default::default(),
         }
     }
 }
@@ -725,6 +729,34 @@ pub struct BlobEventProcessorConfig {
 impl Default for BlobEventProcessorConfig {
     fn default() -> Self {
         Self { num_workers: 10 }
+    }
+}
+
+/// Configuration for garbage collection and related tasks.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[serde(default)]
+pub struct GarbageCollectionConfig {
+    /// Whether to enable the blob info cleanup at the beginning of each epoch.
+    pub enable_blob_info_cleanup: bool,
+}
+
+#[allow(clippy::derivable_impls)] // making the default explicit as a reminder for future changes
+impl Default for GarbageCollectionConfig {
+    fn default() -> Self {
+        Self {
+            // TODO(WAL-1040): Enable this by default.
+            enable_blob_info_cleanup: false,
+        }
+    }
+}
+
+impl GarbageCollectionConfig {
+    /// Returns a default configuration for testing.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn default_for_test() -> Self {
+        Self {
+            enable_blob_info_cleanup: true,
+        }
     }
 }
 

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -593,13 +593,13 @@ impl Storage {
         &self,
         current_epoch: Epoch,
     ) -> anyhow::Result<()> {
-        tracing::info!(epoch = %current_epoch, "processing expired deletable blobs");
+        tracing::info!(epoch = %current_epoch, "processing expired blob objects");
 
         self.blob_info
             .process_expired_blob_objects(current_epoch)
             .await?;
 
-        tracing::info!(epoch = %current_epoch, "finished processing expired deletable blobs");
+        tracing::info!(epoch = %current_epoch, "finished processing expired blob objects");
 
         Ok(())
     }

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -585,6 +585,25 @@ impl Storage {
         }
     }
 
+    /// Processes blobs that are expired in the given epoch.
+    ///
+    /// This function is called during epoch change to clean up the blob info for blob objects that
+    /// are no longer valid.
+    pub(crate) async fn process_expired_blob_objects(
+        &self,
+        current_epoch: Epoch,
+    ) -> anyhow::Result<()> {
+        tracing::info!(epoch = %current_epoch, "processing expired deletable blobs");
+
+        self.blob_info
+            .process_expired_blob_objects(current_epoch)
+            .await?;
+
+        tracing::info!(epoch = %current_epoch, "finished processing expired deletable blobs");
+
+        Ok(())
+    }
+
     /// Repositions the event cursor to the specified event index.
     pub(crate) fn reposition_event_cursor(
         &self,

--- a/crates/walrus-service/src/node/storage/blob_info.rs
+++ b/crates/walrus-service/src/node/storage/blob_info.rs
@@ -369,8 +369,6 @@ impl BlobInfoTable {
         &self,
         current_epoch: Epoch,
     ) -> anyhow::Result<()> {
-        tracing::info!(epoch = %current_epoch, "processing expired deletable blobs");
-
         for entry in self.per_object_blob_info.safe_iter()? {
             let (object_id, per_object_blob_info) = match entry {
                 Ok(entry) => entry,

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -107,6 +107,7 @@ use crate::{
             BlobEventProcessorConfig,
             BlobRecoveryConfig,
             ConfigSynchronizerConfig,
+            GarbageCollectionConfig,
             NodeRecoveryConfig,
             ShardSyncConfig,
             StorageNodeConfig,
@@ -992,6 +993,7 @@ impl StorageNodeHandleBuilder {
                 Default::default()
             },
             blob_recovery: BlobRecoveryConfig::default_for_test(),
+            garbage_collection: GarbageCollectionConfig::default_for_test(),
             ..storage_node_config().inner
         };
 
@@ -1173,6 +1175,7 @@ impl StorageNodeHandleBuilder {
             storage_node_cap: node_capability.map(|cap| cap.id),
             node_recovery_config: self.node_recovery_config.clone().unwrap_or_default(),
             blob_recovery: BlobRecoveryConfig::default_for_test(),
+            garbage_collection: GarbageCollectionConfig::default_for_test(),
             ..storage_node_config().inner
         };
 
@@ -3060,6 +3063,7 @@ pub fn storage_node_config() -> WithTempDir<StorageNodeConfig> {
             node_recovery_config: Default::default(),
             // Uses smaller number of workers in tests to avoid overwhelming the tests.
             blob_event_processor_config: BlobEventProcessorConfig { num_workers: 3 },
+            garbage_collection: GarbageCollectionConfig::default_for_test(),
         },
         temp_dir,
     }

--- a/crates/walrus-service/src/testbed.rs
+++ b/crates/walrus-service/src/testbed.rs
@@ -751,6 +751,7 @@ pub async fn create_storage_node_configs(
             admin_socket_path: Some(working_dir.join(format!("admin-{node_index}.sock"))),
             node_recovery_config: Default::default(),
             blob_event_processor_config: Default::default(),
+            garbage_collection: Default::default(),
         });
     }
 


### PR DESCRIPTION
## Description

For deletable blobs, we store object counts in the aggregate blob info. These need to be updated when deletable blobs expire.

This adds a new (background) task running at the beginning of each epoch that cleans up expired entries in the per-object blob info and updates the aggregate blob info for expired deletable blobs.

This also improves some test utils and fixes several E2E tests that reused object IDs in an incorrect way.

## Test plan

A newly added E2E test (`test_storage_nodes_do_not_serve_data_for_expired_deletable_blobs`) verifies that this works correctly. I verified that the test fails without the added `process_expired_blob_objects` task and succeeds with it.