### PR TITLE
feat: [3/n][tail uploads] Add child process to offload sliver uploads

### DIFF
--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -161,8 +161,6 @@ where
                 .with_tail_handle_collector(tail_handle_collector.clone())
         } else {
             store_args
-                .with_tail_handling(TailHandling::Detached)
-                .with_tail_handle_collector(tail_handle_collector.clone())
         }
     };
 

--- a/crates/walrus-sdk/client_config_example.yaml
+++ b/crates/walrus-sdk/client_config_example.yaml
@@ -31,6 +31,7 @@ communication_config:
     factor: 0.5
     base_millis: 500
   sliver_status_check_threshold: 5560
+  child_process_uploads_enabled: false
   registration_delay_millis: 200
   max_total_blob_size: 1073741824
   committee_change_backoff:

--- a/crates/walrus-sdk/src/config.rs
+++ b/crates/walrus-sdk/src/config.rs
@@ -24,7 +24,11 @@ use walrus_sui::{
     config::WalletConfig,
     wallet::Wallet,
 };
-use walrus_utils::{backoff::ExponentialBackoffConfig, config::path_or_defaults_if_exist};
+use walrus_utils::{
+    backoff::ExponentialBackoffConfig,
+    config::path_or_defaults_if_exist,
+    is_internal_run,
+};
 
 use crate::client::quilt_client::QuiltClientConfig;
 
@@ -36,10 +40,10 @@ mod upload_mode;
 
 pub use self::{
     committees_refresh_config::CommitteesRefreshConfig,
-    communication_config::{ClientCommunicationConfig, CommunicationLimits},
+    communication_config::{ClientCommunicationConfig, CommunicationLimits, UploadMode},
     reqwest_config::RequestRateConfig,
     sliver_write_extra_time::SliverWriteExtraTime,
-    upload_mode::UploadMode,
+    upload_mode::UploadMode as UploadPreset,
 };
 
 /// Returns the default paths for the Walrus configuration file.
@@ -74,11 +78,13 @@ pub fn load_configuration(
     let path = path_or_defaults_if_exist(path, &default_configuration_paths())
         .ok_or(anyhow!("could not find a valid Walrus configuration file"))?;
     let (config, context) = ClientConfig::load_from_multi_config(&path, context)?;
-    tracing::info!(
-        "using Walrus configuration from '{}' with {} context",
-        path.display(),
-        context.map_or("default".to_string(), |c| format!("'{c}'"))
-    );
+    if !is_internal_run() {
+        tracing::info!(
+            "using Walrus configuration from '{}' with {} context",
+            path.display(),
+            context.map_or("default".to_string(), |c| format!("'{c}'"))
+        );
+    }
     Ok(config)
 }
 

--- a/crates/walrus-sdk/src/config/communication_config.rs
+++ b/crates/walrus-sdk/src/config/communication_config.rs
@@ -33,6 +33,24 @@ fn default_sliver_status_check_threshold() -> usize {
     DEFAULT_SLIVER_STATUS_CHECK_THRESHOLD
 }
 
+/// Upload mode for controlling concurrency and aggressiveness of uploads.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UploadMode {
+    /// Conservative mode: lower concurrency, slower but more reliable.
+    Conservative,
+    /// Balanced mode: moderate concurrency (default).
+    Balanced,
+    /// Aggressive mode: higher concurrency, faster but more resource-intensive.
+    Aggressive,
+}
+
+impl Default for UploadMode {
+    fn default() -> Self {
+        Self::Balanced
+    }
+}
+
 /// Configuration for the communication parameters of the client
 #[serde_as]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -65,10 +83,11 @@ pub struct ClientCommunicationConfig {
     /// The extra time allowed for sliver writes.
     pub sliver_write_extra_time: SliverWriteExtraTime,
     /// Limit under which the client skips the sliver status check before uploads.
-    ///
     /// Defaults to 5_560 bytes.
     #[serde(default = "default_sliver_status_check_threshold")]
     pub sliver_status_check_threshold: usize,
+    /// Enable uploading slivers via a detached child process that continues tail writes.
+    pub child_process_uploads_enabled: bool,
     /// The delay for which the client waits before storing data to ensure that storage nodes have
     /// seen the registration event.
     #[serde(rename = "registration_delay_millis")]
@@ -99,6 +118,7 @@ impl Default for ClientCommunicationConfig {
             request_rate_config: Default::default(),
             disable_proxy: Default::default(),
             sliver_write_extra_time: Default::default(),
+            child_process_uploads_enabled: false,
             registration_delay: Duration::from_millis(200),
             max_total_blob_size: 1024 * 1024 * 1024, // 1GiB
             sliver_status_check_threshold: DEFAULT_SLIVER_STATUS_CHECK_THRESHOLD,

--- a/crates/walrus-sdk/src/utils.rs
+++ b/crates/walrus-sdk/src/utils.rs
@@ -361,6 +361,13 @@ pub fn styled_progress_bar(length: u64) -> ProgressBar {
     pb
 }
 
+/// Returns a styled progress bar with the steady tick disabled.
+pub fn styled_progress_bar_with_disabled_steady_tick(length: u64) -> ProgressBar {
+    let pb = styled_progress_bar(length);
+    pb.disable_steady_tick();
+    pb
+}
+
 /// Returns a pre-configured spinner.
 pub fn styled_spinner() -> ProgressBar {
     let spinner = ProgressBar::new_spinner();

--- a/crates/walrus-service/bin/client.rs
+++ b/crates/walrus-service/bin/client.rs
@@ -16,6 +16,7 @@ use walrus_service::{
     utils::{self, MetricsAndLoggingRuntime},
 };
 use walrus_sui::client::retry_client::RetriableRpcError;
+use walrus_utils::is_internal_run;
 
 // Define the `GIT_REVISION` and `VERSION` consts for the Walrus client.
 walrus_utils::bin_version!();
@@ -61,7 +62,9 @@ fn client() -> Result<()> {
     let mut app = ClientArgs::parse().inner;
     app.extract_json_command()?;
 
-    tracing::info!("client version: {VERSION}");
+    if !is_internal_run() {
+        tracing::info!("client version: {VERSION}");
+    }
     let runner = ClientCommandRunner::new(
         &app.config,
         app.context.as_deref(),

--- a/crates/walrus-service/src/client/cli.rs
+++ b/crates/walrus-service/src/client/cli.rs
@@ -25,6 +25,7 @@ use walrus_sui::wallet::Wallet;
 mod args;
 mod backfill;
 mod cli_output;
+mod internal_run;
 mod runner;
 
 pub use args::{

--- a/crates/walrus-service/src/client/cli/args.rs
+++ b/crates/walrus-service/src/client/cli/args.rs
@@ -1183,6 +1183,10 @@ pub struct CommonStoreOptions {
     #[arg(long, value_enum)]
     #[serde(default)]
     pub upload_mode: Option<UploadModeCli>,
+    /// Internal flag to signal the process is running as a child for background uploads.
+    #[arg(long, hide = true)]
+    #[serde(default)]
+    pub internal_run: bool,
 }
 
 #[serde_as]
@@ -1950,6 +1954,7 @@ mod tests {
                 upload_relay: None,
                 skip_tip_confirmation: false,
                 upload_mode: None,
+                internal_run: false,
             },
         })
     }

--- a/crates/walrus-service/src/client/cli/internal_run.rs
+++ b/crates/walrus-service/src/client/cli/internal_run.rs
@@ -1,0 +1,768 @@
+// Copyright (c) Walrus Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Internal-run related functionality for the Walrus client.
+
+use std::{
+    collections::HashMap,
+    env,
+    fs as stdfs,
+    path::PathBuf,
+    process::Stdio,
+    str::FromStr,
+    sync::Arc,
+};
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use colored::Colorize as _;
+use indicatif::{MultiProgress, ProgressBar};
+use reqwest::Url;
+use serde::{Deserialize, Serialize};
+use serde_json;
+use tokio::{
+    io::{AsyncBufRead, AsyncBufReadExt, BufReader},
+    process::{ChildStderr, ChildStdout, Command as TokioCommand},
+    sync::{Mutex as TokioMutex, mpsc::channel as mpsc_channel},
+};
+use walrus_core::BlobId;
+use walrus_sdk::{
+    client::{StoreArgs, WalrusNodeClient, responses as sdk_responses},
+    config::UploadMode,
+    store_optimizations::StoreOptimizations,
+    sui::client::{BlobPersistence, PostStoreAction, SuiContractClient},
+    uploader::{TailHandling, UploaderEvent},
+    utils::styled_progress_bar_with_disabled_steady_tick,
+};
+
+use crate::client::cli::{
+    HumanReadableBytes,
+    HumanReadableFrost,
+    WalrusColors,
+    args::{EpochArg, QuiltBlobInput},
+};
+
+/// Deserializable representation of JSON events from the walrus-uploader-child stdout.
+/// These events are emitted by the child process and sent to the parent process.
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(crate) enum ChildUploaderEvent {
+    SliverProgress {
+        blob_id: String,
+        completed_weight: u64,
+        total_weight: u64,
+    },
+    QuorumReached {
+        blob_id: String,
+        #[serde(default)]
+        #[allow(dead_code)]
+        elapsed_ms: u64,
+        extra_ms: u64,
+    },
+    V1Certified {
+        blob_id: String,
+        object_id: String,
+        #[serde(default)]
+        end_epoch: Option<u64>,
+        #[serde(default)]
+        shared_object_id: Option<String>,
+    },
+    StoreDetailNewlyCreated {
+        path: String,
+        blob_id: String,
+        object_id: String,
+        deletable: bool,
+        unencoded_size: u64,
+        encoded_size: u64,
+        cost: u64,
+        end_epoch: u64,
+        #[serde(default)]
+        shared_blob_object_id: Option<String>,
+        encoding_type: String,
+        operation_note: String,
+    },
+    StoreDetailAlreadyCertified {
+        path: String,
+        blob_id: String,
+        end_epoch: u64,
+        event_or_object: String,
+    },
+    Done {
+        #[allow(dead_code)]
+        ok: bool,
+        #[allow(dead_code)]
+        error: Option<String>,
+        #[serde(default)]
+        newly_certified: u64,
+        #[serde(default)]
+        reuse_and_extend_count: u64,
+        #[serde(default)]
+        total_encoded_size: u64,
+        #[serde(default)]
+        total_cost: u64,
+    },
+}
+
+/// Emits an event to the stdout of the child process.
+pub(crate) fn emit_child_event(event: &ChildUploaderEvent) -> Result<()> {
+    tracing::debug!(?event, "child: emitting event to stdout");
+    println!("{}", serde_json::to_string(event)?);
+    Ok(())
+}
+
+/// Emits a V1Certified event to the stdout of the child process.
+pub(crate) fn emit_v1_certified_event(result: &sdk_responses::BlobStoreResult) -> Result<()> {
+    match result {
+        sdk_responses::BlobStoreResult::NewlyCreated {
+            blob_object,
+            shared_blob_object,
+            ..
+        } => {
+            tracing::debug!(blob_id = %blob_object.blob_id, "child: emitting V1Certified (new)");
+            let event = ChildUploaderEvent::V1Certified {
+                blob_id: blob_object.blob_id.to_string(),
+                object_id: blob_object.id.to_string(),
+                end_epoch: Some(u64::from(blob_object.storage.end_epoch)),
+                shared_object_id: shared_blob_object.as_ref().map(|id| id.to_string()),
+            };
+            emit_child_event(&event)
+        }
+        sdk_responses::BlobStoreResult::AlreadyCertified {
+            blob_id,
+            event_or_object,
+            end_epoch,
+        } => {
+            let object_id = match event_or_object {
+                sdk_responses::EventOrObjectId::Object(id) => id.to_string(),
+                other => other.to_string(),
+            };
+            tracing::debug!(blob_id = %blob_id, "child: emitting V1Certified (already)");
+            let event = ChildUploaderEvent::V1Certified {
+                blob_id: blob_id.to_string(),
+                object_id,
+                end_epoch: Some(u64::from(*end_epoch)),
+                shared_object_id: None,
+            };
+            emit_child_event(&event)
+        }
+        _ => Ok(()),
+    }
+}
+
+/// Converts a quilt blob input to a CLI argument.
+pub(crate) fn quilt_blob_input_to_cli_arg(input: &QuiltBlobInput) -> Result<String> {
+    let mut map = serde_json::Map::new();
+    map.insert(
+        "path".to_string(),
+        serde_json::Value::String(input.path.to_string_lossy().into_owned()),
+    );
+
+    if let Some(identifier) = &input.identifier {
+        map.insert(
+            "identifier".to_string(),
+            serde_json::Value::String(identifier.clone()),
+        );
+    }
+
+    if !input.tags.is_empty() {
+        map.insert(
+            "tags".to_string(),
+            serde_json::to_value(&input.tags).context("serialize quilt blob tags")?,
+        );
+    }
+
+    Ok(serde_json::Value::Object(map).to_string())
+}
+
+/// Spawns a task to print the stderr of the child process to the stderr of the parent process.
+fn spawn_child_stderr_to_stderr(stderr: ChildStderr) {
+    tokio::spawn(async move {
+        let reader = BufReader::new(stderr);
+        let mut lines = reader.lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            eprintln!("[child] {line}");
+            tracing::debug!(target = "walrus.child", line = %line, "child stderr");
+        }
+    });
+}
+
+/// Processes the stdout events of the child process.
+pub(crate) async fn process_child_stdout_events<F, Fut>(
+    stdout: ChildStdout,
+    on_quorum: F,
+    expected_blobs: usize,
+) where
+    F: Fn(BlobId, std::time::Duration) -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
+    process_child_stdout_reader(BufReader::new(stdout), on_quorum, expected_blobs).await;
+}
+
+/// Processes the stdout events of the child process.
+async fn process_child_stdout_reader<R, F, Fut>(reader: R, on_quorum: F, expected_blobs: usize)
+where
+    R: AsyncBufRead + Unpin,
+    F: Fn(BlobId, std::time::Duration) -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
+    let mut lines = reader.lines();
+    let mut certified_count = 0;
+    let multi = MultiProgress::new();
+    let mut per_blob_bars: HashMap<String, ProgressBar> = HashMap::new();
+
+    while let Ok(Some(line)) = lines.next_line().await {
+        match serde_json::from_str::<ChildUploaderEvent>(&line) {
+            Ok(event) => match event {
+                ChildUploaderEvent::SliverProgress {
+                    blob_id,
+                    completed_weight,
+                    total_weight,
+                } => {
+                    tracing::debug!(
+                        completed_weight,
+                        total_weight,
+                        blob_id,
+                        "child: sliver progress"
+                    );
+                    let bar = per_blob_bars.entry(blob_id.clone()).or_insert_with(|| {
+                        let pb = styled_progress_bar_with_disabled_steady_tick(total_weight);
+                        pb.disable_steady_tick();
+                        multi.add(pb)
+                    });
+                    bar.set_length(total_weight);
+                    bar.set_position(std::cmp::min(completed_weight, total_weight));
+                }
+                ChildUploaderEvent::QuorumReached {
+                    blob_id,
+                    extra_ms,
+                    elapsed_ms,
+                } => {
+                    tracing::debug!(elapsed_ms, "child: quorum elapsed");
+                    if let Some(pb) = per_blob_bars.get(&blob_id) {
+                        pb.finish_with_message(format!("slivers sent blob ({})", blob_id));
+                    }
+                    if let Ok(blob_id) = BlobId::from_str(&blob_id) {
+                        tracing::info!(
+                            %blob_id, extra_ms, "child: quorum reached; sending deferral notice");
+                        on_quorum(blob_id, std::time::Duration::from_millis(extra_ms)).await;
+                    } else {
+                        tracing::warn!(blob_id, "child: failed to parse blob_id");
+                    }
+                }
+                ChildUploaderEvent::V1Certified {
+                    blob_id,
+                    object_id,
+                    end_epoch,
+                    shared_object_id,
+                } => {
+                    tracing::info!(
+                        blob_id,
+                        object_id,
+                        ?end_epoch,
+                        ?shared_object_id,
+                        "certified blob on Sui"
+                    );
+                    certified_count += 1;
+                    if certified_count >= expected_blobs {
+                        tracing::info!(
+                            certified_count,
+                            expected_blobs,
+                            "child: all blobs certified; parent can exit"
+                        );
+                    }
+                }
+                ChildUploaderEvent::StoreDetailNewlyCreated {
+                    path,
+                    blob_id,
+                    object_id,
+                    deletable,
+                    unencoded_size,
+                    encoded_size,
+                    cost,
+                    end_epoch,
+                    shared_blob_object_id,
+                    encoding_type,
+                    operation_note,
+                } => {
+                    println!(
+                        "{} {} blob stored successfully.\n\
+                        \nPath: {}\n\
+                        Blob ID: {}\n\
+                        Object ID: {}\n\
+                        Deletable: {}\n\
+                        Unencoded Size: {}\n\
+                        Encoded Size: {}\n\
+                        Cost: {} {}\n\
+                        End Epoch: {}\n\
+                        Shared Blob Object ID: {}\n\
+                        Encoding Type: {}\n",
+                        "Store Detail".bold().walrus_purple(),
+                        if deletable {
+                            "(deletable)"
+                        } else {
+                            "(permanent)"
+                        },
+                        path,
+                        blob_id,
+                        object_id,
+                        deletable,
+                        HumanReadableBytes(unencoded_size),
+                        HumanReadableBytes(encoded_size),
+                        HumanReadableFrost::from(cost),
+                        operation_note,
+                        end_epoch,
+                        shared_blob_object_id.unwrap_or_else(|| "<none>".to_string()),
+                        encoding_type,
+                    );
+                }
+                ChildUploaderEvent::StoreDetailAlreadyCertified {
+                    path,
+                    blob_id,
+                    end_epoch,
+                    event_or_object,
+                } => {
+                    println!(
+                        "{} Blob already certified.\n\
+                        \nPath: {}\n\
+                        Blob ID: {}\n\
+                        End Epoch: {}\n\
+                        Event/Object: {}",
+                        "Store Detail".bold().walrus_purple(),
+                        path,
+                        blob_id,
+                        end_epoch,
+                        event_or_object,
+                    );
+                }
+                ChildUploaderEvent::Done {
+                    ok,
+                    error,
+                    newly_certified,
+                    reuse_and_extend_count,
+                    total_encoded_size,
+                    total_cost,
+                } => {
+                    tracing::debug!(?ok, ?error, "child: done event received");
+
+                    if newly_certified > 0 || reuse_and_extend_count > 0 {
+                        let mut parts = Vec::new();
+                        if newly_certified > 0 {
+                            parts.push(format!("{} newly certified", newly_certified));
+                        }
+                        if reuse_and_extend_count > 0 {
+                            parts.push(format!("{} extended", reuse_and_extend_count));
+                        }
+
+                        println!(
+                            "{} ({})",
+                            "Summary for Modified or Created Blobs"
+                                .bold()
+                                .walrus_purple(),
+                            parts.join(", ")
+                        );
+                        println!(
+                            "Total encoded size: {}",
+                            HumanReadableBytes(total_encoded_size)
+                        );
+                        println!("Total cost: {}", HumanReadableFrost::from(total_cost));
+                    } else {
+                        println!(
+                            "{}",
+                            "No blobs were modified or created".bold().walrus_purple()
+                        );
+                    }
+
+                    return;
+                }
+            },
+            Err(e) => {
+                tracing::debug!(%e, line = line, "child: failed to parse JSON line");
+            }
+        }
+    }
+
+    for (_, pb) in per_blob_bars.into_iter() {
+        pb.finish_and_clear();
+    }
+}
+
+/// Applies the common store child arguments to the command.
+/// This is used to configure the child process for the store command.
+fn apply_common_store_child_args(
+    cmd: &mut TokioCommand,
+    epoch_arg: &EpochArg,
+    dry_run: bool,
+    store_optimizations: &StoreOptimizations,
+    persistence: BlobPersistence,
+    post_store: PostStoreAction,
+    upload_mode: Option<UploadMode>,
+) {
+    if let Some(ref epochs) = epoch_arg.epochs {
+        match epochs {
+            super::args::EpochCountOrMax::Max => {
+                cmd.arg("--epochs").arg("max");
+            }
+            super::args::EpochCountOrMax::Epochs(count) => {
+                cmd.arg("--epochs").arg(count.to_string());
+            }
+        }
+    }
+
+    if let Some(time) = &epoch_arg.earliest_expiry_time {
+        let datetime: DateTime<Utc> = (*time).into();
+        cmd.arg("--earliest-expiry-time").arg(datetime.to_rfc3339());
+    }
+
+    if let Some(end_epoch) = &epoch_arg.end_epoch {
+        cmd.arg("--end-epoch").arg(end_epoch.to_string());
+    }
+
+    if dry_run {
+        cmd.arg("--dry-run");
+    }
+
+    if !store_optimizations.check_status {
+        cmd.arg("--force");
+    }
+
+    if !store_optimizations.reuse_resources {
+        cmd.arg("--ignore-resources");
+    }
+
+    match persistence {
+        BlobPersistence::Deletable => cmd.arg("--deletable"),
+        BlobPersistence::Permanent => cmd.arg("--permanent"),
+    };
+
+    if post_store == PostStoreAction::Share {
+        cmd.arg("--share");
+    }
+
+    if let Some(mode) = upload_mode {
+        cmd.arg("--upload-mode").arg(match mode {
+            UploadMode::Conservative => "conservative",
+            UploadMode::Balanced => "balanced",
+            UploadMode::Aggressive => "aggressive",
+        });
+    }
+}
+
+/// Spawns a child process to handle the upload of blobs.
+/// This is used to handle the upload of blobs in a separate child process.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn maybe_spawn_child_upload_process<F>(
+    client: &WalrusNodeClient<SuiContractClient>,
+    epoch_arg: &EpochArg,
+    dry_run: bool,
+    store_optimizations: &StoreOptimizations,
+    persistence: BlobPersistence,
+    post_store: PostStoreAction,
+    upload_mode: Option<UploadMode>,
+    upload_relay: Option<&Url>,
+    internal_run: bool,
+    command_name: &str,
+    add_command_args: F,
+    num_blobs: usize,
+) -> Result<Option<()>>
+where
+    F: FnOnce(&mut TokioCommand),
+{
+    let child_uploads_enabled = client
+        .config()
+        .communication_config
+        .child_process_uploads_enabled;
+    if !(child_uploads_enabled && upload_relay.is_none() && !internal_run) {
+        return Ok(None);
+    }
+
+    tracing::info!("Spawning child process for uploads");
+
+    let tmp_dir = env::temp_dir();
+    let config_filename = format!(
+        "walrus_child_config_{}_{}.yaml",
+        std::process::id(),
+        Utc::now().timestamp_millis()
+    );
+    let config_yaml_path = tmp_dir.join(config_filename);
+
+    if let Err(e) = stdfs::write(
+        &config_yaml_path,
+        serde_yaml::to_string(client.config()).context("serialize ClientConfig")?,
+    ) {
+        tracing::warn!(
+            error = %e,
+            "failed to write temp client config; falling back to single-process mode"
+        );
+        return Ok(None);
+    }
+
+    let exe = env::current_exe().unwrap_or_else(|_| PathBuf::from("walrus"));
+    let mut cmd = TokioCommand::new(exe);
+    cmd.env("INTERNAL_RUN", "true");
+    cmd.arg(command_name)
+        .arg("--internal-run")
+        .arg("--config")
+        .arg(&config_yaml_path);
+
+    apply_common_store_child_args(
+        &mut cmd,
+        epoch_arg,
+        dry_run,
+        store_optimizations,
+        persistence,
+        post_store,
+        upload_mode,
+    );
+
+    add_command_args(&mut cmd);
+    cmd.kill_on_drop(false);
+
+    match cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).spawn() {
+        Ok(mut child) => {
+            tracing::info!("Child process spawned successfully");
+
+            if let Some(stderr) = child.stderr.take() {
+                spawn_child_stderr_to_stderr(stderr);
+            }
+
+            if let Some(stdout) = child.stdout.take() {
+                process_child_stdout_events(
+                    stdout,
+                    |blob_id, extra| async move {
+                        tracing::info!(%blob_id, extra_ms = extra.as_millis(),
+                            "child quorum reached; tail uploads continuing");
+                    },
+                    num_blobs,
+                )
+                .await;
+
+                tracing::info!(concat!(
+                    "All blobs are now certified and the parent process is exiting, ",
+                    "the child continues tail uploads"
+                ));
+                return Ok(Some(()));
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "failed to spawn child process; falling back to single-process mode"
+            );
+        }
+    }
+
+    if let Err(e) = stdfs::remove_file(&config_yaml_path) {
+        tracing::warn!(error = %e, "failed to remove temp client config");
+    }
+
+    Ok(None)
+}
+
+/// A context for the internal run.
+/// This is used to handle the upload of blobs in a separate child process.
+#[derive(Default)]
+pub(crate) struct InternalRunContext {
+    /// A collector for the tail handles.
+    /// This is used to collect the tail handles from the child process.
+    tail_handle_collector: Option<Arc<TokioMutex<Vec<tokio::task::JoinHandle<()>>>>>,
+    /// A sender for the uploader events.
+    /// This is used to send the uploader events to the child process.
+    uploader_event_tx: Option<tokio::sync::mpsc::Sender<UploaderEvent>>,
+    /// A task for the event forwarding.
+    /// This is used to forward the events from the child process to the parent process.
+    event_task: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl InternalRunContext {
+    pub(crate) fn new(
+        internal_run: bool,
+        client: &WalrusNodeClient<SuiContractClient>,
+        num_items: usize,
+    ) -> Self {
+        if !internal_run {
+            return Self::default();
+        }
+
+        let collector = Arc::new(TokioMutex::new(Vec::new()));
+        let (tx, rx) = mpsc_channel(num_items.max(1));
+
+        let communication_config = client.config().communication_config.clone();
+        let event_task = tokio::spawn(async move {
+            let mut rx = rx;
+            while let Some(event) = rx.recv().await {
+                match event {
+                    UploaderEvent::BlobProgress {
+                        blob_id,
+                        completed_weight,
+                        required_weight,
+                    } => {
+                        tracing::debug!(%blob_id, completed_weight, required_weight,
+                            "child: forwarding progress event to parent");
+                        if let Err(err) = emit_child_event(&ChildUploaderEvent::SliverProgress {
+                            blob_id: blob_id.to_string(),
+                            completed_weight: completed_weight as u64,
+                            total_weight: required_weight as u64,
+                        }) {
+                            tracing::warn!(%err, "failed to emit progress event");
+                        }
+                    }
+                    UploaderEvent::BlobQuorumReached { blob_id, elapsed } => {
+                        let extra_duration = communication_config
+                            .sliver_write_extra_time
+                            .extra_time(elapsed);
+                        let elapsed_ms = u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX);
+                        let extra_ms =
+                            u64::try_from(extra_duration.as_millis()).unwrap_or(u64::MAX);
+                        tracing::debug!(%blob_id, elapsed_ms, extra_ms,
+                            "child: forwarding quorum event to parent");
+                        if let Err(err) = emit_child_event(&ChildUploaderEvent::QuorumReached {
+                            blob_id: blob_id.to_string(),
+                            elapsed_ms,
+                            extra_ms,
+                        }) {
+                            tracing::warn!(%err, "failed to emit quorum event");
+                        }
+                    }
+                }
+            }
+            tracing::debug!("child: quorum forwarding task completed");
+        });
+
+        InternalRunContext {
+            tail_handle_collector: Some(collector),
+            uploader_event_tx: Some(tx),
+            event_task: Some(event_task),
+        }
+    }
+
+    /// Configures the store arguments for the internal run.
+    /// This is used to configure the store arguments for the internal run.
+    pub(crate) fn configure_store_args(
+        &self,
+        internal_run: bool,
+        mut store_args: StoreArgs,
+    ) -> StoreArgs {
+        if let Some(collector) = self.tail_handle_collector.as_ref() {
+            store_args = store_args.with_tail_handle_collector(collector.clone());
+        }
+        if let Some(tx) = self.uploader_event_tx.as_ref() {
+            store_args = store_args.with_quorum_event_tx(tx.clone());
+        }
+        if internal_run {
+            store_args = store_args.with_tail_handling(TailHandling::Detached);
+        }
+        store_args
+    }
+
+    /// Finalizes the store arguments for the internal run.
+    pub(crate) async fn finalize_after_store(&mut self, store_args: &mut StoreArgs) {
+        if let Some(tx) = self.uploader_event_tx.take() {
+            tracing::debug!("child: closing uploader event channel");
+            drop(tx);
+        }
+
+        store_args.quorum_event_tx = None;
+        store_args.tail_handle_collector = None;
+
+        if let Some(task) = self.event_task.take() {
+            tracing::debug!("child: awaiting quorum forwarding task");
+            if let Err(err) = task.await {
+                tracing::warn!(?err, "uploader event task terminated with error");
+            }
+        }
+    }
+
+    /// Awaits the tail handles for the internal run.
+    /// This is used to await the tail handles for the internal run.
+    pub(crate) async fn await_tail_handles(&mut self) {
+        if let Some(collector) = self.tail_handle_collector.take() {
+            let mut handles = collector.lock().await;
+            while let Some(handle) = handles.pop() {
+                tracing::debug!("child: awaiting detached tail handle");
+                if let Err(err) = handle.await {
+                    tracing::warn!(?err, "tail upload task failed");
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::VecDeque,
+        io::Cursor,
+        sync::{Arc, Mutex},
+    };
+
+    use tokio::io::BufReader;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn process_child_events_handles_progress_quorum_and_done() -> Result<()> {
+        let blob_id = "4BKcDC0Ih5RJ8R0tFMz3MZVNZV8b2goT6_JiEEwNHQo";
+        let started = serde_json::json!({
+            "type": "started",
+            "blob_id": blob_id,
+        });
+        let progress = serde_json::json!({
+            "type": "sliver_progress",
+            "blob_id": blob_id,
+            "completed_weight": 2,
+            "total_weight": 6,
+        });
+        let quorum = serde_json::json!({
+            "type": "quorum_reached",
+            "blob_id": blob_id,
+            "elapsed_ms": 5,
+            "extra_ms": 10,
+        });
+        let cert = serde_json::json!({
+            "type": "v1_certified",
+            "blob_id": blob_id,
+            "object_id": "0x1234",
+            "end_epoch": 123,
+            "shared_object_id": null,
+        });
+        let done = serde_json::json!({
+            "type": "done",
+            "ok": true,
+            "error": null,
+        });
+        let json = vec![started, progress, quorum, cert, done]
+            .into_iter()
+            .map(|v| v.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let seen: Arc<Mutex<VecDeque<(BlobId, u64)>>> = Arc::new(Mutex::new(VecDeque::new()));
+        let reader = BufReader::new(Cursor::new(json));
+
+        process_child_stdout_reader(
+            reader,
+            {
+                let seen = seen.clone();
+                move |blob, extra| {
+                    let seen = seen.clone();
+                    async move {
+                        seen.lock().unwrap().push_back((
+                            blob,
+                            u64::try_from(extra.as_millis()).expect("extra is not a millisecond"),
+                        ));
+                    }
+                }
+            },
+            1,
+        )
+        .await;
+
+        let guard = seen.lock().unwrap();
+        assert_eq!(guard.len(), 1);
+        let (observed_blob, extra_ms) = guard.front().unwrap();
+        assert_eq!(observed_blob, &BlobId::from_str(blob_id)?);
+        assert_eq!(*extra_ms, 10);
+
+        Ok(())
+    }
+}

--- a/crates/walrus-service/src/client/cli/runner.rs
+++ b/crates/walrus-service/src/client/cli/runner.rs
@@ -19,6 +19,7 @@ use indicatif::MultiProgress;
 use itertools::Itertools as _;
 use rand::seq::SliceRandom;
 use reqwest::Url;
+use serde_json;
 use sui_config::{SUI_CLIENT_CONFIG, sui_config_dir};
 use sui_types::base_types::ObjectID;
 use walrus_core::{
@@ -50,9 +51,10 @@ use walrus_sdk::{
             read_blobs_from_paths,
         },
         resource::RegisterBlobOp,
+        responses as sdk_responses,
         upload_relay_client::UploadRelayClient,
     },
-    config::{UploadMode, load_configuration},
+    config::{UploadMode, UploadPreset, load_configuration},
     error::ClientErrorKind,
     store_optimizations::StoreOptimizations,
     sui::{
@@ -113,6 +115,14 @@ use crate::{
             get_contract_client,
             get_read_client,
             get_sui_read_client_from_rpc_node_or_wallet,
+            internal_run::{
+                ChildUploaderEvent,
+                InternalRunContext,
+                emit_child_event,
+                emit_v1_certified_event,
+                maybe_spawn_child_upload_process,
+                quilt_blob_input_to_cli_arg,
+            },
             success,
             warning,
         },
@@ -151,7 +161,13 @@ fn apply_upload_mode_to_config(
     mut config: walrus_sdk::config::ClientConfig,
     upload_mode: UploadMode,
 ) -> walrus_sdk::config::ClientConfig {
-    config.communication_config = upload_mode.apply_to(config.communication_config.clone());
+    // Use UploadPreset to apply tuning to the communication config
+    let preset = match upload_mode {
+        UploadMode::Conservative => UploadPreset::Conservative,
+        UploadMode::Balanced => UploadPreset::Balanced,
+        UploadMode::Aggressive => UploadPreset::Aggressive,
+    };
+    config.communication_config = preset.apply_to(config.communication_config.clone());
     config
 }
 
@@ -682,6 +698,7 @@ impl ClientCommandRunner {
             upload_relay,
             confirmation,
             upload_mode,
+            internal_run,
         }: StoreOptions,
     ) -> Result<()> {
         epoch_arg.exactly_one_is_some()?;
@@ -698,7 +715,7 @@ impl ClientCommandRunner {
 
         let system_object = client.sui_client().read_client.get_system_object().await?;
         let epochs_ahead =
-            get_epochs_ahead(epoch_arg, system_object.max_epochs_ahead(), &client).await?;
+            get_epochs_ahead(&epoch_arg, system_object.max_epochs_ahead(), &client).await?;
 
         if persistence.is_deletable() && post_store == PostStoreAction::Share {
             anyhow::bail!("deletable blobs cannot be shared");
@@ -721,13 +738,39 @@ impl ClientCommandRunner {
                 .collect::<Result<Vec<(PathBuf, Vec<u8>)>>>()
         })?;
 
-        let mut store_args = StoreArgs::new(
+        if let Some(()) = maybe_spawn_child_upload_process(
+            &client,
+            &epoch_arg,
+            dry_run,
+            &store_optimizations,
+            persistence,
+            post_store,
+            upload_mode,
+            upload_relay.as_ref(),
+            internal_run,
+            "store",
+            |cmd| {
+                for (path, _) in &blobs {
+                    cmd.arg(path);
+                }
+            },
+            blobs.len(),
+        )
+        .await?
+        {
+            return Ok(());
+        }
+
+        let base_store_args = StoreArgs::new(
             encoding_type,
             epochs_ahead,
             store_optimizations,
             persistence,
             post_store,
         );
+
+        let mut internal_run_ctx = InternalRunContext::new(internal_run, &client, blobs.len());
+        let mut store_args = internal_run_ctx.configure_store_args(internal_run, base_store_args);
 
         if let Some(upload_relay) = upload_relay {
             let upload_relay_client = UploadRelayClient::new(
@@ -757,6 +800,9 @@ impl ClientCommandRunner {
         let results = client
             .reserve_and_store_blobs_retry_committees_with_path(&blobs, &store_args)
             .await?;
+
+        internal_run_ctx.finalize_after_store(&mut store_args).await;
+
         let blobs_len = blobs.len();
         if results.len() != blobs_len {
             let not_stored = results
@@ -772,12 +818,122 @@ impl ClientCommandRunner {
                     .join(", ")
             );
         }
-        tracing::info!(
-            duration = ?start_timer.elapsed(),
-            "{} out of {} blobs stored",
-            results.len(),
-            blobs_len
-        );
+
+        if internal_run {
+            for result in &results {
+                if let Err(err) = emit_v1_certified_event(&result.blob_store_result) {
+                    tracing::warn!(%err, "failed to emit certification event");
+                }
+
+                match &result.blob_store_result {
+                    sdk_responses::BlobStoreResult::NewlyCreated {
+                        blob_object,
+                        resource_operation,
+                        cost,
+                        shared_blob_object,
+                    } => {
+                        let operation_note = match resource_operation {
+                            RegisterBlobOp::RegisterFromScratch { .. } => {
+                                "(storage was purchased, and a new blob object was registered)"
+                                    .to_string()
+                            }
+                            RegisterBlobOp::ReuseStorage { .. } => concat!(
+                                "(already-owned storage was reused, and a ",
+                                "new blob object was registered)"
+                            )
+                            .to_string(),
+                            RegisterBlobOp::ReuseAndExtend { .. } => {
+                                "(previous storage was extended)".to_string()
+                            }
+                            RegisterBlobOp::ReuseAndExtendNonCertified { .. } => {
+                                "(non-certified storage was extended)".to_string()
+                            }
+                            RegisterBlobOp::ReuseRegistration { .. } => {
+                                "(existing registration reused)".to_string()
+                            }
+                        };
+
+                        let event = ChildUploaderEvent::StoreDetailNewlyCreated {
+                            path: result.path.display().to_string(),
+                            blob_id: blob_object.blob_id.to_string(),
+                            object_id: blob_object.id.to_string(),
+                            deletable: blob_object.deletable,
+                            unencoded_size: blob_object.size,
+                            encoded_size: resource_operation.encoded_length(),
+                            cost: *cost,
+                            end_epoch: u64::from(blob_object.storage.end_epoch),
+                            shared_blob_object_id: shared_blob_object
+                                .as_ref()
+                                .map(|id| id.to_string()),
+                            encoding_type: blob_object.encoding_type.to_string(),
+                            operation_note,
+                        };
+                        if let Err(err) = emit_child_event(&event) {
+                            tracing::warn!(%err, "failed to emit store detail (new)");
+                        }
+                    }
+                    sdk_responses::BlobStoreResult::AlreadyCertified {
+                        blob_id,
+                        event_or_object,
+                        end_epoch,
+                    } => {
+                        let event = ChildUploaderEvent::StoreDetailAlreadyCertified {
+                            path: result.path.display().to_string(),
+                            blob_id: blob_id.to_string(),
+                            end_epoch: u64::from(*end_epoch),
+                            event_or_object: event_or_object.to_string(),
+                        };
+                        if let Err(err) = emit_child_event(&event) {
+                            tracing::warn!(%err, "failed to emit store detail (already)");
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
+            let mut total_encoded_size: u64 = 0;
+            let mut total_cost: u64 = 0;
+            let mut reuse_and_extend_count: u64 = 0;
+            let mut newly_certified: u64 = 0;
+            for res in &results {
+                if let sdk_responses::BlobStoreResult::NewlyCreated {
+                    resource_operation,
+                    cost,
+                    ..
+                } = &res.blob_store_result
+                {
+                    total_encoded_size += resource_operation.encoded_length();
+                    total_cost += *cost;
+                    match resource_operation {
+                        RegisterBlobOp::ReuseAndExtend { .. } => reuse_and_extend_count += 1,
+                        RegisterBlobOp::RegisterFromScratch { .. }
+                        | RegisterBlobOp::ReuseAndExtendNonCertified { .. }
+                        | RegisterBlobOp::ReuseStorage { .. }
+                        | RegisterBlobOp::ReuseRegistration { .. } => newly_certified += 1,
+                    }
+                }
+            }
+
+            if let Err(err) = emit_child_event(&ChildUploaderEvent::Done {
+                ok: true,
+                error: None,
+                newly_certified,
+                reuse_and_extend_count,
+                total_encoded_size,
+                total_cost,
+            }) {
+                tracing::warn!(%err, "failed to emit completion event");
+            }
+            internal_run_ctx.await_tail_handles().await;
+        } else {
+            tracing::info!(
+                duration = ?start_timer.elapsed(),
+                "{} out of {} blobs stored",
+                results.len(),
+                blobs_len
+            );
+        }
+
         results.print_output(self.json)
     }
 
@@ -837,6 +993,7 @@ impl ClientCommandRunner {
             upload_relay,
             confirmation,
             upload_mode,
+            internal_run,
         }: StoreOptions,
     ) -> Result<()> {
         epoch_arg.exactly_one_is_some()?;
@@ -857,7 +1014,23 @@ impl ClientCommandRunner {
 
         let system_object = client.sui_client().read_client.get_system_object().await?;
         let epochs_ahead =
-            get_epochs_ahead(epoch_arg, system_object.max_epochs_ahead(), &client).await?;
+            get_epochs_ahead(&epoch_arg, system_object.max_epochs_ahead(), &client).await?;
+
+        let path_args_for_child = if paths.is_empty() {
+            None
+        } else {
+            Some(paths.clone())
+        };
+        let blob_cli_args = if blobs.is_empty() {
+            None
+        } else {
+            Some(
+                blobs
+                    .iter()
+                    .map(quilt_blob_input_to_cli_arg)
+                    .collect::<Result<Vec<_>>>()?,
+            )
+        };
 
         let quilt_store_blobs = Self::load_blobs_for_quilt(&paths, blobs).await?;
 
@@ -872,18 +1045,52 @@ impl ClientCommandRunner {
             .await;
         }
 
+        if let Some(()) = maybe_spawn_child_upload_process(
+            &client,
+            &epoch_arg,
+            dry_run,
+            &store_optimizations,
+            persistence,
+            post_store,
+            upload_mode,
+            upload_relay.as_ref(),
+            internal_run,
+            "store-quilt",
+            move |cmd| {
+                if let Some(path_args) = path_args_for_child.as_ref() {
+                    cmd.arg("--paths");
+                    for path in path_args {
+                        cmd.arg(path);
+                    }
+                } else if let Some(blob_args) = blob_cli_args.as_ref() {
+                    cmd.arg("--blobs");
+                    for arg in blob_args {
+                        cmd.arg(arg);
+                    }
+                }
+            },
+            1,
+        )
+        .await?
+        {
+            return Ok(());
+        }
+
         let start_timer = std::time::Instant::now();
         let quilt_write_client = client.quilt_client();
         let quilt = quilt_write_client
             .construct_quilt::<QuiltVersionV1>(&quilt_store_blobs, encoding_type)
             .await?;
-        let mut store_args = StoreArgs::new(
+        let base_store_args = StoreArgs::new(
             encoding_type,
             epochs_ahead,
             store_optimizations,
             persistence,
             post_store,
         );
+
+        let mut internal_run_ctx = InternalRunContext::new(internal_run, &client, 1);
+        let mut store_args = internal_run_ctx.configure_store_args(internal_run, base_store_args);
 
         if let Some(upload_relay) = upload_relay {
             let upload_relay_client = UploadRelayClient::new(
@@ -914,11 +1121,118 @@ impl ClientCommandRunner {
             .reserve_and_store_quilt::<QuiltVersionV1>(&quilt, &store_args)
             .await?;
 
-        tracing::info!(
-            duration = ?start_timer.elapsed(),
-            "{} blobs stored in quilt",
-            result.stored_quilt_blobs.len(),
-        );
+        internal_run_ctx.finalize_after_store(&mut store_args).await;
+
+        if !internal_run {
+            tracing::info!(
+                duration = ?start_timer.elapsed(),
+                "{} blobs stored in quilt",
+                result.stored_quilt_blobs.len(),
+            );
+        }
+
+        if internal_run {
+            if let Err(err) = emit_v1_certified_event(&result.blob_store_result) {
+                tracing::warn!(%err, "failed to emit certification event");
+            }
+
+            match &result.blob_store_result {
+                sdk_responses::BlobStoreResult::NewlyCreated {
+                    blob_object,
+                    resource_operation,
+                    cost,
+                    shared_blob_object,
+                } => {
+                    let operation_note = match resource_operation {
+                        RegisterBlobOp::RegisterFromScratch { .. } => {
+                            "(storage was purchased, and a new blob object was registered)"
+                                .to_string()
+                        }
+                        RegisterBlobOp::ReuseStorage { .. } => concat!(
+                            "(already-owned storage was reused, and a new blob ",
+                            "object was registered)"
+                        )
+                        .to_string(),
+                        RegisterBlobOp::ReuseAndExtend { .. } => {
+                            "(the blob was extended in lifetime)".to_string()
+                        }
+                        RegisterBlobOp::ReuseAndExtendNonCertified { .. } => {
+                            "(non-certified storage was extended)".to_string()
+                        }
+                        RegisterBlobOp::ReuseRegistration { .. } => {
+                            "(existing registration reused)".to_string()
+                        }
+                    };
+
+                    let event = ChildUploaderEvent::StoreDetailNewlyCreated {
+                        path: "<quilt>".to_string(),
+                        blob_id: blob_object.blob_id.to_string(),
+                        object_id: blob_object.id.to_string(),
+                        deletable: blob_object.deletable,
+                        unencoded_size: blob_object.size,
+                        encoded_size: resource_operation.encoded_length(),
+                        cost: *cost,
+                        end_epoch: u64::from(blob_object.storage.end_epoch),
+                        shared_blob_object_id: shared_blob_object.as_ref().map(|id| id.to_string()),
+                        encoding_type: blob_object.encoding_type.to_string(),
+                        operation_note,
+                    };
+                    if let Err(err) = emit_child_event(&event) {
+                        tracing::warn!(%err, "failed to emit store detail (new)");
+                    }
+                }
+                sdk_responses::BlobStoreResult::AlreadyCertified {
+                    blob_id,
+                    event_or_object,
+                    end_epoch,
+                } => {
+                    let event = ChildUploaderEvent::StoreDetailAlreadyCertified {
+                        path: "<quilt>".to_string(),
+                        blob_id: blob_id.to_string(),
+                        end_epoch: u64::from(*end_epoch),
+                        event_or_object: event_or_object.to_string(),
+                    };
+                    if let Err(err) = emit_child_event(&event) {
+                        tracing::warn!(%err, "failed to emit store detail (already)");
+                    }
+                }
+                _ => {}
+            }
+
+            let (total_encoded_size, total_cost, newly_certified, reuse_and_extend_count) =
+                match &result.blob_store_result {
+                    sdk_responses::BlobStoreResult::NewlyCreated {
+                        resource_operation,
+                        cost,
+                        ..
+                    } => {
+                        let encoded = resource_operation.encoded_length();
+                        let cost = *cost;
+                        let (newly_certified, reuse_and_extend_count) = match resource_operation {
+                            RegisterBlobOp::ReuseAndExtend { .. } => (0, 1),
+                            RegisterBlobOp::RegisterFromScratch { .. }
+                            | RegisterBlobOp::ReuseAndExtendNonCertified { .. }
+                            | RegisterBlobOp::ReuseStorage { .. }
+                            | RegisterBlobOp::ReuseRegistration { .. } => (1, 0),
+                        };
+                        (encoded, cost, newly_certified, reuse_and_extend_count)
+                    }
+                    _ => (0, 0, 0, 0),
+                };
+
+            if let Err(err) = emit_child_event(&ChildUploaderEvent::Done {
+                ok: true,
+                error: None,
+                newly_certified,
+                reuse_and_extend_count,
+                total_encoded_size,
+                total_cost,
+            }) {
+                tracing::warn!(%err, "failed to emit completion event");
+            }
+
+            internal_run_ctx.await_tail_handles().await;
+        }
 
         result.print_output(self.json)
     }
@@ -1617,6 +1931,7 @@ struct StoreOptions {
     upload_relay: Option<Url>,
     confirmation: UserConfirmation,
     upload_mode: Option<UploadMode>,
+    internal_run: bool,
 }
 
 impl TryFrom<CommonStoreOptions> for StoreOptions {
@@ -1635,6 +1950,7 @@ impl TryFrom<CommonStoreOptions> for StoreOptions {
             upload_relay,
             skip_tip_confirmation,
             upload_mode,
+            internal_run,
         }: CommonStoreOptions,
     ) -> Result<Self, Self::Error> {
         Ok(Self {
@@ -1650,6 +1966,7 @@ impl TryFrom<CommonStoreOptions> for StoreOptions {
             upload_relay,
             confirmation: skip_tip_confirmation.into(),
             upload_mode: upload_mode.map(Into::into),
+            internal_run,
         })
     }
 }
@@ -1757,7 +2074,7 @@ async fn delete_blob(
 
 #[tracing::instrument(skip_all)]
 async fn get_epochs_ahead(
-    epoch_arg: EpochArg,
+    epoch_arg: &EpochArg,
     max_epochs_ahead: EpochCount,
     client: &WalrusNodeClient<SuiContractClient>,
 ) -> Result<u32, anyhow::Error> {
@@ -1765,7 +2082,7 @@ async fn get_epochs_ahead(
         EpochArg {
             epochs: Some(epochs),
             ..
-        } => epochs.try_into_epoch_count(max_epochs_ahead)?,
+        } => epochs.clone().try_into_epoch_count(max_epochs_ahead)?,
         EpochArg {
             earliest_expiry_time: Some(earliest_expiry_time),
             ..
@@ -1777,7 +2094,7 @@ async fn get_epochs_ahead(
                 | EpochState::NextParamsSelected(epoch_start) => *epoch_start,
                 EpochState::EpochChangeSync(_) => Utc::now(),
             };
-            let earliest_expiry_ts = DateTime::from(earliest_expiry_time);
+            let earliest_expiry_ts: DateTime<Utc> = (*earliest_expiry_time).into();
             ensure!(
                 earliest_expiry_ts > estimated_start_of_current_epoch
                     && earliest_expiry_ts > Utc::now(),
@@ -1796,10 +2113,10 @@ async fn get_epochs_ahead(
         } => {
             let current_epoch = client.sui_client().current_epoch().await?;
             ensure!(
-                end_epoch > current_epoch,
+                *end_epoch > current_epoch,
                 "end_epoch must be greater than the current epoch"
             );
-            end_epoch - current_epoch
+            *end_epoch - current_epoch
         }
         _ => {
             anyhow::bail!("either epochs or earliest_expiry_time or end_epoch must be provided")

--- a/crates/walrus-sui/src/config.rs
+++ b/crates/walrus-sui/src/config.rs
@@ -13,7 +13,10 @@ use serde::{Deserialize, Serialize};
 use sui_keys::keystore::AccountKeystore;
 use sui_sdk::wallet_context::WalletContext;
 use sui_types::base_types::SuiAddress;
-use walrus_utils::config::{path_or_defaults_if_exist, resolve_home_dir, resolve_home_dir_option};
+use walrus_utils::{
+    config::{path_or_defaults_if_exist, resolve_home_dir, resolve_home_dir_option},
+    is_internal_run,
+};
 
 use crate::wallet::Wallet;
 
@@ -109,7 +112,9 @@ impl WalletConfig {
 
         let path = path_or_defaults_if_exist(wallet_config.and_then(|c| c.path()), &default_paths)
             .ok_or(anyhow!("could not find a valid wallet config file"))?;
-        tracing::info!("using Sui wallet configuration from '{}'", path.display());
+        if !is_internal_run() {
+            tracing::info!("using Sui wallet configuration from '{}'", path.display());
+        }
         let mut wallet_context: WalletContext = WalletContext::new(&path)?;
         if let Some(request_timeout) = request_timeout {
             wallet_context = wallet_context.with_request_timeout(request_timeout);

--- a/crates/walrus-utils/src/lib.rs
+++ b/crates/walrus-utils/src/lib.rs
@@ -3,7 +3,7 @@
 
 #![allow(missing_docs)]
 
-use std::{fs, path::Path};
+use std::{env, fs, path::Path};
 
 use anyhow::Context;
 use serde::de::DeserializeOwned;
@@ -37,6 +37,13 @@ pub mod tests {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(Mutex::default)
     }
+}
+
+#[inline]
+pub fn is_internal_run() -> bool {
+    env::var("INTERNAL_RUN")
+        .map(|v| v == "true")
+        .unwrap_or(false)
 }
 
 /// Load the config from a YAML file located at the provided path.


### PR DESCRIPTION
## Description

This PR adds a config option on the client to optionally perform sliver uploads through a background process in the cli. The main changes are in `internal_run.rs` and `runner.rs`. 
In `internal_run.rs` - we add all the scaffolding to spawn a new child process and do event passing b/w uploader and parent.
In `runner.rs` - we spawn child process if it is enabled in the config for both `store` and `store_quilt` commands

## Test plan

Running locally several times yield expected results.
