### PR TITLE
feat: add price/capacity votes to committee info

### DIFF
--- a/crates/walrus-service/src/client/cli/cli_output.rs
+++ b/crates/walrus-service/src/client/cli/cli_output.rs
@@ -620,7 +620,7 @@ impl CliOutput for InfoCommitteeOutput {
             metadata_storage_size,
             max_sliver_size,
             max_encoded_blob_size,
-            storage_nodes,
+            current_storage_nodes,
             next_storage_nodes,
         } = self;
 
@@ -649,7 +649,7 @@ impl CliOutput for InfoCommitteeOutput {
                 .walrus_purple()
         );
 
-        print_storage_node_table(n_shards, storage_nodes);
+        print_storage_node_table(n_shards, current_storage_nodes);
         if let Some(storage_nodes) = next_storage_nodes.as_ref() {
             println!(
                 "{}",
@@ -1123,6 +1123,9 @@ fn print_storage_node_info(node: &StorageNodeInfo, node_idx: usize, n_shards: &N
         Network public key: {network_public_key}
         Owned shards:
         {shards}
+        Write price vote: {write_price_vote}
+        Storage price vote: {storage_price_vote}
+        Node capacity vote: {node_capacity_vote}
         ",
         heading = format!("{}: {}", node_idx, node.name)
             .bold()
@@ -1133,6 +1136,9 @@ fn print_storage_node_info(node: &StorageNodeInfo, node_idx: usize, n_shards: &N
         public_key = node.public_key,
         network_public_key = node.network_public_key,
         shards = DisplayShardList(&node.shard_ids),
+        write_price_vote = HumanReadableFrost::from(node.voting_params.write_price),
+        storage_price_vote = HumanReadableFrost::from(node.voting_params.storage_price),
+        node_capacity_vote = HumanReadableBytes(node.voting_params.node_capacity),
     );
 }
 

--- a/crates/walrus-sui/src/types/move_structs.rs
+++ b/crates/walrus-sui/src/types/move_structs.rs
@@ -595,6 +595,26 @@ impl StakingObject {
             }
         }
     }
+
+    /// Returns the number of shards in the system.
+    pub fn n_shards(&self) -> NonZeroU16 {
+        self.inner.n_shards
+    }
+
+    /// Returns the shard assignment for the current committee.
+    pub fn current_committee_shard_assignment(&self) -> &[(ObjectID, Vec<u16>)] {
+        &self.inner.committee
+    }
+
+    /// Returns the shard assignment for the next committee.
+    pub fn next_committee_shard_assignment(&self) -> Option<&Vec<(ObjectID, Vec<u16>)>> {
+        self.inner.next_committee.as_ref()
+    }
+
+    /// Returns the shard assignment for the previous committee.
+    pub fn previous_committee_shard_assignment(&self) -> &[(ObjectID, Vec<u16>)] {
+        &self.inner.previous_committee
+    }
 }
 
 /// Sui type for outer staking object. Used for deserialization.


### PR DESCRIPTION
## Description

Adds the votes of the node for price and capacity to the `walrus info committee` output.

## Test plan

Manually ran to confirm output.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
