### PR TITLE
feat(client): Add encoding spinner to cli output when child process is enabled

### DIFF
--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -802,7 +802,7 @@ async fn test_store_with_existing_storage_resource(
             )
         })
         .collect();
-    let encoded_blobs = client.as_ref().encode_blobs(unencoded_blobs, None)?;
+    let encoded_blobs = client.as_ref().encode_blobs(unencoded_blobs, None, None)?;
     let encoded_sizes = encoded_blobs
         .iter()
         .map(|blob| {


### PR DESCRIPTION
## Description

This PR adds an encoding progress channel and event flow so child-process uploads still show spinner updates. Without this, user doesn't realize when encoding started and how long it took when child process is enabled.
## Test plan

Running locally
