### PR TITLE
chore: ensure that contracts builds are clean prior to local-testbed bringup

### DIFF
--- a/scripts/local-testbed.sh
+++ b/scripts/local-testbed.sh
@@ -170,6 +170,7 @@ cleanup=
 
 if ! $use_existing_config; then
   # Cleanup
+  find contracts -name 'build' -type d -exec rm -rf {} +
   rm -f $working_dir/dryrun-node-*.yaml
   cleanup="--cleanup-storage"
 


### PR DESCRIPTION
## Description

During usage of the local-testbed.sh script, I noticed that contracts weren't always getting rebuilt. This change will ensure that they are (might be overkill, but just erring on the side of safety in a non-perf critical codepath.)

## Test plan

Manually tested.