### PR TITLE
chore: fix test for client config

### DIFF
--- a/.github/actions/diffs/action.yml
+++ b/.github/actions/diffs/action.yml
@@ -54,6 +54,7 @@ runs:
             - 'Cargo.lock'
             - 'rust-toolchain.toml'
             - '.github/workflows/code.yml'
+            - 'setup/*.yaml'
           isReleaseNotesEligible:
             - 'contracts/**'
             - 'crates/**'

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -43,8 +43,10 @@ jobs:
       isDenyConfig: ${{ steps.diff.outputs.isDenyConfig }}
       isTestConfig: ${{ steps.diff.outputs.isTestConfig }}
       isOpenapi: ${{ steps.diff.outputs.isOpenapi }}
-      isRelevantForRustTests: ${{ steps.diff.outputs.isRust == 'true' || steps.diff.outputs.isMove == 'true' || steps.diff.outputs.isTestConfig
-        == 'true' || steps.diff.outputs.isTestnetContracts == 'true' }}
+      isRelevantForRustTests:
+        ${{ steps.diff.outputs.isRust == 'true' || steps.diff.outputs.isMove == 'true' || steps.diff.outputs.isTestConfig
+        == 'true' || steps.diff.outputs.isTestnetContracts == 'true' || steps.diff.outputs.isExampleConfig == 'true' || steps.diff.outputs.isOpenapi
+        == 'true' }}
       isTestnetContracts: ${{ steps.diff.outputs.isTestnetContracts }}
       isMainnetContracts: ${{ steps.diff.outputs.isMainnetContracts }}
       isExampleConfig: ${{ steps.diff.outputs.isExampleConfig }}
@@ -205,7 +207,8 @@ jobs:
 
       - name: Install sui
         if: steps.cache-sui-restore.outputs.cache-hit != 'true'
-        run: cargo install --locked --git https://github.com/MystenLabs/sui.git --tag $SUI_TAG --debug --features tracing
+        run:
+          cargo install --locked --git https://github.com/MystenLabs/sui.git --tag $SUI_TAG --debug --features tracing
           sui
       - name: Run Move tests and check coverage
         run: bash ./scripts/move_tests.sh -c

--- a/crates/walrus-sdk/src/config.rs
+++ b/crates/walrus-sdk/src/config.rs
@@ -299,7 +299,7 @@ mod tests {
         check_client_config -> TestResult: [
             testnet: ("../../setup/client_config_testnet.yaml", None, None),
             mainnet: ("../../setup/client_config_mainnet.yaml", None, None),
-            multi_config: ("../../setup/client_config.yaml", None, Some("mainnet")),
+            multi_config: ("../../setup/client_config.yaml", None, Some("testnet")),
             multi_config_with_testnet_context: (
                 "../../setup/client_config.yaml",
                 Some("testnet"),


### PR DESCRIPTION
## Description

#2673 changed the default context in our client configuration. This configuration is actually used for tests, which started failing after the change.

This was not visible in CI of that PR, because the tests are only triggered selectively depending on which files are changed.

This PR fixes the test and also makes sure Rust tests are run in the future in CI when any files we refer to in our tests change.

## Test plan

CI.
