### PR TITLE
chore: group per shard histogram metrics by column family class instead of column family name

### DIFF
--- a/crates/typed-store/src/metrics.rs
+++ b/crates/typed-store/src/metrics.rs
@@ -431,7 +431,7 @@ impl OperationMetrics {
             rocksdb_iter_latency_seconds: register_histogram_vec_with_registry!(
                 "rocksdb_iter_latency_seconds",
                 "Rocksdb iter latency in seconds",
-                &["cf_name"],
+                &["cf_class"],
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
@@ -439,7 +439,7 @@ impl OperationMetrics {
             rocksdb_iter_key_bytes: register_histogram_vec_with_registry!(
                 "rocksdb_iter_key_bytes",
                 "Rocksdb iter key size in bytes",
-                &["cf_name"],
+                &["cf_class"],
                 bucket_vec.clone(),
                 registry,
             )
@@ -447,7 +447,7 @@ impl OperationMetrics {
             rocksdb_iter_bytes: register_histogram_vec_with_registry!(
                 "rocksdb_iter_bytes",
                 "Rocksdb iter size in bytes",
-                &["cf_name"],
+                &["cf_class"],
                 bucket_vec.clone(),
                 registry,
             )
@@ -455,7 +455,7 @@ impl OperationMetrics {
             rocksdb_iter_value_bytes: register_histogram_vec_with_registry!(
                 "rocksdb_iter_value_bytes",
                 "Rocksdb iter value size in bytes",
-                &["cf_name"],
+                &["cf_class"],
                 bucket_vec.clone(),
                 registry,
             )
@@ -470,7 +470,7 @@ impl OperationMetrics {
             rocksdb_get_latency_seconds: register_histogram_vec_with_registry!(
                 "rocksdb_get_latency_seconds",
                 "Rocksdb get latency in seconds. `found` label is true if key was found",
-                &["cf_name", "found"],
+                &["cf_class", "found"],
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
@@ -478,7 +478,7 @@ impl OperationMetrics {
             rocksdb_get_bytes: register_histogram_vec_with_registry!(
                 "rocksdb_get_bytes",
                 "Rocksdb get call returned data size in bytes",
-                &["cf_name"],
+                &["cf_class"],
                 bucket_vec.clone(),
                 registry,
             )
@@ -486,7 +486,7 @@ impl OperationMetrics {
             rocksdb_get_key_bytes: register_histogram_vec_with_registry!(
                 "rocksdb_get_key_bytes",
                 "Rocksdb get call key size in bytes",
-                &["cf_name"],
+                &["cf_class"],
                 bucket_vec.clone(),
                 registry
             )
@@ -494,7 +494,7 @@ impl OperationMetrics {
             rocksdb_get_value_bytes: register_histogram_vec_with_registry!(
                 "rocksdb_get_value_bytes",
                 "Rocksdb get call returned value size in bytes",
-                &["cf_name"],
+                &["cf_class"],
                 bucket_vec.clone(),
                 registry
             )
@@ -502,7 +502,7 @@ impl OperationMetrics {
             rocksdb_contains_key_latency_seconds: register_histogram_vec_with_registry!(
                 "rocksdb_contains_key_latency_seconds",
                 "Rocksdb contains_key latency in seconds. `found` label is true if key was found",
-                &["cf_name", "found"],
+                &["cf_class", "found"],
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry
             )
@@ -510,7 +510,7 @@ impl OperationMetrics {
             rocksdb_bloom_filter_may_exist_true_total: register_int_counter_vec_with_registry!(
                 "rocksdb_bloom_filter_may_exist_true_total",
                 "Number of times key_may_exist_cf returned true (potential positives)",
-                &["cf_name"],
+                &["cf_class"],
                 registry
             )
             .unwrap(),
@@ -518,14 +518,14 @@ impl OperationMetrics {
                 "rocksdb_bloom_filter_false_positive_total",
                 "Number of false positives where key_may_exist_cf \
                 returned true but get found nothing",
-                &["cf_name"],
+                &["cf_class"],
                 registry
             )
             .unwrap(),
             rocksdb_multiget_latency_seconds: register_histogram_vec_with_registry!(
                 "rocksdb_multiget_latency_seconds",
                 "Rocksdb multiget latency in seconds",
-                &["cf_name"],
+                &["cf_class"],
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
@@ -533,7 +533,7 @@ impl OperationMetrics {
             rocksdb_multiget_bytes: register_histogram_vec_with_registry!(
                 "rocksdb_multiget_bytes",
                 "Rocksdb multiget call returned data size in bytes",
-                &["cf_name"],
+                &["cf_class"],
                 bucket_vec.clone(),
                 registry,
             )
@@ -541,7 +541,7 @@ impl OperationMetrics {
             rocksdb_put_latency_seconds: register_histogram_vec_with_registry!(
                 "rocksdb_put_latency_seconds",
                 "Rocksdb put latency in seconds",
-                &["cf_name"],
+                &["cf_class"],
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
@@ -549,7 +549,7 @@ impl OperationMetrics {
             rocksdb_put_bytes: register_histogram_vec_with_registry!(
                 "rocksdb_put_bytes",
                 "Rocksdb put call returned data size in bytes",
-                &["cf_name"],
+                &["cf_class"],
                 bucket_vec.clone(),
                 registry,
             )
@@ -557,7 +557,7 @@ impl OperationMetrics {
             rocksdb_put_key_bytes: register_histogram_vec_with_registry!(
                 "rocksdb_put_key_bytes",
                 "Rocksdb put call key size in bytes",
-                &["cf_name"],
+                &["cf_class"],
                 bucket_vec.clone(),
                 registry,
             )
@@ -565,7 +565,7 @@ impl OperationMetrics {
             rocksdb_put_value_bytes: register_histogram_vec_with_registry!(
                 "rocksdb_put_value_bytes",
                 "Rocksdb put call value size in bytes",
-                &["cf_name"],
+                &["cf_class"],
                 bucket_vec.clone(),
                 registry,
             )
@@ -573,7 +573,7 @@ impl OperationMetrics {
             rocksdb_batch_put_bytes: register_histogram_vec_with_registry!(
                 "rocksdb_batch_put_bytes",
                 "Rocksdb batch put call puts data size in bytes",
-                &["cf_name"],
+                &["cf_class"],
                 bucket_vec.clone(),
                 registry,
             )
@@ -581,7 +581,7 @@ impl OperationMetrics {
             rocksdb_batch_put_key_bytes: register_histogram_vec_with_registry!(
                 "rocksdb_batch_put_key_bytes",
                 "Rocksdb batch put call puts key data size in bytes",
-                &["cf_name"],
+                &["cf_class"],
                 bucket_vec.clone(),
                 registry,
             )
@@ -589,7 +589,7 @@ impl OperationMetrics {
             rocksdb_batch_put_value_bytes: register_histogram_vec_with_registry!(
                 "rocksdb_batch_put_value_bytes",
                 "Rocksdb batch put call puts value data size in bytes",
-                &["cf_name"],
+                &["cf_class"],
                 bucket_vec.clone(),
                 registry,
             )
@@ -597,7 +597,7 @@ impl OperationMetrics {
             rocksdb_delete_latency_seconds: register_histogram_vec_with_registry!(
                 "rocksdb_delete_latency_seconds",
                 "Rocksdb delete latency in seconds",
-                &["cf_name"],
+                &["cf_class"],
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
@@ -605,7 +605,7 @@ impl OperationMetrics {
             rocksdb_deletes: register_int_counter_vec_with_registry!(
                 "rocksdb_deletes",
                 "Rocksdb delete calls",
-                &["cf_name"],
+                &["cf_class"],
                 registry
             )
             .unwrap(),
@@ -649,14 +649,14 @@ impl OperationMetrics {
             rocksdb_very_slow_puts_count: register_int_counter_vec_with_registry!(
                 "rocksdb_num_very_slow_puts",
                 "Number of puts that took more than 1 second",
-                &["cf_name"],
+                &["cf_class"],
                 registry,
             )
             .unwrap(),
             rocksdb_very_slow_puts_duration_ms: register_int_counter_vec_with_registry!(
                 "rocksdb_very_slow_puts_duration",
                 "Total duration of puts that took more than 1 second",
-                &["cf_name"],
+                &["cf_class"],
                 registry,
             )
             .unwrap(),

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -125,13 +125,13 @@ where
 
 #[tokio::test]
 async fn test_open() {
-    let _db = open_map::<_, u32, String>(temp_dir(), None);
+    let _db = open_map::<_, u32, String>(temp_dir(), None, None);
 }
 
 #[tokio::test]
 async fn test_reopen() {
     let arc = {
-        let db = open_map::<_, u32, String>(temp_dir(), None);
+        let db = open_map::<_, u32, String>(temp_dir(), None, None);
         db.insert(&123456789, &"123456789".to_string())
             .expect("Failed to insert");
         db
@@ -153,7 +153,7 @@ async fn test_wrong_reopen() {
 
 #[tokio::test]
 async fn test_contains_key() {
-    let db = open_map(temp_dir(), None);
+    let db = open_map(temp_dir(), None, None);
 
     db.insert(&123456789, &"123456789".to_string())
         .expect("Failed to insert");
@@ -169,7 +169,7 @@ async fn test_contains_key() {
 
 #[tokio::test]
 async fn test_multi_contain() {
-    let db = open_map(temp_dir(), None);
+    let db = open_map(temp_dir(), None, None);
 
     db.insert(&123, &"123".to_string())
         .expect("Failed to insert");
@@ -198,7 +198,7 @@ async fn test_multi_contain() {
 
 #[tokio::test]
 async fn test_get() {
-    let db = open_map(temp_dir(), None);
+    let db = open_map(temp_dir(), None, None);
 
     db.insert(&123456789, &"123456789".to_string())
         .expect("Failed to insert");
@@ -211,7 +211,7 @@ async fn test_get() {
 
 #[tokio::test]
 async fn test_multi_get() {
-    let db = open_map(temp_dir(), None);
+    let db = open_map(temp_dir(), None, None);
 
     db.insert(&123, &"123".to_string())
         .expect("Failed to insert");
@@ -228,7 +228,7 @@ async fn test_multi_get() {
 
 #[tokio::test]
 async fn test_skip() {
-    let db = open_map(temp_dir(), None);
+    let db = open_map(temp_dir(), None, None);
 
     db.insert(&123, &"123".to_string())
         .expect("Failed to insert");
@@ -259,7 +259,7 @@ async fn test_skip() {
 
 #[tokio::test]
 async fn test_reverse_iter_with_bounds() {
-    let db = open_map(temp_dir(), None);
+    let db = open_map(temp_dir(), None, None);
     db.insert(&123, &"123".to_string())
         .expect("Failed to insert");
     db.insert(&456, &"456".to_string())
@@ -281,7 +281,7 @@ async fn test_reverse_iter_with_bounds() {
 
 #[tokio::test]
 async fn test_remove() {
-    let db = open_map(temp_dir(), None);
+    let db = open_map(temp_dir(), None, None);
 
     db.insert(&123456789, &"123456789".to_string())
         .expect("Failed to insert");
@@ -293,7 +293,7 @@ async fn test_remove() {
 
 #[tokio::test]
 async fn test_iter() {
-    let db = open_map(temp_dir(), None);
+    let db = open_map(temp_dir(), None, None);
     db.insert(&123456789, &"123456789".to_string())
         .expect("Failed to insert");
     db.insert(&987654321, &"987654321".to_string())
@@ -308,7 +308,7 @@ async fn test_iter() {
 
 #[tokio::test]
 async fn test_iter_reverse() {
-    let db = open_map(temp_dir(), None);
+    let db = open_map(temp_dir(), None, None);
 
     db.insert(&1, &"1".to_string()).expect("Failed to insert");
     db.insert(&2, &"2".to_string()).expect("Failed to insert");
@@ -327,7 +327,7 @@ async fn test_iter_reverse() {
 
 #[tokio::test]
 async fn test_insert_batch() {
-    let db = open_map(temp_dir(), None);
+    let db = open_map(temp_dir(), None, None);
     let keys_vals = (1..100).map(|i| (i, i.to_string()));
     let mut insert_batch = db.batch();
     insert_batch
@@ -423,6 +423,7 @@ async fn test_delete_batch() {
             MetricConf::default(),
             None,
             None,
+            None,
             &ReadWriteOptions::default(),
         )
         .expect("Failed to open storage")
@@ -454,6 +455,7 @@ async fn test_delete_range() {
         DBMap::open(
             temp_dir(),
             MetricConf::default(),
+            None,
             None,
             None,
             &ReadWriteOptions::default().set_ignore_range_deletions(false),
@@ -498,6 +500,7 @@ async fn test_clear() {
             MetricConf::default(),
             None,
             Some("table"),
+            None,
             &ReadWriteOptions::default(),
         )
         .expect("Failed to open storage")
@@ -529,7 +532,7 @@ async fn test_clear() {
 
 #[tokio::test]
 async fn test_iter_with_bounds() {
-    let db = open_map(temp_dir(), None);
+    let db = open_map(temp_dir(), None, None);
 
     // Add [1, 50) and (50, 100) in the db
     for i in 1..100 {
@@ -595,7 +598,7 @@ async fn test_iter_with_bounds() {
 #[rstest]
 #[tokio::test]
 async fn test_range_iter() {
-    let db = open_map(temp_dir(), None);
+    let db = open_map(temp_dir(), None, None);
 
     // Add [1, 50) and (50, 100) in the db
     for i in 1..100 {
@@ -642,6 +645,7 @@ async fn test_is_empty() {
             MetricConf::default(),
             None,
             Some("table"),
+            None,
             &ReadWriteOptions::default(),
         )
         .expect("Failed to open storage")
@@ -673,7 +677,7 @@ async fn test_is_empty() {
 #[tokio::test]
 async fn test_multi_insert() {
     // Init a DB
-    let db: DBMap<i32, String> = open_map(temp_dir(), Some("table"));
+    let db: DBMap<i32, String> = open_map(temp_dir(), Some("table"), None);
     // Create kv pairs
     let keys_vals = (0..101).map(|i| (i, i.to_string()));
 
@@ -690,7 +694,7 @@ async fn test_multi_insert() {
 async fn test_checkpoint() {
     let path_prefix = temp_dir();
     let db_path = path_prefix.join("db");
-    let db: DBMap<i32, String> = open_map(db_path, Some("table"));
+    let db: DBMap<i32, String> = open_map(db_path, Some("table"), None);
     // Create kv pairs
     let keys_vals = (0..101).map(|i| (i, i.to_string()));
 
@@ -705,7 +709,7 @@ async fn test_checkpoint() {
     db.multi_insert(new_keys_vals.clone())
         .expect("Failed to multi-insert");
     // Verify checkpoint
-    let checkpointed_db: DBMap<i32, String> = open_map(checkpointed_path, Some("table"));
+    let checkpointed_db: DBMap<i32, String> = open_map(checkpointed_path, Some("table"), None);
     // Ensure keys inserted before checkpoint are present in original and checkpointed db
     for (k, v) in keys_vals {
         let val = db.get(&k).expect("Failed to get inserted key");
@@ -726,7 +730,7 @@ async fn test_checkpoint() {
 #[tokio::test]
 async fn test_multi_remove() {
     // Init a DB
-    let db: DBMap<i32, String> = open_map(temp_dir(), Some("table"));
+    let db: DBMap<i32, String> = open_map(temp_dir(), Some("table"), None);
 
     // Create kv pairs
     let keys_vals = (0..101).map(|i| (i, i.to_string()));
@@ -755,7 +759,11 @@ async fn test_multi_remove() {
     }
 }
 
-fn open_map<P: AsRef<Path>, K, V>(path: P, opt_cf: Option<&str>) -> DBMap<K, V> {
+fn open_map<P: AsRef<Path>, K, V>(
+    path: P,
+    opt_cf: Option<&str>,
+    opt_cf_class: Option<&str>,
+) -> DBMap<K, V> {
     let _lock = global_test_lock();
 
     DBMap::<K, V>::open(
@@ -763,6 +771,7 @@ fn open_map<P: AsRef<Path>, K, V>(path: P, opt_cf: Option<&str>) -> DBMap<K, V> 
         MetricConf::default(),
         None,
         opt_cf,
+        opt_cf_class,
         &ReadWriteOptions::default(),
     )
     .expect("failed to open rocksdb")
@@ -806,7 +815,7 @@ async fn test_sampling_time() {
 
 #[tokio::test]
 async fn test_iterator_seek() {
-    let db: DBMap<u32, String> = open_map(temp_dir(), None);
+    let db: DBMap<u32, String> = open_map(temp_dir(), None, None);
 
     db.insert(&123, &"123".to_string())
         .expect("Failed to insert");
@@ -1021,15 +1030,21 @@ fn open_optimistic_rocksdb<P: AsRef<Path>>(path: P, opt_cfs: &[&str]) -> Arc<Roc
         .expect("failed to open optimistic rocksdb")
 }
 
-fn open_optimistic_map<P: AsRef<Path>, K, V>(path: P, cf: &str) -> DBMap<K, V> {
+fn open_optimistic_map<P: AsRef<Path>, K, V>(path: P, cf: &str, cf_class: &str) -> DBMap<K, V> {
     let rocks = open_optimistic_rocksdb(path, &[cf]);
-    DBMap::<K, V>::reopen(&rocks, Some(cf), &ReadWriteOptions::default(), false)
-        .expect("failed to reopen optimistic cf")
+    DBMap::<K, V>::reopen_with_class(
+        &rocks,
+        Some(cf),
+        Some(cf_class),
+        &ReadWriteOptions::default(),
+        false,
+    )
+    .expect("failed to reopen optimistic cf")
 }
 
 #[tokio::test]
 async fn test_optimistic_transaction_commit() {
-    let db: DBMap<i32, String> = open_optimistic_map(temp_dir(), "cf");
+    let db: DBMap<i32, String> = open_optimistic_map(temp_dir(), "cf", "cf");
 
     // Seed initial value
     db.insert(&1, &"v1".to_string()).expect("insert");
@@ -1059,7 +1074,7 @@ async fn test_optimistic_transaction_commit() {
 
 #[tokio::test]
 async fn test_optimistic_transaction_rollback() {
-    let db: DBMap<i32, String> = open_optimistic_map(temp_dir(), "cf");
+    let db: DBMap<i32, String> = open_optimistic_map(temp_dir(), "cf", "cf");
 
     let tx = db
         .rocksdb
@@ -1079,7 +1094,7 @@ async fn test_optimistic_transaction_rollback() {
 
 #[tokio::test]
 async fn test_optimistic_transaction_conflict_and_retry() {
-    let db: DBMap<i32, String> = open_optimistic_map(temp_dir(), "cf");
+    let db: DBMap<i32, String> = open_optimistic_map(temp_dir(), "cf", "cf");
 
     // Seed initial value
     db.insert(&1, &"base".to_string()).expect("insert");


### PR DESCRIPTION
## Description

This can significantly reduce the cardinality of the metrics.

These per cf metrics are not useful in general as we typically just interested in per "class" of the metrics.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
