### PR TITLE
feat: Move upload mode to client config

### DIFF
--- a/crates/walrus-sdk/client_config_example.yaml
+++ b/crates/walrus-sdk/client_config_example.yaml
@@ -42,6 +42,7 @@ communication_config:
     max_permits: 2000
     secondary_weight: 0.5
     min_blob_size_bytes: 52428800
+  upload_mode: balanced
   registration_delay_millis: 200
   max_total_blob_size: 1073741824
   committee_change_backoff:

--- a/crates/walrus-sdk/src/config/communication_config.rs
+++ b/crates/walrus-sdk/src/config/communication_config.rs
@@ -51,6 +51,10 @@ pub enum UploadMode {
     Aggressive,
 }
 
+fn default_upload_mode() -> Option<UploadMode> {
+    Some(UploadMode::Balanced)
+}
+
 /// Default number of sliver uploads that should be observed before evaluating throughput.
 pub const DEFAULT_AUTO_TUNE_WINDOW_SAMPLE_TARGET: usize = 20;
 /// Default timeout while waiting for a throughput sample window to complete.
@@ -188,6 +192,9 @@ pub struct ClientCommunicationConfig {
     pub tail_handling: TailHandling,
     /// Auto-tuning options for write concurrency derived from the data-in-flight limit.
     pub data_in_flight_auto_tune: DataInFlightAutoTuneConfig,
+    /// Optional preset that adjusts concurrency limits unless explicit overrides are provided.
+    #[serde(default = "default_upload_mode")]
+    pub upload_mode: Option<UploadMode>,
     /// The delay for which the client waits before storing data to ensure that storage nodes have
     /// seen the registration event.
     #[serde(rename = "registration_delay_millis")]
@@ -220,6 +227,7 @@ impl Default for ClientCommunicationConfig {
             sliver_write_extra_time: Default::default(),
             tail_handling: TailHandling::Blocking,
             data_in_flight_auto_tune: Default::default(),
+            upload_mode: default_upload_mode(),
             registration_delay: Duration::from_millis(200),
             max_total_blob_size: 1024 * 1024 * 1024, // 1GiB
             sliver_status_check_threshold: DEFAULT_SLIVER_STATUS_CHECK_THRESHOLD,

--- a/crates/walrus-sdk/src/config/upload_mode.rs
+++ b/crates/walrus-sdk/src/config/upload_mode.rs
@@ -5,7 +5,10 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::config::communication_config::ClientCommunicationConfig;
+use crate::config::communication_config::{
+    ClientCommunicationConfig,
+    UploadMode as CommunicationUploadMode,
+};
 
 /// Upload preset modes for tuning client concurrency and network usage.
 ///
@@ -68,5 +71,15 @@ impl UploadMode {
         }
 
         config
+    }
+}
+
+impl From<CommunicationUploadMode> for UploadMode {
+    fn from(value: CommunicationUploadMode) -> Self {
+        match value {
+            CommunicationUploadMode::Conservative => UploadMode::Conservative,
+            CommunicationUploadMode::Balanced => UploadMode::Balanced,
+            CommunicationUploadMode::Aggressive => UploadMode::Aggressive,
+        }
     }
 }

--- a/crates/walrus-service/src/client/cli/args.rs
+++ b/crates/walrus-service/src/client/cli/args.rs
@@ -28,7 +28,6 @@ use walrus_core::{
     encoding::{EncodingConfig, EncodingFactory},
     ensure,
 };
-use walrus_sdk::config::UploadMode;
 use walrus_sui::{
     client::{ExpirySelectionPolicy, ReadClient, SuiContractClient},
     types::{StorageNode, move_structs::Authorized},
@@ -1202,10 +1201,6 @@ pub struct CommonStoreOptions {
     #[arg(long, requires = "upload_relay")]
     #[serde(default)]
     pub skip_tip_confirmation: bool,
-    /// Preset upload mode to tune network concurrency and bytes-in-flight.
-    #[arg(long, value_enum)]
-    #[serde(default)]
-    pub upload_mode: Option<UploadModeCli>,
     /// Spawn a helper process that continues detached tail uploads after quorum is reached.
     /// This is only effective when tail handling is configured as `detached`.
     #[arg(long)]
@@ -1231,26 +1226,6 @@ pub struct FileOrBlobId {
     #[serde_as(as = "Option<DisplayFromStr>")]
     #[serde(default)]
     pub(crate) blob_id: Option<BlobId>,
-}
-
-/// CLI enum for selecting upload presets. Converted to SDK UploadMode at runtime.
-#[derive(Debug, Clone, Default, Copy, PartialEq, Eq, Serialize, Deserialize, clap::ValueEnum)]
-#[serde(rename_all = "camelCase")]
-pub enum UploadModeCli {
-    Conservative,
-    #[default]
-    Balanced,
-    Aggressive,
-}
-
-impl From<UploadModeCli> for UploadMode {
-    fn from(value: UploadModeCli) -> Self {
-        match value {
-            UploadModeCli::Conservative => UploadMode::Conservative,
-            UploadModeCli::Balanced => UploadMode::Balanced,
-            UploadModeCli::Aggressive => UploadMode::Aggressive,
-        }
-    }
 }
 
 impl FileOrBlobId {
@@ -1976,7 +1951,6 @@ mod tests {
                 encoding_type: Default::default(),
                 upload_relay: None,
                 skip_tip_confirmation: false,
-                upload_mode: None,
                 child_process_uploads: false,
                 internal_run: false,
             },

--- a/crates/walrus-service/src/client/cli/internal_run.rs
+++ b/crates/walrus-service/src/client/cli/internal_run.rs
@@ -28,7 +28,6 @@ use tokio::{
 use walrus_core::BlobId;
 use walrus_sdk::{
     client::{StoreArgs, WalrusNodeClient, responses as sdk_responses},
-    config::UploadMode,
     store_optimizations::StoreOptimizations,
     sui::client::{BlobPersistence, PostStoreAction, SuiContractClient},
     uploader::{TailHandling, UploaderEvent},
@@ -422,7 +421,6 @@ fn apply_common_store_child_args(
     store_optimizations: &StoreOptimizations,
     persistence: BlobPersistence,
     post_store: PostStoreAction,
-    upload_mode: Option<UploadMode>,
 ) {
     if let Some(ref epochs) = epoch_arg.epochs {
         match epochs {
@@ -463,14 +461,6 @@ fn apply_common_store_child_args(
 
     if post_store == PostStoreAction::Share {
         cmd.arg("--share");
-    }
-
-    if let Some(mode) = upload_mode {
-        cmd.arg("--upload-mode").arg(match mode {
-            UploadMode::Conservative => "conservative",
-            UploadMode::Balanced => "balanced",
-            UploadMode::Aggressive => "aggressive",
-        });
     }
 }
 
@@ -576,7 +566,6 @@ pub(crate) async fn maybe_spawn_child_upload_process<F>(
     store_optimizations: &StoreOptimizations,
     persistence: BlobPersistence,
     post_store: PostStoreAction,
-    upload_mode: Option<UploadMode>,
     upload_relay: Option<&Url>,
     internal_run: bool,
     command_name: &str,
@@ -631,7 +620,6 @@ where
         store_optimizations,
         persistence,
         post_store,
-        upload_mode,
     );
 
     add_command_args(&mut cmd);


### PR DESCRIPTION
## Description

Added `communication_config.upload_mode ` so a preset can be selected per context while still yielding to explicit concurrency limits, and wired it into the load path so presets are applied as the config is parsed.
Removed the `--upload-mode` CLI knob and the `UploadModeCli` plumbing. Child upload processes now automatically reuse the serialized config without needing extra flags.

## Test plan

Running locally
