### PR TITLE
chore: use correct `console` code block type

### DIFF
--- a/docs/book/usage/networks.md
+++ b/docs/book/usage/networks.md
@@ -87,7 +87,7 @@ sui client switch --env testnet
 
 After this, you should get something like this (everything besides the `testnet` line is optional):
 
-```terminal
+```console
 $ sui client envs
 ╭──────────┬─────────────────────────────────────┬────────╮
 │ alias    │ url                                 │ active │
@@ -105,7 +105,7 @@ Finally, make sure you have at least one gas coin with at least 1 SUI. You can o
 
 After some seconds, you should see your new SUI coins:
 
-```terminal
+```console
 $ sui client gas
 ╭─────────────────┬────────────────────┬──────────────────╮
 │ gasCoinId       │ mistBalance (MIST) │ suiBalance (SUI) │

--- a/docs/book/usage/setup.md
+++ b/docs/book/usage/setup.md
@@ -34,7 +34,7 @@ further details.
 
 After this, you should get something like this (everything besides the `mainnet` line is optional):
 
-```terminal
+```console
 $ sui client envs
 ╭──────────┬─────────────────────────────────────┬────────╮
 │ alias    │ url                                 │ active │
@@ -48,7 +48,7 @@ $ sui client envs
 
 Make sure you have at least one gas coin with at least 1 SUI.
 
-```terminal
+```console
 $ sui client gas
 ╭─────────────────┬────────────────────┬──────────────────╮
 │ gasCoinId       │ mistBalance (MIST) │ suiBalance (SUI) │
@@ -102,7 +102,7 @@ Once this is done, you should be able to run Walrus by using the `walrus` comman
 You can see usage instructions as follows (see [the next chapter](./interacting.md) for further
 details):
 
-```terminal
+```console
 $ walrus --help
 Walrus client
 

--- a/docs/book/walrus-sites/tutorial-install.md
+++ b/docs/book/walrus-sites/tutorial-install.md
@@ -73,7 +73,7 @@ specify the path to the configuration file.
 
 Once this is done, you should be able to simply type `site-builder` in your terminal.
 
-```terminal
+```console
 $ site-builder
 Usage: site-builder [OPTIONS] <COMMAND>
 


### PR DESCRIPTION
## Description

We previously used the non-existent `terminal` code-block type in some markdown files. The correct type, however, is `console`.

## Test plan

Make sure the corresponding code blocks are rendered correctly in the preview.