### PR TITLE
docs: update contribution guidelines for Handlebars templating syntax

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,11 +118,12 @@ In particular, please adhere to the following conventions:
   whenever it makes sense.
 - Module docstrings should be inside the respective module file with `//!` (instead of at the module
   inclusion location).
-- Escape literal `{{ }}` patterns with a backslash (`\{{`) due to Handlebars templating.
-  GitHub Actions `${{ }}` syntax is automatically preserved.
 
 Additionally, if you made any user-facing changes, please adjust our documentation under
 [docs/book](./docs/book/).
+When editing the documentation, escape literal `{{ }}` patterns with a
+backslash (`\{{`) due to Handlebars templating. GitHub Actions `${{ }}` syntax is automatically
+preserved.
 
 ### Formatting
 


### PR DESCRIPTION
## Description

Adding a note on how to escape `{{ }}` on the docs in order to avoid parsing them with handlebars


