### PR TITLE
fix(client): Prevent repeated copying of blob bytes when uploading to relay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13066,6 +13066,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "bimap",
+ "bytes",
  "chrono",
  "enum_dispatch",
  "fastcrypto",

--- a/crates/walrus-sdk/Cargo.toml
+++ b/crates/walrus-sdk/Cargo.toml
@@ -14,6 +14,7 @@ test-utils = [
 anyhow.workspace = true
 base64.workspace = true
 bimap.workspace = true
+bytes.workspace = true
 chrono.workspace = true
 enum_dispatch.workspace = true
 fastcrypto.workspace = true


### PR DESCRIPTION
## Description

This PR adds a simple fix to prevent calling `blob.to_vec()` repeatedly on every retry attempt to upload the blob.

## Test plan

Local run
