### PR TITLE
fix: Increase request timeout to support large blobs

### DIFF
--- a/crates/walrus-sdk/client_config_example.yaml
+++ b/crates/walrus-sdk/client_config_example.yaml
@@ -14,7 +14,7 @@ communication_config:
   max_concurrent_status_reads: null
   max_data_in_flight: 12500000
   reqwest_config:
-    total_timeout_millis: 30000
+    total_timeout_millis: 300000
     pool_idle_timeout_millis: null
     http2_keep_alive_timeout_millis: 5000
     http2_keep_alive_interval_millis: 30000

--- a/crates/walrus-sdk/src/config/reqwest_config.rs
+++ b/crates/walrus-sdk/src/config/reqwest_config.rs
@@ -84,7 +84,7 @@ pub(crate) mod default {
 
     /// Allows for enough time to transfer big slivers on the other side of the world.
     pub fn total_timeout() -> Duration {
-        Duration::from_secs(30)
+        Duration::from_secs(300)
     }
 
     /// Disabled by default, i.e., connections are kept alive.


### PR DESCRIPTION
## Description

While uploading large blob (500 MB or larger), I notice a lot of request timeouts causing retries which leads to re-uploading of partially uploaded slivers. This causes extra network usage which is very sub-optimal.

## Test plan

Running locally.
