### PR TITLE
[DO NOT MERGE] refactor(core): prepare types for increase of max blob size

### DIFF
--- a/crates/walrus-core/benches/blob_encoding.rs
+++ b/crates/walrus-core/benches/blob_encoding.rs
@@ -26,6 +26,8 @@ const BLOB_SIZES: [(u64, &str); 5] = [
     (1 << 20, "1MiB"),
     (1 << 25, "32MiB"),
     (1 << 30, "1GiB"),
+    // TODO(WAL-1081): Uncomment this after the next contract upgrade.
+    // (1 << 34, "16GiB"),
 ];
 
 fn encoding_config() -> ReedSolomonEncodingConfig {

--- a/crates/walrus-core/src/encoding.rs
+++ b/crates/walrus-core/src/encoding.rs
@@ -70,7 +70,8 @@ pub use symbols::{
     RecoverySymbol,
     RecoverySymbolPair,
     SecondaryRecoverySymbol,
+    SymbolSizeType,
     Symbols,
 };
 
-mod utils;
+pub(crate) mod utils;

--- a/crates/walrus-core/src/inconsistency.rs
+++ b/crates/walrus-core/src/inconsistency.rs
@@ -60,6 +60,7 @@ use crate::{
         Secondary,
         SliverData,
         SliverVerificationError,
+        SymbolSizeType,
     },
     ensure,
     merkle::MerkleAuth,
@@ -132,7 +133,7 @@ impl<T: EncodingAxis, U: MerkleAuth> InconsistencyProof<T, U> {
     fn check_recovery_symbols(
         &self,
         metadata: &BlobMetadata,
-        symbol_size: usize,
+        symbol_size: SymbolSizeType,
         encoding_config: &EncodingConfig,
     ) -> Result<(), InconsistencyVerificationError> {
         // Note: The following code may have to be changed if we add encodings that require a
@@ -173,7 +174,7 @@ impl<T: EncodingAxis, U: MerkleAuth> InconsistencyProof<T, U> {
         let symbol_size = metadata
             .symbol_size(encoding_config)
             .map_err(|_| InconsistencyVerificationError::RecoveryFailure)?;
-        self.check_recovery_symbols(metadata, symbol_size.get().into(), encoding_config)?;
+        self.check_recovery_symbols(metadata, symbol_size, encoding_config)?;
         let sliver = SliverData::recover_sliver_without_verification(
             self.recovery_symbols,
             self.target_sliver_index,

--- a/crates/walrus-core/src/metadata.rs
+++ b/crates/walrus-core/src/metadata.rs
@@ -26,6 +26,7 @@ use crate::{
         EncodingConfig,
         EncodingFactory as _,
         QuiltError,
+        SymbolSizeType,
         encoded_blob_length_for_n_shards,
         quilt_encoding::{
             QuiltIndexApi,
@@ -473,7 +474,7 @@ pub trait BlobMetadataApi {
     fn symbol_size(
         &self,
         encoding_config: &EncodingConfig,
-    ) -> Result<NonZeroU16, DataTooLargeError>;
+    ) -> Result<SymbolSizeType, DataTooLargeError>;
 
     /// Returns the encoded size of the blob.
     fn encoded_size(&self) -> Option<u64>;
@@ -569,7 +570,7 @@ impl BlobMetadataApi for BlobMetadataV1 {
     fn symbol_size(
         &self,
         encoding_config: &EncodingConfig,
-    ) -> Result<NonZeroU16, DataTooLargeError> {
+    ) -> Result<SymbolSizeType, DataTooLargeError> {
         encoding_config
             .get_for_type(self.encoding_type)
             .symbol_size_for_blob(self.unencoded_length)

--- a/crates/walrus-core/src/utils.rs
+++ b/crates/walrus-core/src/utils.rs
@@ -109,3 +109,14 @@ pub fn data_prefix_string<T: ToString>(data: &[T], max_values_printed: usize) ->
         format!("[{data_items}, ...]")
     }
 }
+
+/// Converts a `u32` to a `usize`.
+///
+/// This is a helper function to convert a `u32` to a `usize`.
+///
+/// # Panics
+///
+/// Panics if running on a 16-bit architecture.
+pub fn usize_from_u32(value: u32) -> usize {
+    usize::try_from(value).expect("assuming at least a 32-bit architecture")
+}

--- a/crates/walrus-sdk/src/client.rs
+++ b/crates/walrus-sdk/src/client.rs
@@ -1140,11 +1140,12 @@ impl WalrusNodeClient<SuiContractClient> {
 
         let duration = encode_start_timer.elapsed();
         let pair = pairs.first().expect("the encoding produces sliver pairs");
-        let symbol_size = pair.primary.symbols.symbol_size().get();
+        let symbol_size =
+            walrus_core::utils::usize_from_u32(pair.primary.symbols.symbol_size().get());
         tracing::info!(
             symbol_size,
-            primary_sliver_size = pair.primary.symbols.len() * usize::from(symbol_size),
-            secondary_sliver_size = pair.secondary.symbols.len() * usize::from(symbol_size),
+            primary_sliver_size = pair.primary.symbols.len() * symbol_size,
+            secondary_sliver_size = pair.secondary.symbols.len() * symbol_size,
             ?duration,
             "encoded sliver pairs and metadata"
         );

--- a/crates/walrus-service/src/client/cli.rs
+++ b/crates/walrus-service/src/client/cli.rs
@@ -272,8 +272,7 @@ impl std::fmt::Display for HumanReadableBytes {
         // We know that `value >= 1024`, so `exponent >= 1`.
         let exponent = value.ilog(BASE);
         let normalized_value = value as f64 / BASE.pow(exponent) as f64;
-        let unit =
-            UNITS[usize::try_from(exponent - 1).expect("we assume at least a 32-bit architecture")];
+        let unit = UNITS[walrus_core::utils::usize_from_u32(exponent - 1)];
 
         // Get correct number of significant digits (not rounding integer part).
         #[allow(clippy::cast_possible_truncation)] // the truncation is intentional here

--- a/crates/walrus-service/src/node/committee/node_service.rs
+++ b/crates/walrus-service/src/node/committee/node_service.rs
@@ -239,7 +239,7 @@ impl Service<Request> for UnboundedRemoteStorageNode {
                         client
                             .get_and_verify_recovery_symbol::<Primary>(
                                 n_shards,
-                                symbol_size.get().into(),
+                                symbol_size,
                                 &metadata,
                                 sliver_pair_at_remote,
                                 intersecting_pair_index,
@@ -250,7 +250,7 @@ impl Service<Request> for UnboundedRemoteStorageNode {
                         client
                             .get_and_verify_recovery_symbol::<Secondary>(
                                 n_shards,
-                                symbol_size.get().into(),
+                                symbol_size,
                                 &metadata,
                                 sliver_pair_at_remote,
                                 intersecting_pair_index,

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -1123,9 +1123,7 @@ impl Default for Http2Config {
     fn default() -> Self {
         Self {
             http2_max_concurrent_streams: defaults::REST_HTTP2_MAX_CONCURRENT_STREAMS,
-            http2_max_pending_accept_reset_streams: u32::MAX
-                .try_into()
-                .expect("assuming at least 32-bit architecture"),
+            http2_max_pending_accept_reset_streams: walrus_core::utils::usize_from_u32(u32::MAX),
             http2_initial_stream_window_size: None,
             http2_initial_connection_window_size: None,
             http2_adaptive_window: true,

--- a/crates/walrus-storage-node-client/src/client.rs
+++ b/crates/walrus-storage-node-client/src/client.rs
@@ -33,6 +33,7 @@ use walrus_core::{
         RecoverySymbol,
         Secondary,
         SliverData,
+        SymbolSizeType,
     },
     inconsistency::InconsistencyProof,
     keys::ProtocolKeyPair,
@@ -704,7 +705,7 @@ impl StorageNodeClient {
     pub async fn get_and_verify_recovery_symbol<A: EncodingAxis>(
         &self,
         n_shards: NonZeroU16,
-        expected_symbol_size: usize,
+        expected_symbol_size: SymbolSizeType,
         metadata: &VerifiedBlobMetadataWithId,
         remote_sliver_pair: SliverPairIndex,
         local_sliver_pair: SliverPairIndex,


### PR DESCRIPTION
## Description

This commit prepares function and variable types for a future increase of the blob size limit. Specifically, use `SymbolSizeType`, an alias of `NonZeroU32`, instead of `NonZeroU16` to represent symbol sizes.

No behavior changes are introduced by this commit. An actual increase of the maximum blob size requires related changes to the contracts, only then can the limit be increased.

Also contains other minor cleanup and refactoring in the `walrus-core` crate.

Contributes to WAL-971.

## Test plan

Existing (slightly adapted) tests.
