### PR TITLE
fix(sui): avoid redundant RPC requests for staking pools

### DIFF
--- a/crates/walrus-sui/src/types/move_structs.rs
+++ b/crates/walrus-sui/src/types/move_structs.rs
@@ -437,7 +437,8 @@ impl Display for Authorized {
 /// Represents a single staking pool.
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize)]
 pub struct StakingPool {
-    id: ObjectID,
+    /// The object ID of the staking pool, also known as the node ID.
+    pub id: ObjectID,
     /// The current state of the pool.
     state: PoolState,
     /// Current epoch's pool parameters.


### PR DESCRIPTION
## Description

The `get_committees_and_state` calls the `shard_assignment_to_committee` multiple times for the different committees (present, past, and, possibly, next).

Previously, fetching the `StakingPool` objects was done in this inner function. As the different committees are almost identical in most cases, this resulted in redundant RPC requests for the `StakingPool` objects.

With this change, we fetch the `StakingPool` objects of all nodes that are part of any committee once and pass them to the `shard_assignment_to_committee` function. This ensures that each object is only fetched once.

In addition, the requests are now performed concurrently using `try_join_all`.

When running against Testnet, this reduces the duration of this operation from ~800ms (or ~1200ms if the next committee is also fetched) to 150-200ms (assuming the staking object is already cached).

Closes WAL-1099
Contributes to WAL-1005

## Test plan

Compare traces with Jaeger (see https://github.com/MystenLabs/walrus/blob/main/CONTRIBUTING.md#tracing).