### PR TITLE
chore: remove unnecessary reference in EncodingConfigEnum

### DIFF
--- a/crates/walrus-core/src/encoding/blob_encoding.rs
+++ b/crates/walrus-core/src/encoding/blob_encoding.rs
@@ -48,7 +48,7 @@ pub struct BlobEncoder<'a> {
     /// Stored as a `usize` for convenience, but guaranteed to be non-zero.
     n_columns: usize,
     /// Reference to the encoding configuration of this encoder.
-    config: EncodingConfigEnum<'a>,
+    config: EncodingConfigEnum,
     /// A tracing span associated with this blob encoder.
     span: Span,
 }
@@ -68,7 +68,7 @@ impl<'a> BlobEncoder<'a> {
     ///    [`EncodingConfigEnum::max_blob_size`] method.
     /// 2. On 32-bit architectures, the maximally supported blob size can actually be smaller than
     ///    that due to limitations of the address space.
-    pub fn new(config: EncodingConfigEnum<'a>, blob: &'a [u8]) -> Result<Self, DataTooLargeError> {
+    pub fn new(config: EncodingConfigEnum, blob: &'a [u8]) -> Result<Self, DataTooLargeError> {
         tracing::debug!("creating new blob encoder");
         let symbol_size = utils::compute_symbol_size_from_usize(
             blob.len(),
@@ -244,7 +244,7 @@ impl<'a> BlobEncoder<'a> {
     /// Computes the fully expanded message matrix by encoding rows and columns.
     fn get_expanded_matrix(&self) -> ExpandedMessageMatrix<'_> {
         self.span
-            .in_scope(|| ExpandedMessageMatrix::new(&self.config, self.symbol_size, self.blob))
+            .in_scope(|| ExpandedMessageMatrix::new(self.config, self.symbol_size, self.blob))
     }
 }
 
@@ -257,7 +257,7 @@ struct ExpandedMessageMatrix<'a> {
     matrix: Vec<Symbols>,
     // INV: `blob.len() > 0`
     blob: &'a [u8],
-    config: &'a EncodingConfigEnum<'a>,
+    config: EncodingConfigEnum,
     /// The number of rows in the non-expanded message matrix.
     n_rows: usize,
     /// The number of columns in the non-expanded message matrix.
@@ -266,7 +266,7 @@ struct ExpandedMessageMatrix<'a> {
 }
 
 impl<'a> ExpandedMessageMatrix<'a> {
-    fn new(config: &'a EncodingConfigEnum<'a>, symbol_size: NonZeroU16, blob: &'a [u8]) -> Self {
+    fn new(config: EncodingConfigEnum, symbol_size: NonZeroU16, blob: &'a [u8]) -> Self {
         tracing::debug!("computing expanded message matrix");
         let matrix = vec![
             Symbols::zeros(config.n_shards_as_usize(), symbol_size);
@@ -275,9 +275,9 @@ impl<'a> ExpandedMessageMatrix<'a> {
         let mut expanded_matrix = Self {
             matrix,
             blob,
-            config,
             n_rows: config.n_source_symbols::<Primary>().get().into(),
             n_columns: config.n_source_symbols::<Secondary>().get().into(),
+            config,
             symbol_size,
         };
         expanded_matrix.fill_systematic_with_rows();

--- a/crates/walrus-core/src/encoding/blob_encoding.rs
+++ b/crates/walrus-core/src/encoding/blob_encoding.rs
@@ -237,7 +237,7 @@ impl<'a> BlobEncoder<'a> {
     /// are initialized with the appropriate `symbol_size` and `length`.
     fn empty_sliver_pairs(&self) -> Vec<SliverPair> {
         (0..self.config.n_shards().get())
-            .map(|i| SliverPair::new_empty(&self.config, self.symbol_size, SliverPairIndex(i)))
+            .map(|i| SliverPair::new_empty(self.config, self.symbol_size, SliverPairIndex(i)))
             .collect()
     }
 

--- a/crates/walrus-core/src/encoding/config.rs
+++ b/crates/walrus-core/src/encoding/config.rs
@@ -363,7 +363,7 @@ impl EncodingConfig {
     /// [`EncodingConfigEnum`].
     pub fn get_for_type(&self, encoding_type: EncodingType) -> EncodingConfigEnum {
         match encoding_type {
-            EncodingType::RS2 => EncodingConfigEnum::ReedSolomon(self.reed_solomon),
+            EncodingType::RS2 => self.reed_solomon.into(),
             _ => panic!("unsupported encoding type: {:?}", encoding_type),
         }
     }
@@ -510,7 +510,7 @@ impl ReedSolomonEncodingConfig {
         &self,
         blob: &'a [u8],
     ) -> Result<BlobEncoder<'a>, DataTooLargeError> {
-        BlobEncoder::new(EncodingConfigEnum::ReedSolomon(*self), blob)
+        BlobEncoder::new((*self).into(), blob)
     }
 
     /// Returns a [`BlobDecoder`] for the given `blob_size`.

--- a/crates/walrus-core/src/encoding/config.rs
+++ b/crates/walrus-core/src/encoding/config.rs
@@ -361,9 +361,9 @@ impl EncodingConfig {
 
     /// Returns the encoding config for the given encoding type wrapped as an
     /// [`EncodingConfigEnum`].
-    pub fn get_for_type(&self, encoding_type: EncodingType) -> EncodingConfigEnum<'_> {
+    pub fn get_for_type(&self, encoding_type: EncodingType) -> EncodingConfigEnum {
         match encoding_type {
-            EncodingType::RS2 => EncodingConfigEnum::ReedSolomon(&self.reed_solomon),
+            EncodingType::RS2 => EncodingConfigEnum::ReedSolomon(self.reed_solomon),
             _ => panic!("unsupported encoding type: {:?}", encoding_type),
         }
     }
@@ -375,18 +375,18 @@ impl EncodingConfig {
 }
 
 #[enum_dispatch(EncodingFactory)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 /// A wrapper around the encoding config for different encoding types.
-pub enum EncodingConfigEnum<'a> {
+pub enum EncodingConfigEnum {
     /// Configuration of the Reed-Solomon encoding.
-    ReedSolomon(&'a ReedSolomonEncodingConfig),
+    ReedSolomon(ReedSolomonEncodingConfig),
 }
 
 /// Configuration of the Reed-Solomon encoding.
 ///
 /// This consists of the number of source symbols for the two encodings and the total number of
 /// shards.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct ReedSolomonEncodingConfig {
     /// The number of source symbols for the primary encoding, which is, simultaneously, the number
     /// of symbols per secondary sliver. It must be at most `n_shards - 2f`, where `f` is
@@ -492,7 +492,7 @@ impl ReedSolomonEncodingConfig {
     }
 
     fn get_encoder<'a, E: EncodingAxis>(
-        &'_ self,
+        &self,
         data: &'a [u8],
     ) -> Result<ReedSolomonEncoder<'a>, EncodeError> {
         ReedSolomonEncoder::new(data, self.n_source_symbols::<E>(), self.n_shards())
@@ -507,10 +507,10 @@ impl ReedSolomonEncodingConfig {
 
     /// Returns a [`BlobEncoder`] for the given blob.
     pub fn get_blob_encoder<'a>(
-        &'a self,
+        &self,
         blob: &'a [u8],
     ) -> Result<BlobEncoder<'a>, DataTooLargeError> {
-        BlobEncoder::new(self.into(), blob)
+        BlobEncoder::new(EncodingConfigEnum::ReedSolomon(*self), blob)
     }
 
     /// Returns a [`BlobDecoder`] for the given `blob_size`.
@@ -522,7 +522,7 @@ impl ReedSolomonEncodingConfig {
     }
 }
 
-impl EncodingFactory for &ReedSolomonEncodingConfig {
+impl EncodingFactory for ReedSolomonEncodingConfig {
     #[inline]
     fn n_primary_source_symbols(&self) -> NonZeroU16 {
         self.source_symbols_primary
@@ -628,94 +628,6 @@ impl EncodingFactory for &ReedSolomonEncodingConfig {
     {
         self.get_decoder::<E::OrthogonalAxis>(symbol_size)?
             .decode(symbols)
-    }
-}
-
-impl EncodingFactory for ReedSolomonEncodingConfig {
-    fn encoding_type(&self) -> EncodingType {
-        (&self).encoding_type()
-    }
-
-    fn encode_with_metadata(
-        &self,
-        blob: &[u8],
-    ) -> Result<(Vec<SliverPair>, VerifiedBlobMetadataWithId), DataTooLargeError> {
-        (&self).encode_with_metadata(blob)
-    }
-
-    fn compute_metadata(
-        &self,
-        blob: &[u8],
-    ) -> Result<VerifiedBlobMetadataWithId, DataTooLargeError> {
-        (&self).compute_metadata(blob)
-    }
-
-    fn decode<S, E>(&self, blob_size: u64, slivers: S) -> Result<Vec<u8>, DecodeError>
-    where
-        S: IntoIterator<Item = SliverData<E>>,
-        E: EncodingAxis,
-    {
-        (&self).decode(blob_size, slivers)
-    }
-
-    fn decode_and_verify<S, E>(
-        &self,
-        blob_id: &BlobId,
-        blob_size: u64,
-        slivers: S,
-    ) -> Result<(Vec<u8>, VerifiedBlobMetadataWithId), DecodeError>
-    where
-        S: IntoIterator<Item = SliverData<E>>,
-        E: EncodingAxis,
-    {
-        (&self).decode_and_verify(blob_id, blob_size, slivers)
-    }
-
-    fn n_primary_source_symbols(&self) -> NonZeroU16 {
-        (&self).n_primary_source_symbols()
-    }
-
-    fn n_secondary_source_symbols(&self) -> NonZeroU16 {
-        (&self).n_secondary_source_symbols()
-    }
-
-    fn n_shards(&self) -> NonZeroU16 {
-        (&self).n_shards()
-    }
-
-    fn encode_all_symbols<E: EncodingAxis>(
-        &self,
-        data: &[u8],
-    ) -> Result<Vec<Vec<u8>>, EncodeError> {
-        (&self).encode_all_symbols::<E>(data)
-    }
-
-    fn encode_all_repair_symbols<E: EncodingAxis>(
-        &self,
-        data: &[u8],
-    ) -> Result<Vec<Vec<u8>>, EncodeError> {
-        (&self).encode_all_repair_symbols::<E>(data)
-    }
-
-    fn encode_symbol<E: EncodingAxis>(
-        &self,
-        data: &[u8],
-        index: u16,
-    ) -> Result<Vec<u8>, EncodeError> {
-        (&self).encode_symbol::<E>(data, index)
-    }
-
-    fn decode_from_decoding_symbols<T, E>(
-        &self,
-        symbol_size: NonZeroU16,
-        symbols: T,
-    ) -> Result<Vec<u8>, DecodeError>
-    where
-        T: IntoIterator,
-        T::IntoIter: Iterator<Item = DecodingSymbol<E>>,
-        E: EncodingAxis,
-    {
-        (&self).decode_from_decoding_symbols::<T, E>(symbol_size, symbols)
     }
 }
 

--- a/crates/walrus-core/src/encoding/mapping.rs
+++ b/crates/walrus-core/src/encoding/mapping.rs
@@ -140,10 +140,7 @@ mod tests {
     use walrus_test_utils::param_test;
 
     use super::*;
-    use crate::{
-        encoding::{EncodingConfigEnum, ReedSolomonEncodingConfig},
-        test_utils,
-    };
+    use crate::{encoding::ReedSolomonEncodingConfig, test_utils};
 
     // Fixture
     fn sliver_pairs(num: u16) -> Vec<SliverPair> {
@@ -151,7 +148,7 @@ mod tests {
         (0..num)
             .map(|n| {
                 SliverPair::new_empty(
-                    EncodingConfigEnum::ReedSolomon(encoding_config),
+                    encoding_config.into(),
                     1.try_into().unwrap(),
                     SliverPairIndex(n),
                 )

--- a/crates/walrus-core/src/encoding/mapping.rs
+++ b/crates/walrus-core/src/encoding/mapping.rs
@@ -140,7 +140,10 @@ mod tests {
     use walrus_test_utils::param_test;
 
     use super::*;
-    use crate::{encoding::ReedSolomonEncodingConfig, test_utils};
+    use crate::{
+        encoding::{EncodingConfigEnum, ReedSolomonEncodingConfig},
+        test_utils,
+    };
 
     // Fixture
     fn sliver_pairs(num: u16) -> Vec<SliverPair> {
@@ -148,7 +151,7 @@ mod tests {
         (0..num)
             .map(|n| {
                 SliverPair::new_empty(
-                    &(&encoding_config).into(),
+                    EncodingConfigEnum::ReedSolomon(encoding_config),
                     1.try_into().unwrap(),
                     SliverPairIndex(n),
                 )

--- a/crates/walrus-core/src/encoding/quilt_encoding.rs
+++ b/crates/walrus-core/src/encoding/quilt_encoding.rs
@@ -2115,7 +2115,7 @@ mod tests {
     fn construct_quilt(quilt_store_blobs: &[QuiltStoreBlob<'_>], config: EncodingConfigEnum) {
         walrus_test_utils::init_tracing();
 
-        let encoder = QuiltConfigV1::get_encoder(config.clone(), quilt_store_blobs);
+        let encoder = QuiltConfigV1::get_encoder(config, quilt_store_blobs);
 
         let quilt = encoder.construct_quilt().expect("Should construct quilt");
 
@@ -2226,7 +2226,7 @@ mod tests {
 
         let quilt_store_blobs = test_data.take_blobs();
 
-        let encoder = QuiltConfigV1::get_encoder(config.clone(), quilt_store_blobs.as_slice());
+        let encoder = QuiltConfigV1::get_encoder(config, quilt_store_blobs.as_slice());
 
         let (sliver_pairs, quilt_metadata) = encoder
             .encode_with_metadata()

--- a/crates/walrus-core/src/encoding/quilt_encoding.rs
+++ b/crates/walrus-core/src/encoding/quilt_encoding.rs
@@ -184,7 +184,7 @@ pub trait QuiltApi<V: QuiltVersion> {
     /// Returns a new quilt from a quilt blob.
     fn new_from_quilt_blob(
         quilt_blob: Vec<u8>,
-        encoding_config: &EncodingConfigEnum<'_>,
+        encoding_config: EncodingConfigEnum,
     ) -> Result<V::Quilt, QuiltError>;
 
     /// Gets blobs by their identifiers from the quilt.
@@ -339,7 +339,7 @@ pub trait QuiltPatchInternalIdApi: Clone {
 pub trait QuiltConfigApi<'a, V: QuiltVersion> {
     /// Returns a new encoder for the given configuration and blobs.
     fn get_encoder(
-        encoding_config: EncodingConfigEnum<'a>,
+        encoding_config: EncodingConfigEnum,
         blobs: &'a [QuiltStoreBlob<'a>],
     ) -> V::QuiltEncoder<'a>;
 
@@ -487,7 +487,7 @@ impl QuiltEnum {
     /// Construct a new `QuiltEnum`.
     pub fn new(
         quilt_blob: Vec<u8>,
-        encoding_config: &EncodingConfigEnum<'_>,
+        encoding_config: EncodingConfigEnum,
     ) -> Result<QuiltEnum, QuiltError> {
         let quilt_version = QuiltVersionEnum::new_from_sliver(&quilt_blob)?;
         match quilt_version {
@@ -933,7 +933,7 @@ pub struct QuiltV1 {
 impl QuiltApi<QuiltVersionV1> for QuiltV1 {
     fn new_from_quilt_blob(
         quilt_blob: Vec<u8>,
-        encoding_config: &EncodingConfigEnum<'_>,
+        encoding_config: EncodingConfigEnum,
     ) -> Result<QuiltV1, QuiltError> {
         if quilt_blob.is_empty() {
             return Err(QuiltError::EmptyInput("quilt_blob".to_string()));
@@ -1222,7 +1222,7 @@ pub struct QuiltConfigV1;
 
 impl<'a> QuiltConfigApi<'a, QuiltVersionV1> for QuiltConfigV1 {
     fn get_encoder(
-        encoding_config: EncodingConfigEnum<'a>,
+        encoding_config: EncodingConfigEnum,
         blobs: &'a [QuiltStoreBlob<'a>],
     ) -> QuiltEncoderV1<'a> {
         QuiltEncoderV1::new(encoding_config, blobs)
@@ -1255,14 +1255,14 @@ pub struct QuiltEncoderV1<'a> {
     /// The blobs to encode.
     blobs: &'a [QuiltStoreBlob<'a>],
     /// The encoding configuration.
-    config: EncodingConfigEnum<'a>,
+    config: EncodingConfigEnum,
     /// A tracing span associated with this quilt encoder.
     span: Span,
 }
 
 impl<'a> QuiltEncoderV1<'a> {
     /// Creates a new [`QuiltEncoderV1`] from a encoding config and a set of blobs.
-    pub fn new(config: EncodingConfigEnum<'a>, blobs: &'a [QuiltStoreBlob<'a>]) -> Self {
+    pub fn new(config: EncodingConfigEnum, blobs: &'a [QuiltStoreBlob<'a>]) -> Self {
         Self {
             blobs,
             config,
@@ -1553,7 +1553,7 @@ impl QuiltEncoderApi<QuiltVersionV1> for QuiltEncoderV1<'_> {
         tracing::debug!("starting to encode quilt");
 
         let quilt = self.construct_quilt()?;
-        let encoder = BlobEncoder::new(self.config.clone(), quilt.data()).map_err(|_| {
+        let encoder = BlobEncoder::new(self.config, quilt.data()).map_err(|_| {
             QuiltError::QuiltOversize(format!("quilt is too large: {}", quilt.data().len()))
         })?;
         assert_eq!(encoder.symbol_usize(), quilt.symbol_size());
@@ -1566,7 +1566,7 @@ impl QuiltEncoderApi<QuiltVersionV1> for QuiltEncoderV1<'_> {
         tracing::debug!("starting to encode quilt with metadata");
 
         let quilt = self.construct_quilt()?;
-        let encoder = BlobEncoder::new(self.config.clone(), quilt.data()).map_err(|_| {
+        let encoder = BlobEncoder::new(self.config, quilt.data()).map_err(|_| {
             QuiltError::QuiltOversize(format!("quilt is too large: {}", quilt.data.len()))
         })?;
 
@@ -2108,7 +2108,7 @@ mod tests {
 
         construct_quilt(
             quilt_store_blobs,
-            EncodingConfigEnum::ReedSolomon(&reed_solomon_config),
+            EncodingConfigEnum::ReedSolomon(reed_solomon_config),
         );
     }
 
@@ -2217,7 +2217,7 @@ mod tests {
 
         encode_decode_quilt(
             test_data,
-            EncodingConfigEnum::ReedSolomon(&reed_solomon_config),
+            EncodingConfigEnum::ReedSolomon(reed_solomon_config),
         );
     }
 
@@ -2381,7 +2381,7 @@ mod tests {
 
         assert_eq!(metadata_with_id.metadata(), &quilt_metadata_v1.metadata);
 
-        let quilt = QuiltV1::new_from_quilt_blob(quilt_blob, &config).expect("Should create quilt");
+        let quilt = QuiltV1::new_from_quilt_blob(quilt_blob, config).expect("Should create quilt");
         assert_eq!(
             quilt.data(),
             encoder
@@ -2495,6 +2495,6 @@ mod tests {
     fn test_new_from_quilt_blob_panics_on_empty_input() {
         use core::num::NonZeroU16;
         let config = ReedSolomonEncodingConfig::new(NonZeroU16::new(7).unwrap());
-        let _ = QuiltV1::new_from_quilt_blob(Vec::new(), &EncodingConfigEnum::ReedSolomon(&config));
+        let _ = QuiltV1::new_from_quilt_blob(Vec::new(), EncodingConfigEnum::ReedSolomon(config));
     }
 }

--- a/crates/walrus-core/src/encoding/slivers.rs
+++ b/crates/walrus-core/src/encoding/slivers.rs
@@ -599,7 +599,7 @@ mod tests {
             recovery_symbols,
             SliverIndex(0),
             symbol_size.try_into().unwrap(),
-            EncodingConfigEnum::ReedSolomon(config),
+            config.into(),
         );
         assert!(recovered.is_err());
     }

--- a/crates/walrus-core/src/encoding/slivers.rs
+++ b/crates/walrus-core/src/encoding/slivers.rs
@@ -245,7 +245,7 @@ impl<T: EncodingAxis> SliverData<T> {
         recovery_symbols: I,
         target_index: SliverIndex,
         symbol_size: NonZeroU16,
-        config: &EncodingConfigEnum,
+        config: EncodingConfigEnum,
     ) -> Result<Self, DecodeError>
     where
         I: IntoIterator,
@@ -309,7 +309,7 @@ impl<T: EncodingAxis> SliverData<T> {
             verified_recovery_symbols.clone(),
             target_index,
             symbol_size,
-            &config_enum,
+            config_enum,
         )
         .map_err(|_| SliverRecoveryError::DecodingFailure)?;
 
@@ -389,7 +389,7 @@ impl SliverPair {
     /// Creates a new sliver pair containing two empty [`SliverData`] instances of the specified
     /// size.
     pub fn new_empty(
-        config: &EncodingConfigEnum,
+        config: EncodingConfigEnum,
         symbol_size: NonZeroU16,
         index: SliverPairIndex,
     ) -> Self {
@@ -599,7 +599,7 @@ mod tests {
             recovery_symbols,
             SliverIndex(0),
             symbol_size.try_into().unwrap(),
-            &(&config).into(),
+            EncodingConfigEnum::ReedSolomon(config),
         );
         assert!(recovered.is_err());
     }
@@ -653,7 +653,7 @@ mod tests {
                 recovery_symbols.iter().map(|s| s.primary.clone()),
                 pair.primary.index,
                 symbol_size,
-                &encoding_config_enum,
+                encoding_config_enum,
             )
             .unwrap();
             assert_eq!(recovered, pair.primary);
@@ -663,7 +663,7 @@ mod tests {
                 recovery_symbols.iter().map(|s| s.secondary.clone()),
                 pair.secondary.index,
                 symbol_size,
-                &encoding_config_enum,
+                encoding_config_enum,
             )
             .unwrap();
             assert_eq!(recovered, pair.secondary);
@@ -733,7 +733,7 @@ mod tests {
                     }),
                     SliverIndex(n_shards - 1 - target_index),
                     symbol_size,
-                    &encoding_config_enum,
+                    encoding_config_enum,
                 )
                 .unwrap()
             })
@@ -757,7 +757,7 @@ mod tests {
                     }),
                 index.into(),
                 symbol_size,
-                &encoding_config_enum,
+                encoding_config_enum,
             )
             .unwrap()
         }));

--- a/crates/walrus-core/src/inconsistency.rs
+++ b/crates/walrus-core/src/inconsistency.rs
@@ -178,7 +178,7 @@ impl<T: EncodingAxis, U: MerkleAuth> InconsistencyProof<T, U> {
             self.recovery_symbols,
             self.target_sliver_index,
             symbol_size,
-            &encoding_config.get_for_type(metadata.encoding_type()),
+            encoding_config.get_for_type(metadata.encoding_type()),
         )
         .map_err(|_| InconsistencyVerificationError::RecoveryFailure)?;
         match sliver.verify(encoding_config, metadata) {

--- a/crates/walrus-sdk/src/client/quilt_client.rs
+++ b/crates/walrus-sdk/src/client/quilt_client.rs
@@ -711,7 +711,7 @@ impl<T: ReadClient> QuiltClient<'_, T> {
             .encoding_config()
             .get_for_type(metadata.metadata().encoding_type());
 
-        QuiltEnum::new(quilt, &encoding_config_enum).map_err(ClientError::from)
+        QuiltEnum::new(quilt, encoding_config_enum).map_err(ClientError::from)
     }
 }
 


### PR DESCRIPTION
## Description

Remove unnecessary references around EncodingConfigEnum causing unnecessary bloat in impls of EncodingFactory

## Test plan

No functional changes. CI Pipeline.