### PR TITLE
chore: provide for bidirectional shutdown coordination between background processors and the storage node

### DIFF
--- a/crates/walrus-service/bin/node.rs
+++ b/crates/walrus-service/bin/node.rs
@@ -1409,7 +1409,9 @@ impl StorageNodeRuntime {
         let walrus_node_cancel_token = cancel_token.child_token();
         let walrus_node_handle = tokio::spawn(async move {
             let cancel_token = walrus_node_cancel_token.clone();
-            let result = walrus_node_clone.run(walrus_node_cancel_token).await;
+            let result = walrus_node_clone
+                .run_storage_node(walrus_node_cancel_token)
+                .await;
 
             if exit_notifier.send(()).is_err() && !cancel_token.is_cancelled() {
                 tracing::warn!(

--- a/crates/walrus-service/src/node/blob_event_processor.rs
+++ b/crates/walrus-service/src/node/blob_event_processor.rs
@@ -190,7 +190,6 @@ impl BackgroundEventProcessor {
                                     worker_index = self.worker_index,
                                     "error processing blob event, triggering node shutdown"
                                 );
-                                self.node_cancel_token.cancel();
                                 break;
                             }
                         }
@@ -206,6 +205,9 @@ impl BackgroundEventProcessor {
                 }
             }
         }
+        // If any background event processor exits its loop, we should trigger cancellation to the
+        // entire node.
+        self.node_cancel_token.cancel();
     }
 
     /// Processes a blob event.

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -1070,7 +1070,7 @@ impl StorageNodeHandleBuilder {
 
             Some(tokio::task::spawn(
                 async move {
-                    let status = node.run(cancel_token).await;
+                    let status = node.run_storage_node(cancel_token).await;
                     if let Err(error) = status {
                         tracing::error!(?error, "node stopped with an error");
                         std::process::exit(1);


### PR DESCRIPTION
## Description

### Error Flow (WAL-874 Resolved)

  1. Error occurs during event processing in background processor
  2. Processor triggers `node_cancel_token.cancel()`
  3. Processor breaks out of event loop
  4. Node's `select!` detects cancellation
  5. Node executes graceful shutdown sequence
  6. All processors are awaited and finish cleanly
  7. Node returns error to caller

### Normal Shutdown Flow (WAL-876 Resolved)

  1. External cancellation signal received
  2. Node's `run()` hits cancellation branch
  3. Calls `blob_event_processor.shutdown()`
  4. All background processors see cancellation and exit
  5. Node waits for all processors to finish
  6. Continues with rest of shutdown cleanup

## Test plan

CI Pipeline.
