### PR TITLE
fix(client): Fix double memory allocation for blob slivers

### DIFF
--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -373,7 +373,7 @@ async fn test_inconsistency(failed_nodes: &[usize]) -> TestResult {
         .as_ref()
         .send_blob_data_and_get_certificate(
             &metadata,
-            &pairs,
+            Arc::new(pairs),
             &BlobPersistenceType::Permanent,
             None,
             TailHandling::Blocking,

--- a/crates/walrus-sdk/src/client.rs
+++ b/crates/walrus-sdk/src/client.rs
@@ -1468,7 +1468,7 @@ impl WalrusNodeClient<SuiContractClient> {
         let committees = self.get_committees().await?;
 
         let (Some(pairs), Some(metadata), Some(blob_status)) = (
-            registered_blob.get_sliver_pairs(),
+            registered_blob.sliver_pairs_arc(),
             registered_blob.get_metadata(),
             registered_blob.get_status(),
         ) else {
@@ -1682,7 +1682,7 @@ impl<T> WalrusNodeClient<T> {
     pub async fn send_blob_data_and_get_certificate(
         &self,
         metadata: &VerifiedBlobMetadataWithId,
-        pairs: &[SliverPair],
+        pairs: Arc<Vec<SliverPair>>,
         blob_persistence_type: &BlobPersistenceType,
         multi_pb: Option<&MultiProgress>,
         tail_handling: TailHandling,
@@ -1698,7 +1698,7 @@ impl<T> WalrusNodeClient<T> {
             multi_pb.add(pb)
         });
 
-        let blobs = vec![(metadata.clone(), Arc::new(pairs.to_vec()))];
+        let blobs = vec![(metadata.clone(), pairs)];
         let (event_tx, mut event_rx) = tokio::sync::mpsc::channel(blobs.len().max(1));
 
         let mut upload_fut = Box::pin(self.distributed_upload_without_confirmation(

--- a/crates/walrus-sdk/src/client/client_types.rs
+++ b/crates/walrus-sdk/src/client/client_types.rs
@@ -313,6 +313,17 @@ impl<'a, T: Debug + Clone + Send + Sync> WalrusStoreBlob<'a, T> {
             tracing::event!(BLOB_SPAN_LEVEL, state = self.get_state(), message);
         });
     }
+
+    /// Returns the sliver pairs wrapped in an `Arc`, if available.
+    pub fn sliver_pairs_arc(&self) -> Option<Arc<Vec<SliverPair>>> {
+        match self {
+            WalrusStoreBlob::Encoded(blob) => Some(blob.pairs.clone()),
+            WalrusStoreBlob::WithStatus(blob) => Some(blob.pairs.clone()),
+            WalrusStoreBlob::Registered(blob) => Some(blob.pairs.clone()),
+            WalrusStoreBlob::WithCertificate(blob) => Some(blob.pairs.clone()),
+            _ => None,
+        }
+    }
 }
 
 /// Unencoded blob.

--- a/crates/walrus-stress/src/generator/write_client.rs
+++ b/crates/walrus-stress/src/generator/write_client.rs
@@ -223,7 +223,7 @@ impl WriteClient {
             .as_ref()
             .send_blob_data_and_get_certificate(
                 &metadata,
-                &pairs,
+                Arc::new(pairs),
                 &blob_sui_object.blob_persistence_type(),
                 Some(&MultiProgress::new()),
                 TailHandling::Blocking,

--- a/crates/walrus-upload-relay/src/controller.rs
+++ b/crates/walrus-upload-relay/src/controller.rs
@@ -214,7 +214,7 @@ impl Controller {
             .client
             .send_blob_data_and_get_certificate(
                 &metadata,
-                &sliver_pairs,
+                Arc::new(sliver_pairs),
                 &blob_persistence,
                 None,
                 TailHandling::Blocking,


### PR DESCRIPTION
## Description

This PR fixes the double allocation for blob slivers in the client.
