### PR TITLE
[1/n][tail uploads] feat: Remove lifetime from node handles

### DIFF
--- a/crates/walrus-sdk/src/client/communication/factory.rs
+++ b/crates/walrus-sdk/src/client/communication/factory.rs
@@ -73,11 +73,11 @@ impl NodeCommunicationFactory {
     }
 
     /// Returns a vector of [`NodeWriteCommunication`] objects representing nodes in random order.
-    pub(crate) fn node_write_communications<'a>(
-        &'a self,
-        committees: &'a ActiveCommittees,
+    pub(crate) fn node_write_communications(
+        &self,
+        committees: &ActiveCommittees,
         sliver_write_limit: Arc<Semaphore>,
-    ) -> ClientResult<Vec<NodeWriteCommunication<'a>>> {
+    ) -> ClientResult<Vec<NodeWriteCommunication>> {
         self.remove_old_cached_clients(
             committees,
             &mut self
@@ -101,11 +101,11 @@ impl NodeCommunicationFactory {
     ///
     /// Returns a [`ClientError`] with [`ClientErrorKind::BehindCurrentEpoch`] if the certified
     /// epoch is greater than the current committee epoch.
-    pub(crate) fn node_read_communications<'a>(
-        &'a self,
-        committees: &'a ActiveCommittees,
+    pub(crate) fn node_read_communications(
+        &self,
+        committees: &ActiveCommittees,
         certified_epoch: Epoch,
-    ) -> ClientResult<Vec<NodeReadCommunication<'a>>> {
+    ) -> ClientResult<Vec<NodeReadCommunication>> {
         self.remove_old_cached_clients(
             committees,
             &mut self
@@ -128,23 +128,23 @@ impl NodeCommunicationFactory {
 
     /// Returns a vector of [`NodeReadCommunication`] objects, the weight of which is at least a
     /// quorum.
-    pub(crate) fn node_read_communications_quorum<'a>(
-        &'a self,
-        committees: &'a ActiveCommittees,
+    pub(crate) fn node_read_communications_quorum(
+        &self,
+        committees: &ActiveCommittees,
         certified_epoch: Epoch,
-    ) -> ClientResult<Vec<NodeReadCommunication<'a>>> {
+    ) -> ClientResult<Vec<NodeReadCommunication>> {
         self.node_read_communications_threshold(committees, certified_epoch, |weight| {
             committees.is_quorum(weight)
         })
     }
 
     /// Returns a vector of [`NodeWriteCommunication`] objects, matching the specified node IDs.
-    pub(crate) fn node_write_communications_by_id<'a>(
-        &'a self,
-        committees: &'a ActiveCommittees,
+    pub(crate) fn node_write_communications_by_id(
+        &self,
+        committees: &ActiveCommittees,
         sliver_write_limit: Arc<Semaphore>,
         node_ids: impl IntoIterator<Item = ObjectID>,
-    ) -> ClientResult<Vec<NodeWriteCommunication<'a>>> {
+    ) -> ClientResult<Vec<NodeWriteCommunication>> {
         self.remove_old_cached_clients(
             committees,
             &mut self
@@ -190,20 +190,20 @@ impl NodeCommunicationFactory {
     /// # Panics
     ///
     /// Panics if the index is out of range of the committee members.
-    fn create_node_communication<'a>(
-        &'a self,
-        committee: &'a Committee,
+    fn create_node_communication(
+        &self,
+        committee: &Committee,
         index: usize,
-    ) -> Result<Option<NodeCommunication<'a>>, ClientBuildError> {
-        let node = &committee.members()[index];
-        let client = self.create_client(node)?;
+    ) -> Result<Option<NodeCommunication>, ClientBuildError> {
+        let node = Arc::new(committee.members()[index].clone());
+        let client = self.create_client(node.as_ref())?;
 
         Ok(NodeCommunication::new(
             index,
             committee.epoch,
             client,
             node,
-            &self.encoding_config,
+            Arc::clone(&self.encoding_config),
             self.config.request_rate_config.clone(),
         ))
     }
@@ -216,23 +216,23 @@ impl NodeCommunicationFactory {
     /// # Panics
     ///
     /// Panics if the index is out of range of the committee members.
-    fn create_read_communication<'a>(
-        &'a self,
-        read_committee: &'a Committee,
+    fn create_read_communication(
+        &self,
+        read_committee: &Committee,
         index: usize,
-    ) -> Result<Option<NodeReadCommunication<'a>>, ClientBuildError> {
+    ) -> Result<Option<NodeReadCommunication>, ClientBuildError> {
         self.create_node_communication(read_committee, index)
     }
 
     /// Builds a [`NodeWriteCommunication`] object for the given storage node.
     ///
     /// Returns `None` if the node has no shards.
-    fn create_write_communication<'a>(
-        &'a self,
-        write_committee: &'a Committee,
+    fn create_write_communication(
+        &self,
+        write_committee: &Committee,
         index: usize,
         sliver_write_limit: Arc<Semaphore>,
-    ) -> Result<Option<NodeWriteCommunication<'a>>, ClientBuildError> {
+    ) -> Result<Option<NodeWriteCommunication>, ClientBuildError> {
         let maybe_node_communication = self
             .create_node_communication(write_committee, index)?
             .map(|nc| nc.with_write_limits(sliver_write_limit));
@@ -295,12 +295,12 @@ impl NodeCommunicationFactory {
     /// fulfilled after considering all storage nodes. Returns a [`ClientError`] with
     /// [`ClientErrorKind::BehindCurrentEpoch`] if the certified epoch is greater than the current
     /// committee epoch.
-    fn node_read_communications_threshold<'a>(
-        &'a self,
-        committees: &'a ActiveCommittees,
+    fn node_read_communications_threshold(
+        &self,
+        committees: &ActiveCommittees,
         certified_epoch: Epoch,
         threshold_fn: impl Fn(usize) -> bool,
-    ) -> ClientResult<Vec<NodeReadCommunication<'a>>> {
+    ) -> ClientResult<Vec<NodeReadCommunication>> {
         let read_committee = committees.read_committee(certified_epoch).ok_or_else(|| {
             ClientErrorKind::BehindCurrentEpoch {
                 client_epoch: committees.epoch(),
@@ -338,10 +338,10 @@ impl NodeCommunicationFactory {
 }
 
 /// Create a vector of node communication objects from the given committee and constructor.
-fn node_communications<'a, W>(
+fn node_communications<W>(
     committee: &Committee,
-    constructor: impl Fn(usize) -> Result<Option<NodeCommunication<'a, W>>, ClientBuildError>,
-) -> ClientResult<Vec<NodeCommunication<'a, W>>> {
+    constructor: impl Fn(usize) -> Result<Option<NodeCommunication<W>>, ClientBuildError>,
+) -> ClientResult<Vec<NodeCommunication<W>>> {
     if committee.n_members() == 0 {
         return Err(ClientError::from(ClientErrorKind::EmptyCommittee));
     }

--- a/crates/walrus-sdk/src/client/communication/node.rs
+++ b/crates/walrus-sdk/src/client/communication/node.rs
@@ -91,11 +91,12 @@ impl<T, E> WeightedResult for NodeResult<T, E> {
     }
 }
 
-pub(crate) struct NodeCommunication<'a, W = ()> {
+#[derive(Debug)]
+pub struct NodeCommunication<W = ()> {
     pub node_index: NodeIndex,
     pub committee_epoch: Epoch,
-    pub node: &'a StorageNode,
-    pub encoding_config: &'a EncodingConfig,
+    pub node: Arc<StorageNode>,
+    pub encoding_config: Arc<EncodingConfig>,
     pub span: Span,
     pub client: StorageNodeClient,
     pub config: RequestRateConfig,
@@ -103,10 +104,10 @@ pub(crate) struct NodeCommunication<'a, W = ()> {
     pub sliver_write_limit: W,
 }
 
-pub type NodeReadCommunication<'a> = NodeCommunication<'a, ()>;
-pub type NodeWriteCommunication<'a> = NodeCommunication<'a, Arc<Semaphore>>;
+pub type NodeReadCommunication = NodeCommunication;
+pub type NodeWriteCommunication = NodeCommunication<Arc<Semaphore>>;
 
-impl<'a> NodeReadCommunication<'a> {
+impl NodeReadCommunication {
     /// Creates a new [`NodeCommunication`].
     ///
     /// Returns `None` if the `node` has no shards.
@@ -114,8 +115,8 @@ impl<'a> NodeReadCommunication<'a> {
         node_index: NodeIndex,
         committee_epoch: Epoch,
         client: StorageNodeClient,
-        node: &'a StorageNode,
-        encoding_config: &'a EncodingConfig,
+        node: Arc<StorageNode>,
+        encoding_config: Arc<EncodingConfig>,
         config: RequestRateConfig,
     ) -> Option<Self> {
         if node.shard_ids.is_empty() {
@@ -128,6 +129,7 @@ impl<'a> NodeReadCommunication<'a> {
             %config.max_node_connections,
             "initializing communication with node"
         );
+        let pk_prefix = string_prefix(&node.public_key);
         Some(Self {
             node_index,
             committee_epoch,
@@ -138,7 +140,7 @@ impl<'a> NodeReadCommunication<'a> {
                 "node",
                 index = node_index,
                 committee_epoch,
-                pk_prefix = string_prefix(&node.public_key)
+                pk_prefix = pk_prefix
             ),
             client,
             config,
@@ -147,10 +149,7 @@ impl<'a> NodeReadCommunication<'a> {
         })
     }
 
-    pub fn with_write_limits(
-        self,
-        sliver_write_limit: Arc<Semaphore>,
-    ) -> NodeWriteCommunication<'a> {
+    pub fn with_write_limits(self, sliver_write_limit: Arc<Semaphore>) -> NodeWriteCommunication {
         let node_write_limit = Arc::new(Semaphore::new(self.config.max_node_connections));
         let Self {
             node_index,
@@ -176,7 +175,7 @@ impl<'a> NodeReadCommunication<'a> {
     }
 }
 
-impl<W> NodeCommunication<'_, W> {
+impl<W> NodeCommunication<W> {
     /// Returns the number of shards.
     pub fn n_shards(&self) -> NonZeroU16 {
         self.encoding_config.n_shards()
@@ -213,7 +212,7 @@ impl<W> NodeCommunication<'_, W> {
         tracing::debug!(%blob_id, "retrieving metadata");
         let result = self
             .client
-            .get_and_verify_metadata(blob_id, self.encoding_config)
+            .get_and_verify_metadata(blob_id, self.encoding_config.as_ref())
             .await;
         self.to_node_result_with_n_shards(result)
     }
@@ -237,7 +236,7 @@ impl<W> NodeCommunication<'_, W> {
         let sliver_pair_index = shard_index.to_pair_index(self.n_shards(), metadata.blob_id());
         let sliver = self
             .client
-            .get_and_verify_sliver(sliver_pair_index, metadata, self.encoding_config)
+            .get_and_verify_sliver(sliver_pair_index, metadata, self.encoding_config.as_ref())
             .await;
 
         // Each sliver is in this case requested individually, so the weight is 1.
@@ -304,7 +303,7 @@ impl<W> NodeCommunication<'_, W> {
     }
 }
 
-impl NodeWriteCommunication<'_> {
+impl NodeWriteCommunication {
     /// Stores metadata and sliver pairs on a node, and requests a storage confirmation.
     ///
     /// Returns a [`NodeResult`], where the weight is the number of shards for which the storage


### PR DESCRIPTION
## Description

This PR refactorS storage-node communication handles to own their data so async uploader work can hold them 'static. Converted the communication layer to use Arc<StorageNode> and Arc<EncodingConfig> and removed lifetime-heavy APIs making node handles cloneable across tasks.

## Test plan

cargo clippy
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
