### PR TITLE
feat(client): allow specifying number of shards in client config

### DIFF
--- a/crates/walrus-sdk/client_config_example.yaml
+++ b/crates/walrus-sdk/client_config_example.yaml
@@ -1,5 +1,6 @@
 system_object: 0xa2637d13d171b278eadfa8a3fbe8379b5e471e1f3739092e5243da17fc8090eb
 staking_object: 0xca7cf321e47a1fc9bfd032abc31b253f5063521fd5b4c431f2cdd3fee1b4ec00
+n_shards: 1000
 cache_ttl_secs: 10
 exchange_objects:
 - 0xa9b00f69d3b033e7b64acff2672b54fbb7c31361954251e235395dea8bd6dcac

--- a/crates/walrus-sdk/src/client.rs
+++ b/crates/walrus-sdk/src/client.rs
@@ -176,7 +176,7 @@ pub struct WalrusNodeClient<T> {
 
 impl WalrusNodeClient<()> {
     /// Creates a new Walrus client without a Sui client.
-    pub async fn new(
+    pub fn new(
         config: ClientConfig,
         committees_handle: CommitteesRefresherHandle,
     ) -> ClientResult<Self> {
@@ -190,10 +190,10 @@ impl WalrusNodeClient<()> {
             None,
             None,
         )
-        .await
     }
+
     /// Creates a new Walrus client without a Sui client.
-    pub async fn new_with_max_blob_size(
+    pub fn new_with_max_blob_size(
         config: ClientConfig,
         committees_handle: CommitteesRefresherHandle,
         max_blob_size: Option<u64>,
@@ -208,12 +208,11 @@ impl WalrusNodeClient<()> {
             None,
             max_blob_size,
         )
-        .await
     }
 
     /// Creates a new Walrus client without a Sui client, that records metrics to the provided
     /// registry.
-    pub async fn new_with_metrics(
+    pub fn new_with_metrics(
         config: ClientConfig,
         committees_handle: CommitteesRefresherHandle,
         metrics_registry: Registry,
@@ -228,7 +227,6 @@ impl WalrusNodeClient<()> {
             Some(metrics_registry),
             None,
         )
-        .await
     }
 
     fn build_encoding_artifacts(
@@ -241,7 +239,7 @@ impl WalrusNodeClient<()> {
         (encoding_config, communication_limits)
     }
 
-    async fn new_inner(
+    fn new_inner(
         config: ClientConfig,
         committees_handle: CommitteesRefresherHandle,
         encoding_config: Arc<EncodingConfig>,
@@ -268,7 +266,7 @@ impl WalrusNodeClient<()> {
     }
 
     /// Converts `self` to a [`WalrusNodeClient<C>`] by adding the `sui_client`.
-    pub async fn with_client<C>(self, sui_client: C) -> WalrusNodeClient<C> {
+    pub fn with_client<C>(self, sui_client: C) -> WalrusNodeClient<C> {
         let Self {
             config,
             sui_client: _,
@@ -294,29 +292,24 @@ impl WalrusNodeClient<()> {
 
 impl<T: ReadClient> WalrusNodeClient<T> {
     /// Creates a new read client starting from a config file.
-    pub async fn new_read_client(
+    pub fn new_read_client(
         config: ClientConfig,
         committees_handle: CommitteesRefresherHandle,
         sui_read_client: T,
     ) -> ClientResult<Self> {
-        Ok(WalrusNodeClient::new(config, committees_handle)
-            .await?
-            .with_client(sui_read_client)
-            .await)
+        Ok(WalrusNodeClient::new(config, committees_handle)?.with_client(sui_read_client))
     }
 
     /// Creates a new read client starting from a config file with an optional maximum blob size.
-    pub async fn new_read_client_with_max_blob_size(
+    pub fn new_read_client_with_max_blob_size(
         config: ClientConfig,
         committees_handle: CommitteesRefresherHandle,
         sui_read_client: T,
         max_blob_size: Option<u64>,
     ) -> ClientResult<Self> {
         Ok(
-            WalrusNodeClient::new_with_max_blob_size(config, committees_handle, max_blob_size)
-                .await?
-                .with_client(sui_read_client)
-                .await,
+            WalrusNodeClient::new_with_max_blob_size(config, committees_handle, max_blob_size)?
+                .with_client(sui_read_client),
         )
     }
 
@@ -331,14 +324,10 @@ impl<T: ReadClient> WalrusNodeClient<T> {
         T: ReadClient + Clone + 'static,
     {
         let committees_handle = config
-            .refresh_config
             .build_refresher_and_run(sui_read_client.clone())
             .await
             .map_err(|e| ClientError::from(ClientErrorKind::Other(e.into())))?;
-        Ok(WalrusNodeClient::new(config, committees_handle)
-            .await?
-            .with_client(sui_read_client)
-            .await)
+        Ok(WalrusNodeClient::new(config, committees_handle)?.with_client(sui_read_client))
     }
 
     /// Reconstructs the blob by reading slivers from Walrus shards.
@@ -935,10 +924,7 @@ impl WalrusNodeClient<SuiContractClient> {
         committees_handle: CommitteesRefresherHandle,
         sui_client: SuiContractClient,
     ) -> ClientResult<Self> {
-        Ok(WalrusNodeClient::new(config, committees_handle)
-            .await?
-            .with_client(sui_client)
-            .await)
+        Ok(WalrusNodeClient::new(config, committees_handle)?.with_client(sui_client))
     }
 
     /// Creates a new client, and starts a committees refresher process in the background.
@@ -949,14 +935,10 @@ impl WalrusNodeClient<SuiContractClient> {
         sui_client: SuiContractClient,
     ) -> ClientResult<Self> {
         let committees_handle = config
-            .refresh_config
             .build_refresher_and_run(sui_client.read_client().clone())
             .await
             .map_err(|e| ClientError::from(ClientErrorKind::Other(e.into())))?;
-        Ok(WalrusNodeClient::new(config, committees_handle)
-            .await?
-            .with_client(sui_client)
-            .await)
+        Ok(WalrusNodeClient::new(config, committees_handle)?.with_client(sui_client))
     }
 
     /// Stores a list of blobs to Walrus, retrying if it fails because of epoch change.

--- a/crates/walrus-sdk/src/config.rs
+++ b/crates/walrus-sdk/src/config.rs
@@ -6,6 +6,7 @@ use std::{
     collections::HashMap,
     iter::once,
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -13,8 +14,10 @@ use indexmap::IndexSet;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use sui_types::base_types::ObjectID;
+use tokio::sync::{Notify, mpsc};
 use walrus_sui::{
     client::{
+        ReadClient,
         SuiClientError,
         SuiContractClient,
         SuiReadClient,
@@ -30,7 +33,10 @@ use walrus_utils::{
     is_internal_run,
 };
 
-use crate::client::quilt_client::QuiltClientConfig;
+use crate::client::{
+    quilt_client::QuiltClientConfig,
+    refresh::{CommitteesRefresher, CommitteesRefresherHandle},
+};
 
 mod committees_refresh_config;
 /// Communication configuration options.
@@ -230,6 +236,42 @@ impl ClientConfig {
     pub fn backoff_config(&self) -> &ExponentialBackoffConfig {
         &self.communication_config.request_rate_config.backoff_config
     }
+
+    /// Builds a new [`CommitteesRefresher`], spawns it on a separate task, and
+    /// returns the [`CommitteesRefresherHandle`].
+    pub async fn build_refresher_and_run(
+        &self,
+        sui_client: impl ReadClient + 'static,
+    ) -> Result<CommitteesRefresherHandle> {
+        let n_shards = if let Some(n_shards) = self.contract_config.n_shards {
+            n_shards
+        } else {
+            sui_client
+                .n_shards()
+                .await
+                .context("failed to determine n_shards before starting refresher")?
+        };
+
+        let notify = Arc::new(Notify::new());
+        let (req_tx, req_rx) = mpsc::channel(self.refresh_config.refresher_channel_size);
+        let handle = CommitteesRefresherHandle::new(notify.clone(), req_tx, n_shards);
+        let config = self.refresh_config.clone();
+
+        tokio::spawn(async move {
+            if let Err(error) = async {
+                let mut refresher =
+                    CommitteesRefresher::new(config, sui_client, req_rx, notify).await?;
+                refresher.run().await;
+                Ok::<(), anyhow::Error>(())
+            }
+            .await
+            {
+                tracing::error!(%error, "failed to run committees refresher");
+            }
+        });
+
+        Ok(handle)
+    }
 }
 
 /// Combines the main RPC URL with additional RPC endpoints, ensuring uniqueness of each URL string.
@@ -260,6 +302,8 @@ pub enum MultiClientConfig {
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroU16;
+
     use indoc::indoc;
     use rand::{SeedableRng as _, rngs::StdRng};
     use tempfile::TempDir;
@@ -277,10 +321,13 @@ mod tests {
         const EXAMPLE_CONFIG_PATH: &str = "client_config_example.yaml";
 
         let mut rng = StdRng::seed_from_u64(42);
-        let contract_config = ContractConfig::new(
-            ObjectID::random_from_rng(&mut rng),
-            ObjectID::random_from_rng(&mut rng),
-        );
+        let contract_config = ContractConfig {
+            n_shards: Some(NonZeroU16::new(1000).expect("1000 is non-zero")),
+            ..ContractConfig::new(
+                ObjectID::random_from_rng(&mut rng),
+                ObjectID::random_from_rng(&mut rng),
+            )
+        };
         let config = ClientConfig {
             contract_config,
             exchange_objects: vec![

--- a/crates/walrus-service/src/client/cli.rs
+++ b/crates/walrus-service/src/client/cli.rs
@@ -66,7 +66,6 @@ pub async fn get_read_client(
         get_sui_read_client_from_rpc_node_or_wallet(&config, rpc_url, wallet).await?;
 
     let refresh_handle = config
-        .refresh_config
         .build_refresher_and_run(sui_read_client.clone())
         .await?;
     let client = WalrusNodeClient::new_read_client_with_max_blob_size(
@@ -74,8 +73,7 @@ pub async fn get_read_client(
         refresh_handle,
         sui_read_client,
         max_blob_size,
-    )
-    .await?;
+    )?;
 
     if blocklist_path.is_some() {
         Ok(client.with_blocklist(Blocklist::new(blocklist_path)?))
@@ -96,7 +94,6 @@ pub async fn get_contract_client(
     let sui_client = config.new_contract_client(wallet?, gas_budget).await?;
 
     let refresh_handle = config
-        .refresh_config
         .build_refresher_and_run(sui_client.read_client().clone())
         .await?;
     let client = WalrusNodeClient::new_contract_client(config, refresh_handle, sui_client).await?;

--- a/crates/walrus-service/src/client/cli/backfill.rs
+++ b/crates/walrus-service/src/client/cli/backfill.rs
@@ -261,10 +261,13 @@ async fn get_backfill_client(config: ClientConfig) -> Result<WalrusNodeClient<Su
     .await?;
     let sui_read_client = config.new_read_client(retriable_sui_client).await?;
     let refresh_handle = config
-        .refresh_config
         .build_refresher_and_run(sui_read_client.clone())
         .await?;
-    Ok(WalrusNodeClient::new_read_client(config, refresh_handle, sui_read_client).await?)
+    Ok(WalrusNodeClient::new_read_client(
+        config,
+        refresh_handle,
+        sui_read_client,
+    )?)
 }
 
 /// Runs the blob backfill process.

--- a/crates/walrus-service/src/client/cli/runner.rs
+++ b/crates/walrus-service/src/client/cli/runner.rs
@@ -1384,10 +1384,9 @@ impl ClientCommandRunner {
         let encoding_type = encoding_type.unwrap_or(DEFAULT_ENCODING);
 
         let refresher_handle = config
-            .refresh_config
             .build_refresher_and_run(sui_read_client.clone())
             .await?;
-        let client = WalrusNodeClient::new(config, refresher_handle).await?;
+        let client = WalrusNodeClient::new(config, refresher_handle)?;
 
         let file = file_or_blob_id.file.clone();
         let blob_id =

--- a/crates/walrus-service/src/client/multiplexer.rs
+++ b/crates/walrus-service/src/client/multiplexer.rs
@@ -79,15 +79,13 @@ impl ClientMultiplexer {
 
         // Start the refresher here, so that all the clients can share it.
         let refresh_handle = config
-            .refresh_config
             .build_refresher_and_run(sui_read_client.clone())
             .await?;
         let read_client = WalrusNodeClient::new_read_client(
             config.clone(),
             refresh_handle.clone(),
             sui_read_client.clone(),
-        )
-        .await?;
+        )?;
 
         let refiller = Refiller::new(
             contract_client,

--- a/crates/walrus-stress/src/generator.rs
+++ b/crates/walrus-stress/src/generator.rs
@@ -9,7 +9,6 @@ use std::{
 };
 
 use blob::WriteBlobConfig;
-use futures::future::try_join_all;
 use rand::{Rng, thread_rng};
 use sui_sdk::types::base_types::SuiAddress;
 use tokio::{
@@ -82,19 +81,16 @@ impl LoadGenerator {
         let sui_read_client = client_config.new_read_client(sui_client.clone()).await?;
 
         let refresher_handle = client_config
-            .refresh_config
             .build_refresher_and_run(sui_read_client.clone())
             .await?;
-        for read_client in try_join_all((0..n_clients).map(|_| {
-            WalrusNodeClient::new_read_client(
-                client_config.clone(),
-                refresher_handle.clone(),
-                sui_read_client.clone(),
-            )
-        }))
-        .await?
-        {
-            read_client_pool_tx.send(read_client).await?;
+        for _ in 0..n_clients {
+            read_client_pool_tx
+                .send(WalrusNodeClient::new_read_client(
+                    client_config.clone(),
+                    refresher_handle.clone(),
+                    sui_read_client.clone(),
+                )?)
+                .await?;
         }
 
         // Set up write clients

--- a/crates/walrus-sui/src/client/contract_config.rs
+++ b/crates/walrus-sui/src/client/contract_config.rs
@@ -3,7 +3,7 @@
 
 //! Module for the configuration of contract packages and shared objects.
 
-use std::time::Duration;
+use std::{num::NonZeroU16, time::Duration};
 
 use serde::{Deserialize, Serialize};
 use serde_with::{DurationSeconds, serde_as};
@@ -29,6 +29,9 @@ pub struct ContractConfig {
     /// Object ID of the walrus subsidies object.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub walrus_subsidies_object: Option<ObjectID>,
+    /// The number of shards to use for the client.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub n_shards: Option<NonZeroU16>,
     /// The TTL for cached system and staking objects.
     #[serde(default = "defaults::default_cache_ttl", rename = "cache_ttl_secs")]
     #[serde_as(as = "DurationSeconds")]
@@ -43,6 +46,7 @@ impl ContractConfig {
             staking_object,
             credits_object: None,
             walrus_subsidies_object: None,
+            n_shards: None,
             cache_ttl: DEFAULT_CACHE_TTL,
         }
     }

--- a/crates/walrus-sui/src/client/read_client.rs
+++ b/crates/walrus-sui/src/client/read_client.rs
@@ -574,6 +574,7 @@ impl SuiReadClient {
                 .as_ref()
                 .map(|s| s.object_id),
             cache_ttl: self.cache_ttl,
+            n_shards: None,
         }
     }
 

--- a/crates/walrus-sui/src/test_utils/system_setup.rs
+++ b/crates/walrus-sui/src/test_utils/system_setup.rs
@@ -98,6 +98,8 @@ pub struct SystemContext {
     pub walrus_subsidies_object: Option<ObjectID>,
     /// The ID of the walrus subsidies package.
     pub walrus_subsidies_pkg_id: Option<ObjectID>,
+    /// The number of shards in the system.
+    pub n_shards: NonZeroU16,
 }
 
 impl SystemContext {
@@ -127,6 +129,7 @@ impl SystemContext {
             staking_object: self.staking_object,
             credits_object: self.credits_object,
             walrus_subsidies_object: self.walrus_subsidies_object,
+            n_shards: Some(self.n_shards),
             cache_ttl: DEFAULT_CACHE_TTL,
         }
     }
@@ -192,6 +195,7 @@ pub async fn create_and_init_system(
     gas_budget: Option<u64>,
 ) -> Result<(SystemContext, SuiContractClient)> {
     let init_system_params_cloned = init_system_params.clone();
+    let n_shards = init_system_params.n_shards;
     let PublishSystemPackageResult {
         walrus_pkg_id,
         init_cap_id,
@@ -284,6 +288,7 @@ pub async fn create_and_init_system(
             credits_pkg_id,
             walrus_subsidies_pkg_id,
             walrus_subsidies_object,
+            n_shards,
         },
         admin_contract_client,
     ))

--- a/crates/walrus-upload-relay/src/controller.rs
+++ b/crates/walrus-upload-relay/src/controller.rs
@@ -588,10 +588,13 @@ pub async fn get_client_with_config(
     let sui_read_client = client_config.new_read_client(retriable_sui_client).await?;
 
     let refresh_handle = client_config
-        .refresh_config
         .build_refresher_and_run(sui_read_client.clone())
         .await?;
-    Ok(WalrusNodeClient::new_read_client(client_config, refresh_handle, sui_read_client).await?)
+    Ok(WalrusNodeClient::new_read_client(
+        client_config,
+        refresh_handle,
+        sui_read_client,
+    )?)
 }
 
 #[cfg(test)]

--- a/docs/book/usage/setup.md
+++ b/docs/book/usage/setup.md
@@ -218,6 +218,10 @@ The configuration file currently supports the following parameters for each of t
 system_object: 0x2134d52768ea07e8c43570ef975eb3e4c27a39fa6396bef985b5abc58d03ddd2
 staking_object: 0x10b9d30c28448939ce6c4d6c6e0ffce4a7f8a4ada8248bdad09ef8b70e4a3904
 
+# Specifying the number of shards is optional but can speed up some client operations. If this is
+# set, it MUST be consistent with the system object above.
+n_shards: 1000
+
 # You can specify a list of Sui RPC URLs for reads. If none is provided, the RPC URL in the Sui
 # wallet is used.
 rpc_urls:

--- a/setup/client_config.yaml
+++ b/setup/client_config.yaml
@@ -2,7 +2,7 @@ contexts:
   mainnet:
     system_object: 0x2134d52768ea07e8c43570ef975eb3e4c27a39fa6396bef985b5abc58d03ddd2
     staking_object: 0x10b9d30c28448939ce6c4d6c6e0ffce4a7f8a4ada8248bdad09ef8b70e4a3904
-    exchange_objects: []
+    n_shards: 1000
     wallet_config:
       # Optional path to the wallet config file.
       # path: ~/.sui/sui_config/client.yaml
@@ -20,6 +20,7 @@ contexts:
       - 0x19825121c52080bb1073662231cfea5c0e4d905fd13e95f21e9a018f2ef41862
       - 0x83b454e524c71f30803f4d6c302a86fb6a39e96cdfb873c2d1e93bc1c26a3bc5
       - 0x8d63209cf8589ce7aef8f262437163c67577ed09f3e636a9d8e0813843fb8bf1
+    n_shards: 1000
     wallet_config:
       # Optional path to the wallet config file.
       # path: ~/.sui/sui_config/client.yaml

--- a/setup/client_config_mainnet.yaml
+++ b/setup/client_config_mainnet.yaml
@@ -1,4 +1,5 @@
 system_object: 0x2134d52768ea07e8c43570ef975eb3e4c27a39fa6396bef985b5abc58d03ddd2
 staking_object: 0x10b9d30c28448939ce6c4d6c6e0ffce4a7f8a4ada8248bdad09ef8b70e4a3904
+n_shards: 1000
 rpc_urls:
   - https://fullnode.mainnet.sui.io:443

--- a/setup/client_config_testnet.yaml
+++ b/setup/client_config_testnet.yaml
@@ -5,5 +5,6 @@ exchange_objects:
   - 0x19825121c52080bb1073662231cfea5c0e4d905fd13e95f21e9a018f2ef41862
   - 0x83b454e524c71f30803f4d6c302a86fb6a39e96cdfb873c2d1e93bc1c26a3bc5
   - 0x8d63209cf8589ce7aef8f262437163c67577ed09f3e636a9d8e0813843fb8bf1
+n_shards: 1000
 rpc_urls:
   - https://fullnode.testnet.sui.io:443


### PR DESCRIPTION
## Description

As a result, we can start the encoding even without reading the staking object.

Also removes some unnecessary `async`s.

Contributes to WAL-969.

This PR can be merged into #2703 or into main after #2703.

## Test plan

Existing test suite + manual tests.

---

## Release notes

- [x] CLI: Add a parameter to the `client_config.yaml` to specify the number of shards. You can obtain the latest version of the config file at http://docs.wal.app/setup/client_config.yaml.
