### PR TITLE
chore: update simtest CI setup

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -137,7 +137,6 @@ jobs:
     if: ${{ needs.diff.outputs.isRelevantForRustTests == 'true' }}
     runs-on: ubuntu-ghcloud
     env:
-      MSIM_TEST_NUM: 5
       # Turn off Sui logging since it can be very distractive in CI
       RUST_LOG: simtest=info,error,sui_=off,consensus_core=off
     steps:
@@ -150,8 +149,16 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
 
       - run: ./scripts/simtest/install.sh
-      - name: Run tests
-        run: cargo simtest simtest --profile simtest
+      - name: Run tests (seed=1)
+        run: MSIM_TEST_SEED=1 cargo simtest simtest --profile simtest
+      - name: Run tests (seed=2)
+        run: MSIM_TEST_SEED=2 cargo simtest simtest --profile simtest
+      - name: Run tests (seed=3)
+        run: MSIM_TEST_SEED=3 cargo simtest simtest --profile simtest
+      - name: Run tests (seed=4)
+        run: MSIM_TEST_SEED=4 cargo simtest simtest --profile simtest
+      - name: Run tests (seed=5)
+        run: MSIM_TEST_SEED=5 cargo simtest simtest --profile simtest
 
   simtests-build:
     name: Build all simtests


### PR DESCRIPTION
## Description

We have seen in cases where the second test run in a CI simtest may encounter unexpected networking error. This is likely due to that simtest framework may not cleanup all the states from previous run. This appears to only happen in CI and hard to debug.

Instead, we run different test seeds individually in different process to reduce the chance of triggering framework issue.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
