### PR TITLE
refactor: remove unused async await from codebase

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,6 +179,7 @@ cast_lossless = "warn"
 cast_possible_truncation = "warn"
 cast_possible_wrap = "warn"
 empty_structs_with_brackets = "warn"
+unused_async = "warn"
 unwrap_used = "warn"
 
 [profile.release]

--- a/crates/checkpoint-downloader/src/downloader.rs
+++ b/crates/checkpoint-downloader/src/downloader.rs
@@ -616,8 +616,7 @@ mod tests {
             None,
             None,
             Duration::from_secs(30),
-        )
-        .await?;
+        )?;
         let parallel_config = ParallelDownloaderConfig {
             retries: Some(0),
             initial_delay: Duration::from_millis(250),

--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -319,10 +319,7 @@ async fn test_inconsistency(failed_nodes: &[usize]) -> TestResult {
         .get_committees()
         .await
         .expect("committees should be available");
-    let shards_of_failed_nodes = client
-        .as_ref()
-        .shards_of(&failed_node_names, &committees)
-        .await;
+    let shards_of_failed_nodes = client.as_ref().shards_of(&failed_node_names, &committees);
 
     // Encode the blob with false metadata for one shard.
     let (pairs, metadata) = client
@@ -356,7 +353,6 @@ async fn test_inconsistency(failed_nodes: &[usize]) -> TestResult {
     let (blob_sui_object, _) = client
         .as_ref()
         .resource_manager(&committees)
-        .await
         .get_existing_or_register(
             &[&metadata],
             1,
@@ -517,7 +513,6 @@ async fn test_store_with_existing_blob_resource(
     let original_blob_objects = client
         .as_ref()
         .resource_manager(&committees)
-        .await
         .get_existing_or_register(
             &metadata.iter().collect::<Vec<_>>(),
             epochs_ahead_registered,
@@ -581,7 +576,6 @@ async fn register_blob(
     let blob_id = client
         .as_ref()
         .resource_manager(&committees)
-        .await
         .get_existing_or_register(
             &[&metadata],
             epochs_ahead,
@@ -1096,9 +1090,8 @@ async fn test_store_quilt(blobs_to_create: u32) -> TestResult {
     let quilt_client = client
         .quilt_client()
         .with_config(QuiltClientConfig::new(6, Duration::from_mins(1)));
-    let quilt = quilt_client
-        .construct_quilt::<QuiltVersionV1>(&quilt_store_blobs, encoding_type)
-        .await?;
+    let quilt =
+        quilt_client.construct_quilt::<QuiltVersionV1>(&quilt_store_blobs, encoding_type)?;
     let store_args = StoreArgs::default_with_epochs(2)
         .with_encoding_type(encoding_type)
         .no_store_optimizations();
@@ -2466,8 +2459,7 @@ pub async fn test_select_coins_max_objects() -> TestResult {
             .map(|rpc_url| LazySuiClientBuilder::new(rpc_url, None))
             .collect(),
         ExponentialBackoffConfig::default(),
-    )
-    .await?;
+    )?;
 
     let balance = retry_client.get_balance(address, None).await?;
     assert_eq!(balance.total_balance, u128::from(sui(4)));
@@ -2746,7 +2738,6 @@ async fn test_store_with_upload_relay_with_tip() {
             vec![LazySuiClientBuilder::new(&rpc_url, None)],
             ExponentialBackoffConfig::default(),
         )
-        .await
         .expect("create retry client")
     };
 

--- a/crates/walrus-indexer/src/async_task_sorter.rs
+++ b/crates/walrus-indexer/src/async_task_sorter.rs
@@ -491,6 +491,7 @@ mod tests {
     use crate::test_utils::{OrderedTestStore, TestTask};
 
     async_param_test! {
+        #[ignore = "ignore long-running test by default"]
         test_async_task_sorter_basic: [
             no_tasks: (3, 0, 2, 0),
             one_batch_catchup_no_drops: (3, 2, 2, 1),

--- a/crates/walrus-sdk/src/client/quilt_client.rs
+++ b/crates/walrus-sdk/src/client/quilt_client.rs
@@ -206,7 +206,7 @@ where
     SliverData<V::SliverAxis>: TryFrom<Sliver>,
 {
     /// Creates a new QuiltReader.
-    pub async fn new(
+    pub fn new(
         client: &'a QuiltClient<'a, T>,
         config: QuiltClientConfig,
         quilt_index: Option<QuiltIndex>,
@@ -260,7 +260,7 @@ where
     }
 
     /// Retrieves a blob from the quilt by identifier.
-    pub async fn get_blobs_by_identifiers(
+    pub fn get_blobs_by_identifiers(
         &self,
         identifiers: &[&str],
     ) -> ClientResult<Vec<QuiltStoreBlob<'static>>> {
@@ -278,7 +278,7 @@ where
     }
 
     /// Retrieves blobs from the quilt matching the given tag.
-    pub async fn get_blobs_by_tag(
+    pub fn get_blobs_by_tag(
         &self,
         target_tag: &str,
         target_value: &str,
@@ -297,7 +297,7 @@ where
     }
 
     /// Retrieves blobs from the quilt matching the given patch internal ids.
-    pub async fn get_blobs_by_patch_internal_ids(
+    pub fn get_blobs_by_patch_internal_ids(
         &self,
         patch_internal_ids: &[&[u8]],
     ) -> ClientResult<Vec<QuiltStoreBlob<'static>>> {
@@ -536,8 +536,7 @@ impl<T: ReadClient> QuiltClient<'_, T> {
                     self,
                     self.config.clone(),
                     Some(metadata.index.clone().into()),
-                )
-                .await;
+                );
                 quilt_reader
                     .download_data(
                         &sliver_indices,
@@ -545,7 +544,7 @@ impl<T: ReadClient> QuiltClient<'_, T> {
                         certified_epoch,
                     )
                     .await?;
-                quilt_reader.get_blobs_by_identifiers(identifiers).await
+                quilt_reader.get_blobs_by_identifiers(identifiers)
             }
         }
     }
@@ -576,8 +575,7 @@ impl<T: ReadClient> QuiltClient<'_, T> {
                     self,
                     self.config.clone(),
                     Some(metadata.index.clone().into()),
-                )
-                .await;
+                );
                 quilt_reader
                     .download_data(
                         &sliver_indices,
@@ -585,9 +583,7 @@ impl<T: ReadClient> QuiltClient<'_, T> {
                         certified_epoch,
                     )
                     .await?;
-                quilt_reader
-                    .get_blobs_by_tag(target_tag, target_value)
-                    .await
+                quilt_reader.get_blobs_by_tag(target_tag, target_value)
             }
         }
     }
@@ -665,7 +661,7 @@ impl<T: ReadClient> QuiltClient<'_, T> {
         }
 
         let mut quilt_reader =
-            QuiltReader::<'_, QuiltVersionV1, T>::new(self, self.config.clone(), None).await;
+            QuiltReader::<'_, QuiltVersionV1, T>::new(self, self.config.clone(), None);
         quilt_reader
             .download_data(&sliver_indices, metadata, certified_epoch)
             .await?;
@@ -673,9 +669,7 @@ impl<T: ReadClient> QuiltClient<'_, T> {
             .iter()
             .map(|quilt_id| quilt_id.patch_id_bytes.as_slice())
             .collect::<Vec<_>>();
-        quilt_reader
-            .get_blobs_by_patch_internal_ids(&internal_ids)
-            .await
+        quilt_reader.get_blobs_by_patch_internal_ids(&internal_ids)
     }
 
     /// Retrieves all the blobs from the quilt.
@@ -693,7 +687,7 @@ impl<T: ReadClient> QuiltClient<'_, T> {
             .await?;
 
         let mut quilt_reader =
-            QuiltReader::<'_, QuiltVersionV1, T>::new(self, self.config.clone(), None).await;
+            QuiltReader::<'_, QuiltVersionV1, T>::new(self, self.config.clone(), None);
         quilt_reader.get_all_blobs(&metadata, certified_epoch).await
     }
 
@@ -726,7 +720,7 @@ impl<T: ReadClient> QuiltClient<'_, T> {
 /// Stores quilts.
 impl QuiltClient<'_, SuiContractClient> {
     /// Constructs a quilt from a list of blobs.
-    pub async fn construct_quilt<V: QuiltVersion>(
+    pub fn construct_quilt<V: QuiltVersion>(
         &self,
         blobs: &[QuiltStoreBlob<'_>],
         encoding_type: EncodingType,
@@ -746,7 +740,7 @@ impl QuiltClient<'_, SuiContractClient> {
     //
     /// The on-disk file names are used as identifiers for the quilt patches.
     /// If the file name is not valid UTF-8, it will be replaced with "unnamed-blob-index".
-    pub async fn construct_quilt_from_paths<V: QuiltVersion, P: AsRef<Path>>(
+    pub fn construct_quilt_from_paths<V: QuiltVersion, P: AsRef<Path>>(
         &self,
         paths: &[P],
         encoding_type: EncodingType,
@@ -761,7 +755,6 @@ impl QuiltClient<'_, SuiContractClient> {
         let quilt_store_blobs = assign_identifiers_with_paths(blobs_with_paths)?;
 
         self.construct_quilt::<V>(&quilt_store_blobs, encoding_type)
-            .await
     }
 
     /// Stores all blobs from a list of paths as a quilt.
@@ -771,9 +764,7 @@ impl QuiltClient<'_, SuiContractClient> {
         paths: &[P],
         store_args: &StoreArgs,
     ) -> ClientResult<QuiltStoreResult> {
-        let quilt = self
-            .construct_quilt_from_paths::<V, P>(paths, store_args.encoding_type)
-            .await?;
+        let quilt = self.construct_quilt_from_paths::<V, P>(paths, store_args.encoding_type)?;
         let result = self
             .reserve_and_store_quilt::<V>(&quilt, store_args)
             .await?;

--- a/crates/walrus-sdk/src/client/resource.rs
+++ b/crates/walrus-sdk/src/client/resource.rs
@@ -480,15 +480,12 @@ impl<'a> ResourceManager<'a> {
         let mut blob_processing_items = Vec::with_capacity(max_len);
 
         for (metadata, encoded_length) in metadata_list.iter().zip(encoded_lengths) {
-            if let Some(blob) = self
-                .find_blob_owned_by_wallet(
-                    metadata.blob_id(),
-                    persistence,
-                    store_optimizations.should_check_status(),
-                    &owned_blobs,
-                )
-                .await?
-            {
+            if let Some(blob) = self.find_blob_owned_by_wallet(
+                metadata.blob_id(),
+                persistence,
+                store_optimizations.should_check_status(),
+                &owned_blobs,
+            )? {
                 tracing::debug!(
                     end_epoch=%blob.storage.end_epoch,
                     blob_id=%blob.blob_id,
@@ -670,7 +667,7 @@ impl<'a> ResourceManager<'a> {
     ///
     /// If `include_certified` is `true`, the function includes already certified blobs owned by the
     /// wallet.
-    async fn find_blob_owned_by_wallet(
+    fn find_blob_owned_by_wallet(
         &self,
         blob_id: &BlobId,
         persistence: BlobPersistence,

--- a/crates/walrus-service/bin/deploy.rs
+++ b/crates/walrus-service/bin/deploy.rs
@@ -547,8 +547,7 @@ mod commands {
                 rpc_fallback_config_args
                     .as_ref()
                     .and_then(|args| args.to_config()),
-            )
-            .await?;
+            )?;
             let serialized_backup_config = serde_yaml::to_string(&backup_config)
                 .context("Failed to serialize backup config")?;
             let backup_config_path = working_dir.join("backup_config.yaml");

--- a/crates/walrus-service/bin/node.rs
+++ b/crates/walrus-service/bin/node.rs
@@ -1077,8 +1077,7 @@ mod commands {
         let retriable_sui_client = RetriableSuiClient::new(
             vec![LazySuiClientBuilder::new(sui_rpc_url, None)],
             ExponentialBackoffConfig::default(),
-        )
-        .await?;
+        )?;
         let contract_config = ContractConfig::new(system_object_id, staking_object_id);
         let sui_read_client =
             SuiReadClient::new(retriable_sui_client.clone(), &contract_config).await?;
@@ -1121,8 +1120,7 @@ mod commands {
             &db_path,
             wal_path.as_deref(),
             checkpoint_id,
-        )
-        .await?;
+        )?;
 
         let target_checkpoint = checkpoint_id.map_or("latest".to_string(), |id| id.to_string());
         println!(
@@ -1549,7 +1547,7 @@ impl StorageNodeRuntime {
 }
 
 /// Handle log level commands from admin socket.
-async fn handle_log_level_command(level: String, args: &AdminArgs) -> AdminCommandResponse {
+fn handle_log_level_command(level: String, args: &AdminArgs) -> AdminCommandResponse {
     match args.tracing_handle.update_log(level.as_str()) {
         Ok(_) => AdminCommandResponse {
             success: true,
@@ -1624,7 +1622,7 @@ async fn handle_connection(stream: UnixStream, args: AdminArgs) {
             Ok(AdminCommands::Checkpoint { command }) => {
                 handle_checkpoint_command(command, &args).await
             }
-            Ok(AdminCommands::LogLevel { level }) => handle_log_level_command(level, &args).await,
+            Ok(AdminCommands::LogLevel { level }) => handle_log_level_command(level, &args),
             Err(e) => AdminCommandResponse {
                 success: false,
                 message: format!("Failed to parse command: {e}"),

--- a/crates/walrus-service/src/backup/service.rs
+++ b/crates/walrus-service/src/backup/service.rs
@@ -596,7 +596,6 @@ async fn backup_fetcher(
             backup_config.sui.backoff_config.clone(),
             None,
         )
-        .await
         .context("[backup_fetcher] cannot create RetriableSuiClient")?,
         &backup_config.sui.contract_config,
     )

--- a/crates/walrus-service/src/client/cli.rs
+++ b/crates/walrus-service/src/client/cli.rs
@@ -161,7 +161,6 @@ pub async fn get_sui_read_client_from_rpc_node_or_wallet(
         backoff_config,
         config.communication_config.sui_client_request_timeout,
     )
-    .await
     .context(format!(
         "cannot connect to Sui RPC nodes at {}",
         rpc_urls.join(", ")

--- a/crates/walrus-service/src/client/cli/backfill.rs
+++ b/crates/walrus-service/src/client/cli/backfill.rs
@@ -257,8 +257,7 @@ async fn get_backfill_client(config: ClientConfig) -> Result<WalrusNodeClient<Su
         &config.rpc_urls,
         config.backoff_config().clone(),
         None,
-    )
-    .await?;
+    )?;
     let sui_read_client = config.new_read_client(retriable_sui_client).await?;
     let refresh_handle = config
         .refresh_config

--- a/crates/walrus-service/src/client/cli/internal_run.rs
+++ b/crates/walrus-service/src/client/cli/internal_run.rs
@@ -484,7 +484,7 @@ fn spawn_signal_forwarders(handle: ChildProcessHandle, cancel_rx: watch::Receive
                 tokio::spawn(async move {
                     tokio::select! {
                         _ = stream.recv() => {
-                            forward_unix_signal_to_child(handle_clone, signo, name).await;
+                            forward_unix_signal_to_child(handle_clone, signo, name);
                             // When not catching the signal, the process will exit with
                             // 128 + signo by default. But when catching the signal, we need
                             // to do it ourself.
@@ -507,7 +507,7 @@ fn spawn_signal_forwarders(handle: ChildProcessHandle, cancel_rx: watch::Receive
 /// Forwards a Unix signal to the child uploader process.
 /// This is used to forward the Unix signals from the parent process to the child process.
 #[cfg(unix)]
-async fn forward_unix_signal_to_child(
+fn forward_unix_signal_to_child(
     handle: ChildProcessHandle,
     signo: libc::c_int,
     signal_name: &'static str,

--- a/crates/walrus-service/src/client/cli/runner.rs
+++ b/crates/walrus-service/src/client/cli/runner.rs
@@ -648,7 +648,7 @@ impl ClientCommandRunner {
         tracing::info!("retrieved {} blobs from quilt", retrieved_blobs.len());
 
         if let Some(out) = out.as_ref() {
-            Self::write_blobs_dedup(&mut retrieved_blobs, out).await?;
+            Self::write_blobs_dedup(&mut retrieved_blobs, out)?;
         }
 
         ReadQuiltOutput::new(out.clone(), retrieved_blobs).print_output(self.json)
@@ -1048,7 +1048,7 @@ impl ClientCommandRunner {
             )
         };
 
-        let quilt_store_blobs = Self::load_blobs_for_quilt(&paths, blobs).await?;
+        let quilt_store_blobs = Self::load_blobs_for_quilt(&paths, blobs)?;
 
         if dry_run {
             return Self::store_quilt_dry_run(
@@ -1095,8 +1095,7 @@ impl ClientCommandRunner {
         let start_timer = std::time::Instant::now();
         let quilt_write_client = client.quilt_client();
         let quilt = quilt_write_client
-            .construct_quilt::<QuiltVersionV1>(&quilt_store_blobs, encoding_type)
-            .await?;
+            .construct_quilt::<QuiltVersionV1>(&quilt_store_blobs, encoding_type)?;
         let base_store_args = StoreArgs::new(
             encoding_type,
             epochs_ahead,
@@ -1285,7 +1284,7 @@ impl ClientCommandRunner {
         result.print_output(self.json)
     }
 
-    async fn load_blobs_for_quilt(
+    fn load_blobs_for_quilt(
         paths: &[PathBuf],
         blob_inputs: Vec<QuiltBlobInput>,
     ) -> Result<Vec<QuiltStoreBlob<'static>>> {
@@ -1334,9 +1333,7 @@ impl ClientCommandRunner {
         tracing::info!("performing dry-run for quilt from {} blobs", blobs.len());
 
         let quilt_client = client.quilt_client();
-        let quilt = quilt_client
-            .construct_quilt::<QuiltVersionV1>(blobs, encoding_type)
-            .await?;
+        let quilt = quilt_client.construct_quilt::<QuiltVersionV1>(blobs, encoding_type)?;
         let (_, metadata) =
             client.encode_pairs_and_metadata(quilt.data(), encoding_type, &MultiProgress::new())?;
         let unencoded_size = metadata.metadata().unencoded_length();
@@ -1932,10 +1929,7 @@ impl ClientCommandRunner {
         Ok(())
     }
 
-    async fn write_blobs_dedup(
-        blobs: &mut [QuiltStoreBlob<'static>],
-        out_dir: &Path,
-    ) -> Result<()> {
+    fn write_blobs_dedup(blobs: &mut [QuiltStoreBlob<'static>], out_dir: &Path) -> Result<()> {
         let mut filename_counters = std::collections::HashMap::new();
 
         for blob in &mut *blobs {

--- a/crates/walrus-service/src/client/daemon.rs
+++ b/crates/walrus-service/src/client/daemon.rs
@@ -291,7 +291,6 @@ impl WalrusWriteClient for WalrusNodeClient<SuiContractClient> {
         // TODO(WAL-927): Make QuiltConfig part of ClientConfig.
         self.quilt_client()
             .construct_quilt::<V>(blobs, encoding_type)
-            .await
     }
 
     async fn write_quilt<V: QuiltVersion>(
@@ -629,7 +628,7 @@ pub(crate) async fn auth_layer(
 /// Handles errors from Tower middleware layers for service endpoints.
 ///
 /// Returns HTTP 429 for overload errors, and HTTP 500 with error details for other errors.
-async fn handle_service_error(error: BoxError, service_name: &str) -> Response {
+fn handle_service_error(error: BoxError, service_name: &str) -> Response {
     if error.is::<Overloaded>() {
         (
             StatusCode::TOO_MANY_REQUESTS,
@@ -646,11 +645,11 @@ async fn handle_service_error(error: BoxError, service_name: &str) -> Response {
 }
 
 async fn handle_aggregator_error(error: BoxError) -> Response {
-    handle_service_error(error, "aggregator").await
+    handle_service_error(error, "aggregator")
 }
 
 async fn handle_publisher_error(error: BoxError) -> Response {
-    handle_service_error(error, "publisher").await
+    handle_service_error(error, "publisher")
 }
 
 #[cfg(test)]

--- a/crates/walrus-service/src/client/daemon/cache.rs
+++ b/crates/walrus-service/src/client/daemon/cache.rs
@@ -164,7 +164,7 @@ where
             tokio::select! {
                 request = self.query_rx.recv() => {
                     if let Some(request) = request {
-                        self.handle_request(request).await;
+                        self.handle_request(request);
                     } else {
                         tracing::info!("the channel is closed, stopping the cache");
                         break;
@@ -182,7 +182,7 @@ where
     }
 
     /// Handles a request to the cache.
-    async fn handle_request(&mut self, request: CacheRequest<T>) {
+    fn handle_request(&mut self, request: CacheRequest<T>) {
         let response = match request.kind {
             CacheRequestKind::Exists(key) => {
                 tracing::debug!(key=?key, "checking if element exists in the cache");

--- a/crates/walrus-service/src/client/multiplexer.rs
+++ b/crates/walrus-service/src/client/multiplexer.rs
@@ -147,7 +147,7 @@ impl ClientMultiplexer {
         persistence: BlobPersistence,
         post_store: PostStoreAction,
     ) -> ClientResult<BlobStoreResult> {
-        let client = self.client_pool.next_client().await;
+        let client = self.client_pool.next_client();
         tracing::debug!("submitting write request to client in pool");
 
         let result = client
@@ -208,7 +208,7 @@ impl WalrusWriteClient for ClientMultiplexer {
         blobs: &[QuiltStoreBlob<'_>],
         encoding_type: Option<EncodingType>,
     ) -> ClientResult<V::Quilt> {
-        let client = self.client_pool.next_client().await;
+        let client = self.client_pool.next_client();
         tracing::debug!("submitting construct quilt request to client in pool");
 
         let result = client.construct_quilt::<V>(blobs, encoding_type).await?;
@@ -224,7 +224,7 @@ impl WalrusWriteClient for ClientMultiplexer {
         persistence: BlobPersistence,
         post_store: PostStoreAction,
     ) -> ClientResult<QuiltStoreResult> {
-        let client = self.client_pool.next_client().await;
+        let client = self.client_pool.next_client();
         tracing::debug!("submitting write quilt request to client in pool");
 
         let result = client
@@ -315,7 +315,7 @@ impl WriteClientPool {
     }
 
     /// Returns the next client in the pool.
-    pub async fn next_client(&self) -> Arc<WalrusNodeClient<SuiContractClient>> {
+    pub fn next_client(&self) -> Arc<WalrusNodeClient<SuiContractClient>> {
         let cur_idx = self.cur_idx.fetch_add(1, Ordering::Relaxed) % self.pool.len();
 
         self.pool
@@ -442,8 +442,7 @@ impl<'a> SubClientLoader<'a> {
             rpc_urls,
             self.config.backoff_config().clone(),
             self.config.communication_config.sui_client_request_timeout,
-        )
-        .await?;
+        )?;
 
         if should_refill(&sui_client, address, None, min_balance).await {
             self.refiller.send_gas_request(address).await?;

--- a/crates/walrus-service/src/common/utils.rs
+++ b/crates/walrus-service/src/common/utils.rs
@@ -493,7 +493,7 @@ pub async fn generate_sui_wallet(
     );
     let mut wallet = walrus_sui::utils::create_wallet(path, sui_network.env(), None, None).await?;
     let rpc_urls = &[wallet.get_rpc_url()?];
-    let client = RetriableSuiClient::new_for_rpc_urls(rpc_urls, Default::default(), None).await?;
+    let client = RetriableSuiClient::new_for_rpc_urls(rpc_urls, Default::default(), None)?;
 
     let wallet_address = wallet.active_address()?;
     tracing::info!("generated a new Sui wallet; address: {wallet_address}");

--- a/crates/walrus-service/src/event/event_processor/catchup.rs
+++ b/crates/walrus-service/src/event/event_processor/catchup.rs
@@ -291,7 +291,7 @@ impl EventBlobCatchupManager {
             return Ok(());
         }
 
-        if let Err(e) = coordination_state.start_catchup_processing_phase().await {
+        if let Err(e) = coordination_state.start_catchup_processing_phase() {
             tracing::error!(
                 error = ?e,
                 "failed to send stop message to checkpoint tailing"
@@ -340,7 +340,7 @@ impl EventBlobCatchupManager {
             }
         }
 
-        if let Err(e) = coordination_state.complete_catchup().await {
+        if let Err(e) = coordination_state.complete_catchup() {
             tracing::error!(error = ?e, "failed to send restart message to checkpoint tailing");
             Err(CatchupError::NonRecoverable(anyhow::anyhow!(
                 "failed to send restart message to checkpoint tailing"
@@ -447,7 +447,7 @@ impl EventBlobCatchupManager {
         let mut next_event_index = next_event_index;
 
         for blob_id in blobs.iter().rev() {
-            let downloaded_blob = self.process_single_blob(blob_id, next_event_index).await?;
+            let downloaded_blob = self.process_single_blob(blob_id, next_event_index)?;
 
             tracing::debug!("processed event blob {:?}", downloaded_blob);
 
@@ -498,7 +498,7 @@ impl EventBlobCatchupManager {
         Ok(num_events_recovered)
     }
 
-    async fn process_single_blob(
+    fn process_single_blob(
         &self,
         blob_id: &BlobId,
         next_event_index: Option<u64>,
@@ -562,8 +562,7 @@ impl EventBlobCatchupManager {
             &downloaded_blob.prev_blob_id,
             downloaded_blob.prev_event_id,
             downloaded_blob.epoch,
-        )
-        .await?;
+        )?;
 
         batch.write()?;
 
@@ -623,7 +622,7 @@ impl EventBlobCatchupManager {
         }
     }
 
-    async fn update_init_state(
+    fn update_init_state(
         &self,
         batch: &mut DBBatch,
         first_event_index: u64,

--- a/crates/walrus-service/src/event/event_processor/client.rs
+++ b/crates/walrus-service/src/event/event_processor/client.rs
@@ -54,7 +54,7 @@ impl ClientManager {
     ///
     /// A Result containing either the new ClientManager instance or an
     /// error if initialization fails.
-    pub async fn new(
+    pub fn new(
         rest_urls: &[String],
         request_timeout: Duration,
         rpc_fallback_config: Option<&RpcFallbackConfig>,
@@ -77,8 +77,7 @@ impl ClientManager {
             rpc_fallback_config.cloned(),
             Some(metrics.clone()),
             sampled_tracing_interval,
-        )
-        .await?;
+        )?;
 
         let sui_client = RetriableSuiClient::new(
             rest_urls
@@ -86,8 +85,7 @@ impl ClientManager {
                 .map(|rpc_url| LazySuiClientBuilder::new(rpc_url, Some(request_timeout)))
                 .collect(),
             ExponentialBackoffConfig::default(),
-        )
-        .await?;
+        )?;
 
         Ok(Self {
             rpc_client: client,

--- a/crates/walrus-service/src/event/event_processor/coordination.rs
+++ b/crates/walrus-service/src/event/event_processor/coordination.rs
@@ -123,7 +123,7 @@ impl CatchupCoordinationState {
 
     /// Transition from download phase to processing phase.
     /// This sends a message to stop checkpoint tailing.
-    pub async fn start_catchup_processing_phase(
+    pub fn start_catchup_processing_phase(
         &self,
     ) -> Result<(), mpsc::error::SendError<CoordinationMessage>> {
         tracing::info!(
@@ -137,9 +137,7 @@ impl CatchupCoordinationState {
 
     /// Complete catchup processing and signal for checkpoint tailing restart.
     /// This sends a message to restart checkpoint tailing from the new latest checkpoint.
-    pub async fn complete_catchup(
-        &self,
-    ) -> Result<(), mpsc::error::SendError<CoordinationMessage>> {
+    pub fn complete_catchup(&self) -> Result<(), mpsc::error::SendError<CoordinationMessage>> {
         tracing::info!("completing catchup - sending restart message to checkpoint tailing");
 
         self.catchup_active
@@ -150,7 +148,7 @@ impl CatchupCoordinationState {
     }
 
     /// Signal catchup failure and resume normal operation.
-    pub async fn catchup_failed(&self) -> Result<(), mpsc::error::SendError<CoordinationMessage>> {
+    pub fn catchup_failed(&self) -> Result<(), mpsc::error::SendError<CoordinationMessage>> {
         tracing::warn!("catchup failed - sending failure message to checkpoint tailing");
 
         self.catchup_active
@@ -205,7 +203,7 @@ mod tests {
         let (state, mut rx) = CatchupCoordinationState::new();
 
         // Test sending stop message
-        state.start_catchup_processing_phase().await.unwrap();
+        state.start_catchup_processing_phase().unwrap();
 
         match rx.recv().await {
             Some(CoordinationMessage::StopCheckpointTailing) => {
@@ -215,7 +213,7 @@ mod tests {
         }
 
         // Test sending restart message
-        state.complete_catchup().await.unwrap();
+        state.complete_catchup().unwrap();
 
         match rx.recv().await {
             Some(CoordinationMessage::RestartCheckpointTailing) => {

--- a/crates/walrus-service/src/event/event_processor/processor.rs
+++ b/crates/walrus-service/src/event/event_processor/processor.rs
@@ -119,8 +119,7 @@ impl EventProcessor {
             runtime_config.rpc_fallback_config.as_ref(),
             metrics_registry,
             config.sampled_tracing_interval,
-        )
-        .await?;
+        )?;
 
         let stores = EventProcessorStores::new(&runtime_config.db_config, &runtime_config.db_path)?;
 

--- a/crates/walrus-service/src/node/blob_sync.rs
+++ b/crates/walrus-service/src/node/blob_sync.rs
@@ -277,7 +277,7 @@ impl BlobSyncHandler {
         self.cancel_syncs(|(_, sync)| sync.cancel(), false).await
     }
 
-    async fn remove_sync_handle(&self, blob_id: &BlobId) {
+    fn remove_sync_handle(&self, blob_id: &BlobId) {
         self.blob_syncs_in_progress
             .lock()
             .expect("should be able to acquire lock")
@@ -440,7 +440,7 @@ impl BlobSyncHandler {
         };
 
         // We remove the blob handler regardless of the result.
-        self.remove_sync_handle(&blob_id).await;
+        self.remove_sync_handle(&blob_id);
 
         walrus_utils::with_label!(self.node.metrics.recover_blob_duration_seconds, label)
             .observe(start.elapsed().as_secs_f64());

--- a/crates/walrus-service/src/node/db_checkpoint.rs
+++ b/crates/walrus-service/src/node/db_checkpoint.rs
@@ -214,7 +214,7 @@ impl DelayedTask {
     }
 
     /// Cancel the task.
-    pub async fn cancel(&self) {
+    pub fn cancel(&self) {
         if let Ok(mut status_guard) = self.status.lock() {
             *status_guard = TaskStatus::Cancelled;
             self.handle.abort();
@@ -281,10 +281,7 @@ impl DbCheckpointManager {
     /// Create a new db_checkpoint manager for RocksDB.
     //
     // TODO(WAL-845): Add metrics for db_checkpoint creation and restore.
-    pub async fn new(
-        db: Arc<RocksDB>,
-        config: DbCheckpointConfig,
-    ) -> Result<Self, DbCheckpointError> {
+    pub fn new(db: Arc<RocksDB>, config: DbCheckpointConfig) -> Result<Self, DbCheckpointError> {
         tracing::info!(?config, "DbCheckpointManager starting...");
         if let Some(db_checkpoint_dir) = config.db_checkpoint_dir.as_ref() {
             create_dir_all(db_checkpoint_dir).map_err(|e| DbCheckpointError::Other(e.into()))?;
@@ -465,7 +462,7 @@ impl DbCheckpointManager {
                         },
                         DbCheckpointRequest::CancelBackup { response } => {
                             if let Some(task) = current_task.as_ref() {
-                                task.cancel().await;
+                                task.cancel();
                                 let _ = response.send(true);
                             } else {
                                 let _ = response.send(false);
@@ -498,9 +495,7 @@ impl DbCheckpointManager {
             match Self::calculate_first_db_checkpoint_time(
                 db_checkpoint_dir,
                 config.db_checkpoint_interval,
-            )
-            .await
-            {
+            ) {
                 Ok(time) => break time,
                 Err(e) => {
                     tracing::error!(
@@ -577,7 +572,7 @@ impl DbCheckpointManager {
     }
 
     /// Calculate the first db_checkpoint time.
-    async fn calculate_first_db_checkpoint_time(
+    fn calculate_first_db_checkpoint_time(
         db_checkpoint_dir: &Path,
         db_checkpoint_interval: StdDuration,
     ) -> Result<time::Instant, DbCheckpointError> {
@@ -654,7 +649,7 @@ impl DbCheckpointManager {
     ///
     /// If backup_id is provided, restore from the specified backup.
     /// If backup_id is not provided, restore from the latest backup.
-    pub async fn restore_from_backup(
+    pub fn restore_from_backup(
         db_checkpoint_dir: &Path,
         db_path: &Path,
         wal_dir: Option<&Path>,
@@ -840,8 +835,7 @@ mod tests {
                     db_checkpoint_dir: Some(db_checkpoint_dir.path().to_path_buf()),
                     ..Default::default()
                 },
-            )
-            .await?;
+            )?;
 
             db_checkpoint_manager
                 .schedule_and_wait_for_db_checkpoint_creation(Some(db_checkpoint_dir.path()), None)
@@ -859,8 +853,7 @@ mod tests {
             restore_dir.path(),
             None,
             None,
-        )
-        .await?;
+        )?;
 
         // Reopen restored DB and verify contents.
         {

--- a/crates/walrus-service/src/node/event_blob_writer.rs
+++ b/crates/walrus-service/src/node/event_blob_writer.rs
@@ -350,7 +350,7 @@ impl EventBlobWriterFactory {
     }
 
     /// Create a new event blob writer factory.
-    pub async fn new(
+    pub fn new(
         root_dir_path: &Path,
         db_config: &DatabaseConfig,
         node: Arc<StorageNodeInner>,
@@ -1091,7 +1091,7 @@ impl EventBlobWriter {
     }
 
     /// Update the event blob writer with the initial state.
-    pub async fn update(&mut self, init_state: InitState) -> Result<()> {
+    pub fn update(&mut self, init_state: InitState) -> Result<()> {
         self.event_cursor = init_state.event_cursor;
         self.current_epoch = init_state.epoch;
         self.prev_certified_blob_id = init_state.prev_blob_id;
@@ -1301,7 +1301,7 @@ impl EventBlobWriter {
     /// Cuts the current blob and prepares for a new one.
     ///
     /// This method finalizes the current blob file and renames it to its final name.
-    async fn cut(&mut self) -> Result<()> {
+    fn cut(&mut self) -> Result<()> {
         self.finalize()?;
         self.rename_blob_file()?;
         Ok(())
@@ -1563,7 +1563,7 @@ impl EventBlobWriter {
         self.update_epoch(&element, &mut batch)?;
 
         if self.should_cut_new_blob(&element) {
-            self.cut_and_reset_blob(&mut batch, element_index).await?;
+            self.cut_and_reset_blob(&mut batch, element_index)?;
         }
 
         self.handle_event_blob_certification(&element, element_index, &mut batch)?;
@@ -1613,8 +1613,8 @@ impl EventBlobWriter {
     ///
     /// Returns an error if either `self.start.is_none()` or `self.end.is_none()` or the DB
     /// operation fails.
-    async fn cut_and_reset_blob(&mut self, batch: &mut DBBatch, element_index: u64) -> Result<()> {
-        self.cut().await?;
+    fn cut_and_reset_blob(&mut self, batch: &mut DBBatch, element_index: u64) -> Result<()> {
+        self.cut()?;
         let blob_metadata = PendingEventBlobMetadata::new(
             self.start.context("start is not set")?,
             self.end.context("end is not set")?,
@@ -1857,8 +1857,7 @@ mod tests {
             Some(10),
             None,
             None,
-        )
-        .await?;
+        )?;
         let mut blob_writer = blob_writer_factory.create().await?;
         let num_checkpoints: u64 = NUM_BLOBS * u64::from(blob_writer.num_checkpoints_per_blob());
 
@@ -1912,8 +1911,7 @@ mod tests {
             Some(10),
             None,
             None,
-        )
-        .await?;
+        )?;
         let mut blob_writer = blob_writer_factory.create().await?;
         let num_checkpoints: u64 = NUM_BLOBS * u64::from(blob_writer.num_checkpoints_per_blob());
 
@@ -1997,8 +1995,7 @@ mod tests {
             Some(10),
             None,
             None,
-        )
-        .await?;
+        )?;
         let mut blob_writer = blob_writer_factory.create().await?;
         let num_checkpoints: u64 = NUM_BLOBS * u64::from(blob_writer.num_checkpoints_per_blob());
 
@@ -2075,8 +2072,7 @@ mod tests {
             Some(10),
             None,
             None,
-        )
-        .await?;
+        )?;
         let mut blob_writer = blob_writer_factory.create().await?;
         let num_checkpoints: u64 = u64::from(blob_writer.num_checkpoints_per_blob());
 

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -371,10 +371,9 @@ impl Storage {
     ) -> Result<(), TypedStoreError> {
         let shard_map_lock = self.lock_shards().await;
         self.create_storage_for_shards_locked(shard_map_lock, new_shards)
-            .await
     }
 
-    pub(crate) async fn create_storage_for_shards_locked(
+    pub(crate) fn create_storage_for_shards_locked(
         &self,
         mut locked_map: StorageShardLock,
         new_shards: &[ShardIndex],

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -2800,7 +2800,7 @@ pub mod test_cluster {
 
             let event_processor_config = Default::default();
             let mut cluster_builder = if test_nodes_config.use_legacy_event_processor {
-                setup_legacy_event_processors(sui_read_client.clone(), cluster_builder).await?
+                setup_legacy_event_processors(sui_read_client.clone(), cluster_builder)?
             } else {
                 setup_checkpoint_based_event_processors(
                     &event_processor_config,
@@ -2997,7 +2997,7 @@ pub mod test_cluster {
         Ok(res)
     }
 
-    async fn setup_legacy_event_processors(
+    fn setup_legacy_event_processors(
         sui_read_client: SuiReadClient,
         test_cluster_builder: TestClusterBuilder,
     ) -> anyhow::Result<TestClusterBuilder> {

--- a/crates/walrus-service/src/testbed.rs
+++ b/crates/walrus-service/src/testbed.rs
@@ -378,8 +378,7 @@ pub async fn deploy_walrus_contract(
         let sui_client = RetriableSuiClient::new(
             vec![LazySuiClientBuilder::new(rpc_url, None)],
             Default::default(),
-        )
-        .await?;
+        )?;
         request_sui_from_faucet(admin_wallet.active_address()?, &sui_network, &sui_client).await?;
         admin_wallet
     };
@@ -534,7 +533,7 @@ pub async fn create_client_config(
 }
 
 /// Create the config for the walrus-backup node associated with a network.
-pub async fn create_backup_config(
+pub fn create_backup_config(
     system_ctx: &SystemContext,
     working_dir: &Path,
     database_url: &str,

--- a/crates/walrus-stress/src/generator.rs
+++ b/crates/walrus-stress/src/generator.rs
@@ -76,8 +76,7 @@ impl LoadGenerator {
             client_config
                 .communication_config
                 .sui_client_request_timeout,
-        )
-        .await?;
+        )?;
 
         let sui_read_client = client_config.new_read_client(sui_client.clone()).await?;
 

--- a/crates/walrus-stress/src/generator/write_client.rs
+++ b/crates/walrus-stress/src/generator/write_client.rs
@@ -203,7 +203,6 @@ impl WriteClient {
             .client
             .as_ref()
             .resource_manager(&committees)
-            .await
             .get_existing_or_register(
                 &[&metadata],
                 epochs_to_store,
@@ -268,8 +267,7 @@ async fn new_client(
             })
             .collect(),
         Default::default(),
-    )
-    .await?;
+    )?;
     let sui_read_client = config.new_read_client(sui_client).await?;
     let sui_contract_client = wallet.and_then(|wallet| {
         SuiContractClient::new_with_read_client(wallet, gas_budget, Arc::new(sui_read_client))

--- a/crates/walrus-stress/src/lib.rs
+++ b/crates/walrus-stress/src/lib.rs
@@ -3,4 +3,6 @@
 
 //! Stress testing for Walrus.
 
+#![recursion_limit = "256"]
+
 pub mod single_client_workload;

--- a/crates/walrus-sui/src/client.rs
+++ b/crates/walrus-sui/src/client.rs
@@ -492,8 +492,7 @@ impl SuiContractClient {
     ) -> SuiClientResult<Self> {
         let read_client = Arc::new(
             SuiReadClient::new(
-                RetriableSuiClient::new_for_rpc_urls(rpc_urls, backoff_config.clone(), None)
-                    .await?,
+                RetriableSuiClient::new_for_rpc_urls(rpc_urls, backoff_config.clone(), None)?,
                 contract_config,
             )
             .await?,
@@ -512,8 +511,7 @@ impl SuiContractClient {
     ) -> SuiClientResult<Self> {
         let read_client = Arc::new(
             SuiReadClient::new(
-                RetriableSuiClient::new_for_rpc_urls(rpc_urls, backoff_config.clone(), None)
-                    .await?
+                RetriableSuiClient::new_for_rpc_urls(rpc_urls, backoff_config.clone(), None)?
                     .with_metrics(Some(metrics)),
                 contract_config,
             )

--- a/crates/walrus-sui/src/client/read_client.rs
+++ b/crates/walrus-sui/src/client/read_client.rs
@@ -381,8 +381,7 @@ impl SuiReadClient {
         contract_config: &ContractConfig,
         backoff_config: ExponentialBackoffConfig,
     ) -> SuiClientResult<Self> {
-        let client =
-            RetriableSuiClient::new_for_rpc_urls(rpc_addresses, backoff_config, None).await?;
+        let client = RetriableSuiClient::new_for_rpc_urls(rpc_addresses, backoff_config, None)?;
         Self::new(client, contract_config).await
     }
 
@@ -456,7 +455,7 @@ impl SuiReadClient {
         })
     }
 
-    pub(crate) async fn object_arg_for_credits_obj(
+    pub(crate) fn object_arg_for_credits_obj(
         &self,
         mutability: SharedObjectMutability,
     ) -> SuiClientResult<ObjectArg> {
@@ -472,7 +471,7 @@ impl SuiReadClient {
         })
     }
 
-    pub(crate) async fn object_arg_for_walrus_subsidies_obj(
+    pub(crate) fn object_arg_for_walrus_subsidies_obj(
         &self,
         mutability: SharedObjectMutability,
     ) -> SuiClientResult<ObjectArg> {

--- a/crates/walrus-sui/src/client/retry_client/retriable_rpc_client.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_rpc_client.rs
@@ -216,7 +216,7 @@ impl RetriableRpcClient {
     // TODO(WAL-718): The timeout should ideally be set directly on the tonic client.
 
     /// Creates a new retriable client.
-    pub async fn new(
+    pub fn new(
         lazy_client_builders: Vec<LazyFallibleRpcClientBuilder>,
         request_timeout: Duration,
         backoff_config: ExponentialBackoffConfig,
@@ -230,7 +230,7 @@ impl RetriableRpcClient {
         });
 
         Ok(Self {
-            client: Arc::new(FailoverWrapper::new(lazy_client_builders).await?),
+            client: Arc::new(FailoverWrapper::new(lazy_client_builders)?),
             request_timeout,
             backoff_config,
             fallback_client,

--- a/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
@@ -232,13 +232,12 @@ pub struct RetriableSuiClient {
 
 impl RetriableSuiClient {
     /// Creates a new retriable client.
-    pub async fn new(
+    pub fn new(
         lazy_client_builders: Vec<LazySuiClientBuilder>,
         backoff_config: ExponentialBackoffConfig,
     ) -> anyhow::Result<Self> {
         Ok(RetriableSuiClient {
             failover_sui_client: FailoverWrapper::new(lazy_client_builders)
-                .await
                 .context("creating failover wrapper")?,
             backoff_config,
             metrics: None,
@@ -257,7 +256,7 @@ impl RetriableSuiClient {
     }
 
     /// Creates a new retriable client from an RCP address.
-    pub async fn new_for_rpc_urls<S: AsRef<str>>(
+    pub fn new_for_rpc_urls<S: AsRef<str>>(
         rpc_addresses: &[S],
         backoff_config: ExponentialBackoffConfig,
         request_timeout: Option<Duration>,
@@ -266,7 +265,7 @@ impl RetriableSuiClient {
             .iter()
             .map(|rpc_url| LazySuiClientBuilder::new(rpc_url, request_timeout))
             .collect::<Vec<_>>();
-        Ok(Self::new(failover_clients, backoff_config).await?)
+        Ok(Self::new(failover_clients, backoff_config)?)
     }
 
     // Reimplementation of the `SuiClient` methods.

--- a/crates/walrus-sui/src/client/transaction_builder.rs
+++ b/crates/walrus-sui/src/client/transaction_builder.rs
@@ -290,7 +290,7 @@ impl WalrusPtbBuilder {
         self.fill_wal_balance(price).await?;
 
         let reserve_arguments = vec![
-            self.credits_arg(SharedObjectMutability::Mutable).await?,
+            self.credits_arg(SharedObjectMutability::Mutable)?,
             self.system_arg(SharedObjectMutability::Mutable).await?,
             self.pt_builder.pure(encoded_size)?,
             self.pt_builder.pure(epochs_ahead)?,
@@ -381,7 +381,7 @@ impl WalrusPtbBuilder {
         let storage_resource_arg = self.argument_from_arg_or_obj(storage_resource).await?;
 
         let register_arguments = vec![
-            self.credits_arg(SharedObjectMutability::Mutable).await?,
+            self.credits_arg(SharedObjectMutability::Mutable)?,
             self.system_arg(SharedObjectMutability::Mutable).await?,
             storage_resource_arg,
             self.pt_builder.pure(blob_metadata.blob_id)?,
@@ -483,7 +483,7 @@ impl WalrusPtbBuilder {
     }
 
     /// Adds a call to create a new instance of Metadata and returns the result [`Argument`].
-    pub async fn new_metadata(&mut self) -> SuiClientResult<Argument> {
+    pub fn new_metadata(&mut self) -> SuiClientResult<Argument> {
         let result_arg = self.walrus_move_call(contracts::metadata::new, vec![])?;
         self.add_result_to_be_consumed(result_arg);
         Ok(result_arg)
@@ -513,7 +513,7 @@ impl WalrusPtbBuilder {
         blob_attribute: BlobAttribute,
     ) -> SuiClientResult<()> {
         // Create a new metadata object
-        let metadata_arg = self.new_metadata().await?;
+        let metadata_arg = self.new_metadata()?;
 
         // Iterate through the passed-in metadata and populate the move metadata
         for (key, value) in blob_attribute.iter() {
@@ -706,7 +706,7 @@ impl WalrusPtbBuilder {
         self.fill_wal_balance(price).await?;
 
         let args = vec![
-            self.credits_arg(SharedObjectMutability::Mutable).await?,
+            self.credits_arg(SharedObjectMutability::Mutable)?,
             self.system_arg(SharedObjectMutability::Mutable).await?,
             self.argument_from_arg_or_obj(blob_object).await?,
             self.pt_builder.pure(epochs_ahead)?,
@@ -874,8 +874,7 @@ impl WalrusPtbBuilder {
         let args = vec![
             self.pt_builder.obj(
                 self.read_client
-                    .object_arg_for_walrus_subsidies_obj(SharedObjectMutability::Mutable)
-                    .await?,
+                    .object_arg_for_walrus_subsidies_obj(SharedObjectMutability::Mutable)?,
             )?,
             split_coin,
         ];
@@ -945,8 +944,7 @@ impl WalrusPtbBuilder {
     /// Adds a call to `walrus_subsidies::process_subsidies` to the PTB.
     pub async fn process_subsidies(&mut self) -> SuiClientResult<()> {
         let args = vec![
-            self.walrus_subsidies_arg(SharedObjectMutability::Mutable)
-                .await?,
+            self.walrus_subsidies_arg(SharedObjectMutability::Mutable)?,
             self.staking_arg(SharedObjectMutability::Mutable).await?,
             self.system_arg(SharedObjectMutability::Mutable).await?,
             self.pt_builder.obj(CLOCK_OBJECT_ARG)?,
@@ -1027,7 +1025,7 @@ impl WalrusPtbBuilder {
         node_parameters: &NodeRegistrationParams,
         proof_of_possession: ProofOfPossession,
     ) -> SuiClientResult<Argument> {
-        let node_metadata_arg = self.create_node_metadata(&node_parameters.metadata).await?;
+        let node_metadata_arg = self.create_node_metadata(&node_parameters.metadata)?;
         let args = vec![
             self.staking_arg(SharedObjectMutability::Mutable).await?,
             self.pt_builder.pure(&node_parameters.name)?,
@@ -1051,7 +1049,7 @@ impl WalrusPtbBuilder {
     }
 
     /// Adds a call to `create_node_metadata` to the PTB and returns the result [`Argument`].
-    pub async fn create_node_metadata(
+    pub fn create_node_metadata(
         &mut self,
         node_metadata: &NodeMetadata,
     ) -> SuiClientResult<Argument> {
@@ -1073,7 +1071,7 @@ impl WalrusPtbBuilder {
         storage_node_cap: &ArgumentOrOwnedObject,
         node_metadata: &NodeMetadata,
     ) -> SuiClientResult<()> {
-        let metadata_arg = self.create_node_metadata(node_metadata).await?;
+        let metadata_arg = self.create_node_metadata(node_metadata)?;
         let args = vec![
             self.staking_arg(SharedObjectMutability::Mutable).await?,
             self.argument_from_arg_or_obj(*storage_node_cap).await?,
@@ -1723,20 +1721,19 @@ impl WalrusPtbBuilder {
             .obj(self.read_client.object_arg_for_staking_obj(mutable).await?)?)
     }
 
-    async fn credits_arg(&mut self, mutable: SharedObjectMutability) -> SuiClientResult<Argument> {
+    fn credits_arg(&mut self, mutable: SharedObjectMutability) -> SuiClientResult<Argument> {
         Ok(self
             .pt_builder
-            .obj(self.read_client.object_arg_for_credits_obj(mutable).await?)?)
+            .obj(self.read_client.object_arg_for_credits_obj(mutable)?)?)
     }
 
-    async fn walrus_subsidies_arg(
+    fn walrus_subsidies_arg(
         &mut self,
         mutable: SharedObjectMutability,
     ) -> SuiClientResult<Argument> {
         Ok(self.pt_builder.obj(
             self.read_client
-                .object_arg_for_walrus_subsidies_obj(mutable)
-                .await?,
+                .object_arg_for_walrus_subsidies_obj(mutable)?,
         )?)
     }
 

--- a/crates/walrus-sui/src/system_setup.rs
+++ b/crates/walrus-sui/src/system_setup.rs
@@ -167,8 +167,7 @@ pub(crate) async fn publish_package(
     let retry_client = RetriableSuiClient::new(
         vec![LazySuiClientBuilder::new(wallet.get_rpc_url()?, None)],
         Default::default(),
-    )
-    .await?;
+    )?;
 
     let chain_id = retry_client.get_chain_identifier().await.ok();
 
@@ -489,8 +488,7 @@ pub async fn create_system_and_staking_objects(
     let retry_client = RetriableSuiClient::new(
         vec![LazySuiClientBuilder::new(wallet.get_rpc_url()?, None)],
         Default::default(),
-    )
-    .await?;
+    )?;
     let gas_price = retry_client.get_reference_gas_price().await?;
 
     let gas_budget = if let Some(gas_budget) = gas_budget {

--- a/crates/walrus-sui/src/utils.rs
+++ b/crates/walrus-sui/src/utils.rs
@@ -428,7 +428,7 @@ pub async fn get_sui_from_wallet_or_faucet(
     let min_balance = sui_amount + 2 * one_sui;
     let sender = wallet.active_address()?;
     let rpc_urls = &[wallet.get_rpc_url()?];
-    let client = RetriableSuiClient::new_for_rpc_urls(rpc_urls, Default::default(), None).await?;
+    let client = RetriableSuiClient::new_for_rpc_urls(rpc_urls, Default::default(), None)?;
     let balance = client.get_balance(sender, None).await?;
     if balance.total_balance >= u128::from(min_balance) {
         let mut ptb = ProgrammableTransactionBuilder::new();

--- a/crates/walrus-test-utils/src/lib.rs
+++ b/crates/walrus-test-utils/src/lib.rs
@@ -438,6 +438,7 @@ pub fn init_tracing() {
 }
 
 #[cfg(test)]
+#[allow(clippy::unused_async)]
 mod tests {
     use std::error::Error;
 

--- a/crates/walrus-upload-relay/src/controller.rs
+++ b/crates/walrus-upload-relay/src/controller.rs
@@ -581,8 +581,7 @@ pub async fn get_client_with_config(
         &client_config.rpc_urls,
         client_config.backoff_config().clone(),
         None,
-    )
-    .await?
+    )?
     .with_metrics(Some(Arc::new(SuiClientMetricSet::new(registry))));
 
     let sui_read_client = client_config.new_read_client(retriable_sui_client).await?;


### PR DESCRIPTION
## Description

Also enable the [unused_async][unused_async] Clippy lint to prevent introducing these in the future.

[unused_async]: https://rust-lang.github.io/rust-clippy/rust-1.91.0/index.html#unused_async

## Test plan

Existing test suite.