### PR TITLE
feat(client): Unblock blob encoding to run without downloading committee and shard assignments

### DIFF
--- a/crates/walrus-sdk/src/client.rs
+++ b/crates/walrus-sdk/src/client.rs
@@ -193,32 +193,35 @@ pub struct WalrusNodeClient<T> {
 
 impl WalrusNodeClient<()> {
     /// Creates a new Walrus client without a Sui client.
+    #[allow(clippy::unused_async)]
     pub async fn new(
         config: ClientConfig,
         committees_handle: CommitteesRefresherHandle,
     ) -> ClientResult<Self> {
-        Self::new_inner(config, committees_handle, None, None).await
+        Self::new_inner(config, committees_handle, None, None)
     }
     /// Creates a new Walrus client without a Sui client.
+    #[allow(clippy::unused_async)]
     pub async fn new_with_max_blob_size(
         config: ClientConfig,
         committees_handle: CommitteesRefresherHandle,
         max_blob_size: Option<u64>,
     ) -> ClientResult<Self> {
-        Self::new_inner(config, committees_handle, None, max_blob_size).await
+        Self::new_inner(config, committees_handle, None, max_blob_size)
     }
 
     /// Creates a new Walrus client without a Sui client, that records metrics to the provided
     /// registry.
+    #[allow(clippy::unused_async)]
     pub async fn new_with_metrics(
         config: ClientConfig,
         committees_handle: CommitteesRefresherHandle,
         metrics_registry: Registry,
     ) -> ClientResult<Self> {
-        Self::new_inner(config, committees_handle, Some(metrics_registry), None).await
+        Self::new_inner(config, committees_handle, Some(metrics_registry), None)
     }
 
-    async fn new_inner(
+    fn new_inner(
         config: ClientConfig,
         committees_handle: CommitteesRefresherHandle,
         metrics_registry: Option<Registry>,
@@ -226,17 +229,9 @@ impl WalrusNodeClient<()> {
     ) -> ClientResult<Self> {
         tracing::debug!(?config, "running client");
 
-        // Request the committees and price computation from the cache.
-        let (committees, _) = committees_handle
-            .send_committees_and_price_request(RequestKind::Get)
-            .await
-            .map_err(ClientError::other)?;
-
-        let encoding_config = EncodingConfig::new(committees.n_shards());
+        let encoding_config = Arc::new(EncodingConfig::new(committees_handle.n_shards()));
         let communication_limits =
             CommunicationLimits::new(&config.communication_config, encoding_config.n_shards());
-
-        let encoding_config = Arc::new(encoding_config);
 
         Ok(Self {
             sui_client: (),

--- a/crates/walrus-sdk/src/client/refresh.rs
+++ b/crates/walrus-sdk/src/client/refresh.rs
@@ -5,6 +5,7 @@
 //! when needed.
 
 use std::{
+    num::NonZeroU16,
     ops::ControlFlow,
     sync::Arc,
     time::{Duration, Instant},
@@ -277,12 +278,21 @@ pub enum RefresherCommunicationError {
 pub struct CommitteesRefresherHandle {
     notify: Arc<Notify>,
     req_tx: mpsc::Sender<CommitteesRequest>,
+    n_shards: NonZeroU16,
 }
 
 impl CommitteesRefresherHandle {
     /// Creates a new handle to communicate with the refresher.
-    pub fn new(notify: Arc<Notify>, req_tx: mpsc::Sender<CommitteesRequest>) -> Self {
-        Self { notify, req_tx }
+    pub fn new(
+        notify: Arc<Notify>,
+        req_tx: mpsc::Sender<CommitteesRequest>,
+        n_shards: NonZeroU16,
+    ) -> Self {
+        Self {
+            notify,
+            req_tx,
+            n_shards,
+        }
     }
 
     /// Sends a request to the refresher to refresh and get the active committees and the price
@@ -300,6 +310,11 @@ impl CommitteesRefresherHandle {
     /// Awaits for a notification from the refresher that the active committee has changed.
     pub async fn change_notified(&self) {
         self.notify.notified().await
+    }
+
+    /// Returns the configured number of shards for the Walrus network.
+    pub fn n_shards(&self) -> NonZeroU16 {
+        self.n_shards
     }
 }
 

--- a/crates/walrus-sui/src/client.rs
+++ b/crates/walrus-sui/src/client.rs
@@ -7,6 +7,7 @@ use core::fmt;
 use std::{
     collections::HashMap,
     future::Future,
+    num::NonZeroU16,
     path::PathBuf,
     str::FromStr,
     sync::Arc,
@@ -2976,6 +2977,10 @@ impl ReadClient for SuiContractClient {
         self.read_client
             .storage_and_write_price_per_unit_size()
             .await
+    }
+
+    async fn n_shards(&self) -> SuiClientResult<NonZeroU16> {
+        self.read_client.n_shards().await
     }
 
     async fn event_stream(

--- a/crates/walrus-sui/src/client/read_client.rs
+++ b/crates/walrus-sui/src/client/read_client.rs
@@ -137,6 +137,9 @@ pub trait ReadClient: Send + Sync {
         &self,
     ) -> impl Future<Output = SuiClientResult<(u64, u64)>> + Send;
 
+    /// Returns the configured number of shards for the Walrus network.
+    fn n_shards(&self) -> impl Future<Output = SuiClientResult<NonZeroU16>> + Send;
+
     /// Returns a stream of new blob events.
     ///
     /// The `polling_interval` defines how often the connected full node is polled for events.
@@ -1205,6 +1208,10 @@ impl ReadClient for SuiReadClient {
             system_object.storage_price_per_unit_size(),
             system_object.write_price_per_unit_size(),
         ))
+    }
+
+    async fn n_shards(&self) -> SuiClientResult<NonZeroU16> {
+        Ok(self.get_staking_object().await?.inner.n_shards)
     }
 
     async fn event_stream(


### PR DESCRIPTION
## Description

Today, we cannot start blob encoding until `WalrusNodeClient` when called from `get_contract_client` downloads the full committee and shard assignment before becoming usable. But blob encoding doesn't really need any of that. All it needs is `n_shards`.
In this PR, we make `WalrusNodeClient` no longer blocks on full committee hydration before becoming usable. When we build a contract client we now read `n_shards` directly from the staking object and return the client immediately. The committees refresher still runs in the background and takes over once it finishes loading the full committee data.

This change cut ~1.5 s off CLI startup - the encoding and registration phases can begin as soon as the shard count is known, while the committee fan-out now happen concurrently in the refresher task.

## Test plan

Ran locally and observed speed-up.
