### PR TITLE
chore: simplify rpc client in fallible rpc client

### DIFF
--- a/crates/walrus-service/src/client/cli/runner.rs
+++ b/crates/walrus-service/src/client/cli/runner.rs
@@ -1866,9 +1866,8 @@ async fn get_latest_checkpoint_sequence_number(
 
     // Now url is a String, not an Option<String>
     let rpc_client_result = rpc_client::create_sui_rpc_client(&url);
-    if let Ok(rpc_client) = rpc_client_result {
-        let mut client = (*rpc_client).clone();
-        match client.get_latest_checkpoint().await {
+    if let Ok(mut rpc_client) = rpc_client_result {
+        match rpc_client.get_latest_checkpoint().await {
             Ok(checkpoint) => Some(checkpoint.sequence_number),
             Err(e) => {
                 eprintln!("Failed to get latest checkpoint: {e}");

--- a/crates/walrus-simtest/tests/simtest_failure.rs
+++ b/crates/walrus-simtest/tests/simtest_failure.rs
@@ -825,12 +825,11 @@ mod tests {
         tokio::time::sleep(Duration::from_secs(30)).await;
 
         // Get the latest checkpoint from Sui.
-        let rpc_client = rpc_client::create_sui_rpc_client(
+        let mut rpc_client = rpc_client::create_sui_rpc_client(
             &sui_cluster.lock().await.additional_rpc_urls()[0].clone(),
         )
         .expect("Failed to create RPC client");
-        let mut client = (*rpc_client).clone();
-        let latest_sui_checkpoint = client
+        let latest_sui_checkpoint = rpc_client
             .get_latest_checkpoint()
             .await
             .expect("Failed to get latest checkpoint from Sui");

--- a/crates/walrus-sui/src/client/retry_client/fallible.rs
+++ b/crates/walrus-sui/src/client/retry_client/fallible.rs
@@ -24,7 +24,7 @@ pub struct FallibleRpcClient {
     /// The RPC URL.
     rpc_url: String,
     /// The underlying RPC client.
-    client: Arc<RwLock<Arc<RpcClient>>>,
+    client: Arc<RwLock<RpcClient>>,
     /// The instant of the last successful RPC call.
     last_success: AtomicInstant,
     /// The number of failures since the last successful RPC call.
@@ -49,7 +49,7 @@ impl FallibleRpcClient {
     }
 
     /// Returns the underlying RPC client.
-    pub async fn inner(&self) -> Arc<RpcClient> {
+    pub async fn inner(&self) -> RpcClient {
         self.client.read().await.clone()
     }
 
@@ -61,7 +61,7 @@ impl FallibleRpcClient {
     /// Calls the underlying RPC client with the given function.
     pub async fn call<F, Fut, T>(&self, f: F, timeout: Duration) -> Result<T, tonic::Status>
     where
-        F: FnOnce(Arc<RpcClient>) -> Fut,
+        F: FnOnce(RpcClient) -> Fut,
         Fut: Future<Output = Result<T, tonic::Status>>,
     {
         let client = self.client.read().await;

--- a/crates/walrus-sui/src/client/rpc_client.rs
+++ b/crates/walrus-sui/src/client/rpc_client.rs
@@ -3,14 +3,12 @@
 
 //! Module for the RPC client.
 
-use std::sync::Arc;
-
 use sui_rpc_api::Client as RpcClient;
 
 use crate::client::rpc_config::{RpcAuthConfig, RpcEndpointAuth};
 
 /// Creates a new RPC client with authentication if configured
-fn create_client(rpc_url: &str, auth_config: &RpcAuthConfig) -> anyhow::Result<Arc<RpcClient>> {
+fn create_client(rpc_url: &str, auth_config: &RpcAuthConfig) -> anyhow::Result<RpcClient> {
     let mut client = RpcClient::new(rpc_url.to_string())?;
 
     let auth_config = auth_config.get_auth_for_url(rpc_url);
@@ -23,16 +21,16 @@ fn create_client(rpc_url: &str, auth_config: &RpcAuthConfig) -> anyhow::Result<A
                 tracing::debug!("Configuring bearer token authentication for RPC client");
                 sui_rpc_api::client::AuthInterceptor::bearer(token)
             } else {
-                return Ok(Arc::new(client));
+                return Ok(client);
             };
         client = client.with_auth(auth_interceptor);
     }
 
-    Ok(Arc::new(client))
+    Ok(client)
 }
 
 /// Creates a new RPC client with authentication if configured from environment variables
-pub fn create_sui_rpc_client(rpc_url: &str) -> anyhow::Result<Arc<RpcClient>> {
+pub fn create_sui_rpc_client(rpc_url: &str) -> anyhow::Result<RpcClient> {
     let auth_config = RpcAuthConfig::from_environment();
     create_client(rpc_url, &auth_config)
 }


### PR DESCRIPTION
## Description

It turns out the `sui_rpc_api::client::Client` is already `Send + Sync + Clone` so we don't need to wrap it in `Arc<_>`.

## Test plan

Compilation and tests.
