### PR TITLE
refactor: reduce database impact on recovery symbol calls

### DIFF
--- a/crates/walrus-service/src/node/thread_pool.rs
+++ b/crates/walrus-service/src/node/thread_pool.rs
@@ -161,6 +161,7 @@ impl Default for RayonThreadPool {
     fn default() -> Self {
         RayonThreadPool::new(
             RayonThreadPoolBuilder::new()
+                .thread_name(|i| format!("rayon-worker-{i}"))
                 .build()
                 .expect("non-argument thread-pool construction must succeed")
                 .into(),


### PR DESCRIPTION
## Description

This commit improves the serving of recovery symbols in several ways.

First, it makes the fetching of the associated sliver an asynchronous operation so that it does not block the core tokio thread. Second, fetching metadata is currently unnecessary since there is only one supported encoding type, which can be known in advance. Third, requests to the blob-info table which were performed once per symbol to check blob access is now performed once per request (get-symbol or list-symbol).

Finally, whereas before it was possible that a single list-symbols request could have some symbols fail to be fetched due to the symbol service being unavailable. Now, if the symbol service is ready at the beginning of the request an attempt will be made to process all of the symbols.

## Test plan

Existing tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
