### PR TITLE
feat: Enable tail uploads in the daemon

### DIFF
--- a/crates/walrus-sdk/client_config_example.yaml
+++ b/crates/walrus-sdk/client_config_example.yaml
@@ -31,7 +31,7 @@ communication_config:
     factor: 0.5
     base_millis: 500
   sliver_status_check_threshold: 5560
-  child_process_uploads_enabled: false
+  tail_handling: blocking
   data_in_flight_auto_tune:
     enabled: false
     window_sample_target: 20

--- a/crates/walrus-sdk/src/config/communication_config.rs
+++ b/crates/walrus-sdk/src/config/communication_config.rs
@@ -16,9 +16,12 @@ use walrus_core::{
 };
 use walrus_utils::backoff::ExponentialBackoffConfig;
 
-use crate::config::{
-    reqwest_config::{RequestRateConfig, ReqwestConfig},
-    sliver_write_extra_time::SliverWriteExtraTime,
+use crate::{
+    config::{
+        reqwest_config::{RequestRateConfig, ReqwestConfig},
+        sliver_write_extra_time::SliverWriteExtraTime,
+    },
+    uploader::TailHandling,
 };
 
 /// Below this threshold, the `NodeCommunication` client will not check if the sliver is present on
@@ -186,8 +189,8 @@ pub struct ClientCommunicationConfig {
     /// Defaults to 5_560 bytes.
     #[serde(default = "default_sliver_status_check_threshold")]
     pub sliver_status_check_threshold: usize,
-    /// Enable uploading slivers via a detached child process that continues tail writes.
-    pub child_process_uploads_enabled: bool,
+    /// Preferred handling mode for tail uploads once quorum has been reached.
+    pub tail_handling: TailHandling,
     /// Auto-tuning options for write concurrency derived from the data-in-flight limit.
     pub data_in_flight_auto_tune: DataInFlightAutoTuneConfig,
     /// The delay for which the client waits before storing data to ensure that storage nodes have
@@ -220,7 +223,7 @@ impl Default for ClientCommunicationConfig {
             request_rate_config: Default::default(),
             disable_proxy: Default::default(),
             sliver_write_extra_time: Default::default(),
-            child_process_uploads_enabled: false,
+            tail_handling: TailHandling::Blocking,
             data_in_flight_auto_tune: Default::default(),
             registration_delay: Duration::from_millis(200),
             max_total_blob_size: 1024 * 1024 * 1024, // 1GiB

--- a/crates/walrus-sdk/src/uploader.rs
+++ b/crates/walrus-sdk/src/uploader.rs
@@ -14,6 +14,7 @@ use std::{
 };
 
 use futures::Future;
+use serde::{Deserialize, Serialize};
 use tokio::task::JoinHandle;
 use walrus_core::{BlobId, encoding::SliverPair, metadata::VerifiedBlobMetadataWithId};
 
@@ -26,7 +27,8 @@ use crate::{
 };
 
 /// Controls how the extra tail window is handled once quorum is reached.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum TailHandling {
     /// The uploader will block until the tail upload is complete.
     Blocking,

--- a/crates/walrus-service/src/client/cli/args.rs
+++ b/crates/walrus-service/src/client/cli/args.rs
@@ -1190,6 +1190,11 @@ pub struct CommonStoreOptions {
     #[arg(long, value_enum)]
     #[serde(default)]
     pub upload_mode: Option<UploadModeCli>,
+    /// Spawn a helper process that continues detached tail uploads after quorum is reached.
+    /// This is only effective when tail handling is configured as `detached`.
+    #[arg(long)]
+    #[serde(default)]
+    pub child_process_uploads: bool,
     /// Internal flag to signal the process is running as a child for background uploads.
     #[arg(long, hide = true)]
     #[serde(default)]
@@ -1961,6 +1966,7 @@ mod tests {
                 upload_relay: None,
                 skip_tip_confirmation: false,
                 upload_mode: None,
+                child_process_uploads: false,
                 internal_run: false,
             },
         })

--- a/crates/walrus-service/src/client/cli/internal_run.rs
+++ b/crates/walrus-service/src/client/cli/internal_run.rs
@@ -570,6 +570,7 @@ fn spawn_signal_forwarders(handle: ChildProcessHandle, mut cancel_rx: watch::Rec
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn maybe_spawn_child_upload_process<F>(
     client: &WalrusNodeClient<SuiContractClient>,
+    child_process_uploads: bool,
     epoch_arg: &EpochArg,
     dry_run: bool,
     store_optimizations: &StoreOptimizations,
@@ -585,11 +586,12 @@ pub(crate) async fn maybe_spawn_child_upload_process<F>(
 where
     F: FnOnce(&mut TokioCommand),
 {
-    let child_uploads_enabled = client
-        .config()
-        .communication_config
-        .child_process_uploads_enabled;
-    if !(child_uploads_enabled && upload_relay.is_none() && !internal_run) {
+    let tail_handling = client.config().communication_config.tail_handling;
+    if !(child_process_uploads
+        && matches!(tail_handling, TailHandling::Detached)
+        && upload_relay.is_none()
+        && !internal_run)
+    {
         return Ok(None);
     }
 

--- a/crates/walrus-service/src/client/daemon.rs
+++ b/crates/walrus-service/src/client/daemon.rs
@@ -261,14 +261,15 @@ impl WalrusWriteClient for WalrusNodeClient<SuiContractClient> {
         post_store: PostStoreAction,
     ) -> ClientResult<BlobStoreResult> {
         let encoding_type = encoding_type.unwrap_or(DEFAULT_ENCODING);
-
+        let tail_mode = self.config().communication_config.tail_handling;
         let store_args = StoreArgs::new(
             encoding_type,
             epochs_ahead,
             store_optimizations,
             persistence,
             post_store,
-        );
+        )
+        .with_tail_handling(tail_mode);
         let result = self
             .reserve_and_store_blobs_retry_committees(&[blob], &[], &store_args)
             .await?;
@@ -302,14 +303,15 @@ impl WalrusWriteClient for WalrusNodeClient<SuiContractClient> {
         post_store: PostStoreAction,
     ) -> ClientResult<QuiltStoreResult> {
         let encoding_type = encoding_type.unwrap_or(DEFAULT_ENCODING);
-
+        let tail_mode = self.config().communication_config.tail_handling;
         let store_args = StoreArgs::new(
             encoding_type,
             epochs_ahead,
             store_optimizations,
             persistence,
             post_store,
-        );
+        )
+        .with_tail_handling(tail_mode);
         self.quilt_client()
             .reserve_and_store_quilt::<V>(&quilt, &store_args)
             .await


### PR DESCRIPTION
## Description

This PR is needed to enable tail uploads in the publisher. Tail uploads are set to detached mode based on the configs. 

1. We added a new config `tail_handling` which can be set to `blocked` or `detached` and handles tail upload.
2. `child_process` is removed from the config and added as a cli param to the store commands (as this is a cli construct) and remove ambiguity from tail handling.