### PR TITLE
feat: export the Sui checkpoint of the last processed Walrus event

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -1168,6 +1168,10 @@ impl StorageNode {
             };
 
             TaskMonitor::instrument(&monitor, task).await?;
+
+            self.inner
+                .metrics
+                .set_last_processed_event_position(stream_element.checkpoint_event_position);
         }
 
         bail!("event stream for blob events stopped")

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -1134,6 +1134,10 @@ impl StorageNode {
             })
             .await
         {
+            self.inner
+                .metrics
+                .started_processing_event(stream_element.checkpoint_event_position);
+
             let event_label: &'static str = stream_element.element.label();
             let monitor = task_monitors.get_or_insert_with_task_name(&event_label, || {
                 format!("process_event {event_label}")
@@ -1171,7 +1175,7 @@ impl StorageNode {
 
             self.inner
                 .metrics
-                .set_last_processed_event_position(stream_element.checkpoint_event_position);
+                .completed_processing_event(stream_element.checkpoint_event_position);
         }
 
         bail!("event stream for blob events stopped")

--- a/crates/walrus-service/src/node/metrics.rs
+++ b/crates/walrus-service/src/node/metrics.rs
@@ -24,7 +24,7 @@ use walrus_sui::types::{
 
 use crate::{
     common::telemetry::{CurrentEpochMetric, CurrentEpochStateMetric},
-    event::events::EventStreamElement,
+    event::events::{CheckpointEventPosition, EventStreamElement},
 };
 
 pub(crate) const STATUS_FAILURE: &str = "failure";
@@ -177,6 +177,21 @@ walrus_utils::metrics::define_metric_set! {
 
         #[help = "The number of blob events pending processing in the BlobEventProcessor."]
         pending_processing_blob_event_in_background_processors: IntGaugeVec["worker_index"],
+
+        #[help = "The Sui checkpoint of the last Walrus event processed."]
+        last_processed_event_position_sui_checkpoint: U64Gauge[],
+
+        #[help = "The index within Sui checkpoint of the last Walrus event processed."]
+        last_processed_event_position_sui_checkpoint_index: U64Gauge[],
+    }
+}
+
+impl NodeMetricSet {
+    pub fn set_last_processed_event_position(&self, position: CheckpointEventPosition) {
+        self.last_processed_event_position_sui_checkpoint
+            .set(position.checkpoint_sequence_number);
+        self.last_processed_event_position_sui_checkpoint_index
+            .set(position.counter);
     }
 }
 


### PR DESCRIPTION
## Description

Exports the Sui checkpoint from which the last processed walrus event was taken. This allows us to

- determine storage node lag independently of other storage nodes, and without a global view of the network (currently we measure this by how far behind a storage node is relative to other nodes; and
- determine the delay between a Sui checkpoint and a node actually processing the related walrus events, which is an input to write latency.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
