### PR TITLE
Replace duplicated version matching logic in record_network_protocol_…

### DIFF
--- a/crates/walrus-service/src/common/telemetry.rs
+++ b/crates/walrus-service/src/common/telemetry.rs
@@ -245,14 +245,7 @@ impl MakeHttpSpan {
     }
 
     fn record_network_protocol_version<B>(&self, request: &Request<B>, span: &Span) {
-        let version = match request.version() {
-            Version::HTTP_09 => "0.9",
-            Version::HTTP_10 => "1.0",
-            Version::HTTP_11 => "1.1",
-            Version::HTTP_2 => "2.0",
-            Version::HTTP_3 => "3.0",
-            _ => return,
-        };
+        let version = http_version(request);
         span.record("network.protocol.version", version);
     }
 


### PR DESCRIPTION
…version()

   with a call to http_version() to ensure consistent format between tracing spans
   and Prometheus metrics. This follows the OpenTelemetry standard format where
   HTTP/2 → "2" and HTTP/3 → "3" instead of "2.0" and "3.0".

## Description

Describe the changes or additions included in this PR.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
