### PR TITLE
chore: remove use_legacy_event_provider option

### DIFF
--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -939,9 +939,10 @@ async fn test_storage_nodes_do_not_serve_data_for_deleted_blobs() -> TestResult 
 
     let count_deleted = client.delete_owned_blob(&blob_id).await?;
     assert_eq!(count_deleted, 1, "should have deleted one blob");
-    tokio::time::sleep(Duration::from_millis(50)).await;
 
-    check_that_blob_is_not_available(client, blob_id).await
+    // Wait for the deletion event to be processed by storage nodes.
+    // The checkpoint-based event processor needs time to process the deletion.
+    wait_for_blob_to_be_unavailable(client, blob_id, Duration::from_secs(30)).await
 }
 
 /// Tests that nodes correctly update the blob info for expired deletable blobs and no longer serve
@@ -1027,6 +1028,44 @@ async fn test_storage_nodes_do_not_serve_data_for_expired_deletable_blobs() -> T
     check_that_blob_is_not_available(client, blob_id).await
 }
 
+/// Polls until the blob status becomes `Nonexistent` and the blob cannot be read.
+async fn wait_for_blob_to_be_unavailable(
+    client: &WalrusNodeClient<SuiContractClient>,
+    blob_id: BlobId,
+    timeout: Duration,
+) -> TestResult {
+    walrus_test_utils::retry_until_success_or_timeout(timeout, || async {
+        let status_result = client
+            .get_verified_blob_status(
+                &blob_id,
+                client.sui_client().read_client(),
+                Duration::from_secs(1),
+            )
+            .await
+            .map_err(Box::new)?;
+
+        if !matches!(status_result, BlobStatus::Nonexistent) {
+            return Err(format!(
+                "blob status is still {:?}, expected Nonexistent",
+                status_result
+            )
+            .into());
+        }
+
+        // Also verify we can't read the blob.
+        let read_result = client.read_blob::<Primary>(&blob_id).await;
+        if !matches!(
+            read_result.as_ref().map_err(|e| e.kind()),
+            Err(ClientErrorKind::BlobIdDoesNotExist)
+        ) {
+            return Err("blob is still readable".into());
+        }
+
+        Ok(())
+    })
+    .await
+}
+
 async fn check_that_blob_is_not_available(
     client: &WalrusNodeClient<SuiContractClient>,
     blob_id: BlobId,
@@ -1081,10 +1120,9 @@ async_param_test! {
 async fn test_store_quilt(blobs_to_create: u32) -> TestResult {
     walrus_test_utils::init_tracing();
 
-    let test_nodes_config = TestNodesConfig {
-        node_weights: vec![7, 7, 7, 7, 7],
-        ..Default::default()
-    };
+    let test_nodes_config = TestNodesConfig::builder()
+        .with_node_weights(&[7, 7, 7, 7, 7])
+        .build();
     let test_cluster_builder =
         test_cluster::E2eTestSetupBuilder::new().with_test_nodes_config(test_nodes_config);
     let (_sui_cluster_handle, _cluster, client, _) = test_cluster_builder.build().await?;
@@ -1216,10 +1254,11 @@ async fn test_blocklist() -> TestResult {
     walrus_test_utils::init_tracing();
     let blocklist_dir = tempfile::tempdir().expect("temporary directory creation must succeed");
     let (_sui_cluster_handle, _cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
-        .with_test_nodes_config(TestNodesConfig {
-            blocklist_dir: Some(blocklist_dir.path().to_path_buf()),
-            ..Default::default()
-        })
+        .with_test_nodes_config(
+            TestNodesConfig::builder()
+                .with_blocklist_dir(blocklist_dir.path().to_path_buf())
+                .build(),
+        )
         .build()
         .await?;
 
@@ -1555,10 +1594,11 @@ async fn test_repeated_shard_move() -> TestResult {
     walrus_test_utils::init_tracing();
     let (_sui_cluster_handle, walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
         .with_epoch_duration(Duration::from_secs(20))
-        .with_test_nodes_config(TestNodesConfig {
-            node_weights: vec![1, 1],
-            ..Default::default()
-        })
+        .with_test_nodes_config(
+            TestNodesConfig::builder()
+                .with_node_weights(&[1, 1])
+                .build(),
+        )
         .build()
         .await?;
 
@@ -2298,10 +2338,11 @@ async fn test_shard_move_out_and_back_in_immediately() -> TestResult {
     walrus_test_utils::init_tracing();
     let (_sui_cluster_handle, walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
         .with_epoch_duration(Duration::from_secs(20))
-        .with_test_nodes_config(TestNodesConfig {
-            node_weights: vec![1, 1],
-            ..Default::default()
-        })
+        .with_test_nodes_config(
+            TestNodesConfig::builder()
+                .with_node_weights(&[1, 1])
+                .build(),
+        )
         .build()
         .await?;
 
@@ -2828,10 +2869,9 @@ async fn test_store_with_upload_relay_with_tip() {
 async fn test_byte_range_read_client() -> TestResult {
     walrus_test_utils::init_tracing();
 
-    let test_nodes_config = TestNodesConfig {
-        node_weights: vec![7, 7, 7, 7, 7],
-        ..Default::default()
-    };
+    let test_nodes_config = TestNodesConfig::builder()
+        .with_node_weights(&[7, 7, 7, 7, 7])
+        .build();
     let test_cluster_builder =
         test_cluster::E2eTestSetupBuilder::new().with_test_nodes_config(test_nodes_config);
     let (_sui_cluster_handle, _cluster, client, _) = test_cluster_builder.build().await?;

--- a/crates/walrus-e2e-tests/tests/test_event_blobs.rs
+++ b/crates/walrus-e2e-tests/tests/test_event_blobs.rs
@@ -20,11 +20,12 @@ use walrus_sui::client::ReadClient;
 #[ignore = "ignore E2E tests by default"]
 async fn test_event_blobs() -> anyhow::Result<()> {
     let (_sui_cluster, _cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
-        .with_test_nodes_config(TestNodesConfig {
-            node_weights: vec![2, 2],
-            use_legacy_event_processor: false,
-            ..Default::default()
-        })
+        .with_test_nodes_config(
+            TestNodesConfig::builder()
+                .with_node_weights(&[2, 2])
+                .with_enable_event_blob_writer()
+                .build(),
+        )
         .build()
         .await?;
 
@@ -80,12 +81,12 @@ async fn test_event_blobs() -> anyhow::Result<()> {
 #[ignore = "ignore E2E tests by default"]
 async fn test_disabled_event_blob_writer() -> anyhow::Result<()> {
     let (_sui_cluster, _cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
-        .with_test_nodes_config(TestNodesConfig {
-            node_weights: vec![1, 1],
-            use_legacy_event_processor: false,
-            disable_event_blob_writer: true,
-            ..Default::default()
-        })
+        .with_test_nodes_config(
+            TestNodesConfig::builder()
+                .with_node_weights(&[1, 1])
+                .with_disable_event_blob_writer()
+                .build(),
+        )
         .build()
         .await?;
 

--- a/crates/walrus-service/bin/deploy.rs
+++ b/crates/walrus-service/bin/deploy.rs
@@ -203,9 +203,6 @@ struct GenerateDryRunConfigsArgs {
     /// sending another request.
     #[arg(long, value_parser = humantime::parse_duration)]
     faucet_cooldown: Option<Duration>,
-    /// Use the legacy event processor instead of the standard checkpoint-based event processor.
-    #[arg(long)]
-    use_legacy_event_provider: bool,
     /// Disable the event blob writer.
     /// This will disable the event blob writer and the event blob writer service.
     #[arg(long)]
@@ -478,7 +475,6 @@ mod commands {
             listening_ips,
             set_db_path,
             faucet_cooldown,
-            use_legacy_event_provider,
             disable_event_blob_writer,
             backup_database_url,
             rpc_fallback_config_args,
@@ -576,7 +572,6 @@ mod commands {
                 .as_ref()
                 .and_then(|args| args.to_config()),
             &mut admin_contract_client,
-            use_legacy_event_provider,
             disable_event_blob_writer,
             sui_amount,
             sui_client_request_timeout,

--- a/crates/walrus-service/bin/node.rs
+++ b/crates/walrus-service/bin/node.rs
@@ -701,7 +701,6 @@ mod commands {
                 .map(|config| config.into())
                 .expect("Sui configuration must be present"),
             config.event_processor_config.clone(),
-            config.use_legacy_event_provider,
             &config.storage_path,
             &metrics_runtime.registry,
             cancel_token.child_token(),

--- a/crates/walrus-service/node_config_example.yaml
+++ b/crates/walrus-service/node_config_example.yaml
@@ -186,7 +186,6 @@ pending_sliver_cache:
 pending_metadata_cache:
   max_cached_entries: 512
   cache_ttl: 10
-use_legacy_event_provider: false
 disable_event_blob_writer: false
 commission_rate: 6000
 voting_params:

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -140,8 +140,6 @@ pub struct StorageNodeConfig {
     #[serde(default, skip_serializing_if = "defaults::is_default")]
     pub shard_sync_config: ShardSyncConfig,
     /// Configuration for the event processor.
-    ///
-    /// This is ignored if `use_legacy_event_provider` is set to `true`.
     #[serde(default, skip_serializing_if = "defaults::is_default")]
     pub event_processor_config: EventProcessorConfig,
     /// Configuration for the pending sliver cache.
@@ -150,11 +148,6 @@ pub struct StorageNodeConfig {
     /// Configuration for the pending metadata cache.
     #[serde(default, skip_serializing_if = "defaults::is_default")]
     pub pending_metadata_cache: PendingMetadataCacheConfig,
-    /// Use the legacy event provider.
-    ///
-    /// This is deprecated and will be removed in the future.
-    #[serde(default, skip_serializing_if = "defaults::is_default")]
-    pub use_legacy_event_provider: bool,
     /// Disable the event-blob writer
     #[serde(default, skip_serializing_if = "defaults::is_default")]
     pub disable_event_blob_writer: bool,
@@ -233,7 +226,6 @@ impl Default for StorageNodeConfig {
             event_processor_config: Default::default(),
             pending_sliver_cache: Default::default(),
             pending_metadata_cache: Default::default(),
-            use_legacy_event_provider: false,
             disable_event_blob_writer: Default::default(),
             commission_rate: defaults::commission_rate(),
             voting_params: VotingParams {

--- a/crates/walrus-service/src/node/system_events.rs
+++ b/crates/walrus-service/src/node/system_events.rs
@@ -3,7 +3,7 @@
 
 //! Walrus events observed by the storage node.
 
-use std::{fmt::Debug, future::ready, pin::Pin, sync::Arc, thread, time::Duration};
+use std::{fmt::Debug, future::ready, pin::Pin, sync::Arc, thread};
 
 use anyhow::Error;
 use async_trait::async_trait;
@@ -13,14 +13,12 @@ use sui_types::{digests::TransactionDigest, event::EventID};
 use tokio::time::MissedTickBehavior;
 use tokio_stream::{Stream, wrappers::IntervalStream};
 use tracing::Level;
-use walrus_sui::client::{ReadClient, SuiReadClient};
 
 use super::{STATUS_PENDING, STATUS_PERSISTED, StorageNodeInner};
 use crate::{
-    common::config::SuiConfig,
     event::{
         event_processor::processor::EventProcessor,
-        events::{CheckpointEventPosition, EventStreamCursor, InitState, PositionedStreamEvent},
+        events::{EventStreamCursor, InitState, PositionedStreamEvent},
     },
     node::{metrics::STATUS_HIGHEST_FINISHED, storage::EventProgress},
 };
@@ -161,32 +159,6 @@ impl CompletableHandle for Option<EventHandle> {
     }
 }
 
-/// A [`SystemEventProvider`] that uses a [`SuiReadClient`] to fetch events.
-#[derive(Debug, Clone)]
-pub struct SuiSystemEventProvider {
-    read_client: SuiReadClient,
-    polling_interval: Duration,
-}
-
-impl SuiSystemEventProvider {
-    /// Creates a new provider with the supplied [`SuiReadClient`], which polls
-    /// for new events every polling_interval.
-    pub fn new(read_client: SuiReadClient, polling_interval: Duration) -> Self {
-        Self {
-            read_client,
-            polling_interval,
-        }
-    }
-
-    /// Creates a new provider with for a [`SuiReadClient`] constructed from the config.
-    pub async fn from_config(config: &SuiConfig) -> Result<Self, anyhow::Error> {
-        Ok(Self::new(
-            config.new_read_client().await?,
-            config.event_polling_interval,
-        ))
-    }
-}
-
 /// A provider of system events to a storage node.
 #[async_trait]
 pub trait SystemEventProvider: std::fmt::Debug + Sync + Send {
@@ -228,49 +200,6 @@ pub trait EventRetentionManager: std::fmt::Debug + Sync + Send {
 pub trait EventManager: SystemEventProvider + EventRetentionManager {
     /// Get the latest checkpoint sequence number.
     fn latest_checkpoint_sequence_number(&self) -> Option<u64>;
-}
-
-#[async_trait]
-impl SystemEventProvider for SuiSystemEventProvider {
-    async fn events(
-        &self,
-        cursor: EventStreamCursor,
-    ) -> Result<Box<dyn Stream<Item = PositionedStreamEvent> + Send + Sync + 'life0>, anyhow::Error>
-    {
-        tracing::info!(?cursor, "resuming from event");
-        let events = self
-            .read_client
-            .event_stream(self.polling_interval, cursor.event_id)
-            .await?;
-        let event_stream = events
-            .map(|event| PositionedStreamEvent::new(event, CheckpointEventPosition::new(0, 0)));
-        Ok(Box::new(event_stream))
-    }
-
-    async fn init_state(
-        &self,
-        _from: EventStreamCursor,
-    ) -> Result<Option<InitState>, anyhow::Error> {
-        Ok(None)
-    }
-
-    fn as_event_processor(&self) -> Option<&EventProcessor> {
-        None
-    }
-}
-
-#[async_trait]
-impl EventRetentionManager for SuiSystemEventProvider {
-    async fn drop_events_before(&self, _cursor: EventStreamCursor) -> Result<(), anyhow::Error> {
-        Ok(())
-    }
-}
-
-#[async_trait]
-impl EventManager for SuiSystemEventProvider {
-    fn latest_checkpoint_sequence_number(&self) -> Option<u64> {
-        None
-    }
 }
 
 #[async_trait]

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -15,7 +15,7 @@ use std::{
     default::Default,
     net::{SocketAddr, TcpStream},
     num::{NonZeroU16, NonZeroUsize},
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::Arc,
 };
 
@@ -201,33 +201,159 @@ pub trait StorageNodeHandleTrait {
     fn use_distinct_ip() -> bool;
 }
 
-/// Configuration for test node setup
+/// Minimum number of shards required for Reed-Solomon encoding when the event blob writer is
+/// enabled. With fewer shards, the recovery shard count becomes zero, which is unsupported.
+///
+/// With n_shards=4: max_n_faulty=1, source_symbols_primary=2, source_symbols_secondary=3,
+/// giving recovery counts of 2 and 1 respectively (both > 0).
+pub const MIN_SHARDS_FOR_EVENT_BLOB_WRITER: u16 = 4;
+
+/// Configuration for test node setup.
+///
+/// Use [`TestNodesConfig::builder()`] to create instances. The builder validates that
+/// configurations with the event blob writer enabled have at least
+/// [`MIN_SHARDS_FOR_EVENT_BLOB_WRITER`] shards.
 #[derive(Debug, Clone)]
 pub struct TestNodesConfig {
-    /// The weights of the nodes in the cluster.
-    pub node_weights: Vec<u16>,
-    /// Whether to use the legacy event processor.
-    pub use_legacy_event_processor: bool,
-    /// Whether to disable the event blob writer.
-    pub disable_event_blob_writer: bool,
-    /// The directory to store the blocklist.
-    pub blocklist_dir: Option<PathBuf>,
-    /// Whether to enable the node config monitor.
-    pub enable_node_config_synchronizer: bool,
-    /// The node recovery config for the nodes.
-    pub node_recovery_config: Option<NodeRecoveryConfig>,
+    node_weights: Vec<u16>,
+    disable_event_blob_writer: bool,
+    blocklist_dir: Option<PathBuf>,
+    enable_node_config_synchronizer: bool,
+    node_recovery_config: Option<NodeRecoveryConfig>,
+}
+
+impl TestNodesConfig {
+    /// Returns the weights of the nodes in the cluster.
+    pub fn node_weights(&self) -> &[u16] {
+        &self.node_weights
+    }
+
+    /// Returns whether the event blob writer is disabled.
+    pub fn disable_event_blob_writer(&self) -> bool {
+        self.disable_event_blob_writer
+    }
+
+    /// Returns the directory to store the blocklist.
+    pub fn blocklist_dir(&self) -> Option<&Path> {
+        self.blocklist_dir.as_deref()
+    }
+
+    /// Returns whether the node config synchronizer is enabled.
+    pub fn enable_node_config_synchronizer(&self) -> bool {
+        self.enable_node_config_synchronizer
+    }
+
+    /// Returns the node recovery config.
+    pub fn node_recovery_config(&self) -> Option<&NodeRecoveryConfig> {
+        self.node_recovery_config.as_ref()
+    }
+
+    /// Creates a new builder for `TestNodesConfig`.
+    pub fn builder() -> TestNodesConfigBuilder {
+        TestNodesConfigBuilder::new()
+    }
 }
 
 impl Default for TestNodesConfig {
     fn default() -> Self {
+        TestNodesConfigBuilder::new().build()
+    }
+}
+
+/// Builder for [`TestNodesConfig`] that validates configuration constraints.
+#[derive(Debug, Clone)]
+pub struct TestNodesConfigBuilder {
+    node_weights: Vec<u16>,
+    disable_event_blob_writer: bool,
+    blocklist_dir: Option<PathBuf>,
+    enable_node_config_synchronizer: bool,
+    node_recovery_config: Option<NodeRecoveryConfig>,
+}
+
+impl Default for TestNodesConfigBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TestNodesConfigBuilder {
+    /// Creates a new builder with default values.
+    ///
+    /// By default, the event blob writer is **disabled** to avoid interference with tests.
+    /// Use [`with_enable_event_blob_writer`](Self::with_enable_event_blob_writer) for tests
+    /// that specifically need event blob functionality.
+    pub fn new() -> Self {
         Self {
             node_weights: vec![1, 2, 3, 3, 4],
-            // TODO(WAL-405): change default to checkpoint-based event processor
-            use_legacy_event_processor: true,
-            disable_event_blob_writer: false,
+            disable_event_blob_writer: true, // Disabled by default to avoid test interference
             blocklist_dir: None,
             enable_node_config_synchronizer: false,
             node_recovery_config: None,
+        }
+    }
+
+    /// Sets the weights of the nodes in the cluster.
+    pub fn with_node_weights(mut self, weights: &[u16]) -> Self {
+        self.node_weights = weights.to_vec();
+        self
+    }
+
+    /// Disables the event blob writer (this is the default).
+    pub fn with_disable_event_blob_writer(mut self) -> Self {
+        self.disable_event_blob_writer = true;
+        self
+    }
+
+    /// Enables the event blob writer.
+    ///
+    /// Use this for tests that specifically need event blob functionality.
+    /// Note: Requires at least [`MIN_SHARDS_FOR_EVENT_BLOB_WRITER`] shards.
+    pub fn with_enable_event_blob_writer(mut self) -> Self {
+        self.disable_event_blob_writer = false;
+        self
+    }
+
+    /// Sets the directory to store the blocklist.
+    pub fn with_blocklist_dir(mut self, dir: PathBuf) -> Self {
+        self.blocklist_dir = Some(dir);
+        self
+    }
+
+    /// Enables the node config synchronizer.
+    pub fn with_enable_node_config_synchronizer(mut self) -> Self {
+        self.enable_node_config_synchronizer = true;
+        self
+    }
+
+    /// Sets the node recovery config.
+    pub fn with_node_recovery_config(mut self, config: NodeRecoveryConfig) -> Self {
+        self.node_recovery_config = Some(config);
+        self
+    }
+
+    /// Builds the [`TestNodesConfig`], validating constraints.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the event blob writer is enabled but the total number of shards
+    /// (sum of node_weights) is less than [`MIN_SHARDS_FOR_EVENT_BLOB_WRITER`].
+    pub fn build(self) -> TestNodesConfig {
+        let n_shards: u16 = self.node_weights.iter().sum();
+        if !self.disable_event_blob_writer && n_shards < MIN_SHARDS_FOR_EVENT_BLOB_WRITER {
+            panic!(
+                "TestNodesConfig: event blob writer requires at least {} shards for \
+                Reed-Solomon encoding, but node_weights {:?} sum to only {} shards. \
+                Either increase node_weights or remove with_enable_event_blob_writer().",
+                MIN_SHARDS_FOR_EVENT_BLOB_WRITER, self.node_weights, n_shards
+            );
+        }
+
+        TestNodesConfig {
+            node_weights: self.node_weights,
+            disable_event_blob_writer: self.disable_event_blob_writer,
+            blocklist_dir: self.blocklist_dir,
+            enable_node_config_synchronizer: self.enable_node_config_synchronizer,
+            node_recovery_config: self.node_recovery_config,
         }
     }
 }
@@ -562,12 +688,7 @@ impl SimStorageNodeHandle {
         // Starts the event processor thread if the node is configured to use the checkpoint
         // based event processor.
         let sui_read_client = sui_config.new_read_client().await?;
-        let event_provider: Box<dyn EventManager> = if config.use_legacy_event_provider {
-            Box::new(crate::node::system_events::SuiSystemEventProvider::new(
-                sui_read_client.clone(),
-                Duration::from_millis(100),
-            ))
-        } else {
+        let event_provider: Box<dyn EventManager> = {
             let processor_config = EventProcessorRuntimeConfig {
                 rpc_addresses: combine_rpc_urls(
                     &sui_config.rpc,
@@ -1155,7 +1276,6 @@ impl StorageNodeHandleBuilder {
                 ..Default::default()
             },
             pending_sliver_cache: Default::default(),
-            use_legacy_event_provider: false,
             disable_event_blob_writer,
             sui: Some(SuiConfig {
                 rpc: sui_rpc_urls.remove(0),
@@ -1296,30 +1416,8 @@ async fn wait_for_rest_api_ready(client: &StorageNodeClient) -> anyhow::Result<(
     .await?
 }
 
-/// Retries until success or a timeout, returning the last result.
-pub(crate) async fn retry_until_success_or_timeout<F, Fut, T, E>(
-    duration: Duration,
-    mut func_to_retry: F,
-) -> Result<T, E>
-where
-    F: FnMut() -> Fut,
-    Fut: Future<Output = Result<T, E>>,
-{
-    let mut last_result = None;
-
-    let _ = tokio::time::timeout(duration, async {
-        loop {
-            last_result = Some(func_to_retry().await);
-            if last_result.as_ref().unwrap().is_ok() {
-                return;
-            }
-            tokio::time::sleep(Duration::from_millis(5)).await;
-        }
-    })
-    .await;
-
-    last_result.expect("function to have completed at least once")
-}
+// Re-export from walrus_test_utils for internal use.
+pub(crate) use walrus_test_utils::retry_until_success_or_timeout;
 
 /// Waits until garbage collection has completed for the specified epoch on all provided nodes.
 ///
@@ -2840,9 +2938,7 @@ pub mod test_cluster {
                 .with_system_contract_services(node_contract_services);
 
             let event_processor_config = Default::default();
-            let mut cluster_builder = if test_nodes_config.use_legacy_event_processor {
-                setup_legacy_event_processors(sui_read_client.clone(), cluster_builder)?
-            } else {
+            let mut cluster_builder = {
                 setup_checkpoint_based_event_processors(
                     &event_processor_config,
                     sui_rpc_urls.as_slice(),
@@ -3039,18 +3135,6 @@ pub mod test_cluster {
         Ok(res)
     }
 
-    fn setup_legacy_event_processors(
-        sui_read_client: SuiReadClient,
-        test_cluster_builder: TestClusterBuilder,
-    ) -> anyhow::Result<TestClusterBuilder> {
-        let event_provider = crate::node::system_events::SuiSystemEventProvider::new(
-            sui_read_client.clone(),
-            Duration::from_millis(100),
-        );
-        let res = test_cluster_builder.with_system_event_providers(event_provider);
-        Ok(res)
-    }
-
     // Prevent tests running simultaneously to avoid interferences or race conditions.
     fn global_test_lock() -> &'static TokioMutex<()> {
         static LOCK: OnceLock<TokioMutex<()>> = OnceLock::new();
@@ -3093,7 +3177,6 @@ pub fn storage_node_config() -> WithTempDir<StorageNodeConfig> {
             },
             event_processor_config: Default::default(),
             pending_sliver_cache: Default::default(),
-            use_legacy_event_provider: false,
             disable_event_blob_writer: false,
             commission_rate: 0,
             voting_params: VotingParams {

--- a/crates/walrus-service/src/testbed.rs
+++ b/crates/walrus-service/src/testbed.rs
@@ -573,7 +573,6 @@ pub async fn create_storage_node_configs(
     faucet_cooldown: Option<Duration>,
     rpc_fallback_config: Option<RpcFallbackConfig>,
     admin_contract_client: &mut SuiContractClient,
-    use_legacy_event_provider: bool,
     disable_event_blob_writer: bool,
     sui_amount: u64,
     sui_client_request_timeout: Option<Duration>,
@@ -585,7 +584,6 @@ pub async fn create_storage_node_configs(
         ?set_config_dir,
         ?set_db_path,
         ?faucet_cooldown,
-        use_legacy_event_provider,
         disable_event_blob_writer,
         "starting to create storage-node configs"
     );
@@ -730,7 +728,6 @@ pub async fn create_storage_node_configs(
             event_processor_config: Default::default(),
             pending_sliver_cache: Default::default(),
             pending_metadata_cache: Default::default(),
-            use_legacy_event_provider,
             disable_event_blob_writer,
             commission_rate: node.commission_rate,
             voting_params: VotingParams {

--- a/crates/walrus-service/tests/epoch_change.rs
+++ b/crates/walrus-service/tests/epoch_change.rs
@@ -17,10 +17,11 @@ async fn nodes_drive_epoch_change() -> walrus_test_utils::Result {
     let epoch_duration = Duration::from_secs(5);
     let (_sui, storage_nodes, _, _) = test_cluster::E2eTestSetupBuilder::new()
         .with_epoch_duration(epoch_duration)
-        .with_test_nodes_config(TestNodesConfig {
-            node_weights: vec![1, 1],
-            ..Default::default()
-        })
+        .with_test_nodes_config(
+            TestNodesConfig::builder()
+                .with_node_weights(&[1, 1])
+                .build(),
+        )
         .with_default_num_checkpoints_per_blob()
         .build()
         .await?;

--- a/crates/walrus-simtest/tests/simtest.rs
+++ b/crates/walrus-simtest/tests/simtest.rs
@@ -99,10 +99,12 @@ mod tests {
         let blob_info_consistency_check = BlobInfoConsistencyCheck::new();
 
         let (_sui_cluster, _cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
-            .with_test_nodes_config(TestNodesConfig {
-                node_weights: vec![1, 2, 3, 3, 4],
-                ..Default::default()
-            })
+            .with_test_nodes_config(
+                TestNodesConfig::builder()
+                    .with_node_weights(&[1, 2, 3, 3, 4])
+                    .with_enable_event_blob_writer()
+                    .build(),
+            )
             .build_generic::<SimStorageNodeHandle>()
             .await
             .unwrap();
@@ -160,11 +162,12 @@ mod tests {
         let mut node_weights = vec![2, 2, 3, 3, 3];
         let (_sui_cluster, walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
             .with_epoch_duration(Duration::from_secs(30))
-            .with_test_nodes_config(TestNodesConfig {
-                node_weights: node_weights.clone(),
-                use_legacy_event_processor: false,
-                ..Default::default()
-            })
+            .with_test_nodes_config(
+                TestNodesConfig::builder()
+                    .with_node_weights(&node_weights)
+                    .with_enable_event_blob_writer()
+                    .build(),
+            )
             .with_communication_config(
                 ClientCommunicationConfig::default_for_test_with_reqwest_timeout(
                     Duration::from_secs(2),
@@ -281,11 +284,13 @@ mod tests {
         let (_sui_cluster, mut walrus_cluster, client, _) =
             test_cluster::E2eTestSetupBuilder::new()
                 .with_epoch_duration(Duration::from_secs(30))
-                .with_test_nodes_config(TestNodesConfig {
-                    node_weights: vec![1, 2, 3, 3, 4, 0],
-                    node_recovery_config: Some(node_recovery_config),
-                    ..Default::default()
-                })
+                .with_test_nodes_config(
+                    TestNodesConfig::builder()
+                        .with_node_weights(&[1, 2, 3, 3, 4, 0])
+                        .with_node_recovery_config(node_recovery_config)
+                        .with_enable_event_blob_writer()
+                        .build(),
+                )
                 .with_communication_config(
                     ClientCommunicationConfig::default_for_test_with_reqwest_timeout(
                         Duration::from_secs(2),
@@ -497,10 +502,11 @@ mod tests {
             test_cluster::E2eTestSetupBuilder::new()
                 .with_epoch_duration(EPOCH_DURATION)
                 .with_max_epochs_ahead(MAX_EPOCHS_AHEAD)
-                .with_test_nodes_config(TestNodesConfig {
-                    node_weights: vec![1, 2, 3, 3, 4, 0],
-                    ..Default::default()
-                })
+                .with_test_nodes_config(
+                    TestNodesConfig::builder()
+                        .with_node_weights(&[1, 2, 3, 3, 4, 0])
+                        .build(),
+                )
                 .with_communication_config(
                     ClientCommunicationConfig::default_for_test_with_reqwest_timeout(
                         Duration::from_secs(2),
@@ -667,12 +673,12 @@ mod tests {
 
         let (_sui_cluster, walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
             .with_epoch_duration(Duration::from_secs(30))
-            .with_test_nodes_config(TestNodesConfig {
-                node_weights: vec![1, 2, 3, 3, 4],
-                use_legacy_event_processor: false,
-                node_recovery_config: Some(node_recovery_config),
-                ..Default::default()
-            })
+            .with_test_nodes_config(
+                TestNodesConfig::builder()
+                    .with_node_weights(&[1, 2, 3, 3, 4])
+                    .with_node_recovery_config(node_recovery_config)
+                    .build(),
+            )
             .with_communication_config(
                 ClientCommunicationConfig::default_for_test_with_reqwest_timeout(
                     Duration::from_secs(2),
@@ -767,10 +773,11 @@ mod tests {
         });
 
         let (_sui_cluster, walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
-            .with_test_nodes_config(TestNodesConfig {
-                node_weights: vec![1, 2, 3, 3, 4],
-                ..Default::default()
-            })
+            .with_test_nodes_config(
+                TestNodesConfig::builder()
+                    .with_node_weights(&[1, 2, 3, 3, 4])
+                    .build(),
+            )
             .with_epoch_duration(Duration::from_secs(30))
             .build_generic::<SimStorageNodeHandle>()
             .await
@@ -831,11 +838,11 @@ mod tests {
     async fn test_recovery_in_progress_with_node_restart() {
         let (_sui_cluster, walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
             .with_epoch_duration(Duration::from_secs(30))
-            .with_test_nodes_config(TestNodesConfig {
-                node_weights: vec![1, 2, 3, 3, 4],
-                use_legacy_event_processor: false,
-                ..Default::default()
-            })
+            .with_test_nodes_config(
+                TestNodesConfig::builder()
+                    .with_node_weights(&[1, 2, 3, 3, 4])
+                    .build(),
+            )
             .with_communication_config(
                 ClientCommunicationConfig::default_for_test_with_reqwest_timeout(
                     Duration::from_secs(2),
@@ -966,6 +973,11 @@ mod tests {
                 .with_contract_directory(testnet_contract_dir().unwrap())
                 .with_epoch_duration(epoch_duration)
                 .with_num_checkpoints_per_blob(20)
+                .with_test_nodes_config(
+                    TestNodesConfig::builder()
+                        .with_enable_event_blob_writer()
+                        .build(),
+                )
                 .build_generic::<SimStorageNodeHandle>()
                 .await?;
         let client = Arc::new(client);
@@ -1171,10 +1183,11 @@ mod tests {
         };
 
         let (_sui_cluster, cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
-            .with_test_nodes_config(TestNodesConfig {
-                node_weights: vec![10; 7],
-                ..Default::default()
-            })
+            .with_test_nodes_config(
+                TestNodesConfig::builder()
+                    .with_node_weights(&[10; 7])
+                    .build(),
+            )
             .with_epoch_duration(Duration::from_secs(20))
             .with_communication_config(communication_config)
             .build_generic::<SimStorageNodeHandle>()
@@ -1278,10 +1291,11 @@ mod tests {
         let blob_info_consistency_check = BlobInfoConsistencyCheck::new();
 
         let (_sui_cluster, _cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
-            .with_test_nodes_config(TestNodesConfig {
-                node_weights: vec![1, 2, 3, 3, 4],
-                ..Default::default()
-            })
+            .with_test_nodes_config(
+                TestNodesConfig::builder()
+                    .with_node_weights(&[1, 2, 3, 3, 4])
+                    .build(),
+            )
             // Use a long epoch duration to avoid operation across epoch change.
             // TODO(WAL-937): shorten this and fix any issues exposed by this.
             .with_epoch_duration(Duration::from_mins(10))

--- a/crates/walrus-simtest/tests/simtest_event_blob.rs
+++ b/crates/walrus-simtest/tests/simtest_event_blob.rs
@@ -195,10 +195,12 @@ mod tests {
         let (_sui_cluster, mut walrus_cluster, client, _) =
             test_cluster::E2eTestSetupBuilder::new()
                 .with_epoch_duration(Duration::from_secs(15))
-                .with_test_nodes_config(TestNodesConfig {
-                    node_weights: vec![2, 2, 3, 3, 3],
-                    ..Default::default()
-                })
+                .with_test_nodes_config(
+                    TestNodesConfig::builder()
+                        .with_node_weights(&[2, 2, 3, 3, 3])
+                        .with_enable_event_blob_writer()
+                        .build(),
+                )
                 .with_num_checkpoints_per_blob(20)
                 // Low event_stream_catchup_min_checkpoint_lag may cause reading latest event blob
                 // fail since the event blob's certified events have not been processed yet.
@@ -249,10 +251,12 @@ mod tests {
         let (_sui_cluster, mut walrus_cluster, client, _) =
             test_cluster::E2eTestSetupBuilder::new()
                 .with_epoch_duration(Duration::from_secs(15))
-                .with_test_nodes_config(TestNodesConfig {
-                    node_weights: vec![2, 2, 3, 3, 3],
-                    ..Default::default()
-                })
+                .with_test_nodes_config(
+                    TestNodesConfig::builder()
+                        .with_node_weights(&[2, 2, 3, 3, 3])
+                        .with_enable_event_blob_writer()
+                        .build(),
+                )
                 .with_num_checkpoints_per_blob(20)
                 // Low event_stream_catchup_min_checkpoint_lag may cause reading latest event blob
                 // fail since the event blob's certified events have not been processed yet.
@@ -303,11 +307,12 @@ mod tests {
                 .with_epoch_duration(Duration::from_secs(15))
                 .with_num_checkpoints_per_blob(20)
                 //.with_event_stream_catchup_min_checkpoint_lag(Some(u64::MAX))
-                .with_test_nodes_config(TestNodesConfig {
-                    node_weights: vec![2, 2, 3, 3, 3],
-                    use_legacy_event_processor: false,
-                    ..Default::default()
-                })
+                .with_test_nodes_config(
+                    TestNodesConfig::builder()
+                        .with_node_weights(&[2, 2, 3, 3, 3])
+                        .with_enable_event_blob_writer()
+                        .build(),
+                )
                 .with_communication_config(
                     ClientCommunicationConfig::default_for_test_with_reqwest_timeout(
                         Duration::from_secs(2),

--- a/crates/walrus-simtest/tests/simtest_failure.rs
+++ b/crates/walrus-simtest/tests/simtest_failure.rs
@@ -41,10 +41,12 @@ mod tests {
     #[walrus_simtest]
     async fn test_walrus_with_single_node_crash_and_restart() {
         let (sui_cluster, _walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
-            .with_test_nodes_config(TestNodesConfig {
-                node_weights: vec![1, 2, 3, 3, 4],
-                ..Default::default()
-            })
+            .with_test_nodes_config(
+                TestNodesConfig::builder()
+                    .with_node_weights(&[1, 2, 3, 3, 4])
+                    .with_enable_event_blob_writer()
+                    .build(),
+            )
             .build_generic::<SimStorageNodeHandle>()
             .await
             .unwrap();
@@ -216,12 +218,12 @@ mod tests {
 
         let (_sui_cluster, walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
             .with_epoch_duration(Duration::from_secs(30))
-            .with_test_nodes_config(TestNodesConfig {
-                node_weights: vec![1, 2, 3, 3, 4],
-                use_legacy_event_processor: false,
-                node_recovery_config: Some(node_recovery_config),
-                ..Default::default()
-            })
+            .with_test_nodes_config(
+                TestNodesConfig::builder()
+                    .with_node_weights(&[1, 2, 3, 3, 4])
+                    .with_node_recovery_config(node_recovery_config)
+                    .build(),
+            )
             .with_communication_config(
                 ClientCommunicationConfig::default_for_test_with_reqwest_timeout(
                     Duration::from_secs(2),
@@ -345,11 +347,11 @@ mod tests {
         // changes in the test.
         let (_sui_cluster, walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
             .with_epoch_duration(Duration::from_secs(10))
-            .with_test_nodes_config(TestNodesConfig {
-                node_weights: vec![2, 2, 3, 3, 3],
-                use_legacy_event_processor: false,
-                ..Default::default()
-            })
+            .with_test_nodes_config(
+                TestNodesConfig::builder()
+                    .with_node_weights(&[2, 2, 3, 3, 3])
+                    .build(),
+            )
             .with_communication_config(
                 ClientCommunicationConfig::default_for_test_with_reqwest_timeout(
                     Duration::from_secs(1),
@@ -510,11 +512,11 @@ mod tests {
         // changes in the test.
         let (_sui_cluster, walrus_cluster, _, _) = test_cluster::E2eTestSetupBuilder::new()
             .with_epoch_duration(Duration::from_secs(10))
-            .with_test_nodes_config(TestNodesConfig {
-                node_weights: vec![2, 2, 3, 3, 3],
-                use_legacy_event_processor: false,
-                ..Default::default()
-            })
+            .with_test_nodes_config(
+                TestNodesConfig::builder()
+                    .with_node_weights(&[2, 2, 3, 3, 3])
+                    .build(),
+            )
             .with_communication_config(
                 ClientCommunicationConfig::default_for_test_with_reqwest_timeout(
                     Duration::from_secs(1),
@@ -603,11 +605,11 @@ mod tests {
 
         let (_sui_cluster, walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
             .with_epoch_duration(Duration::from_secs(30))
-            .with_test_nodes_config(TestNodesConfig {
-                node_weights: vec![1, 2, 3, 3, 4],
-                use_legacy_event_processor: false,
-                ..Default::default()
-            })
+            .with_test_nodes_config(
+                TestNodesConfig::builder()
+                    .with_node_weights(&[1, 2, 3, 3, 4])
+                    .build(),
+            )
             .with_communication_config(
                 ClientCommunicationConfig::default_for_test_with_reqwest_timeout(
                     Duration::from_secs(2),
@@ -775,10 +777,12 @@ mod tests {
         let checkpoints_per_event_blob = 20;
         let (sui_cluster, mut walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
             .with_epoch_duration(Duration::from_secs(15))
-            .with_test_nodes_config(TestNodesConfig {
-                node_weights: vec![2, 2, 3, 3, 3],
-                ..Default::default()
-            })
+            .with_test_nodes_config(
+                TestNodesConfig::builder()
+                    .with_node_weights(&[2, 2, 3, 3, 3])
+                    .with_enable_event_blob_writer()
+                    .build(),
+            )
             .with_num_checkpoints_per_blob(checkpoints_per_event_blob)
             .with_communication_config(
                 ClientCommunicationConfig::default_for_test_with_reqwest_timeout(

--- a/crates/walrus-simtest/tests/simtest_param_sync.rs
+++ b/crates/walrus-simtest/tests/simtest_param_sync.rs
@@ -216,12 +216,12 @@ mod tests {
         let (_sui_cluster, mut walrus_cluster, client, _) =
             test_cluster::E2eTestSetupBuilder::new()
                 .with_epoch_duration(Duration::from_secs(30))
-                .with_test_nodes_config(TestNodesConfig {
-                    node_weights: vec![1, 2, 3, 3, 4, 0],
-                    use_legacy_event_processor: false,
-                    enable_node_config_synchronizer: true,
-                    ..Default::default()
-                })
+                .with_test_nodes_config(
+                    TestNodesConfig::builder()
+                        .with_node_weights(&[1, 2, 3, 3, 4, 0])
+                        .with_enable_node_config_synchronizer()
+                        .build(),
+                )
                 .with_communication_config(
                     ClientCommunicationConfig::default_for_test_with_reqwest_timeout(
                         Duration::from_secs(2),
@@ -406,12 +406,12 @@ mod tests {
     async fn test_registered_node_update_protocol_key() {
         let (_sui_cluster, walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
             .with_epoch_duration(Duration::from_secs(10))
-            .with_test_nodes_config(TestNodesConfig {
-                node_weights: vec![1, 2, 3, 3, 4, 2],
-                use_legacy_event_processor: false,
-                enable_node_config_synchronizer: true,
-                ..Default::default()
-            })
+            .with_test_nodes_config(
+                TestNodesConfig::builder()
+                    .with_node_weights(&[1, 2, 3, 3, 4, 2])
+                    .with_enable_node_config_synchronizer()
+                    .build(),
+            )
             .with_communication_config(
                 ClientCommunicationConfig::default_for_test_with_reqwest_timeout(
                     Duration::from_secs(2),
@@ -486,12 +486,12 @@ mod tests {
         let (_sui_cluster, mut walrus_cluster, client, _) =
             test_cluster::E2eTestSetupBuilder::new()
                 .with_epoch_duration(Duration::from_secs(30))
-                .with_test_nodes_config(TestNodesConfig {
-                    node_weights: vec![1, 2, 3, 3, 4, 0],
-                    use_legacy_event_processor: false,
-                    enable_node_config_synchronizer: true,
-                    ..Default::default()
-                })
+                .with_test_nodes_config(
+                    TestNodesConfig::builder()
+                        .with_node_weights(&[1, 2, 3, 3, 4, 0])
+                        .with_enable_node_config_synchronizer()
+                        .build(),
+                )
                 .with_communication_config(
                     ClientCommunicationConfig::default_for_test_with_reqwest_timeout(
                         Duration::from_secs(2),
@@ -731,12 +731,12 @@ mod tests {
     async fn test_sync_node_params(update_params: &TestUpdateParams) {
         let (_sui_cluster, walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
             .with_epoch_duration(Duration::from_secs(10))
-            .with_test_nodes_config(TestNodesConfig {
-                node_weights: vec![1, 2, 3, 3, 4, 2],
-                use_legacy_event_processor: false,
-                enable_node_config_synchronizer: true,
-                ..Default::default()
-            })
+            .with_test_nodes_config(
+                TestNodesConfig::builder()
+                    .with_node_weights(&[1, 2, 3, 3, 4, 2])
+                    .with_enable_node_config_synchronizer()
+                    .build(),
+            )
             .with_communication_config(
                 ClientCommunicationConfig::default_for_test_with_reqwest_timeout(
                     Duration::from_secs(2),

--- a/crates/walrus-test-utils/Cargo.toml
+++ b/crates/walrus-test-utils/Cargo.toml
@@ -11,6 +11,7 @@ anyhow.workspace = true
 once_cell.workspace = true
 rand.workspace = true
 tempfile.workspace = true
+tokio = { workspace = true, features = ["time"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true
 

--- a/docker/walrus-antithesis/build-test-config-image/docker-compose.yaml
+++ b/docker/walrus-antithesis/build-test-config-image/docker-compose.yaml
@@ -24,13 +24,7 @@ services:
       /bin/sh -c "cp /usr/local/bin/sui /root/sui_bin/ && \
       sui start --with-faucet --force-regenesis --committee-size 1 --epoch-duration-ms 86400000"
     healthcheck:
-      test:
-        [
-          "CMD",
-          "/bin/bash",
-          "-c",
-          "echo > /dev/tcp/127.0.0.1/9123 && echo > /dev/tcp/127.0.0.1/9000",
-        ]
+      test: ["CMD", "/bin/bash", "-c", "echo > /dev/tcp/127.0.0.1/9123 && echo > /dev/tcp/127.0.0.1/9000"]
       interval: 10s
       timeout: 10s
       retries: 10


### PR DESCRIPTION
## Description

Usage of the legacy event provider is no longer supported. Let's remove it.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [x] Storage node: Storage nodes will need to remove the `use_legacy_event_provider` flag from their configuration if it is present.
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
