### PR TITLE
fix: set default aggregator request buffer size correctly

### DIFF
--- a/crates/walrus-service/src/client/cli/args.rs
+++ b/crates/walrus-service/src/client/cli/args.rs
@@ -895,7 +895,7 @@ pub struct AggregatorArgs {
     #[serde(default)]
     pub max_blob_size: Option<u64>,
     /// The maximum number of requests that can be buffered before the server starts rejecting new
-    /// ones.
+    /// ones. Note that this includes the number of requests that are being processed currently.
     #[arg(long = "max-buffer-size", default_value_t = default::max_aggregator_buffer_size())]
     #[serde(default = "default::max_aggregator_buffer_size")]
     pub max_request_buffer_size: usize,
@@ -1901,7 +1901,7 @@ pub(crate) mod default {
     }
 
     pub(crate) fn max_aggregator_buffer_size() -> usize {
-        128
+        320 // 256 + 64
     }
 }
 

--- a/crates/walrus-service/src/client/daemon.rs
+++ b/crates/walrus-service/src/client/daemon.rs
@@ -701,7 +701,7 @@ mod tests {
 
         // Configure very low limits to easily trigger rate limiting
         let max_concurrent = 2;
-        let max_buffer = 1;
+        let max_buffer = 3;
         let num_requests = 5; // More than max_concurrent + max_buffer
 
         // Create mock client with slow responses
@@ -777,12 +777,13 @@ mod tests {
             "Total responses should equal number of requests"
         );
 
-        // The number of successful requests should not exceed max_concurrent + max_buffer
+        // The number of successful requests should be the same as max_buffer. Note that this
+        //includes the number of requests that are being processed currently.
         assert!(
-            success_count <= max_concurrent + max_buffer,
-            "Success count {} should not exceed max_concurrent + max_buffer = {}",
+            success_count == max_buffer,
+            "Success count {} should be the same as max_buffer {}",
             success_count,
-            max_concurrent + max_buffer
+            max_buffer
         );
 
         // Ensure no requests are still active


### PR DESCRIPTION
## Description

I dig into one of @giac-mysten's [comment](https://github.com/MystenLabs/walrus/pull/2628#discussion_r2444865178), and realized that I understood `buffer` completely wrong. I thought it meant `additional` requests, which is also implied from the BufferLayer doc, but it actually also includes the current being service requests.

This PR fix the default (needs to be greater than the max concurrent limit), and update the test to use the correct assertion. Thanks for catching this @giac-mysten !

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
