### PR TITLE
fix(metrics): count extensions separately

### DIFF
--- a/crates/walrus-service/src/node/metrics.rs
+++ b/crates/walrus-service/src/node/metrics.rs
@@ -307,7 +307,11 @@ impl TelemetryLabel for EventStreamElement {
 
 impl TelemetryLabel for BlobCertified {
     fn label(&self) -> &'static str {
-        "certified"
+        if self.is_extension {
+            "extended"
+        } else {
+            "certified"
+        }
     }
 }
 


### PR DESCRIPTION
## Description

Blob extensions emit a `BlobCertified` event with `is_extension == true`. So far, we counted these as certification events, but this is not ideal when analyzing metrics.

This changes the label from `certified` to `extended` for events resulting from blob extensions.