### PR TITLE
feat: Wire upload intent into client code

### DIFF
--- a/crates/walrus-sdk/src/client.rs
+++ b/crates/walrus-sdk/src/client.rs
@@ -60,7 +60,7 @@ use walrus_core::{
     messages::{BlobPersistenceType, ConfirmationCertificate, SignedStorageConfirmation},
     metadata::{BlobMetadataApi as _, VerifiedBlobMetadataWithId},
 };
-use walrus_storage_node_client::api::BlobStatus;
+use walrus_storage_node_client::{UploadIntent, api::BlobStatus};
 use walrus_sui::{
     client::{CertifyAndExtendBlobResult, ExpirySelectionPolicy, ReadClient, SuiContractClient},
     types::{
@@ -894,6 +894,7 @@ impl<T: ReadClient> WalrusNodeClient<T> {
                     pairs_per_node
                         .remove(&nc.node_index)
                         .expect("there are shards for each node"),
+                    UploadIntent::Immediate,
                 )
             })
             .collect();
@@ -1655,6 +1656,7 @@ impl<T> WalrusNodeClient<T> {
                             .store_metadata_and_pairs_without_confirmation(
                                 &item.metadata,
                                 item.pair_indices.iter().map(|&i| &item.pairs[i]),
+                                UploadIntent::Immediate,
                             )
                             .await;
 

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -5015,7 +5015,10 @@ mod tests {
                     || store_at_shard(&shard, SliverType::Secondary))
             {
                 retry_until_success_or_timeout(TIMEOUT, || {
-                    node.client().store_metadata(&blob.metadata)
+                    node.client().store_metadata(
+                        &blob.metadata,
+                        walrus_storage_node_client::UploadIntent::Immediate,
+                    )
                 })
                 .await?;
                 metadata_stored.push(node.public_key());
@@ -5025,13 +5028,23 @@ mod tests {
 
             if store_at_shard(&shard, SliverType::Primary) {
                 node.client()
-                    .store_sliver(blob.blob_id(), sliver_pair.index(), &sliver_pair.primary)
+                    .store_sliver(
+                        blob.blob_id(),
+                        sliver_pair.index(),
+                        &sliver_pair.primary,
+                        walrus_storage_node_client::UploadIntent::Immediate,
+                    )
                     .await?;
             }
 
             if store_at_shard(&shard, SliverType::Secondary) {
                 node.client()
-                    .store_sliver(blob.blob_id(), sliver_pair.index(), &sliver_pair.secondary)
+                    .store_sliver(
+                        blob.blob_id(),
+                        sliver_pair.index(),
+                        &sliver_pair.secondary,
+                        walrus_storage_node_client::UploadIntent::Immediate,
+                    )
                     .await?;
             }
         }

--- a/crates/walrus-service/src/node/server.rs
+++ b/crates/walrus-service/src/node/server.rs
@@ -1020,7 +1020,12 @@ mod tests {
         let sliver_pair_id = SliverPairIndex(0); // Triggers an ok response
 
         client
-            .store_sliver_by_type(&blob_id, sliver_pair_id, &sliver)
+            .store_sliver_by_type(
+                &blob_id,
+                sliver_pair_id,
+                &sliver,
+                walrus_storage_node_client::UploadIntent::Immediate,
+            )
             .await
             .expect("sliver should be successfully stored");
     }
@@ -1035,7 +1040,12 @@ mod tests {
         let sliver_pair_id = SliverPairIndex(1); // Triggers an internal server error
 
         let err = client
-            .store_sliver_by_type(&blob_id, sliver_pair_id, &sliver)
+            .store_sliver_by_type(
+                &blob_id,
+                sliver_pair_id,
+                &sliver,
+                walrus_storage_node_client::UploadIntent::Immediate,
+            )
             .await
             .expect_err("store sliver should fail");
 

--- a/crates/walrus-storage-node-client/src/client.rs
+++ b/crates/walrus-storage-node-client/src/client.rs
@@ -59,6 +59,23 @@ pub use builder::StorageNodeClientBuilder;
 
 mod middleware;
 
+/// Indicates how the storage node should treat uploads.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum UploadIntent {
+    /// Store immediately; reject if the blob is not yet registered.
+    #[default]
+    Immediate,
+    /// Cache the upload until the blob registration is observed.
+    Pending,
+}
+
+impl UploadIntent {
+    /// Returns true if the upload should be cached until registration completes.
+    pub fn is_pending(self) -> bool {
+        matches!(self, Self::Pending)
+    }
+}
+
 const METADATA_URL_TEMPLATE: &str = "/v1/blobs/:blob_id/metadata";
 const METADATA_STATUS_URL_TEMPLATE: &str = "/v1/blobs/:blob_id/metadata/status";
 const SLIVER_URL_TEMPLATE: &str = "/v1/blobs/:blob_id/slivers/:sliver_pair_index/:sliver_type";
@@ -213,6 +230,13 @@ impl UrlEndpoints {
             SYNC_SHARD_TEMPLATE,
         )
     }
+}
+
+fn url_with_intent(mut url: Url, intent: UploadIntent) -> Url {
+    if intent.is_pending() {
+        url.query_pairs_mut().append_pair("pending", "true");
+    }
+    url
 }
 
 /// Filter for [`StorageNodeClient::list_recovery_symbols()`] endpoint.
@@ -641,28 +665,35 @@ impl StorageNodeClient {
         .map_err(|_| NodeError::other(ListAndVerifyRecoverySymbolsError::BackgroundWorkerFailed))?
     }
 
-    /// Stores the metadata on the node.
+    /// Stores the metadata on the node with the provided upload intent.
     #[tracing::instrument(
-        skip_all, fields(walrus.blob_id = %metadata.blob_id()), err(level = Level::DEBUG)
+        skip_all, fields(walrus.blob_id = %metadata.blob_id(), walrus.intent = ?intent),
+        err(level = Level::DEBUG)
     )]
     pub async fn store_metadata(
         &self,
         metadata: &VerifiedBlobMetadataWithId,
+        intent: UploadIntent,
     ) -> Result<(), NodeError> {
         let (url, template) = self.endpoints.metadata(metadata.blob_id());
-        let request = self.create_request_with_payload(Method::PUT, url, metadata.as_ref());
+        let request = self.create_request_with_payload(
+            Method::PUT,
+            url_with_intent(url, intent),
+            metadata.as_ref(),
+        );
         self.send_and_parse_service_response::<String>(request, template)
             .await?;
         Ok(())
     }
 
-    /// Stores a sliver on a node.
+    /// Stores a sliver on a node with the provided upload intent.
     #[tracing::instrument(
         skip_all,
         fields(
             walrus.blob_id = %blob_id,
             walrus.sliver.pair_index = %pair_index,
             walrus.sliver.type_ = %A::NAME,
+            walrus.intent = ?intent,
         ),
         err(level = Level::DEBUG)
     )]
@@ -671,27 +702,32 @@ impl StorageNodeClient {
         blob_id: &BlobId,
         pair_index: SliverPairIndex,
         sliver: &SliverData<A>,
+        intent: UploadIntent,
     ) -> Result<(), NodeError> {
         tracing::trace!("starting to store sliver");
         let (url, template) = self.endpoints.sliver::<A>(blob_id, pair_index);
-        let request = self.create_request_with_payload(Method::PUT, url, &sliver);
+        let request =
+            self.create_request_with_payload(Method::PUT, url_with_intent(url, intent), &sliver);
         self.send_and_parse_service_response::<String>(request, template)
             .await
             .inspect_err(|error| tracing::debug!(?error, "error storing sliver"))?;
         Ok(())
     }
 
-    /// Stores a sliver on a node.
+    /// Stores a sliver on a node with the provided upload intent.
     #[tracing::instrument(skip_all, err(level = Level::DEBUG))]
     pub async fn store_sliver_by_type(
         &self,
         blob_id: &BlobId,
         pair_index: SliverPairIndex,
         sliver: &Sliver,
+        intent: UploadIntent,
     ) -> Result<(), NodeError> {
         match sliver {
-            Sliver::Primary(sliver) => self.store_sliver(blob_id, pair_index, sliver).await,
-            Sliver::Secondary(sliver) => self.store_sliver(blob_id, pair_index, sliver).await,
+            Sliver::Primary(sliver) => self.store_sliver(blob_id, pair_index, sliver, intent).await,
+            Sliver::Secondary(sliver) => {
+                self.store_sliver(blob_id, pair_index, sliver, intent).await
+            }
         }
     }
 

--- a/crates/walrus-storage-node-client/src/lib.rs
+++ b/crates/walrus-storage-node-client/src/lib.rs
@@ -9,7 +9,13 @@ use fastcrypto::traits::ToFromBytes as _;
 use walrus_core::NetworkPublicKey;
 
 pub use self::{
-    client::{RecoverySymbolsFilter, StorageNodeClient, StorageNodeClientBuilder, SymbolIdFilter},
+    client::{
+        RecoverySymbolsFilter,
+        StorageNodeClient,
+        StorageNodeClientBuilder,
+        SymbolIdFilter,
+        UploadIntent,
+    },
     error::{ClientBuildError, NodeError},
 };
 


### PR DESCRIPTION
## Description

This PR adds upload intent into the client code base. The intent is currently `Immediate` everywhere, but in the next PR we will start using `Pending` intent for blobs to be buffered in the storage node caches.
