### PR TITLE
ci: bump Sui testnet version to testnet-v1.57.0 in `releases/walrus-v1.33.0-release` branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2098,7 +2098,7 @@ name = "consensus-config"
 version = "0.1.0"
 source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "mysten-network",
  "rand 0.8.5",
  "serde",
@@ -2125,7 +2125,7 @@ dependencies = [
  "dashmap",
  "enum_dispatch",
  "eyre",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "futures",
  "http 1.3.1",
  "itertools 0.13.0",
@@ -2169,7 +2169,7 @@ source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5d
 dependencies = [
  "base64 0.21.7",
  "consensus-config",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "serde",
 ]
 
@@ -3377,56 +3377,6 @@ dependencies = [
 [[package]]
 name = "fastcrypto"
 version = "0.1.9"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=16fa86d0dd943024a9088d46850a72ecd55b7f46#16fa86d0dd943024a9088d46850a72ecd55b7f46"
-dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-secp256r1",
- "ark-serialize",
- "auto_ops",
- "base64ct",
- "bech32",
- "bincode",
- "blake2",
- "blst",
- "bs58 0.4.0",
- "curve25519-dalek-ng",
- "derive_more 0.99.20",
- "digest 0.10.7",
- "ecdsa 0.16.9",
- "ed25519-consensus",
- "elliptic-curve 0.13.8",
- "fastcrypto-derive 0.1.3 (git+https://github.com/MystenLabs/fastcrypto?rev=16fa86d0dd943024a9088d46850a72ecd55b7f46)",
- "generic-array",
- "hex",
- "hex-literal",
- "hkdf",
- "lazy_static",
- "num-bigint 0.4.6",
- "once_cell",
- "p256",
- "rand 0.8.5",
- "readonly",
- "rfc6979 0.4.0",
- "rsa",
- "schemars 0.8.22",
- "secp256k1",
- "serde",
- "serde_json",
- "serde_with",
- "sha2 0.10.9",
- "sha3 0.10.8",
- "signature 2.2.0",
- "static_assertions",
- "thiserror 1.0.69",
- "tokio",
- "typenum",
- "zeroize",
-]
-
-[[package]]
-name = "fastcrypto"
-version = "0.1.9"
 source = "git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3#204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3"
 dependencies = [
  "aes",
@@ -3452,7 +3402,7 @@ dependencies = [
  "ecdsa 0.16.9",
  "ed25519-consensus",
  "elliptic-curve 0.13.8",
- "fastcrypto-derive 0.1.3 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto-derive",
  "generic-array",
  "hex",
  "hex-literal",
@@ -3483,15 +3433,6 @@ dependencies = [
 [[package]]
 name = "fastcrypto-derive"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=16fa86d0dd943024a9088d46850a72ecd55b7f46#16fa86d0dd943024a9088d46850a72ecd55b7f46"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "fastcrypto-derive"
-version = "0.1.3"
 source = "git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3#204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3"
 dependencies = [
  "quote",
@@ -3505,7 +3446,7 @@ source = "git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c
 dependencies = [
  "bcs",
  "digest 0.10.7",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "hex",
  "itertools 0.10.5",
  "rand 0.8.5",
@@ -3523,7 +3464,7 @@ version = "0.1.0"
 source = "git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3#204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3"
 dependencies = [
  "bcs",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "lazy_static",
  "num-bigint 0.4.6",
  "num-integer",
@@ -3549,7 +3490,7 @@ dependencies = [
  "bcs",
  "byte-slice-cast",
  "derive_more 0.99.20",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "ff 0.13.1",
  "im",
  "itertools 0.12.1",
@@ -6341,7 +6282,7 @@ dependencies = [
  "antithesis_sdk",
  "anyhow",
  "either",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "futures",
  "mysten-metrics",
  "once_cell",
@@ -6388,7 +6329,7 @@ dependencies = [
  "bcs",
  "bytes",
  "eyre",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "futures",
  "http 1.3.1",
  "http-body 1.0.1",
@@ -9094,7 +9035,7 @@ source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5d
 dependencies = [
  "bcs",
  "eyre",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "serde",
  "serde_repr",
 ]
@@ -9197,7 +9138,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bcs",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "futures",
  "move-binary-format",
  "move-bytecode-utils",
@@ -9722,7 +9663,7 @@ dependencies = [
  "consensus-config",
  "csv",
  "dirs",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "move-vm-config",
  "mysten-common",
  "nonzero_ext",
@@ -9767,7 +9708,7 @@ dependencies = [
  "either",
  "enum_dispatch",
  "eyre",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "fastcrypto-tbls",
  "fastcrypto-zkp",
  "futures",
@@ -10001,7 +9942,7 @@ dependencies = [
  "anyhow",
  "bcs",
  "camino",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "move-binary-format",
  "move-core-types",
  "prometheus",
@@ -10061,7 +10002,7 @@ dependencies = [
  "diesel",
  "diesel-async",
  "diesel_migrations",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "futures",
  "hex",
  "indicatif",
@@ -10183,7 +10124,7 @@ source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5d
 dependencies = [
  "anyhow",
  "bcs",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "move-binary-format",
  "move-bytecode-utils",
  "move-core-types",
@@ -10208,7 +10149,7 @@ dependencies = [
  "cached",
  "chrono",
  "eyre",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "fastcrypto-zkp",
  "futures",
  "http-body 0.4.6",
@@ -10258,7 +10199,7 @@ version = "0.0.0"
 source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "jsonrpsee",
  "mysten-metrics",
  "once_cell",
@@ -10281,7 +10222,7 @@ dependencies = [
  "bcs",
  "colored",
  "enum_dispatch",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "itertools 0.13.0",
  "json_to_table",
  "move-binary-format",
@@ -10316,7 +10257,7 @@ dependencies = [
  "bcs",
  "bip32",
  "colored",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "jsonrpc",
  "mockall 0.11.4",
  "rand 0.8.5",
@@ -10348,7 +10289,7 @@ version = "0.1.0"
 source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "mysten-metrics",
  "prometheus",
  "reqwest",
@@ -10366,7 +10307,7 @@ version = "1.57.0"
 source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "move-binary-format",
  "move-bytecode-utils",
  "move-bytecode-verifier",
@@ -10392,7 +10333,7 @@ source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5d
 dependencies = [
  "bcs",
  "better_any",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "fastcrypto-vdf",
  "fastcrypto-zkp",
  "indexmap 2.11.0",
@@ -10415,7 +10356,7 @@ source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5d
 dependencies = [
  "bcs",
  "better_any",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "fastcrypto-zkp",
  "linked-hash-map",
  "move-binary-format",
@@ -10436,7 +10377,7 @@ source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5d
 dependencies = [
  "bcs",
  "better_any",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "fastcrypto-zkp",
  "linked-hash-map",
  "move-binary-format",
@@ -10457,7 +10398,7 @@ source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5d
 dependencies = [
  "bcs",
  "better_any",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "fastcrypto-zkp",
  "indexmap 2.11.0",
  "move-binary-format",
@@ -10496,7 +10437,7 @@ dependencies = [
  "bcs",
  "bytes",
  "dashmap",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "fastcrypto-tbls",
  "futures",
  "governor",
@@ -10539,7 +10480,7 @@ dependencies = [
  "bin-version",
  "clap",
  "consensus-core",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "fastcrypto-zkp",
  "futures",
  "http 1.3.1",
@@ -10689,7 +10630,7 @@ version = "0.1.0"
 source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "clap",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "move-core-types",
  "move-vm-config",
  "schemars 0.8.22",
@@ -10742,7 +10683,7 @@ dependencies = [
  "base64 0.21.7",
  "bcs",
  "bytes",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "http 1.3.1",
  "itertools 0.13.0",
  "mime",
@@ -10789,7 +10730,7 @@ dependencies = [
  "bcs",
  "clap",
  "colored",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "futures",
  "futures-core",
  "jsonrpsee",
@@ -10840,7 +10781,7 @@ dependencies = [
  "anemo",
  "anemo-tower",
  "bcs",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "lru 0.10.1",
  "move-package",
  "msim",
@@ -10865,7 +10806,7 @@ dependencies = [
  "bcs",
  "byteorder",
  "bytes",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "futures",
  "indicatif",
  "integer-encoding 3.0.4",
@@ -10910,7 +10851,7 @@ dependencies = [
  "chrono",
  "clap",
  "eyre",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "futures",
  "hyper",
  "hyper-rustls",
@@ -10980,7 +10921,7 @@ dependencies = [
  "anemo",
  "anyhow",
  "bcs",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "move-bytecode-utils",
  "mysten-common",
  "prometheus",
@@ -11034,7 +10975,7 @@ dependencies = [
  "axum 0.8.4",
  "axum-server 0.6.1",
  "ed25519",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "pkcs8 0.10.2",
  "rcgen",
  "reqwest",
@@ -11099,7 +11040,7 @@ dependencies = [
  "derive_more 1.0.0",
  "enum_dispatch",
  "eyre",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "fastcrypto-tbls",
  "fastcrypto-zkp",
  "im",
@@ -11404,7 +11345,7 @@ source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5d
 dependencies = [
  "anyhow",
  "bcs",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "fastcrypto-zkp",
  "futures",
  "jsonrpsee",
@@ -12327,7 +12268,7 @@ dependencies = [
  "bincode",
  "collectable",
  "eyre",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
+ "fastcrypto",
  "fdlimit 0.2.1",
  "hdrhistogram",
  "itertools 0.13.0",
@@ -12752,7 +12693,7 @@ dependencies = [
  "bcs",
  "criterion",
  "enum_dispatch",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=16fa86d0dd943024a9088d46850a72ecd55b7f46)",
+ "fastcrypto",
  "hex",
  "p256",
  "rand 0.8.5",
@@ -12853,7 +12794,7 @@ dependencies = [
  "bytes",
  "clap",
  "const-str 0.6.4",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=16fa86d0dd943024a9088d46850a72ecd55b7f46)",
+ "fastcrypto",
  "futures",
  "hyper",
  "itertools 0.14.0",
@@ -12889,7 +12830,7 @@ dependencies = [
  "bimap",
  "chrono",
  "enum_dispatch",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=16fa86d0dd943024a9088d46850a72ecd55b7f46)",
+ "fastcrypto",
  "futures",
  "home",
  "humantime",
@@ -12947,7 +12888,7 @@ dependencies = [
  "diesel-async",
  "diesel_migrations",
  "enum_dispatch",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=16fa86d0dd943024a9088d46850a72ecd55b7f46)",
+ "fastcrypto",
  "futures",
  "futures-util",
  "hex",
@@ -13068,7 +13009,7 @@ dependencies = [
  "axum-server 0.7.2",
  "bcs",
  "bytes",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=16fa86d0dd943024a9088d46850a72ecd55b7f46)",
+ "fastcrypto",
  "futures",
  "http 1.3.1",
  "mime",
@@ -13134,7 +13075,7 @@ dependencies = [
  "bcs",
  "chrono",
  "clap",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=16fa86d0dd943024a9088d46850a72ecd55b7f46)",
+ "fastcrypto",
  "futures",
  "home",
  "indoc",
@@ -13200,7 +13141,7 @@ dependencies = [
  "bcs",
  "clap",
  "clap_complete",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=16fa86d0dd943024a9088d46850a72ecd55b7f46)",
+ "fastcrypto",
  "futures",
  "git-version",
  "mysten-metrics",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1364,8 +1364,8 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bin-version"
-version = "1.56.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+version = "1.57.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "const-str 0.5.7",
  "git-version",
@@ -2096,9 +2096,9 @@ dependencies = [
 [[package]]
 name = "consensus-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "mysten-network",
  "rand 0.8.5",
  "serde",
@@ -2108,7 +2108,7 @@ dependencies = [
 [[package]]
 name = "consensus-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -2125,7 +2125,7 @@ dependencies = [
  "dashmap",
  "enum_dispatch",
  "eyre",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "futures",
  "http 1.3.1",
  "itertools 0.13.0",
@@ -2165,11 +2165,11 @@ dependencies = [
 [[package]]
 name = "consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "base64 0.21.7",
  "consensus-config",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "serde",
 ]
 
@@ -3241,7 +3241,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -3379,6 +3379,56 @@ name = "fastcrypto"
 version = "0.1.9"
 source = "git+https://github.com/MystenLabs/fastcrypto?rev=16fa86d0dd943024a9088d46850a72ecd55b7f46#16fa86d0dd943024a9088d46850a72ecd55b7f46"
 dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-secp256r1",
+ "ark-serialize",
+ "auto_ops",
+ "base64ct",
+ "bech32",
+ "bincode",
+ "blake2",
+ "blst",
+ "bs58 0.4.0",
+ "curve25519-dalek-ng",
+ "derive_more 0.99.20",
+ "digest 0.10.7",
+ "ecdsa 0.16.9",
+ "ed25519-consensus",
+ "elliptic-curve 0.13.8",
+ "fastcrypto-derive 0.1.3 (git+https://github.com/MystenLabs/fastcrypto?rev=16fa86d0dd943024a9088d46850a72ecd55b7f46)",
+ "generic-array",
+ "hex",
+ "hex-literal",
+ "hkdf",
+ "lazy_static",
+ "num-bigint 0.4.6",
+ "once_cell",
+ "p256",
+ "rand 0.8.5",
+ "readonly",
+ "rfc6979 0.4.0",
+ "rsa",
+ "schemars 0.8.22",
+ "secp256k1",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sha2 0.10.9",
+ "sha3 0.10.8",
+ "signature 2.2.0",
+ "static_assertions",
+ "thiserror 1.0.69",
+ "tokio",
+ "typenum",
+ "zeroize",
+]
+
+[[package]]
+name = "fastcrypto"
+version = "0.1.9"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3#204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3"
+dependencies = [
  "aes",
  "aes-gcm",
  "aes-gcm-siv",
@@ -3388,6 +3438,7 @@ dependencies = [
  "ark-serialize",
  "auto_ops",
  "base64ct",
+ "bcs",
  "bech32",
  "bincode",
  "blake2",
@@ -3401,7 +3452,7 @@ dependencies = [
  "ecdsa 0.16.9",
  "ed25519-consensus",
  "elliptic-curve 0.13.8",
- "fastcrypto-derive",
+ "fastcrypto-derive 0.1.3 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "generic-array",
  "hex",
  "hex-literal",
@@ -3439,13 +3490,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastcrypto-derive"
+version = "0.1.3"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3#204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "fastcrypto-tbls"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=16fa86d0dd943024a9088d46850a72ecd55b7f46#16fa86d0dd943024a9088d46850a72ecd55b7f46"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3#204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3"
 dependencies = [
  "bcs",
  "digest 0.10.7",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "hex",
  "itertools 0.10.5",
  "rand 0.8.5",
@@ -3460,10 +3520,10 @@ dependencies = [
 [[package]]
 name = "fastcrypto-vdf"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=16fa86d0dd943024a9088d46850a72ecd55b7f46#16fa86d0dd943024a9088d46850a72ecd55b7f46"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3#204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3"
 dependencies = [
  "bcs",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "lazy_static",
  "num-bigint 0.4.6",
  "num-integer",
@@ -3477,7 +3537,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-zkp"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=16fa86d0dd943024a9088d46850a72ecd55b7f46#16fa86d0dd943024a9088d46850a72ecd55b7f46"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3#204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3489,7 +3549,7 @@ dependencies = [
  "bcs",
  "byte-slice-cast",
  "derive_more 0.99.20",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "ff 0.13.1",
  "im",
  "itertools 0.12.1",
@@ -4757,7 +4817,7 @@ dependencies = [
 [[package]]
 name = "jsonrpc"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "serde",
  "serde_json",
@@ -5505,12 +5565,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 
 [[package]]
 name = "move-abstract-interpreter-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "move-binary-format",
 ]
@@ -5518,12 +5578,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "enum-compat-util",
@@ -5539,12 +5599,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5560,7 +5620,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "indexmap 2.11.0",
@@ -5573,7 +5633,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -5588,7 +5648,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -5598,7 +5658,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
@@ -5613,7 +5673,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
@@ -5628,7 +5688,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
@@ -5643,7 +5703,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5664,7 +5724,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5700,7 +5760,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5725,7 +5785,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5750,7 +5810,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5771,7 +5831,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "clap",
@@ -5794,7 +5854,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -5812,7 +5872,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "hex",
@@ -5825,7 +5885,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -5838,7 +5898,7 @@ dependencies = [
 [[package]]
 name = "move-model-2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5861,7 +5921,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "clap",
@@ -5897,7 +5957,7 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "enum-compat-util",
  "quote",
@@ -5907,7 +5967,7 @@ dependencies = [
 [[package]]
 name = "move-regex-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "itertools 0.10.5",
  "move-binary-format",
@@ -5918,7 +5978,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -5933,7 +5993,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v0"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -5948,7 +6008,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v1"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -5963,7 +6023,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives-v2"
 version = "0.1.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -5978,7 +6038,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "once_cell",
  "phf",
@@ -5988,7 +6048,7 @@ dependencies = [
 [[package]]
 name = "move-trace-format"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -6000,7 +6060,7 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "move-binary-format",
  "once_cell",
@@ -6009,7 +6069,7 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "move-trace-format",
  "move-vm-config",
@@ -6022,7 +6082,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "better_any",
  "fail",
@@ -6041,7 +6101,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "better_any",
  "fail",
@@ -6059,7 +6119,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "better_any",
  "fail",
@@ -6077,7 +6137,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "better_any",
  "fail",
@@ -6095,7 +6155,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6109,7 +6169,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -6122,7 +6182,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -6134,7 +6194,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -6146,7 +6206,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -6276,12 +6336,12 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "mysten-common"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "antithesis_sdk",
  "anyhow",
  "either",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "futures",
  "mysten-metrics",
  "once_cell",
@@ -6299,7 +6359,7 @@ dependencies = [
 [[package]]
 name = "mysten-metrics"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "async-trait",
  "axum 0.8.4",
@@ -6320,7 +6380,7 @@ dependencies = [
 [[package]]
 name = "mysten-network"
 version = "0.2.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -6328,7 +6388,7 @@ dependencies = [
  "bcs",
  "bytes",
  "eyre",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "futures",
  "http 1.3.1",
  "http-body 1.0.1",
@@ -6356,7 +6416,7 @@ dependencies = [
 [[package]]
 name = "mysten-service"
 version = "0.0.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -7559,7 +7619,7 @@ dependencies = [
 [[package]]
 name = "prometheus-closure-metric"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -9030,11 +9090,11 @@ dependencies = [
 [[package]]
 name = "shared-crypto"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "bcs",
  "eyre",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "serde",
  "serde_repr",
 ]
@@ -9132,12 +9192,12 @@ dependencies = [
 [[package]]
 name = "simulacrum"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "async-trait",
  "bcs",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "futures",
  "move-binary-format",
  "move-bytecode-utils",
@@ -9526,7 +9586,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 [[package]]
 name = "sui-adapter-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9559,7 +9619,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9587,7 +9647,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9614,7 +9674,7 @@ dependencies = [
 [[package]]
 name = "sui-adapter-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9641,7 +9701,7 @@ dependencies = [
 [[package]]
 name = "sui-authority-aggregation"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "futures",
  "mysten-metrics",
@@ -9653,7 +9713,7 @@ dependencies = [
 [[package]]
 name = "sui-config"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anemo",
  "anyhow",
@@ -9662,7 +9722,7 @@ dependencies = [
  "consensus-config",
  "csv",
  "dirs",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "move-vm-config",
  "mysten-common",
  "nonzero_ext",
@@ -9686,7 +9746,7 @@ dependencies = [
 [[package]]
 name = "sui-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anemo",
  "antithesis_sdk",
@@ -9707,7 +9767,7 @@ dependencies = [
  "either",
  "enum_dispatch",
  "eyre",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "fastcrypto-tbls",
  "fastcrypto-zkp",
  "futures",
@@ -9777,7 +9837,7 @@ dependencies = [
 [[package]]
 name = "sui-crypto"
 version = "0.0.7"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=e7f07ac938706473d0a68ede78ba8587ec271f88#e7f07ac938706473d0a68ede78ba8587ec271f88"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=8eee97380cac1a1899d3cca427bde7ac906abdb9#8eee97380cac1a1899d3cca427bde7ac906abdb9"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -9802,7 +9862,7 @@ dependencies = [
 [[package]]
 name = "sui-data-ingestion-core"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9830,8 +9890,8 @@ dependencies = [
 
 [[package]]
 name = "sui-display"
-version = "1.56.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+version = "1.57.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -9843,7 +9903,7 @@ dependencies = [
 [[package]]
 name = "sui-enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "serde_yaml 0.8.26",
 ]
@@ -9851,7 +9911,7 @@ dependencies = [
 [[package]]
 name = "sui-execution"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-interpreter-v2",
@@ -9889,16 +9949,16 @@ dependencies = [
 
 [[package]]
 name = "sui-field-count"
-version = "1.56.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+version = "1.57.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "sui-field-count-derive",
 ]
 
 [[package]]
 name = "sui-field-count-derive"
-version = "1.56.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+version = "1.57.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -9907,7 +9967,7 @@ dependencies = [
 [[package]]
 name = "sui-framework"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -9920,8 +9980,8 @@ dependencies = [
 
 [[package]]
 name = "sui-framework-snapshot"
-version = "1.56.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+version = "1.57.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "bcs",
@@ -9936,12 +9996,12 @@ dependencies = [
 [[package]]
 name = "sui-genesis-builder"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "bcs",
  "camino",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "move-binary-format",
  "move-core-types",
  "prometheus",
@@ -9964,7 +10024,7 @@ dependencies = [
 [[package]]
 name = "sui-http"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "bytes",
  "http 1.3.1",
@@ -9983,8 +10043,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer"
-version = "1.56.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+version = "1.57.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10001,7 +10061,7 @@ dependencies = [
  "diesel",
  "diesel-async",
  "diesel_migrations",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "futures",
  "hex",
  "indicatif",
@@ -10054,8 +10114,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-framework"
-version = "1.56.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+version = "1.57.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10091,8 +10151,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-framework-store-traits"
-version = "1.56.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+version = "1.57.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10102,8 +10162,8 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-metrics"
-version = "1.56.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+version = "1.57.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -10119,11 +10179,11 @@ dependencies = [
 [[package]]
 name = "sui-json"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "bcs",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "move-binary-format",
  "move-bytecode-utils",
  "move-core-types",
@@ -10136,7 +10196,7 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -10148,7 +10208,7 @@ dependencies = [
  "cached",
  "chrono",
  "eyre",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "fastcrypto-zkp",
  "futures",
  "http-body 0.4.6",
@@ -10195,10 +10255,10 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc-api"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "jsonrpsee",
  "mysten-metrics",
  "once_cell",
@@ -10215,13 +10275,13 @@ dependencies = [
 [[package]]
 name = "sui-json-rpc-types"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "bcs",
  "colored",
  "enum_dispatch",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "itertools 0.13.0",
  "json_to_table",
  "move-binary-format",
@@ -10248,7 +10308,7 @@ dependencies = [
 [[package]]
 name = "sui-keys"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10256,7 +10316,7 @@ dependencies = [
  "bcs",
  "bip32",
  "colored",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "jsonrpc",
  "mockall 0.11.4",
  "rand 0.8.5",
@@ -10274,7 +10334,7 @@ dependencies = [
 [[package]]
 name = "sui-macros"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "futures",
  "once_cell",
@@ -10285,10 +10345,10 @@ dependencies = [
 [[package]]
 name = "sui-metrics-push-client"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "mysten-metrics",
  "prometheus",
  "reqwest",
@@ -10302,11 +10362,11 @@ dependencies = [
 
 [[package]]
 name = "sui-move-build"
-version = "1.56.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+version = "1.57.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "move-binary-format",
  "move-bytecode-utils",
  "move-bytecode-verifier",
@@ -10328,11 +10388,11 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "bcs",
  "better_any",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "fastcrypto-vdf",
  "fastcrypto-zkp",
  "indexmap 2.11.0",
@@ -10351,11 +10411,11 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "bcs",
  "better_any",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "fastcrypto-zkp",
  "linked-hash-map",
  "move-binary-format",
@@ -10372,11 +10432,11 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "bcs",
  "better_any",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "fastcrypto-zkp",
  "linked-hash-map",
  "move-binary-format",
@@ -10393,11 +10453,11 @@ dependencies = [
 [[package]]
 name = "sui-move-natives-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "bcs",
  "better_any",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "fastcrypto-zkp",
  "indexmap 2.11.0",
  "move-binary-format",
@@ -10413,8 +10473,8 @@ dependencies = [
 
 [[package]]
 name = "sui-name-service"
-version = "1.56.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+version = "1.57.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "bcs",
  "move-core-types",
@@ -10426,7 +10486,7 @@ dependencies = [
 [[package]]
 name = "sui-network"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anemo",
  "anemo-build",
@@ -10436,7 +10496,7 @@ dependencies = [
  "bcs",
  "bytes",
  "dashmap",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "fastcrypto-tbls",
  "futures",
  "governor",
@@ -10465,8 +10525,8 @@ dependencies = [
 
 [[package]]
 name = "sui-node"
-version = "1.56.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+version = "1.57.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -10479,7 +10539,7 @@ dependencies = [
  "bin-version",
  "clap",
  "consensus-core",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "fastcrypto-zkp",
  "futures",
  "http 1.3.1",
@@ -10523,8 +10583,8 @@ dependencies = [
 
 [[package]]
 name = "sui-open-rpc"
-version = "1.56.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+version = "1.57.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "bcs",
  "schemars 0.8.22",
@@ -10536,7 +10596,7 @@ dependencies = [
 [[package]]
 name = "sui-open-rpc-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -10548,8 +10608,8 @@ dependencies = [
 
 [[package]]
 name = "sui-package-management"
-version = "1.56.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+version = "1.57.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -10567,7 +10627,7 @@ dependencies = [
 [[package]]
 name = "sui-package-resolver"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "async-trait",
  "bcs",
@@ -10584,8 +10644,8 @@ dependencies = [
 
 [[package]]
 name = "sui-pg-db"
-version = "1.56.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+version = "1.57.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10614,7 +10674,7 @@ dependencies = [
 [[package]]
 name = "sui-proc-macros"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -10626,10 +10686,10 @@ dependencies = [
 [[package]]
 name = "sui-protocol-config"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "clap",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "move-core-types",
  "move-vm-config",
  "schemars 0.8.22",
@@ -10643,7 +10703,7 @@ dependencies = [
 [[package]]
 name = "sui-protocol-config-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10653,11 +10713,12 @@ dependencies = [
 [[package]]
 name = "sui-rpc"
 version = "0.0.7"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=e7f07ac938706473d0a68ede78ba8587ec271f88#e7f07ac938706473d0a68ede78ba8587ec271f88"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=8eee97380cac1a1899d3cca427bde7ac906abdb9#8eee97380cac1a1899d3cca427bde7ac906abdb9"
 dependencies = [
  "base64 0.22.1",
  "bcs",
  "bytes",
+ "futures",
  "http 1.3.1",
  "prost 0.13.5",
  "prost-types",
@@ -10665,13 +10726,14 @@ dependencies = [
  "serde_json",
  "sui-sdk-types",
  "tap",
+ "tokio",
  "tonic 0.13.1",
 ]
 
 [[package]]
 name = "sui-rpc-api"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -10680,7 +10742,7 @@ dependencies = [
  "base64 0.21.7",
  "bcs",
  "bytes",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "http 1.3.1",
  "itertools 0.13.0",
  "mime",
@@ -10718,8 +10780,8 @@ dependencies = [
 
 [[package]]
 name = "sui-sdk"
-version = "1.56.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+version = "1.57.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10727,7 +10789,7 @@ dependencies = [
  "bcs",
  "clap",
  "colored",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "futures",
  "futures-core",
  "jsonrpsee",
@@ -10752,7 +10814,7 @@ dependencies = [
 [[package]]
 name = "sui-sdk-types"
 version = "0.0.7"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=e7f07ac938706473d0a68ede78ba8587ec271f88#e7f07ac938706473d0a68ede78ba8587ec271f88"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=8eee97380cac1a1899d3cca427bde7ac906abdb9#8eee97380cac1a1899d3cca427bde7ac906abdb9"
 dependencies = [
  "base64ct",
  "bcs",
@@ -10773,12 +10835,12 @@ dependencies = [
 [[package]]
 name = "sui-simulator"
 version = "0.7.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anemo",
  "anemo-tower",
  "bcs",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "lru 0.10.1",
  "move-package",
  "msim",
@@ -10797,13 +10859,13 @@ dependencies = [
 [[package]]
 name = "sui-snapshot"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "bcs",
  "byteorder",
  "bytes",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "futures",
  "indicatif",
  "integer-encoding 3.0.4",
@@ -10825,8 +10887,8 @@ dependencies = [
 
 [[package]]
 name = "sui-sql-macro"
-version = "1.56.1"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+version = "1.57.0"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -10836,7 +10898,7 @@ dependencies = [
 [[package]]
 name = "sui-storage"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10848,7 +10910,7 @@ dependencies = [
  "chrono",
  "clap",
  "eyre",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "futures",
  "hyper",
  "hyper-rustls",
@@ -10886,7 +10948,7 @@ dependencies = [
 [[package]]
 name = "sui-swarm"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "futures",
@@ -10913,12 +10975,12 @@ dependencies = [
 [[package]]
 name = "sui-swarm-config"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anemo",
  "anyhow",
  "bcs",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "move-bytecode-utils",
  "mysten-common",
  "prometheus",
@@ -10940,7 +11002,7 @@ dependencies = [
 [[package]]
 name = "sui-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "reqwest",
  "serde",
@@ -10951,7 +11013,7 @@ dependencies = [
 [[package]]
 name = "sui-test-transaction-builder"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "bcs",
  "move-core-types",
@@ -10965,14 +11027,14 @@ dependencies = [
 [[package]]
 name = "sui-tls"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "arc-swap",
  "axum 0.8.4",
  "axum-server 0.6.1",
  "ed25519",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "pkcs8 0.10.2",
  "rcgen",
  "reqwest",
@@ -10987,7 +11049,7 @@ dependencies = [
 [[package]]
 name = "sui-transaction-builder"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11004,7 +11066,7 @@ dependencies = [
 [[package]]
 name = "sui-transaction-checks"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "fastcrypto-zkp",
  "once_cell",
@@ -11019,7 +11081,7 @@ dependencies = [
 [[package]]
 name = "sui-types"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anemo",
  "anyhow",
@@ -11037,7 +11099,7 @@ dependencies = [
  "derive_more 1.0.0",
  "enum_dispatch",
  "eyre",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "fastcrypto-tbls",
  "fastcrypto-zkp",
  "im",
@@ -11095,7 +11157,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-latest"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -11111,7 +11173,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v0"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -11127,7 +11189,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v1"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -11142,7 +11204,7 @@ dependencies = [
 [[package]]
 name = "sui-verifier-v2"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "move-abstract-stack",
  "move-binary-format",
@@ -11262,7 +11324,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "telemetry-subscribers"
 version = "0.2.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -11338,11 +11400,11 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 [[package]]
 name = "test-cluster"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "anyhow",
  "bcs",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "fastcrypto-zkp",
  "futures",
  "jsonrpsee",
@@ -12256,15 +12318,16 @@ dependencies = [
 [[package]]
 name = "typed-store"
 version = "0.4.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
+ "anyhow",
  "async-trait",
  "backoff",
  "bcs",
  "bincode",
  "collectable",
  "eyre",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3)",
  "fdlimit 0.2.1",
  "hdrhistogram",
  "itertools 0.13.0",
@@ -12317,7 +12380,7 @@ dependencies = [
 [[package]]
 name = "typed-store-derive"
 version = "0.3.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -12328,7 +12391,7 @@ dependencies = [
 [[package]]
 name = "typed-store-error"
 version = "0.4.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "serde",
  "thiserror 1.0.69",
@@ -12337,7 +12400,7 @@ dependencies = [
 [[package]]
 name = "typed-store-workspace-hack"
 version = "0.0.0"
-source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.56.1#9139745700449ec7752b19ee1b8aa8eab50b12fd"
+source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.57.0#3b96ab72dd5db2fb800837d6067bf45839178b62"
 dependencies = [
  "cc",
  "lazy_static",
@@ -12689,7 +12752,7 @@ dependencies = [
  "bcs",
  "criterion",
  "enum_dispatch",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=16fa86d0dd943024a9088d46850a72ecd55b7f46)",
  "hex",
  "p256",
  "rand 0.8.5",
@@ -12790,7 +12853,7 @@ dependencies = [
  "bytes",
  "clap",
  "const-str 0.6.4",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=16fa86d0dd943024a9088d46850a72ecd55b7f46)",
  "futures",
  "hyper",
  "itertools 0.14.0",
@@ -12826,7 +12889,7 @@ dependencies = [
  "bimap",
  "chrono",
  "enum_dispatch",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=16fa86d0dd943024a9088d46850a72ecd55b7f46)",
  "futures",
  "home",
  "humantime",
@@ -12884,7 +12947,7 @@ dependencies = [
  "diesel-async",
  "diesel_migrations",
  "enum_dispatch",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=16fa86d0dd943024a9088d46850a72ecd55b7f46)",
  "futures",
  "futures-util",
  "hex",
@@ -13005,7 +13068,7 @@ dependencies = [
  "axum-server 0.7.2",
  "bcs",
  "bytes",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=16fa86d0dd943024a9088d46850a72ecd55b7f46)",
  "futures",
  "http 1.3.1",
  "mime",
@@ -13071,7 +13134,7 @@ dependencies = [
  "bcs",
  "chrono",
  "clap",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=16fa86d0dd943024a9088d46850a72ecd55b7f46)",
  "futures",
  "home",
  "indoc",
@@ -13137,7 +13200,7 @@ dependencies = [
  "bcs",
  "clap",
  "clap_complete",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=16fa86d0dd943024a9088d46850a72ecd55b7f46)",
  "futures",
  "git-version",
  "mysten-metrics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ diesel-async = { version = "0.5", features = ["postgres"] }
 diesel_migrations = { version = "2.2.0", features = ["postgres"] }
 enum_dispatch = "0.3"
 eyre = "0.6.12"
-fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "16fa86d0dd943024a9088d46850a72ecd55b7f46" }
+fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "204cd95e5a9f9a0d3d09c3c236dc5b2263c73fd3" }
 fdlimit = "0.3.0"
 futures = { version = "0.3.31", default-features = false, features = ["async-await", "std"] }
 futures-timer = "=3.0.3" # required for MSIM

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,9 +76,9 @@ jsonwebtoken = "9.3.1"
 md5 = "0.7.0"
 mime = "0.3.17"
 mockall = "0.12.1"
-move-core-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.56.1" }
-move-package = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.56.1" }
-mysten-metrics = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.56.1" }
+move-core-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.57.0" }
+move-package = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.57.0" }
+mysten-metrics = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.57.0" }
 num-bigint = { version = "0.4.5", default-features = false }
 object_store = { version = "0.11.2", features = ["gcp"] }
 once_cell = { version = "1.21.3" }
@@ -109,25 +109,25 @@ serde_with = { version = "3.14", features = ["base64"] }
 serde_yaml = "0.9"
 sha2 = "0.10.9"
 snap = "1.1.0"
-sui-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.56.1" }
-sui-json-rpc-api = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.56.1" }
-sui-json-rpc-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.56.1" }
-sui-keys = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.56.1" }
-sui-macros = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.56.1" }
-sui-move-build = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.56.1" }
-sui-package-management = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.56.1" }
-sui-package-resolver = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.56.1" }
-sui-protocol-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.56.1" }
-sui-rpc-api = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.56.1" }
-sui-sdk = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.56.1" }
-sui-simulator = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.56.1" }
-sui-storage = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.56.1" }
-sui-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.56.1" }
+sui-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.57.0" }
+sui-json-rpc-api = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.57.0" }
+sui-json-rpc-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.57.0" }
+sui-keys = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.57.0" }
+sui-macros = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.57.0" }
+sui-move-build = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.57.0" }
+sui-package-management = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.57.0" }
+sui-package-resolver = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.57.0" }
+sui-protocol-config = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.57.0" }
+sui-rpc-api = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.57.0" }
+sui-sdk = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.57.0" }
+sui-simulator = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.57.0" }
+sui-storage = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.57.0" }
+sui-types = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.57.0" }
 syn = "2.0"
 tap = "1.0.1"
-telemetry-subscribers = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.56.1" }
+telemetry-subscribers = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.57.0" }
 tempfile = "3.21.0"
-test-cluster = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.56.1" }
+test-cluster = { git = "https://github.com/MystenLabs/sui", tag = "testnet-v1.57.0" }
 thiserror = "2.0.16"
 tokio = { version = "=1.47.1", features = ["macros", "rt-multi-thread", "signal"] }
 tokio-metrics = { version = "0.4.2", default-features = false }

--- a/contracts/subsidies/Move.lock
+++ b/contracts/subsidies/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "0D3884E7ED71EB87BCDF3C6084C84F91FABE0CD1D61D25B6F9388AA9B8F8C486"
+manifest_digest = "FC28B85E5E0A6A0DBC187A06805A2443DAD869BA0DBE4A91B10C64A6A8BB7142"
 deps_digest = "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -12,11 +12,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.56.1", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.57.0", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.56.1", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.57.0", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -40,7 +40,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.56.1"
+compiler-version = "1.57.0"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/contracts/subsidies/Move.toml
+++ b/contracts/subsidies/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.56.1" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.57.0" }
 WAL = { local = "../wal" }
 Walrus = { local = "../walrus" }
 

--- a/contracts/wal/Move.lock
+++ b/contracts/wal/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "DFD0837C51220E9EECD487C9A076323842F8355B45A806AB019DE490E688BEE6"
+manifest_digest = "9DAE5D37735D121734B3EF7642B18F2DFA7D4D2FFEFCCC499EC78AB6296F7EEB"
 deps_digest = "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -10,18 +10,18 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.56.1", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.57.0", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.56.1", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.57.0", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
 ]
 
 [move.toolchain-version]
-compiler-version = "1.56.1"
+compiler-version = "1.57.0"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/contracts/wal/Move.toml
+++ b/contracts/wal/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.56.1" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.57.0" }
 
 [addresses]
 wal = "0x0"

--- a/contracts/wal_exchange/Move.lock
+++ b/contracts/wal_exchange/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "67B9CE91B5A39F949E27137D24BD95E855BB6C079C99CCC4F4A9F3288FE977A8"
+manifest_digest = "D629AF39A22837564285A981D85A3FC82C5B9D03DCE6ABD7EB445E8F3D6F89E7"
 deps_digest = "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -11,11 +11,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.56.1", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.57.0", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.56.1", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.57.0", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -30,6 +30,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.56.1"
+compiler-version = "1.57.0"
 edition = "2024.beta"
 flavor = "sui"

--- a/contracts/wal_exchange/Move.toml
+++ b/contracts/wal_exchange/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.56.1" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.57.0" }
 WAL = { local = "../wal" }
 
 [addresses]

--- a/contracts/walrus/Move.lock
+++ b/contracts/walrus/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "6DDD4EB808BBFAA4BC34B6141601FB241CA6D85803E2C9767645231AC459EE12"
+manifest_digest = "1CB17B295915C12B7D4D514A2CB67CB8BA6F6FDF6CB937AE436C4318323A6383"
 deps_digest = "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -11,11 +11,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.56.1", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.57.0", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.56.1", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.57.0", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -30,7 +30,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.56.1"
+compiler-version = "1.57.0"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/contracts/walrus/Move.toml
+++ b/contracts/walrus/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.56.1" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.57.0" }
 WAL = { local = "../wal" }
 
 [addresses]

--- a/contracts/walrus_subsidies/Move.lock
+++ b/contracts/walrus_subsidies/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "2AB5240A833AB0C38FCD6FCBEA6E2A36009934A9E5E9A2535D498B205220A60B"
+manifest_digest = "235C7B73254D5B76EBA20CF9C11A251823567C8423C8761DD67902EDA7245D1B"
 deps_digest = "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -12,11 +12,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.56.1", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.57.0", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.56.1", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.57.0", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -40,6 +40,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.56.1"
+compiler-version = "1.57.0"
 edition = "2024.beta"
 flavor = "sui"

--- a/contracts/walrus_subsidies/Move.toml
+++ b/contracts/walrus_subsidies/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.56.1" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.57.0" }
 WAL = { local = "../wal" }
 Walrus = { local = "../walrus" }
 

--- a/docker/walrus-antithesis/sui_version.toml
+++ b/docker/walrus-antithesis/sui_version.toml
@@ -1,1 +1,1 @@
-SUI_VERSION = "testnet-v1.56.1"
+SUI_VERSION = "testnet-v1.57.0"

--- a/scripts/bump_sui_testnet_version.sh
+++ b/scripts/bump_sui_testnet_version.sh
@@ -27,14 +27,14 @@ if [[ ! "$NEW_TAG" =~ ^testnet-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   echo "Warning: NEW_TAG '$NEW_TAG' doesn't look like testnet-vX.Y.Z" >&2
 fi
 
-# Make sure GITHUB_ACTOR is set.
-if [[ -z "${GITHUB_ACTOR:-}" ]]; then
-  GITHUB_ACTOR="$(git config user.name 2>/dev/null || echo github-actions[bot])"
-fi
+# # Make sure GITHUB_ACTOR is set.
+# if [[ -z "${GITHUB_ACTOR:-}" ]]; then
+#   GITHUB_ACTOR="$(git config user.name 2>/dev/null || echo github-actions[bot])"
+# fi
 
 # Set up branch for changes.
 STAMP="$(date +%Y%m%d%H%M%S)"
-BRANCH="${GITHUB_ACTOR}/bump-sui-${NEW_TAG}-${STAMP}"
+BRANCH="ebmifa/bump-sui-${NEW_TAG}-${STAMP}"
 git checkout -b "$BRANCH"
 
 # Allow recursive globs.
@@ -105,7 +105,7 @@ BODY="This PR updates the Sui testnet version to ${NEW_TAG}"
 # Create PR
 echo "Creating pull request..."
 if PR_OUTPUT=$(gh pr create \
-  --base main \
+  --base releases/walrus-v1.33.0-release \
   --head "$BRANCH" \
   --title "ci: bump Sui testnet version to ${NEW_TAG}" \
   --reviewer "wbbradley,halfprice,liquid-helium,ebmifa" \

--- a/testnet-contracts/subsidies/Move.lock
+++ b/testnet-contracts/subsidies/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "0D3884E7ED71EB87BCDF3C6084C84F91FABE0CD1D61D25B6F9388AA9B8F8C486"
+manifest_digest = "FC28B85E5E0A6A0DBC187A06805A2443DAD869BA0DBE4A91B10C64A6A8BB7142"
 deps_digest = "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -12,11 +12,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.56.1", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.57.0", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.56.1", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.57.0", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -40,7 +40,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.56.1"
+compiler-version = "1.57.0"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/testnet-contracts/subsidies/Move.toml
+++ b/testnet-contracts/subsidies/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.56.1" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.57.0" }
 WAL = { local = "../wal" }
 Walrus = { local = "../walrus" }
 

--- a/testnet-contracts/wal/Move.lock
+++ b/testnet-contracts/wal/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "DFD0837C51220E9EECD487C9A076323842F8355B45A806AB019DE490E688BEE6"
+manifest_digest = "9DAE5D37735D121734B3EF7642B18F2DFA7D4D2FFEFCCC499EC78AB6296F7EEB"
 deps_digest = "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -10,18 +10,18 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.56.1", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.57.0", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.56.1", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.57.0", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
 ]
 
 [move.toolchain-version]
-compiler-version = "1.56.1"
+compiler-version = "1.57.0"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/testnet-contracts/wal/Move.toml
+++ b/testnet-contracts/wal/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.56.1" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.57.0" }
 
 [addresses]
 wal = "0x0"

--- a/testnet-contracts/wal_exchange/Move.lock
+++ b/testnet-contracts/wal_exchange/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "67B9CE91B5A39F949E27137D24BD95E855BB6C079C99CCC4F4A9F3288FE977A8"
+manifest_digest = "D629AF39A22837564285A981D85A3FC82C5B9D03DCE6ABD7EB445E8F3D6F89E7"
 deps_digest = "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -11,11 +11,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.56.1", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.57.0", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.56.1", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.57.0", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -30,7 +30,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.56.1"
+compiler-version = "1.57.0"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/testnet-contracts/wal_exchange/Move.toml
+++ b/testnet-contracts/wal_exchange/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.56.1" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.57.0" }
 WAL = { local = "../wal" }
 
 [addresses]

--- a/testnet-contracts/walrus/Move.lock
+++ b/testnet-contracts/walrus/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "6DDD4EB808BBFAA4BC34B6141601FB241CA6D85803E2C9767645231AC459EE12"
+manifest_digest = "1CB17B295915C12B7D4D514A2CB67CB8BA6F6FDF6CB937AE436C4318323A6383"
 deps_digest = "3C4103934B1E040BB6B23F1D610B4EF9F2F1166A50A104EADCF77467C004C600"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -11,11 +11,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.56.1", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.57.0", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.56.1", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.57.0", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -30,7 +30,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.56.1"
+compiler-version = "1.57.0"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/testnet-contracts/walrus/Move.toml
+++ b/testnet-contracts/walrus/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.56.1" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.57.0" }
 WAL = { local = "../wal" }
 
 [addresses]

--- a/testnet-contracts/walrus_subsidies/Move.lock
+++ b/testnet-contracts/walrus_subsidies/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "2AB5240A833AB0C38FCD6FCBEA6E2A36009934A9E5E9A2535D498B205220A60B"
+manifest_digest = "235C7B73254D5B76EBA20CF9C11A251823567C8423C8761DD67902EDA7245D1B"
 deps_digest = "060AD7E57DFB13104F21BE5F5C3759D03F0553FC3229247D9A7A6B45F50D03A3"
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -12,11 +12,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.56.1", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.57.0", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.56.1", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "testnet-v1.57.0", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -40,7 +40,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.56.1"
+compiler-version = "1.57.0"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/testnet-contracts/walrus_subsidies/Move.toml
+++ b/testnet-contracts/walrus_subsidies/Move.toml
@@ -5,7 +5,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.56.1" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.57.0" }
 WAL = { local = "../wal" }
 Walrus = { local = "../walrus" }
 


### PR DESCRIPTION
This PR updates the Sui testnet version to testnet-v1.57.0