### PR TITLE
chore: tag get_object(s) calls with type

### DIFF
--- a/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
@@ -789,7 +789,9 @@ impl RetriableSuiClient {
     }
 
     /// Returns the Sui Object of type `U` with the provided [`ObjectID`].
-    #[tracing::instrument(level = Level::DEBUG, skip_all)]
+    #[tracing::instrument(
+        level = Level::DEBUG, skip_all, fields(object_type = %U::CONTRACT_STRUCT)
+    )]
     pub async fn get_sui_object<U>(&self, object_id: ObjectID) -> SuiClientResult<U>
     where
         U: AssociatedContractStruct,
@@ -804,7 +806,9 @@ impl RetriableSuiClient {
     }
 
     /// Returns the Sui Objects of type `U` with the provided [`ObjectID`]s.
-    #[tracing::instrument(level = Level::DEBUG, skip_all)]
+    #[tracing::instrument(
+        level = Level::DEBUG, skip_all, fields(object_type = %U::CONTRACT_STRUCT)
+    )]
     pub async fn get_sui_objects<U>(&self, object_ids: &[ObjectID]) -> SuiClientResult<Vec<U>>
     where
         U: AssociatedContractStruct,


### PR DESCRIPTION
## Description

This adds the move `module::struct_name` tag to spans emitted from get_object and get_objects.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
