### PR TITLE
chore: remove single recovery symbol endpoint

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -311,17 +311,6 @@ pub trait ServiceState {
         inconsistency_proof: InconsistencyProof,
     ) -> impl Future<Output = Result<InvalidBlobIdAttestation, InconsistencyProofError>> + Send;
 
-    /// Retrieves a recovery symbol from a shard held by this storage node.
-    ///
-    /// Returns a recovery symbol for the identified symbol, if it can be constructed from the
-    /// slivers stored with the storage node.
-    fn retrieve_recovery_symbol(
-        &self,
-        blob_id: &BlobId,
-        symbol_id: SymbolId,
-        sliver_type: Option<SliverType>,
-    ) -> impl Future<Output = Result<GeneralRecoverySymbol, RetrieveSymbolError>> + Send;
-
     /// Retrieves multiple recovery symbols.
     ///
     /// Attempts to retrieve multiple recovery symbols, skipping any failures that occur. Returns an
@@ -3621,16 +3610,6 @@ impl ServiceState for StorageNode {
             .verify_inconsistency_proof(blob_id, inconsistency_proof)
     }
 
-    fn retrieve_recovery_symbol(
-        &self,
-        blob_id: &BlobId,
-        symbol_id: SymbolId,
-        sliver_type: Option<SliverType>,
-    ) -> impl Future<Output = Result<GeneralRecoverySymbol, RetrieveSymbolError>> + Send {
-        self.inner
-            .retrieve_recovery_symbol(blob_id, symbol_id, sliver_type)
-    }
-
     fn retrieve_multiple_recovery_symbols(
         &self,
         blob_id: &BlobId,
@@ -3947,38 +3926,6 @@ impl ServiceState for StorageNodeInner {
 
         let message = InvalidBlobIdMsg::new(self.current_committee_epoch(), blob_id.to_owned());
         Ok(sign_message(message, self.protocol_key_pair.clone()).await?)
-    }
-
-    #[tracing::instrument(skip(self))]
-    async fn retrieve_recovery_symbol(
-        &self,
-        blob_id: &BlobId,
-        symbol_id: SymbolId,
-        sliver_type: Option<SliverType>,
-    ) -> Result<GeneralRecoverySymbol, RetrieveSymbolError> {
-        // Begin by fetching a ready worker, as this gates all database reads based
-        // on whether we have capacity to even serve the request.
-        let worker = self.get_ready_symbol_service()?;
-
-        self.validate_blob_access(
-            blob_id,
-            RetrieveSliverError::Forbidden,
-            RetrieveSliverError::Unavailable,
-        )?;
-
-        let encoding_type = self
-            .get_encoding_type_for_blob(blob_id)
-            .context("could not retrieve blob encoding type")?
-            .ok_or_else(|| anyhow!("encoding type unavailable for blob {:?}", blob_id))?;
-
-        self.retrieve_recovery_symbol_unchecked(
-            blob_id,
-            symbol_id,
-            sliver_type,
-            encoding_type,
-            worker,
-        )
-        .await
     }
 
     #[tracing::instrument(skip_all)]

--- a/crates/walrus-service/src/node/server.rs
+++ b/crates/walrus-service/src/node/server.rs
@@ -396,10 +396,6 @@ where
                 get(routes::get_deletable_blob_confirmation),
             )
             .route(
-                routes::RECOVERY_SYMBOL_ENDPOINT,
-                get(routes::get_recovery_symbol_by_id),
-            )
-            .route(
                 routes::RECOVERY_SYMBOL_LIST_ENDPOINT,
                 get(routes::list_recovery_symbols),
             )
@@ -564,7 +560,6 @@ mod tests {
             InconsistencyProofError,
             RetrieveMetadataError,
             RetrieveSliverError,
-            RetrieveSymbolError,
             StoreMetadataError,
             StoreSliverError,
             SyncShardServiceError,
@@ -625,50 +620,19 @@ mod tests {
             Ok(walrus_core::test_utils::sliver())
         }
 
-        /// Returns a valid response only for the pair index 0, otherwise, returns
-        /// an internal error.
-        async fn retrieve_recovery_symbol(
-            &self,
-            _blob_id: &BlobId,
-            symbol_id: SymbolId,
-            _sliver_type: Option<SliverType>,
-        ) -> Result<GeneralRecoverySymbol, RetrieveSymbolError> {
-            if symbol_id == SymbolId::new(0.into(), 0.into()) {
-                if let Some(SliverType::Secondary) = _sliver_type {
-                    let RecoverySymbol::Secondary(symbol) =
-                        walrus_core::test_utils::recovery_symbol()
-                    else {
-                        panic!("util method must return secondary recovery symbol");
-                    };
-                    Ok(GeneralRecoverySymbol::from_recovery_symbol(
-                        symbol,
-                        SliverIndex(0),
-                    ))
-                } else {
-                    let RecoverySymbol::Primary(symbol) =
-                        walrus_core::test_utils::primary_recovery_symbol()
-                    else {
-                        panic!("util method must return primary recovery symbol");
-                    };
-                    Ok(GeneralRecoverySymbol::from_recovery_symbol(
-                        symbol,
-                        SliverIndex(0),
-                    ))
-                }
-            } else {
-                Err(RetrieveSliverError::Unavailable.into())
-            }
-        }
-
         async fn retrieve_multiple_recovery_symbols(
             &self,
-            blob_id: &BlobId,
+            _blob_id: &BlobId,
             _filter: RecoverySymbolsFilter,
         ) -> Result<Vec<GeneralRecoverySymbol>, ListSymbolsError> {
-            let symbol = self
-                .retrieve_recovery_symbol(blob_id, SymbolId::new(0.into(), 0.into()), None)
-                .await
-                .unwrap();
+            // Mock implementation returning a single symbol with id (0, 0)
+
+            let RecoverySymbol::Primary(symbol) =
+                walrus_core::test_utils::primary_recovery_symbol()
+            else {
+                panic!("util method must return primary recovery symbol");
+            };
+            let symbol = GeneralRecoverySymbol::from_recovery_symbol(symbol, SliverIndex(0));
             Ok(vec![symbol.clone(), symbol])
         }
 

--- a/crates/walrus-storage-node-client/src/client.rs
+++ b/crates/walrus-storage-node-client/src/client.rs
@@ -67,7 +67,6 @@ const SLIVER_STATUS_TEMPLATE: &str =
 const PERMANENT_BLOB_CONFIRMATION_URL_TEMPLATE: &str = "/v1/blobs/:blob_id/confirmation/permanent";
 const DELETABLE_BLOB_CONFIRMATION_URL_TEMPLATE: &str =
     "/v1/blobs/:blob_id/confirmation/deletable/:object_id";
-const RECOVERY_SYMBOL_URL_TEMPLATE: &str = "/v1/blobs/:blob_id/recoverySymbols/:symbol_id";
 const LIST_RECOVERY_SYMBOLS_URL_TEMPLATE: &str = "/v1/blobs/:blob_id/recoverySymbols";
 const INCONSISTENCY_PROOF_URL_TEMPLATE: &str = "/v1/blobs/:blob_id/inconsistencyProof/:sliver_type";
 const BLOB_STATUS_URL_TEMPLATE: &str = "/v1/blobs/:blob_id/status";
@@ -174,13 +173,6 @@ impl UrlEndpoints {
         (
             self.sliver_path::<A>(blob_id, sliver_pair_index, Some("status")),
             SLIVER_STATUS_TEMPLATE,
-        )
-    }
-
-    fn recovery_symbol(&self, blob_id: &BlobId, symbol_id: SymbolId) -> (Url, &'static str) {
-        (
-            self.blob_resource(blob_id, &format!("recoverySymbols/{symbol_id}")),
-            RECOVERY_SYMBOL_URL_TEMPLATE,
         )
     }
 
@@ -539,22 +531,6 @@ impl StorageNodeClient {
             .map_err(NodeError::other)?;
 
         Ok(sliver)
-    }
-
-    /// Gets a recovery symbol that can be used to recover a sliver.
-    #[tracing::instrument(
-        skip_all,
-        fields(walrus.blob_id = %blob_id, walrus.recovery.symbol_id = %symbol_id),
-        err(level = Level::DEBUG)
-    )]
-    pub async fn get_recovery_symbol(
-        &self,
-        blob_id: &BlobId,
-        symbol_id: SymbolId,
-    ) -> Result<GeneralRecoverySymbol, NodeError> {
-        let (url, template) = self.endpoints.recovery_symbol(blob_id, symbol_id);
-        self.send_and_parse_bcs_response(Request::new(Method::GET, url), template)
-            .await
     }
 
     /// Gets multiple recovery symbols.


### PR DESCRIPTION
## Description

Removes single recovery symbol end point. This is never used and should be exposed as is, given how expensive to return
a general recovery symbol with proof. Note that the other ListRecoverySymbol endpoint does have ability to query
individual symbol. So we are not completely losing this functionality.

If a client wants to retrieve single symbol, a more efficient recovery symbol endpoint is currently under develop, which
is meant for client.

Related to WAL-386

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
