### PR TITLE
fix(core): correct `Symbols::with_capacity` semantics

### DIFF
--- a/crates/walrus-core/src/encoding/blob_encoding.rs
+++ b/crates/walrus-core/src/encoding/blob_encoding.rs
@@ -568,15 +568,18 @@ impl<D: Decoder, E: EncodingAxis> BlobDecoder<D, E> {
 
         let sliver_length = config.n_source_symbols::<E::OrthogonalAxis>().get().into();
         let sliver_count = usize::from(n_source_symbols.get());
-        let workspace_size = sliver_length * sliver_count;
+        let n_symbols_in_workspace = sliver_length * sliver_count;
 
         let (n_columns, workspace) = if E::IS_PRIMARY {
             (
                 sliver_length,
-                Symbols::with_capacity(workspace_size, symbol_size),
+                Symbols::with_capacity(n_symbols_in_workspace, symbol_size),
             )
         } else {
-            (sliver_count, Symbols::zeros(workspace_size, symbol_size))
+            (
+                sliver_count,
+                Symbols::zeros(n_symbols_in_workspace, symbol_size),
+            )
         };
 
         Ok(Self {

--- a/crates/walrus-core/src/encoding/symbols.rs
+++ b/crates/walrus-core/src/encoding/symbols.rs
@@ -88,9 +88,9 @@ impl Symbols {
     /// #
     /// assert!(Symbols::with_capacity(42, 1.try_into().unwrap()).is_empty());
     /// ```
-    pub fn with_capacity(capacity: usize, symbol_size: NonZeroU16) -> Self {
+    pub fn with_capacity(n_symbols: usize, symbol_size: NonZeroU16) -> Self {
         Symbols {
-            data: Vec::<u8>::with_capacity(capacity),
+            data: Vec::<u8>::with_capacity(n_symbols * usize::from(symbol_size.get())),
             symbol_size,
         }
     }


### PR DESCRIPTION
## Description

The semantics of the `Symbols::with_capacity` function were inconsistent with other related functions like `len`, `zeros`, `truncate`.

## Test plan

Review changes.
