### PR TITLE
fix: fix daemon command arg collision

### DIFF
--- a/crates/walrus-service/src/client/cli/args.rs
+++ b/crates/walrus-service/src/client/cli/args.rs
@@ -896,7 +896,10 @@ pub struct AggregatorArgs {
     pub max_blob_size: Option<u64>,
     /// The maximum number of requests that can be buffered before the server starts rejecting new
     /// ones. Note that this includes the number of requests that are being processed currently.
-    #[arg(long = "max-buffer-size", default_value_t = default::max_aggregator_buffer_size())]
+    #[arg(
+        long = "aggregator-max-buffer-size",
+        default_value_t = default::max_aggregator_buffer_size()
+    )]
     #[serde(default = "default::max_aggregator_buffer_size")]
     pub max_request_buffer_size: usize,
     /// The maximum number of requests the aggregator can process concurrently.
@@ -904,7 +907,10 @@ pub struct AggregatorArgs {
     /// If more requests than this maximum are received, the excess requests are buffered up to
     /// `--max-buffer-size`. Any outstanding request will result in a response with a
     /// 429 HTTP status code.
-    #[arg(long, default_value_t = default::max_aggregator_concurrent_requests())]
+    #[arg(
+        long = "aggregator-max-concurrent-requests",
+        default_value_t = default::max_aggregator_concurrent_requests()
+    )]
     #[serde(default = "default::max_aggregator_concurrent_requests")]
     pub max_concurrent_requests: usize,
 }


### PR DESCRIPTION
## Description

There is an arg collision reported by #2651 . This PR changes the newly added args so that the command is still backward compatible.

Resolve #2651 

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
