### PR TITLE
feat: Introduce tail sliver uploads in the background

### DIFF
--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -68,6 +68,7 @@ use walrus_sdk::{
     },
     store_optimizations::StoreOptimizations,
     upload_relay::tip_config::{TipConfig, TipKind},
+    uploader::TailHandling,
 };
 use walrus_service::test_utils::{
     StorageNodeHandleTrait,
@@ -359,6 +360,9 @@ async fn test_inconsistency(failed_nodes: &[usize]) -> TestResult {
             &metadata,
             &pairs,
             &BlobPersistenceType::Permanent,
+            None,
+            TailHandling::Blocking,
+            None,
             None,
         )
         .await?;

--- a/crates/walrus-sdk/src/client/communication.rs
+++ b/crates/walrus-sdk/src/client/communication.rs
@@ -4,7 +4,8 @@
 //! Logic to handle the communication between the client and the storage nodes.
 
 pub mod factory;
-pub(crate) mod node;
+#[doc = "Node communication primitives."]
+pub mod node;
 
 pub use factory::NodeCommunicationFactory;
 pub(crate) use node::{

--- a/crates/walrus-sdk/src/client/communication/factory.rs
+++ b/crates/walrus-sdk/src/client/communication/factory.rs
@@ -73,11 +73,11 @@ impl NodeCommunicationFactory {
     }
 
     /// Returns a vector of [`NodeWriteCommunication`] objects representing nodes in random order.
-    pub(crate) fn node_write_communications<'a>(
-        &'a self,
-        committees: &'a ActiveCommittees,
+    pub fn node_write_communications(
+        &self,
+        committees: &ActiveCommittees,
         sliver_write_limit: Arc<Semaphore>,
-    ) -> ClientResult<Vec<NodeWriteCommunication<'a>>> {
+    ) -> ClientResult<Vec<NodeWriteCommunication>> {
         self.remove_old_cached_clients(
             committees,
             &mut self
@@ -101,11 +101,11 @@ impl NodeCommunicationFactory {
     ///
     /// Returns a [`ClientError`] with [`ClientErrorKind::BehindCurrentEpoch`] if the certified
     /// epoch is greater than the current committee epoch.
-    pub(crate) fn node_read_communications<'a>(
-        &'a self,
-        committees: &'a ActiveCommittees,
+    pub(crate) fn node_read_communications(
+        &self,
+        committees: &ActiveCommittees,
         certified_epoch: Epoch,
-    ) -> ClientResult<Vec<NodeReadCommunication<'a>>> {
+    ) -> ClientResult<Vec<NodeReadCommunication>> {
         self.remove_old_cached_clients(
             committees,
             &mut self
@@ -128,23 +128,23 @@ impl NodeCommunicationFactory {
 
     /// Returns a vector of [`NodeReadCommunication`] objects, the weight of which is at least a
     /// quorum.
-    pub(crate) fn node_read_communications_quorum<'a>(
-        &'a self,
-        committees: &'a ActiveCommittees,
+    pub(crate) fn node_read_communications_quorum(
+        &self,
+        committees: &ActiveCommittees,
         certified_epoch: Epoch,
-    ) -> ClientResult<Vec<NodeReadCommunication<'a>>> {
+    ) -> ClientResult<Vec<NodeReadCommunication>> {
         self.node_read_communications_threshold(committees, certified_epoch, |weight| {
             committees.is_quorum(weight)
         })
     }
 
     /// Returns a vector of [`NodeWriteCommunication`] objects, matching the specified node IDs.
-    pub(crate) fn node_write_communications_by_id<'a>(
-        &'a self,
-        committees: &'a ActiveCommittees,
+    pub(crate) fn node_write_communications_by_id(
+        &self,
+        committees: &ActiveCommittees,
         sliver_write_limit: Arc<Semaphore>,
         node_ids: impl IntoIterator<Item = ObjectID>,
-    ) -> ClientResult<Vec<NodeWriteCommunication<'a>>> {
+    ) -> ClientResult<Vec<NodeWriteCommunication>> {
         self.remove_old_cached_clients(
             committees,
             &mut self
@@ -190,20 +190,20 @@ impl NodeCommunicationFactory {
     /// # Panics
     ///
     /// Panics if the index is out of range of the committee members.
-    fn create_node_communication<'a>(
-        &'a self,
-        committee: &'a Committee,
+    fn create_node_communication(
+        &self,
+        committee: &Committee,
         index: usize,
-    ) -> Result<Option<NodeCommunication<'a>>, ClientBuildError> {
-        let node = &committee.members()[index];
-        let client = self.create_client(node)?;
+    ) -> Result<Option<NodeCommunication>, ClientBuildError> {
+        let node = Arc::new(committee.members()[index].clone());
+        let client = self.create_client(node.as_ref())?;
 
         Ok(NodeCommunication::new(
             index,
             committee.epoch,
             client,
             node,
-            &self.encoding_config,
+            Arc::clone(&self.encoding_config),
             self.config.request_rate_config.clone(),
         ))
     }
@@ -216,23 +216,23 @@ impl NodeCommunicationFactory {
     /// # Panics
     ///
     /// Panics if the index is out of range of the committee members.
-    fn create_read_communication<'a>(
-        &'a self,
-        read_committee: &'a Committee,
+    fn create_read_communication(
+        &self,
+        read_committee: &Committee,
         index: usize,
-    ) -> Result<Option<NodeReadCommunication<'a>>, ClientBuildError> {
+    ) -> Result<Option<NodeReadCommunication>, ClientBuildError> {
         self.create_node_communication(read_committee, index)
     }
 
     /// Builds a [`NodeWriteCommunication`] object for the given storage node.
     ///
     /// Returns `None` if the node has no shards.
-    fn create_write_communication<'a>(
-        &'a self,
-        write_committee: &'a Committee,
+    fn create_write_communication(
+        &self,
+        write_committee: &Committee,
         index: usize,
         sliver_write_limit: Arc<Semaphore>,
-    ) -> Result<Option<NodeWriteCommunication<'a>>, ClientBuildError> {
+    ) -> Result<Option<NodeWriteCommunication>, ClientBuildError> {
         let maybe_node_communication = self
             .create_node_communication(write_committee, index)?
             .map(|nc| nc.with_write_limits(sliver_write_limit));
@@ -295,12 +295,12 @@ impl NodeCommunicationFactory {
     /// fulfilled after considering all storage nodes. Returns a [`ClientError`] with
     /// [`ClientErrorKind::BehindCurrentEpoch`] if the certified epoch is greater than the current
     /// committee epoch.
-    fn node_read_communications_threshold<'a>(
-        &'a self,
-        committees: &'a ActiveCommittees,
+    fn node_read_communications_threshold(
+        &self,
+        committees: &ActiveCommittees,
         certified_epoch: Epoch,
         threshold_fn: impl Fn(usize) -> bool,
-    ) -> ClientResult<Vec<NodeReadCommunication<'a>>> {
+    ) -> ClientResult<Vec<NodeReadCommunication>> {
         let read_committee = committees.read_committee(certified_epoch).ok_or_else(|| {
             ClientErrorKind::BehindCurrentEpoch {
                 client_epoch: committees.epoch(),
@@ -338,10 +338,10 @@ impl NodeCommunicationFactory {
 }
 
 /// Create a vector of node communication objects from the given committee and constructor.
-fn node_communications<'a, W>(
+fn node_communications<W>(
     committee: &Committee,
-    constructor: impl Fn(usize) -> Result<Option<NodeCommunication<'a, W>>, ClientBuildError>,
-) -> ClientResult<Vec<NodeCommunication<'a, W>>> {
+    constructor: impl Fn(usize) -> Result<Option<NodeCommunication<W>>, ClientBuildError>,
+) -> ClientResult<Vec<NodeCommunication<W>>> {
     if committee.n_members() == 0 {
         return Err(ClientError::from(ClientErrorKind::EmptyCommittee));
     }

--- a/crates/walrus-sdk/src/config.rs
+++ b/crates/walrus-sdk/src/config.rs
@@ -34,11 +34,13 @@ mod reqwest_config;
 mod sliver_write_extra_time;
 mod upload_mode;
 
+pub use sliver_write_extra_time::SliverWriteExtraTime;
+
 pub use self::{
     committees_refresh_config::CommitteesRefreshConfig,
-    communication_config::{ClientCommunicationConfig, CommunicationLimits},
+    communication_config::{ClientCommunicationConfig, CommunicationLimits, UploadMode},
     reqwest_config::RequestRateConfig,
-    upload_mode::UploadMode,
+    upload_mode::UploadMode as UploadPreset,
 };
 
 /// Returns the default paths for the Walrus configuration file.
@@ -73,11 +75,16 @@ pub fn load_configuration(
     let path = path_or_defaults_if_exist(path, &default_configuration_paths())
         .ok_or(anyhow!("could not find a valid Walrus configuration file"))?;
     let (config, context) = ClientConfig::load_from_multi_config(&path, context)?;
-    tracing::info!(
-        "using Walrus configuration from '{}' with {} context",
-        path.display(),
-        context.map_or("default".to_string(), |c| format!("'{c}'"))
-    );
+    if !std::env::var("INTERNAL_RUN")
+        .map(|v| v == "true")
+        .unwrap_or(false)
+    {
+        tracing::info!(
+            "using Walrus configuration from '{}' with {} context",
+            path.display(),
+            context.map_or("default".to_string(), |c| format!("'{c}'"))
+        );
+    }
     Ok(config)
 }
 

--- a/crates/walrus-sdk/src/config/communication_config.rs
+++ b/crates/walrus-sdk/src/config/communication_config.rs
@@ -19,6 +19,24 @@ use crate::config::{
     sliver_write_extra_time::SliverWriteExtraTime,
 };
 
+/// Upload mode for controlling concurrency and aggressiveness of uploads.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UploadMode {
+    /// Conservative mode: lower concurrency, slower but more reliable
+    Conservative,
+    /// Balanced mode: moderate concurrency (default)
+    Balanced,
+    /// Aggressive mode: higher concurrency, faster but more resource-intensive
+    Aggressive,
+}
+
+impl Default for UploadMode {
+    fn default() -> Self {
+        Self::Balanced
+    }
+}
+
 /// Configuration for the communication parameters of the client
 #[serde_as]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -50,6 +68,8 @@ pub struct ClientCommunicationConfig {
     pub disable_native_certs: bool,
     /// The extra time allowed for sliver writes.
     pub sliver_write_extra_time: SliverWriteExtraTime,
+    /// Enable uploading slivers via a detached child process that continues tail writes.
+    pub child_uploads_enabled: bool,
     /// The delay for which the client waits before storing data to ensure that storage nodes have
     /// seen the registration event.
     #[serde(rename = "registration_delay_millis")]
@@ -80,6 +100,7 @@ impl Default for ClientCommunicationConfig {
             request_rate_config: Default::default(),
             disable_proxy: Default::default(),
             sliver_write_extra_time: Default::default(),
+            child_uploads_enabled: false,
             registration_delay: Duration::from_millis(200),
             max_total_blob_size: 1024 * 1024 * 1024, // 1GiB
             committee_change_backoff: ExponentialBackoffConfig::new(

--- a/crates/walrus-sdk/src/lib.rs
+++ b/crates/walrus-sdk/src/lib.rs
@@ -12,6 +12,7 @@ pub mod config;
 pub mod error;
 pub mod store_optimizations;
 pub mod upload_relay;
+pub mod uploader;
 pub mod utils;
 
 pub use sui_types::{base_types::ObjectID, event::EventID};

--- a/crates/walrus-sdk/src/uploader.rs
+++ b/crates/walrus-sdk/src/uploader.rs
@@ -1,0 +1,298 @@
+// Copyright (c) Walrus Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(missing_docs)]
+
+//! A component for orchestrating the distributed upload of multiple blobs to the Walrus network.
+//!
+//! The `DistributedUploader` is designed to handle the complexity of a multi-blob, multi-stage
+//! upload process in an efficient and robust manner. It is the single source of truth for the
+//! core upload logic, used by all parts of the client.
+
+use std::{collections::HashMap, sync::Arc, time::Duration};
+
+use futures::Future;
+use tokio::sync::Semaphore;
+use walrus_core::{BlobId, encoding::SliverPair, metadata::VerifiedBlobMetadataWithId};
+
+use crate::{
+    active_committees::ActiveCommittees,
+    client::communication::{NodeResult, NodeWriteCommunication},
+    config::SliverWriteExtraTime,
+    error::ClientError,
+    utils::WeightedFutures,
+};
+
+/// Controls how the extra tail window is handled once quorum is reached.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TailHandling {
+    Blocking,
+    Detached,
+}
+
+/// Outcome returned by the uploader run.
+#[derive(Debug)]
+pub struct RunOutput<R, E> {
+    pub results: Vec<NodeResult<R, E>>,
+    pub tail_handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+/// A trait for types that have a `BlobId`.
+pub trait HasBlobId {
+    fn blob_id(&self) -> &BlobId;
+}
+
+impl HasBlobId for BlobId {
+    fn blob_id(&self) -> &BlobId {
+        self
+    }
+}
+
+impl<T> HasBlobId for (BlobId, T) {
+    fn blob_id(&self) -> &BlobId {
+        &self.0
+    }
+}
+
+/// A work item for the uploader, representing a set of sliver pairs for a single blob
+/// that need to be sent to a specific node.
+#[derive(Debug, Clone)]
+pub struct UploadWorkItem {
+    pub metadata: VerifiedBlobMetadataWithId,
+    pub pairs: Vec<SliverPair>,
+}
+
+impl UploadWorkItem {
+    pub fn blob_id(&self) -> &BlobId {
+        self.metadata.blob_id()
+    }
+}
+
+/// Tracks the upload progress for a single blob.
+#[derive(Debug, Clone, Default)]
+pub struct BlobUploadProgress {
+    /// The total weight of the nodes that have successfully stored the slivers for this blob.
+    pub completed_weight: usize,
+    /// A flag indicating whether the quorum has been reached for this blob.
+    pub quorum_reached: bool,
+}
+
+/// Events emitted by the `DistributedUploader` to report progress.
+#[derive(Debug, Clone)]
+pub enum UploaderEvent {
+    /// Progress update for a blob.
+    BlobProgress {
+        blob_id: BlobId,
+        completed_weight: usize,
+        required_weight: usize,
+    },
+    /// A blob has reached the required quorum of storage nodes.
+    BlobQuorumReached { blob_id: BlobId, elapsed: Duration },
+}
+
+/// The `DistributedUploader` component.
+#[derive(Debug)]
+pub struct DistributedUploader {
+    /// The blobs to be uploaded.
+    work_items: HashMap<usize, Vec<UploadWorkItem>>,
+    /// The committees object.
+    committees: Arc<ActiveCommittees>,
+    /// A map to track the upload progress for each blob.
+    progress: HashMap<BlobId, BlobUploadProgress>,
+    /// The communication objects for the storage nodes.
+    comms: Vec<NodeWriteCommunication>,
+    /// The concurrency limiter for the uploads.
+    sliver_write_limit: usize,
+    /// The extra time to wait for tail-end writes.
+    sliver_write_extra_time: SliverWriteExtraTime,
+}
+
+impl DistributedUploader {
+    /// Creates a new `DistributedUploader`.
+    pub fn new(
+        blobs: &[(VerifiedBlobMetadataWithId, Vec<SliverPair>)],
+        committees: Arc<ActiveCommittees>,
+        comms: Vec<NodeWriteCommunication>,
+        sliver_write_limit: usize,
+        sliver_write_extra_time: SliverWriteExtraTime,
+    ) -> Self {
+        let mut work_items: HashMap<usize, Vec<UploadWorkItem>> = HashMap::new();
+        let mut progress: HashMap<BlobId, BlobUploadProgress> = HashMap::new();
+
+        for (metadata, pairs) in blobs {
+            let blob_id = *metadata.blob_id();
+            progress.entry(blob_id).or_default();
+
+            let mut pairs_per_node: HashMap<usize, Vec<SliverPair>> = HashMap::new();
+            for pair in pairs {
+                let shard_index = pair.index().to_shard_index(committees.n_shards(), &blob_id);
+                for (node_index, node) in committees.write_committee().members().iter().enumerate()
+                {
+                    if node.shard_ids.contains(&shard_index) {
+                        pairs_per_node
+                            .entry(node_index)
+                            .or_default()
+                            .push(pair.clone());
+                    }
+                }
+            }
+
+            for (node_index, pairs_for_node) in pairs_per_node {
+                work_items
+                    .entry(node_index)
+                    .or_default()
+                    .push(UploadWorkItem {
+                        metadata: metadata.clone(),
+                        pairs: pairs_for_node,
+                    });
+            }
+        }
+
+        Self {
+            work_items,
+            committees,
+            progress,
+            comms,
+            sliver_write_limit,
+            sliver_write_extra_time,
+        }
+    }
+
+    /// Runs the distributed upload process.
+    pub async fn run<F, Fut, R, T, E>(
+        &mut self,
+        upload_action: F,
+        event_sender: tokio::sync::mpsc::Sender<UploaderEvent>,
+        tail_handling: TailHandling,
+    ) -> Result<RunOutput<R, E>, ClientError>
+    where
+        F: Fn(NodeWriteCommunication, Vec<UploadWorkItem>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = NodeResult<R, E>> + Send + 'static,
+        R: AsRef<[T]> + Send + Sync + 'static,
+        T: HasBlobId,
+        E: Send + Sync + 'static,
+    {
+        let semaphore = Arc::new(Semaphore::new(self.sliver_write_limit));
+        let scheduled: Vec<_> = self
+            .comms
+            .drain(..)
+            .map(|n| {
+                let work = self.work_items.remove(&n.node_index).unwrap_or_default();
+                (n, work)
+            })
+            .collect();
+
+        let upload_action = Arc::new(upload_action);
+        let futures = scheduled.into_iter().map({
+            let upload_action = Arc::clone(&upload_action);
+            let semaphore = Arc::clone(&semaphore);
+            move |(n, work)| {
+                let upload_action = Arc::clone(&upload_action);
+                let sem_clone = Arc::clone(&semaphore);
+                async move {
+                    let _permit = sem_clone
+                        .acquire()
+                        .await
+                        .expect("semaphore acquire should not fail");
+                    (*upload_action)(n, work).await
+                }
+            }
+        });
+
+        let mut requests = WeightedFutures::new(futures);
+        let start = std::time::Instant::now();
+
+        let mut blobs_at_quorum = 0;
+        let mut results: Vec<NodeResult<R, E>> = Vec::new();
+
+        while let Some(node_result) = requests.next(self.committees.n_shards().get().into()).await {
+            if let Ok(successful_blobs) = &node_result.result {
+                for successful_blob in successful_blobs.as_ref() {
+                    let blob_id = successful_blob.blob_id();
+                    let prog = self.progress.entry(*blob_id).or_default();
+                    prog.completed_weight += node_result.weight;
+
+                    let required_weight = self.committees.min_n_correct();
+                    if let Err(err) = event_sender
+                        .send(UploaderEvent::BlobProgress {
+                            blob_id: *blob_id,
+                            completed_weight: prog.completed_weight,
+                            required_weight,
+                        })
+                        .await
+                    {
+                        tracing::warn!(blob_id = %blob_id, ?err,
+                            "failed to send blob progress event");
+                    }
+
+                    if !prog.quorum_reached
+                        && self
+                            .committees
+                            .write_committee()
+                            .is_at_least_min_n_correct(prog.completed_weight)
+                    {
+                        prog.quorum_reached = true;
+                        blobs_at_quorum += 1;
+                        tracing::debug!(blob_id = %blob_id, "sending blob quorum reached event");
+                        if let Err(err) = event_sender
+                            .send(UploaderEvent::BlobQuorumReached {
+                                blob_id: *blob_id,
+                                elapsed: start.elapsed(),
+                            })
+                            .await
+                        {
+                            tracing::warn!(blob_id = %blob_id, ?err,
+                                "failed to send blob quorum reached event");
+                        } else {
+                            tracing::debug!(blob_id = %blob_id, "sent blob quorum reached event");
+                        }
+                    }
+                }
+            }
+
+            results.push(node_result);
+            let done = blobs_at_quorum == self.progress.len();
+            if done {
+                break;
+            }
+        }
+
+        let extra_time = self.sliver_write_extra_time.extra_time(start.elapsed());
+        let n_shards: usize = self.committees.n_shards().get().into();
+
+        let tail_handle = if matches!(tail_handling, TailHandling::Detached)
+            && extra_time > Duration::from_millis(0)
+        {
+            tracing::debug!("uploader: spawning detached tail handle");
+            Some(tokio::spawn(async move {
+                let mut requests = requests;
+                let reason = requests.execute_time(extra_time, n_shards).await;
+                tracing::debug!(
+                    "uploader: detached tail handle completed with reason: {:?}",
+                    reason
+                );
+                let results = requests.into_results();
+                tracing::debug!(
+                    "uploader: detached tail handle results: {:?}",
+                    results.len()
+                );
+            }))
+        } else {
+            if extra_time > Duration::from_millis(0) {
+                let reason = requests.execute_time(extra_time, n_shards).await;
+                tracing::debug!(
+                    "uploader: detached tail handle completed with reason: {:?}",
+                    reason
+                );
+            }
+
+            results.extend(requests.take_results());
+            None
+        };
+
+        Ok(RunOutput {
+            results,
+            tail_handle,
+        })
+    }
+}

--- a/crates/walrus-sdk/src/utils.rs
+++ b/crates/walrus-sdk/src/utils.rs
@@ -361,6 +361,22 @@ pub fn styled_progress_bar(length: u64) -> ProgressBar {
     pb
 }
 
+/// Returns a progress bar with the given length and stlyle already applied with steady
+/// tick disabled
+pub fn styled_progress_bar_with_disabled_steady_tick(length: u64) -> ProgressBar {
+    let pb = ProgressBar::new(length);
+    pb.set_style(
+        ProgressStyle::with_template(
+            " {spinner:.122} {msg} [{elapsed_precise}] [{wide_bar:.122/177}] {pos}/{len} ({eta})",
+        )
+        .expect("the template is valid")
+        .tick_chars("•◉◎○◌○◎◉")
+        .progress_chars("#>-"),
+    );
+    pb.disable_steady_tick();
+    pb
+}
+
 /// Returns a pre-configured spinner.
 pub fn styled_spinner() -> ProgressBar {
     let spinner = ProgressBar::new_spinner();

--- a/crates/walrus-service/bin/client.rs
+++ b/crates/walrus-service/bin/client.rs
@@ -61,7 +61,13 @@ fn client() -> Result<()> {
     let mut app = ClientArgs::parse().inner;
     app.extract_json_command()?;
 
-    tracing::info!("client version: {VERSION}");
+    if !std::env::var("INTERNAL_RUN")
+        .map(|v| v == "true")
+        .unwrap_or(false)
+    {
+        tracing::info!("client version: {VERSION}");
+    }
+
     let runner = ClientCommandRunner::new(
         &app.config,
         app.context.as_deref(),

--- a/crates/walrus-stress/src/generator/write_client.rs
+++ b/crates/walrus-stress/src/generator/write_client.rs
@@ -27,6 +27,7 @@ use walrus_sdk::{
     },
     error::ClientError,
     store_optimizations::StoreOptimizations,
+    uploader::TailHandling,
 };
 use walrus_service::client::{ClientConfig, Refiller};
 use walrus_sui::{
@@ -225,6 +226,9 @@ impl WriteClient {
                 &pairs,
                 &blob_sui_object.blob_persistence_type(),
                 Some(&MultiProgress::new()),
+                TailHandling::Blocking,
+                None,
+                None,
             )
             .await?;
 

--- a/crates/walrus-sui/src/config.rs
+++ b/crates/walrus-sui/src/config.rs
@@ -109,7 +109,12 @@ impl WalletConfig {
 
         let path = path_or_defaults_if_exist(wallet_config.and_then(|c| c.path()), &default_paths)
             .ok_or(anyhow!("could not find a valid wallet config file"))?;
-        tracing::info!("using Sui wallet configuration from '{}'", path.display());
+        if !std::env::var("INTERNAL_RUN")
+            .map(|v| v == "true")
+            .unwrap_or(false)
+        {
+            tracing::info!("using Sui wallet configuration from '{}'", path.display());
+        }
         let mut wallet_context: WalletContext = WalletContext::new(&path)?;
         if let Some(request_timeout) = request_timeout {
             wallet_context = wallet_context.with_request_timeout(request_timeout);

--- a/crates/walrus-upload-relay/src/controller.rs
+++ b/crates/walrus-upload-relay/src/controller.rs
@@ -55,6 +55,7 @@ use walrus_sdk::{
         params::{DigestSchema, NONCE_LEN, Params, TransactionDigestSchema},
         tip_config::{TipConfig, TipKind},
     },
+    uploader::TailHandling,
 };
 
 use crate::{
@@ -211,7 +212,15 @@ impl Controller {
         };
         let confirmation_certificate: ConfirmationCertificate = self
             .client
-            .send_blob_data_and_get_certificate(&metadata, &sliver_pairs, &blob_persistence, None)
+            .send_blob_data_and_get_certificate(
+                &metadata,
+                &sliver_pairs,
+                &blob_persistence,
+                None,
+                TailHandling::Blocking,
+                None,
+                None,
+            )
             .await?;
 
         self.metric_set.blobs_uploaded.inc();


### PR DESCRIPTION
## Description

This PR introduces a new mode of operation which spawns a child process to perform sliver uploads. 
The child process communicates to the parent via events published to its stdout stream. 
We can also now create a blob certificate right after quorum without blocking for the tail uploads to finish.
Child continues tail uploads in the background while parent can terminate.

## Test plan

Added a unit test to ensure stdout parsing is working as expected.
Ran locally, and ensure everything works as expected.
