### PR TITLE
test: disable Sui execution time injection in Walrus antithesis test

### DIFF
--- a/docker/walrus-antithesis/build-test-config-image/docker-compose.yaml
+++ b/docker/walrus-antithesis/build-test-config-image/docker-compose.yaml
@@ -19,11 +19,18 @@ services:
     environment:
       - NO_COLOR=1
       - SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE=mainnet # Always use sui mainnet protocol config.
+      - ANTITHESIS_ENABLE_EXECUTION_TIME_INJECTION=false # Disable execution time injection to avoid artificial congestion control.
     command: >
       /bin/sh -c "cp /usr/local/bin/sui /root/sui_bin/ && \
-      sui start --with-faucet --force-regenesis --committee-size 3 --epoch-duration-ms 86400000"
+      sui start --with-faucet --force-regenesis --committee-size 1 --epoch-duration-ms 86400000"
     healthcheck:
-      test: ["CMD", "/bin/bash", "-c", "echo > /dev/tcp/127.0.0.1/9123 && echo > /dev/tcp/127.0.0.1/9000"]
+      test:
+        [
+          "CMD",
+          "/bin/bash",
+          "-c",
+          "echo > /dev/tcp/127.0.0.1/9123 && echo > /dev/tcp/127.0.0.1/9000",
+        ]
       interval: 10s
       timeout: 10s
       retries: 10


### PR DESCRIPTION
## Description

Current artificial added execution time causes congestion control to kick in. 

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
