### PR TITLE
fix(core): optimize memory allocations during blob decoding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -280,7 +280,7 @@ file is located at [`target/criterion/report/index.html].
 
 Criterion automatically compares the results from multiple runs. To check if your code changes
 improve or worsen the performance, run the benchmarks first on the latest `main` branch and then
-again with your code changes or explicitly set and use baselines with `--set-baseline` and
+again with your code changes or explicitly set and use baselines with `--save-baseline` and
 `--baseline`. See the [Criterion
 documentation](https://bheisler.github.io/criterion.rs/book/user_guide/command_line_options.html#baselines)
 for further details.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,7 +138,7 @@ tower = "0.5"
 tower-http = { version = "0.5.2", features = ["cors", "timeout", "trace"] }
 tracing = "0.1.41"
 tracing-opentelemetry = { version = "=0.28.0", default-features = false }
-tracing-subscriber = { version = "0.3.20", default-features = false, features = ["fmt"] }
+tracing-subscriber = { version = "0.3.20", default-features = false, features = ["env-filter", "fmt"] }
 twox-hash = "2.1.2"
 typed-store = { path = "crates/typed-store" }
 uint = "0.10.0"

--- a/crates/walrus-core/src/encoding/basic_encoding.rs
+++ b/crates/walrus-core/src/encoding/basic_encoding.rs
@@ -210,7 +210,9 @@ impl<'a> ReedSolomonEncoder<'a> {
     }
 }
 
-/// Wrapper to perform a single decoding with Reed-Solomon for the provided parameters.
+/// Wrapper to perform a 1D decoding with Reed-Solomon for the provided parameters.
+///
+/// The object can be reused for multiple consecutive decodings with the same parameters.
 pub struct ReedSolomonDecoder {
     decoder: reed_solomon_simd::ReedSolomonDecoder,
     n_source_symbols: NonZeroU16,

--- a/crates/walrus-core/src/encoding/blob_encoding.rs
+++ b/crates/walrus-core/src/encoding/blob_encoding.rs
@@ -461,11 +461,13 @@ pub struct BlobDecoder<'a, D: Decoder, E: EncodingAxis = Primary> {
     blob_size: usize,
     symbol_size: NonZeroU16,
     sliver_length: usize,
+    /// The number of columns of the blob's message matrix (i.e., the number of secondary slivers).
     n_columns: usize,
     config: &'a D::Config,
     /// The workspace used to store the sliver data and iteratively overwrite it with the decoded
-    /// blob. The layout is the same as the resulting blob; that is, primary slivers are written as
-    /// "rows" while secondary slivers are written as "columns".
+    /// blob. While a flat byte array, this is interpreted as a matrix of symbols. The layout is the
+    /// same as the blob's message matrix; that is, primary slivers are written as "rows" while
+    /// secondary slivers are written as "columns".
     workspace: Symbols,
     /// The indices of the slivers that have been provided and added to the workspace.
     sliver_indices: Vec<SliverIndex>,

--- a/crates/walrus-core/src/encoding/config.rs
+++ b/crates/walrus-core/src/encoding/config.rs
@@ -99,6 +99,11 @@ pub trait EncodingFactory {
         blob: &[u8],
     ) -> Result<VerifiedBlobMetadataWithId, DataTooLargeError>;
 
+    /// Computes the blob ID for the provided blob.
+    fn compute_blob_id(&self, blob: &[u8]) -> Result<BlobId, DataTooLargeError> {
+        Ok(*self.compute_metadata(blob)?.blob_id())
+    }
+
     /// Attempts to decode the source blob from the provided slivers.
     ///
     /// Returns the source blob as a byte vector if decoding succeeds or `None` if decoding fails.

--- a/crates/walrus-core/src/encoding/slivers.rs
+++ b/crates/walrus-core/src/encoding/slivers.rs
@@ -574,10 +574,10 @@ mod tests {
     param_test! {
         test_recover_sliver_failure: [
             no_symbols: (&[], 2, 2),
-            #[should_panic] empty_symbols: (&[&[], &[]], 2, 2),
+            empty_symbols: (&[&[], &[]], 2, 2),
             too_few_symbols: (&[&[1,2]], 2, 2),
-            #[should_panic] inconsistent_size: (&[&[1,2],&[3]], 2, 2),
-            #[should_panic] inconsistent_and_empty_size: (&[&[1],&[]], 2, 2),
+            inconsistent_size: (&[&[1,2],&[3]], 2, 2),
+            inconsistent_and_empty_size: (&[&[1],&[]], 2, 2),
         ]
     }
     // Only testing for failures in the decoding. The correct decoding is tested below.

--- a/crates/walrus-core/src/encoding/slivers.rs
+++ b/crates/walrus-core/src/encoding/slivers.rs
@@ -574,10 +574,10 @@ mod tests {
     param_test! {
         test_recover_sliver_failure: [
             no_symbols: (&[], 2, 2),
-            empty_symbols: (&[&[], &[]], 2, 2),
+            #[should_panic] empty_symbols: (&[&[], &[]], 2, 2),
             too_few_symbols: (&[&[1,2]], 2, 2),
-            inconsistent_size: (&[&[1,2],&[3]], 2, 2),
-            inconsistent_and_empty_size: (&[&[1],&[]], 2, 2),
+            #[should_panic] inconsistent_size: (&[&[1,2],&[3]], 2, 2),
+            #[should_panic] inconsistent_and_empty_size: (&[&[1],&[]], 2, 2),
         ]
     }
     // Only testing for failures in the decoding. The correct decoding is tested below.


### PR DESCRIPTION
## Description

In the past, when we were using RaptorQ for the 1D encoding, it was necessary to keep around intermediate decoding state as the exact number of slivers needed for decoding was unknown and we would potentially have to reuse the decoder for a new decoding attempt.

This is no longer the case with Reed-Solomon, as we know the exact number of slivers needed for decoding. As a result, we can allocate a single 1D decoder and reuse it for all sub-decodings during blob decoding.

This commit also makes some other changes to reduce the number of allocations during blob decoding, specifically by using flat arrays instead of nested vectors where possible.

Both together result in both a **major reduction in memory usage** and a **significant performance improvement**:

- The peak memory usage while reading a 1GiB sliver from the public Testnet (before the blob re-encoding) was reduced from more than 10GiB to ~2.5GiB.
- The decoding time (without re-encoding) for 1GiB blobs was reduced by more than 60% (corresponding to a ~160% throughput improvement).

<details><summary>Benchmark details</summary>

```console
$ cargo bench -p walrus-core blob_decoding/decode/ -- --baseline main
     Running benches/basic_encoding.rs (target/release/deps/basic_encoding-669d9b131c7330c5)
     Running benches/blob_encoding.rs (target/release/deps/blob_encoding-6ae446cf9853bda3)
blob_decoding/decode/1B time:   [237.42 ms 239.74 ms 242.12 ms]
                        thrpt:  [4.1302   B/s 4.1712   B/s 4.2119   B/s]
                 change:
                        time:   [-17.007% -16.021% -14.985%] (p = 0.00 < 0.05)
                        thrpt:  [+17.626% +19.077% +20.492%]
                        Performance has improved.
blob_decoding/decode/1KiB
                        time:   [236.83 ms 238.76 ms 241.03 ms]
                        thrpt:  [4.1488 KiB/s 4.1883 KiB/s 4.2224 KiB/s]
                 change:
                        time:   [-20.303% -18.427% -16.803%] (p = 0.00 < 0.05)
                        thrpt:  [+20.196% +22.590% +25.475%]
                        Performance has improved.
blob_decoding/decode/1MiB
                        time:   [238.91 ms 240.91 ms 243.52 ms]
                        thrpt:  [4.1065 MiB/s 4.1510 MiB/s 4.1856 MiB/s]
                 change:
                        time:   [-18.806% -17.945% -16.974%] (p = 0.00 < 0.05)
                        thrpt:  [+20.444% +21.869% +23.162%]
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
blob_decoding/decode/16MiB
                        time:   [285.12 ms 286.72 ms 289.04 ms]
                        thrpt:  [55.356 MiB/s 55.804 MiB/s 56.117 MiB/s]
                 change:
                        time:   [-39.476% -38.440% -37.370%] (p = 0.00 < 0.05)
                        thrpt:  [+59.667% +62.443% +65.223%]
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking blob_decoding/decode/256MiB: Warming up for 10.000 ms
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 11.4s.
blob_decoding/decode/256MiB
                        time:   [1.0962 s 1.1041 s 1.1144 s]
                        thrpt:  [229.72 MiB/s 231.86 MiB/s 233.54 MiB/s]
                 change:
                        time:   [-60.495% -60.093% -59.635%] (p = 0.00 < 0.05)
                        thrpt:  [+147.74% +150.58% +153.13%]
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking blob_decoding/decode/1GiB: Warming up for 10.000 ms
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 40.2s.
blob_decoding/decode/1GiB
                        time:   [3.9828 s 4.0173 s 4.0607 s]
                        thrpt:  [252.18 MiB/s 254.90 MiB/s 257.10 MiB/s]
                 change:
                        time:   [-62.436% -61.965% -61.439%] (p = 0.00 < 0.05)
                        thrpt:  [+159.33% +162.91% +166.21%]
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe

```

</details> 



## Test plan

Existing test suite.

Additionally checked memory usage with `cargo instruments` and performance through benchmarks (see above).

---

## Release notes

- [x] Aggregator: Major reduction in memory usage for large blobs.
- [x] CLI: Major reduction in memory usage when reading large blobs.
