### PR TITLE
chore: bump Rust to 1.91

### DIFF
--- a/crates/typed-store/src/metrics.rs
+++ b/crates/typed-store/src/metrics.rs
@@ -67,8 +67,7 @@ pub struct SamplingInterval {
 
 impl Default for SamplingInterval {
     fn default() -> Self {
-        // Enabled with 60 second interval
-        SamplingInterval::new(Duration::from_secs(60), 0)
+        SamplingInterval::new(Duration::from_mins(1), 0)
     }
 }
 

--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -1095,7 +1095,7 @@ async fn test_store_quilt(blobs_to_create: u32) -> TestResult {
     // Store the quilt.
     let quilt_client = client
         .quilt_client()
-        .with_config(QuiltClientConfig::new(6, Duration::from_secs(60)));
+        .with_config(QuiltClientConfig::new(6, Duration::from_mins(1)));
     let quilt = quilt_client
         .construct_quilt::<QuiltVersionV1>(&quilt_store_blobs, encoding_type)
         .await?;
@@ -2572,7 +2572,7 @@ async fn test_store_with_upload_relay_no_tip() {
         upload_relay_sui_client,
         WalrusUploadRelayConfig {
             tip_config: TipConfig::NoTip,
-            tx_freshness_threshold: Duration::from_secs(300),
+            tx_freshness_threshold: Duration::from_mins(5),
             tx_max_future_threshold: Duration::from_secs(10),
         },
         server_address,
@@ -2703,7 +2703,7 @@ async fn test_store_with_upload_relay_with_tip() {
                     encoded_size_mul_per_kib: TIP_MULTIPLIER,
                 },
             },
-            tx_freshness_threshold: Duration::from_secs(300),
+            tx_freshness_threshold: Duration::from_mins(5),
             tx_max_future_threshold: Duration::from_secs(10),
         },
         server_address,

--- a/crates/walrus-orchestrator/src/faults.rs
+++ b/crates/walrus-orchestrator/src/faults.rs
@@ -182,7 +182,7 @@ mod faults_tests {
     #[test]
     fn crash_recovery_1_fault() {
         let max_faults = 1;
-        let interval = Duration::from_secs(60);
+        let interval = Duration::from_mins(1);
         let faulty = (0..max_faults)
             .map(|i| Instance::new_for_test(i.to_string()))
             .collect();
@@ -214,7 +214,7 @@ mod faults_tests {
     #[test]
     fn crash_recovery_2_faults() {
         let max_faults = 2;
-        let interval = Duration::from_secs(60);
+        let interval = Duration::from_mins(1);
         let faulty = (0..max_faults)
             .map(|i| Instance::new_for_test(i.to_string()))
             .collect();
@@ -245,7 +245,7 @@ mod faults_tests {
 
     #[test]
     fn crash_recovery() {
-        let interval = Duration::from_secs(60);
+        let interval = Duration::from_mins(1);
         for i in 3..33 {
             let max_faults = i;
             let min_faults = max_faults / 3;

--- a/crates/walrus-sdk/src/config/committees_refresh_config.rs
+++ b/crates/walrus-sdk/src/config/committees_refresh_config.rs
@@ -97,6 +97,6 @@ mod default {
     pub(crate) const REFRESH_GRACE_PERIOD: Duration = Duration::from_secs(10);
     pub(crate) const MAX_AUTO_REFRESH_INTERVAL: Duration = Duration::from_secs(30);
     pub(crate) const MIN_AUTO_REFRESH_INTERVAL: Duration = Duration::from_secs(5);
-    pub(crate) const EPOCH_CHANGE_DISTANCE_THRS: Duration = Duration::from_secs(300);
+    pub(crate) const EPOCH_CHANGE_DISTANCE_THRS: Duration = Duration::from_mins(5);
     pub const REFRESHER_CHANNEL_SIZE: usize = 100;
 }

--- a/crates/walrus-sdk/src/config/communication_config.rs
+++ b/crates/walrus-sdk/src/config/communication_config.rs
@@ -39,21 +39,16 @@ fn default_sliver_status_check_threshold() -> usize {
 }
 
 /// Upload mode for controlling concurrency and aggressiveness of uploads.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum UploadMode {
     /// Conservative mode: lower concurrency, slower but more reliable.
     Conservative,
     /// Balanced mode: moderate concurrency (default).
+    #[default]
     Balanced,
     /// Aggressive mode: higher concurrency, faster but more resource-intensive.
     Aggressive,
-}
-
-impl Default for UploadMode {
-    fn default() -> Self {
-        Self::Balanced
-    }
 }
 
 /// Default number of sliver uploads that should be observed before evaluating throughput.

--- a/crates/walrus-sdk/src/config/reqwest_config.rs
+++ b/crates/walrus-sdk/src/config/reqwest_config.rs
@@ -84,7 +84,7 @@ pub(crate) mod default {
 
     /// Allows for enough time to transfer big slivers on the other side of the world.
     pub fn total_timeout() -> Duration {
-        Duration::from_secs(300)
+        Duration::from_mins(5)
     }
 
     /// Disabled by default, i.e., connections are kept alive.

--- a/crates/walrus-service/src/backup/config.rs
+++ b/crates/walrus-service/src/backup/config.rs
@@ -208,11 +208,11 @@ pub mod defaults {
     }
     /// Default time to allow blob uploads to take before timing out.
     pub fn blob_upload_timeout() -> Duration {
-        Duration::from_secs(60)
+        Duration::from_mins(1)
     }
     /// Default time to allow blob deletions to take before timing out.
     pub fn blob_delete_timeout() -> Duration {
-        Duration::from_secs(60)
+        Duration::from_mins(1)
     }
     pub fn blob_job_chunk_size() -> u32 {
         10

--- a/crates/walrus-service/src/client/cli/args.rs
+++ b/crates/walrus-service/src/client/cli/args.rs
@@ -1234,18 +1234,13 @@ pub struct FileOrBlobId {
 }
 
 /// CLI enum for selecting upload presets. Converted to SDK UploadMode at runtime.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, clap::ValueEnum)]
+#[derive(Debug, Clone, Default, Copy, PartialEq, Eq, Serialize, Deserialize, clap::ValueEnum)]
 #[serde(rename_all = "camelCase")]
 pub enum UploadModeCli {
     Conservative,
+    #[default]
     Balanced,
     Aggressive,
-}
-
-impl Default for UploadModeCli {
-    fn default() -> Self {
-        Self::Balanced
-    }
 }
 
 impl From<UploadModeCli> for UploadMode {
@@ -1909,7 +1904,7 @@ pub(crate) mod default {
     }
 
     pub(crate) fn faucet_timeout() -> Duration {
-        Duration::from_secs(60)
+        Duration::from_mins(1)
     }
 
     pub(crate) fn allowed_headers() -> Vec<String> {

--- a/crates/walrus-service/src/client/cli/backfill.rs
+++ b/crates/walrus-service/src/client/cli/backfill.rs
@@ -50,7 +50,7 @@ use walrus_sdk::{ObjectID, client::WalrusNodeClient, config::ClientConfig};
 use walrus_sui::client::{SuiReadClient, retry_client::RetriableSuiClient};
 
 const TOMBSTONE_FILENAME: &str = "tombstone";
-const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(15 * 60);
+const DOWNLOAD_TIMEOUT: Duration = Duration::from_mins(15);
 
 // TODO: Possibly make this configurable.
 const DOWNLOAD_BATCH_SIZE: usize = 10;

--- a/crates/walrus-service/src/client/daemon/routes.rs
+++ b/crates/walrus-service/src/client/daemon/routes.rs
@@ -504,7 +504,7 @@ pub(super) fn daemon_cors_layer() -> CorsLayer {
     CorsLayer::new()
         .allow_origin(Any)
         .allow_methods(Any)
-        .max_age(Duration::from_secs(86400))
+        .max_age(Duration::from_hours(24))
         .allow_headers(Any)
 }
 

--- a/crates/walrus-service/src/event/event_processor/config.rs
+++ b/crates/walrus-service/src/event/event_processor/config.rs
@@ -130,16 +130,16 @@ pub struct EventProcessorConfig {
 impl Default for EventProcessorConfig {
     fn default() -> Self {
         Self {
-            pruning_interval: Duration::from_secs(3600),
-            checkpoint_request_timeout: Duration::from_secs(60),
+            pruning_interval: Duration::from_hours(1),
+            checkpoint_request_timeout: Duration::from_mins(1),
             adaptive_downloader_config: Default::default(),
             event_stream_catchup_min_checkpoint_lag: 20_000,
-            sampled_tracing_interval: Duration::from_secs(3600),
+            sampled_tracing_interval: Duration::from_hours(1),
             runtime_catchup_lag_threshold: 20_000,
-            runtime_lag_check_interval: Duration::from_secs(300),
+            runtime_lag_check_interval: Duration::from_mins(5),
             enable_runtime_catchup: true,
-            catchup_coordination_timeout: Duration::from_secs(3000),
-            catchup_processing_timeout: Duration::from_secs(3000),
+            catchup_coordination_timeout: Duration::from_mins(50),
+            catchup_processing_timeout: Duration::from_mins(50),
         }
     }
 }

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -4467,7 +4467,7 @@ mod tests {
 
         // Wait for the node runtime to finish, and check that a panic was thrown.
         match tokio::time::timeout(
-            Duration::from_secs(120),
+            Duration::from_mins(2),
             cluster.nodes[0].node_runtime_handle.as_mut().unwrap(),
         )
         .await
@@ -5674,7 +5674,7 @@ mod tests {
 
         async fn wait_until_no_sync_tasks(shard_sync_handler: &ShardSyncHandler) -> TestResult {
             // Timeout needs to be longer than shard sync retry interval.
-            tokio::time::timeout(Duration::from_secs(120), async {
+            tokio::time::timeout(Duration::from_mins(2), async {
                 loop {
                     if shard_sync_handler.current_sync_task_count().await == 0
                         && shard_sync_handler.no_pending_recover_metadata().await
@@ -7128,8 +7128,8 @@ mod tests {
                 Ok(FixedSystemParameters {
                     n_shards: NonZeroU16::new(1000).expect("1000 > 0"),
                     max_epochs_ahead: 200,
-                    epoch_duration: Duration::from_secs(600),
-                    epoch_zero_end: Utc::now() + Duration::from_secs(60),
+                    epoch_duration: Duration::from_mins(10),
+                    epoch_zero_end: Utc::now() + Duration::from_mins(1),
                 })
             });
         contract_service

--- a/crates/walrus-service/src/node/committee/test_committee_service.rs
+++ b/crates/walrus-service/src/node/committee/test_committee_service.rs
@@ -227,7 +227,7 @@ macro_rules! assert_timeout {
         time::timeout($duration, $future).await.expect_err($msg)
     };
     ($future:expr, $msg:expr) => {
-        assert_timeout!(Duration::from_secs(60), $future, $msg)
+        assert_timeout!(Duration::from_mins(1), $future, $msg)
     };
 }
 
@@ -265,7 +265,7 @@ async fn metadata_request_succeeds_if_available(
         .await?;
 
     let returned_metadata = time::timeout(
-        Duration::from_secs(60),
+        Duration::from_mins(1),
         committee_service.get_and_verify_metadata(*expected_metadata.blob_id(), 1),
     )
     .await?;
@@ -318,7 +318,7 @@ async fn new_committee_unavailable_for_reads_until_transition_completes() -> Tes
     committee_handle.finish_transition();
     committee_service.end_committee_change(new_epoch)?;
 
-    let returned_metadata = time::timeout(Duration::from_secs(60), &mut pending_request)
+    let returned_metadata = time::timeout(Duration::from_mins(1), &mut pending_request)
         .await
         .expect("request must succeed since new committee has metadata");
 
@@ -396,7 +396,7 @@ async fn requests_for_metadata_are_dispatched_to_correct_committee(
         .await?;
 
     let returned_metadata = time::timeout(
-        Duration::from_secs(60),
+        Duration::from_mins(1),
         committee_service.get_and_verify_metadata(*expected_metadata.blob_id(), certified_epoch),
     )
     .await
@@ -563,7 +563,7 @@ async fn recovers_slivers_across_epoch_change() -> TestResult {
     committee_handle.finish_transition();
     committee_service.end_committee_change(new_epoch)?;
 
-    let _sliver = time::timeout(Duration::from_secs(60), &mut pending_request)
+    let _sliver = time::timeout(Duration::from_mins(1), &mut pending_request)
         .await
         .expect("request must succeed since new committee has remaining recovery symbols");
 
@@ -693,7 +693,7 @@ async fn collects_inconsistency_proof_despite_epoch_change() -> TestResult {
     committee_handle.begin_transition_to(next_committee);
     committee_service.begin_committee_change(new_epoch).await?;
 
-    let _ = time::timeout(Duration::from_secs(60), &mut pending_request)
+    let _ = time::timeout(Duration::from_mins(1), &mut pending_request)
         .await
         .expect("request must succeed since new committee has sufficient responses");
 

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -578,7 +578,7 @@ impl Default for BlobRecoveryConfig {
             max_concurrent_sliver_syncs: 2_000,
             max_proof_cache_elements: 7_500,
             committee_service_config: CommitteeServiceConfig::default(),
-            monitor_interval: Duration::from_secs(60),
+            monitor_interval: Duration::from_mins(1),
         }
     }
 }
@@ -634,10 +634,10 @@ impl Default for CommitteeServiceConfig {
     fn default() -> Self {
         Self {
             retry_interval_min: Duration::from_secs(1),
-            retry_interval_max: Duration::from_secs(3600),
+            retry_interval_max: Duration::from_hours(1),
             metadata_request_timeout: Duration::from_secs(5),
             sliver_request_timeout: Duration::from_secs(45),
-            invalidity_sync_timeout: Duration::from_secs(300),
+            invalidity_sync_timeout: Duration::from_mins(5),
             max_concurrent_metadata_requests: NonZeroUsize::new(1).expect("1 is non-zero"),
             node_connect_timeout: Duration::from_secs(1),
             experimental_sliver_recovery_additional_symbols: 0,
@@ -688,13 +688,13 @@ impl Default for ShardSyncConfig {
     fn default() -> Self {
         Self {
             sliver_count_per_sync_request: 1000,
-            shard_sync_retry_min_backoff: Duration::from_secs(60),
-            shard_sync_retry_max_backoff: Duration::from_secs(600),
+            shard_sync_retry_min_backoff: Duration::from_mins(1),
+            shard_sync_retry_max_backoff: Duration::from_mins(10),
             max_concurrent_blob_recovery_during_shard_recovery: 100,
-            blob_certified_check_interval: Duration::from_secs(60),
+            blob_certified_check_interval: Duration::from_mins(1),
             max_concurrent_metadata_fetch: 100,
             shard_sync_concurrency: 10,
-            shard_sync_retry_switch_to_recovery_interval: Duration::from_secs(12 * 60 * 60), // 12hr
+            shard_sync_retry_switch_to_recovery_interval: Duration::from_hours(12),
             restart_shard_sync_always_retry_transfer_first: true,
             sst_ingestion_config: None,
         }
@@ -806,7 +806,7 @@ pub mod defaults {
     /// Default interval between config monitoring checks in seconds.
     pub const CONFIG_SYNCHRONIZER_INTERVAL_SECS: u64 = 900;
     /// Default frequency with which balance checks are performed.
-    pub const BALANCE_CHECK_FREQUENCY: Duration = Duration::from_secs(60 * 60);
+    pub const BALANCE_CHECK_FREQUENCY: Duration = Duration::from_hours(1);
     /// SUI MIST threshold under which balance checks log a warning.
     pub const BALANCE_CHECK_WARNING_THRESHOLD_MIST: u64 = 5_000_000_000;
     /// The default number of max concurrent streams for the rest API.
@@ -858,7 +858,7 @@ pub mod defaults {
 
     /// Configure the default push interval for metrics.
     pub fn push_interval() -> Duration {
-        Duration::from_secs(60)
+        Duration::from_mins(1)
     }
 
     /// Returns true if the `duration` is equal to the default push interval for metrics.

--- a/crates/walrus-service/src/node/contract_service.rs
+++ b/crates/walrus-service/src/node/contract_service.rs
@@ -49,7 +49,7 @@ use super::{
 use crate::common::config::SuiConfig;
 
 const MIN_BACKOFF: Duration = Duration::from_secs(1);
-const MAX_BACKOFF: Duration = Duration::from_secs(3600);
+const MAX_BACKOFF: Duration = Duration::from_hours(1);
 type UIntGaugeVec = GenericGaugeVec<AtomicU64>;
 
 enum ProtocolKeyAction {

--- a/crates/walrus-service/src/node/db_checkpoint.rs
+++ b/crates/walrus-service/src/node/db_checkpoint.rs
@@ -86,7 +86,7 @@ impl Default for DbCheckpointConfig {
         Self {
             db_checkpoint_dir: None,
             max_db_checkpoints: 3,
-            db_checkpoint_interval: StdDuration::from_secs(86400), // 1 day.
+            db_checkpoint_interval: StdDuration::from_hours(24),
             sync: true,
             max_background_operations: 1,
             periodic_db_checkpoints: false,
@@ -272,11 +272,11 @@ pub struct DbCheckpointManager {
 
 impl DbCheckpointManager {
     /// Initial delay before first db_checkpoint creation, to avoid resource contention.
-    const CHECKPOINT_CREATION_INITIAL_DELAY: time::Duration = time::Duration::from_secs(15 * 60);
+    const CHECKPOINT_CREATION_INITIAL_DELAY: time::Duration = time::Duration::from_mins(15);
     /// Delay between db_checkpoint creation retries.
-    const CHECKPOINT_CREATION_RETRY_DELAY: time::Duration = time::Duration::from_secs(300);
+    const CHECKPOINT_CREATION_RETRY_DELAY: time::Duration = time::Duration::from_mins(5);
     /// Default timeout for tasks.
-    const DEFAULT_TASK_TIMEOUT: StdDuration = time::Duration::from_secs(60 * 60);
+    const DEFAULT_TASK_TIMEOUT: StdDuration = time::Duration::from_hours(1);
 
     /// Create a new db_checkpoint manager for RocksDB.
     //
@@ -508,7 +508,7 @@ impl DbCheckpointManager {
                         "Failed to calculate next db_checkpoint time, retrying..."
                     );
                     // Wait 10 minutes before retrying.
-                    time::sleep(time::Duration::from_secs(600)).await;
+                    time::sleep(time::Duration::from_mins(10)).await;
                 }
             }
         };
@@ -548,7 +548,7 @@ impl DbCheckpointManager {
                                 "failed to receive db_checkpoint creation result"
                             );
                             next_db_checkpoint_time = time::Instant::now() +
-                                StdDuration::from_secs(300);
+                                StdDuration::from_mins(5);
                             continue;
                         }
                     };

--- a/crates/walrus-service/src/node/epoch_change_driver.rs
+++ b/crates/walrus-service/src/node/epoch_change_driver.rs
@@ -26,13 +26,13 @@ use walrus_utils::backoff::ExponentialBackoffState;
 use super::contract_service::SystemContractService;
 
 /// Maximum number of seconds that an operation can be randomly delayed by.
-const MAX_SCHEDULE_JITTER: Duration = Duration::from_secs(180);
+const MAX_SCHEDULE_JITTER: Duration = Duration::from_mins(3);
 /// The minimum exponential backoff when performing retries.
 const MIN_BACKOFF: Duration = Duration::from_secs(5);
 /// The maximum exponential backoff when performing retries.
-const MAX_BACKOFF: Duration = Duration::from_secs(300);
+const MAX_BACKOFF: Duration = Duration::from_mins(5);
 /// The maximum amount of time before the epoch change that process subsidies is scheduled.
-const MAX_SUBSIDIES_TIME_BEFORE_EPOCH_CHANGE: Duration = Duration::from_secs(300);
+const MAX_SUBSIDIES_TIME_BEFORE_EPOCH_CHANGE: Duration = Duration::from_mins(5);
 
 /// Function returning the current time in Utc.
 type UtcNowFn = Arc<dyn Fn() -> DateTime<Utc> + Send + Sync>;

--- a/crates/walrus-service/src/node/start_epoch_change_finisher.rs
+++ b/crates/walrus-service/src/node/start_epoch_change_finisher.rs
@@ -58,7 +58,7 @@ impl StartEpochChangeFinisher {
         let handle = tokio::spawn(async move {
             let backoff = ExponentialBackoff::new_with_seed(
                 Duration::from_secs(10),
-                Duration::from_secs(300),
+                Duration::from_mins(5),
                 // Since this function is in charge of marking the event as completed, we have to
                 // keep retrying until success. Otherwise, the event process is blocked anyway.
                 None,

--- a/crates/walrus-service/src/node/storage/shard.rs
+++ b/crates/walrus-service/src/node/storage/shard.rs
@@ -1379,8 +1379,8 @@ impl ShardStorage {
                 // TODO: in test, check that we have recovered all the certified blobs.
                 break;
             }
-            tracing::warn!("recovering missing blobs still misses blobs. Retrying in 60 seconds.",);
-            tokio::time::sleep(Duration::from_secs(60)).await;
+            tracing::warn!("recovering missing blobs still misses blobs; retrying in 1 minute");
+            tokio::time::sleep(Duration::from_mins(1)).await;
         }
 
         Ok(())

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -1598,8 +1598,8 @@ impl Default for StubContractService {
             system_parameters: FixedSystemParameters {
                 n_shards: NonZeroU16::new(4).unwrap(),
                 max_epochs_ahead: DEFAULT_MAX_EPOCHS_AHEAD,
-                epoch_duration: Duration::from_secs(600),
-                epoch_zero_end: Utc::now() + Duration::from_secs(60),
+                epoch_duration: Duration::from_mins(10),
+                epoch_zero_end: Utc::now() + Duration::from_mins(1),
             },
             node_capability_object: StorageNodeCap::new_for_testing(),
             certify_event_blob_tx: Arc::new(std::sync::Mutex::new(tx)),
@@ -2574,7 +2574,7 @@ pub mod test_cluster {
     pub const FROST_PER_NODE_WEIGHT: u64 = 1_000_000_000_000;
 
     /// The default epoch duration for tests
-    pub const DEFAULT_EPOCH_DURATION_FOR_TESTS: Duration = Duration::from_secs(60 * 60);
+    pub const DEFAULT_EPOCH_DURATION_FOR_TESTS: Duration = Duration::from_hours(1);
 
     #[derive(Debug)]
     /// Builder for the E2E test setup.

--- a/crates/walrus-simtest/tests/simtest.rs
+++ b/crates/walrus-simtest/tests/simtest.rs
@@ -170,7 +170,7 @@ mod tests {
             simtest_utils::start_background_workload(client_arc.clone(), true, None, None);
 
         // Run the workload to get some data in the system.
-        tokio::time::sleep(Duration::from_secs(60)).await;
+        tokio::time::sleep(Duration::from_mins(1)).await;
 
         // Repeatedly move shards among storage nodes.
         for _i in 0..3 {
@@ -684,12 +684,12 @@ mod tests {
             simtest_utils::start_background_workload(client_arc.clone(), false, None, None);
 
         // Run the workload to get some data in the system.
-        tokio::time::sleep(Duration::from_secs(60)).await;
+        tokio::time::sleep(Duration::from_mins(1)).await;
 
         // Register a fail point to have a temporary pause in the first node recovery process that
         // is longer than epoch length.
         // Note that when a node is in RecoveryInProgress state, it will not start a new recovery
-        // everytime when a new epoch change start event is processed. So here we only delay the
+        // every time when a new epoch change start event is processed. So here we only delay the
         // first recovery.
         let delay_triggered = Arc::new(AtomicBool::new(false));
         register_fail_point_async("start_node_recovery_entry", move || {
@@ -698,7 +698,7 @@ mod tests {
                 if !delay_triggered_clone.load(Ordering::SeqCst) {
                     delay_triggered_clone.store(true, Ordering::SeqCst);
                     tracing::info!("delaying node recovery for 60s");
-                    tokio::time::sleep(Duration::from_secs(60)).await;
+                    tokio::time::sleep(Duration::from_mins(1)).await;
                 }
             }
         });
@@ -714,11 +714,11 @@ mod tests {
             crash_target_node(
                 target_fail_node_id,
                 fail_triggered_clone.clone(),
-                Duration::from_secs(60),
+                Duration::from_mins(1),
             );
         });
 
-        tokio::time::sleep(Duration::from_secs(180)).await;
+        tokio::time::sleep(Duration::from_mins(3)).await;
 
         let node_health_info = simtest_utils::get_nodes_health_info(&walrus_cluster.nodes).await;
 
@@ -771,15 +771,15 @@ mod tests {
             simtest_utils::start_background_workload(Arc::new(client), true, None, None);
 
         // Run the workload to get some data in the system.
-        tokio::time::sleep(Duration::from_secs(120)).await;
+        tokio::time::sleep(Duration::from_mins(2)).await;
 
         workload_handle.abort();
 
         // Wait for event to catch up.
-        tokio::time::sleep(Duration::from_secs(60)).await;
+        tokio::time::sleep(Duration::from_mins(1)).await;
 
         // Wait for all nodes to have event_progress.pending < 10 with timeout
-        let timeout = Duration::from_secs(60);
+        let timeout = Duration::from_mins(1);
         let start_time = Instant::now();
 
         loop {
@@ -847,7 +847,7 @@ mod tests {
             simtest_utils::start_background_workload(client_arc.clone(), false, None, None);
 
         // Run the workload to get some data in the system.
-        tokio::time::sleep(Duration::from_secs(60)).await;
+        tokio::time::sleep(Duration::from_mins(1)).await;
 
         // Register a fail point to have a temporary pause in the first node recovery process that
         // is longer than epoch length.
@@ -861,7 +861,7 @@ mod tests {
                 if !delay_triggered_clone.load(Ordering::SeqCst) {
                     delay_triggered_clone.store(true, Ordering::SeqCst);
                     tracing::info!("delaying node recovery for 60s");
-                    tokio::time::sleep(Duration::from_secs(60)).await;
+                    tokio::time::sleep(Duration::from_mins(1)).await;
                 }
             }
         });
@@ -879,7 +879,7 @@ mod tests {
                 crash_target_node(
                     target_fail_node_id,
                     fail_triggered_clone.clone(),
-                    Duration::from_secs(60),
+                    Duration::from_mins(1),
                 );
             });
 
@@ -897,7 +897,7 @@ mod tests {
         {
             let next_fail_triggered = Arc::new(Mutex::new(Instant::now()));
             let next_fail_triggered_clone = next_fail_triggered.clone();
-            let crash_end_time = Instant::now() + Duration::from_secs(120);
+            let crash_end_time = Instant::now() + Duration::from_mins(2);
             let target_fail_node_id = walrus_cluster.nodes[0]
                 .node_id
                 .expect("node id should be set");
@@ -917,7 +917,7 @@ mod tests {
             });
         }
 
-        tokio::time::sleep(Duration::from_secs(180)).await;
+        tokio::time::sleep(Duration::from_mins(3)).await;
 
         let node_health_info = simtest_utils::get_nodes_health_info(&walrus_cluster.nodes).await;
 
@@ -1150,7 +1150,7 @@ mod tests {
             })
             // Use a long epoch duration to avoid operation across epoch change.
             // TODO(WAL-937): shorten this and fix any issues exposed by this.
-            .with_epoch_duration(Duration::from_secs(600))
+            .with_epoch_duration(Duration::from_mins(10))
             .with_communication_config(
                 ClientCommunicationConfig::default_for_test_with_reqwest_timeout(
                     Duration::from_secs(2),
@@ -1196,7 +1196,7 @@ mod tests {
                 .expect("single client workload exited with error");
         });
 
-        tokio::time::sleep(Duration::from_secs(240)).await;
+        tokio::time::sleep(Duration::from_mins(4)).await;
 
         handle.abort();
 

--- a/crates/walrus-simtest/tests/simtest_event_blob.rs
+++ b/crates/walrus-simtest/tests/simtest_event_blob.rs
@@ -58,7 +58,7 @@ mod tests {
                 break;
             }
 
-            if start.elapsed() > Duration::from_secs(180) {
+            if start.elapsed() > Duration::from_mins(3) {
                 panic!("Timeout waiting for event blob to get stuck");
             }
 

--- a/crates/walrus-simtest/tests/simtest_failure.rs
+++ b/crates/walrus-simtest/tests/simtest_failure.rs
@@ -98,7 +98,7 @@ mod tests {
         }
 
         // Continue running the workload for another 60 seconds.
-        let _ = tokio::time::timeout(Duration::from_secs(60), async {
+        let _ = tokio::time::timeout(Duration::from_mins(1), async {
             let mut blobs_written = HashSet::new();
             loop {
                 // TODO(#995): use stress client for better coverage of the workload.
@@ -242,7 +242,7 @@ mod tests {
             simtest_utils::start_background_workload(client_arc.clone(), false, None, None);
 
         // Running the workload for 60 seconds to get some data in the system.
-        tokio::time::sleep(Duration::from_secs(60)).await;
+        tokio::time::sleep(Duration::from_mins(1)).await;
 
         // Tracks if a crash has been triggered.
         let fail_triggered = Arc::new(AtomicBool::new(false));
@@ -255,7 +255,7 @@ mod tests {
             crash_target_node(
                 target_fail_node_id,
                 fail_triggered_clone.clone(),
-                Duration::from_secs(120),
+                Duration::from_mins(2),
             );
         });
 
@@ -405,7 +405,7 @@ mod tests {
 
         let next_fail_triggered = Arc::new(Mutex::new(Instant::now()));
         let next_fail_triggered_clone = next_fail_triggered.clone();
-        let crash_end_time = Instant::now() + Duration::from_secs(2 * 60);
+        let crash_end_time = Instant::now() + Duration::from_mins(2);
 
         sui_macros::register_fail_points(CRASH_NODE_FAIL_POINTS, move || {
             repeatedly_crash_target_node(
@@ -454,7 +454,7 @@ mod tests {
             .await
             .expect("stake with node pool should not fail");
 
-        tokio::time::sleep(Duration::from_secs(3 * 60)).await;
+        tokio::time::sleep(Duration::from_mins(3)).await;
 
         workload_handle.abort();
 
@@ -463,7 +463,7 @@ mod tests {
         let mut last_persisted_event_time = Instant::now();
         let start_time = Instant::now();
         loop {
-            if start_time.elapsed() > Duration::from_secs(1 * 60) {
+            if start_time.elapsed() > Duration::from_mins(1) {
                 break;
             }
             let node_health_info =
@@ -534,7 +534,7 @@ mod tests {
         let mut last_checkpoint_update_time = Instant::now();
         let start_time = Instant::now();
         loop {
-            if start_time.elapsed() > Duration::from_secs(60) {
+            if start_time.elapsed() > Duration::from_mins(1) {
                 break;
             }
             let node_health_info =
@@ -628,7 +628,7 @@ mod tests {
             simtest_utils::start_background_workload(client_arc.clone(), false, None, None);
 
         // Running the workload for 60 seconds to get some data in the system.
-        tokio::time::sleep(Duration::from_secs(60)).await;
+        tokio::time::sleep(Duration::from_mins(1)).await;
 
         // Tracks if a lagging event processing has been triggered.
         let fail_triggered = Arc::new(AtomicBool::new(false));

--- a/crates/walrus-stress/src/generator.rs
+++ b/crates/walrus-stress/src/generator.rs
@@ -384,7 +384,7 @@ fn burst_load(load: u64) -> (u64, Interval) {
         // Set the interval to ~100 years. `Duration::MAX` causes an overflow in tokio.
         return (
             0,
-            tokio::time::interval(Duration::from_secs(100 * 365 * 24 * 60 * 60)),
+            tokio::time::interval(Duration::from_hours(100 * 365 * 24)),
         );
     }
     let duration_per_op = Duration::from_secs_f64(SECS_PER_LOAD_PERIOD as f64 / (load as f64));

--- a/crates/walrus-sui/benches/gas_cost_bench.rs
+++ b/crates/walrus-sui/benches/gas_cost_bench.rs
@@ -142,7 +142,7 @@ async fn gas_cost_for_contract_calls(args: Args) -> anyhow::Result<()> {
 
     let (sui_cluster_handle, walrus_client, _, test_node_keys) =
         initialize_contract_and_wallet_for_testing(
-            Duration::from_secs(3600),
+            Duration::from_hours(1),
             args.with_credits,
             0,
             args.committee_size.get() as usize,

--- a/crates/walrus-sui/src/client/retry_client/download_handler.rs
+++ b/crates/walrus-sui/src/client/retry_client/download_handler.rs
@@ -410,7 +410,7 @@ mod tests {
 
     #[test]
     fn assess_immediate_fallback_error() {
-        let config = test_config(5, Duration::from_secs(300), 3, Duration::from_secs(60));
+        let config = test_config(5, Duration::from_mins(5), 3, Duration::from_mins(1));
         let handler = CheckpointDownloadHandler::new(Some(config), None);
         let seq = 100;
         let err = rpc_error_pruned(seq);
@@ -425,7 +425,7 @@ mod tests {
     #[tokio::test]
     #[ignore = "ignore long-running test by default"]
     async fn assess_overall_window_exceeded_triggers_fallback_and_sets_skip() {
-        let skip_duration = Duration::from_secs(60);
+        let skip_duration = Duration::from_mins(1);
         let config = test_config(3, Duration::from_secs(10), 5, skip_duration);
         let handler = CheckpointDownloadHandler::new(Some(config), None);
         let seq = 100;
@@ -456,7 +456,7 @@ mod tests {
 
     #[test]
     fn assess_specific_consecutive_failure_triggers_fallback() {
-        let config = test_config(10, Duration::from_secs(300), 3, Duration::from_secs(60));
+        let config = test_config(10, Duration::from_mins(5), 3, Duration::from_mins(1));
         let handler = CheckpointDownloadHandler::new(Some(config.clone()), None);
         let seq = 100;
         let err = rpc_error_generic(seq);

--- a/crates/walrus-sui/src/client/retry_client/fallible.rs
+++ b/crates/walrus-sui/src/client/retry_client/fallible.rs
@@ -33,7 +33,7 @@ pub struct FallibleRpcClient {
 
 impl FallibleRpcClient {
     /// The time window during which failures are counted.
-    const FAILURE_WINDOW: Duration = Duration::from_secs(600);
+    const FAILURE_WINDOW: Duration = Duration::from_mins(10);
     /// The maximum number of failures allowed.
     const MAX_FAILURES: usize = 100;
 

--- a/crates/walrus-sui/src/client/rpc_config.rs
+++ b/crates/walrus-sui/src/client/rpc_config.rs
@@ -170,11 +170,11 @@ impl RpcFallbackConfig {
     }
 
     fn default_failure_window_to_start_fallback_duration() -> Duration {
-        Duration::from_secs(300)
+        Duration::from_mins(5)
     }
 
     fn default_skip_rpc_for_checkpoint_duration() -> Duration {
-        Duration::from_secs(300)
+        Duration::from_mins(5)
     }
 
     fn default_max_consecutive_failures() -> usize {

--- a/crates/walrus-sui/src/utils.rs
+++ b/crates/walrus-sui/src/utils.rs
@@ -387,7 +387,7 @@ pub async fn request_sui_from_faucet(
     sui_client: &RetriableSuiClient,
 ) -> Result<()> {
     let mut backoff = Duration::from_millis(100);
-    let max_backoff = Duration::from_secs(300);
+    let max_backoff = Duration::from_mins(5);
     // Set of coins to allow checking if we have received a new coin from the faucet
     let coins = sui_coin_set(sui_client, address).await?;
 

--- a/crates/walrus-sui/tests/test_walrus_sui.rs
+++ b/crates/walrus-sui/tests/test_walrus_sui.rs
@@ -52,7 +52,7 @@ async fn initialize_contract_and_wallet_with_single_node() -> anyhow::Result<(
     SystemContext,
     TestNodeKeys,
 )> {
-    initialize_contract_and_wallet_for_testing(Duration::from_secs(3600), false, 0, 1).await
+    initialize_contract_and_wallet_for_testing(Duration::from_hours(1), false, 0, 1).await
 }
 
 async fn initialize_contract_and_wallet_with_credits_with_single_node() -> anyhow::Result<(
@@ -61,7 +61,7 @@ async fn initialize_contract_and_wallet_with_credits_with_single_node() -> anyho
     SystemContext,
     TestNodeKeys,
 )> {
-    initialize_contract_and_wallet_for_testing(Duration::from_secs(3600), true, 10_000, 1).await
+    initialize_contract_and_wallet_for_testing(Duration::from_hours(1), true, 10_000, 1).await
 }
 
 #[tokio::test]

--- a/crates/walrus-upload-relay/src/controller.rs
+++ b/crates/walrus-upload-relay/src/controller.rs
@@ -463,7 +463,7 @@ pub(crate) fn cors_layer() -> CorsLayer {
     CorsLayer::new()
         .allow_origin(Any)
         .allow_methods(Any)
-        .max_age(Duration::from_secs(86400))
+        .max_age(Duration::from_hours(24))
         .allow_headers(Any)
 }
 
@@ -614,7 +614,7 @@ mod tests {
                 address: SuiAddress::from_bytes([42; 32]).expect("valid bytes"),
                 kind: TipKind::Const(42),
             },
-            tx_freshness_threshold: Duration::from_secs(60 * 60 * 10), // 10 hours.
+            tx_freshness_threshold: Duration::from_hours(10),
             tx_max_future_threshold: Duration::from_secs(30),
         };
 

--- a/crates/walrus-utils/src/backoff.rs
+++ b/crates/walrus-utils/src/backoff.rs
@@ -250,7 +250,7 @@ mod tests {
     #[test]
     fn backoff_is_exponential() {
         let min = Duration::from_millis(500);
-        let max = Duration::from_secs(3600);
+        let max = Duration::from_hours(1);
 
         let expected: Vec<_> = (0u32..)
             .map(|i| min * 2u32.pow(i))

--- a/docker/walrus-antithesis/build-walrus-image-for-antithesis/Dockerfile
+++ b/docker/walrus-antithesis/build-walrus-image-for-antithesis/Dockerfile
@@ -8,7 +8,7 @@
 
 # Stage 1: Base Build Environment + Builder
 # -------------------------------------
-FROM rust:1.90-bookworm AS builder
+FROM rust:1.91-bookworm AS builder
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION
 WORKDIR "$WORKDIR/walrus"

--- a/docker/walrus-orchestrator/Dockerfile
+++ b/docker/walrus-orchestrator/Dockerfile
@@ -3,7 +3,7 @@
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
 
-FROM rust:1.90-bookworm AS builder
+FROM rust:1.91-bookworm AS builder
 
 ARG PROFILE=release
 ARG GIT_REVISION

--- a/docker/walrus-proxy/Dockerfile
+++ b/docker/walrus-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.90-bookworm as builder
+FROM rust:1.91-bookworm as builder
 
 ARG PROFILE=release
 WORKDIR /work

--- a/docker/walrus-service/Dockerfile
+++ b/docker/walrus-service/Dockerfile
@@ -3,7 +3,7 @@
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
 
-FROM rust:1.90-bookworm AS builder
+FROM rust:1.91-bookworm AS builder
 
 ARG PROFILE=release
 ARG GIT_REVISION

--- a/docker/walrus-service/Dockerfile.walrus-backup
+++ b/docker/walrus-service/Dockerfile.walrus-backup
@@ -3,7 +3,7 @@
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
 
-FROM rust:1.90-bookworm AS builder
+FROM rust:1.91-bookworm AS builder
 
 ARG PROFILE=release
 ARG RUST_LOG=info,walrus_service::common::event_blob_downloader=warn

--- a/docker/walrus-stress/Dockerfile
+++ b/docker/walrus-stress/Dockerfile
@@ -3,7 +3,7 @@
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
 
-FROM rust:1.90-bookworm AS builder
+FROM rust:1.91-bookworm AS builder
 
 ARG PROFILE=release
 ARG GIT_REVISION

--- a/docker/walrus-upload-relay/Dockerfile
+++ b/docker/walrus-upload-relay/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.90-bookworm AS builder
+FROM rust:1.91-bookworm AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.90"
+channel = "1.91"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Description

Bumps Rust to the latest stable toolchain and makes the following minor changes:
- Uses new stable `Duration::from_mins` and `Duration::from_hours` where we previously had `from_secs` with a clear multiple of 60 or 3600.
- Fixes some new lint warnings through `cargo clippy --fix`.

## Test plan

CI.
