### PR TITLE
fix: runtime catchup using event blob and checkpoint tailing should never run at the same time

### DIFF
--- a/crates/walrus-service/src/event/event_processor/checkpoint.rs
+++ b/crates/walrus-service/src/event/event_processor/checkpoint.rs
@@ -232,10 +232,8 @@ impl CheckpointProcessor {
         }
 
         // Update checkpoint store
-        write_batch.insert_batch(
-            &self.stores.checkpoint_store,
-            std::iter::once(((), verified_checkpoint.serializable_ref())),
-        )?;
+        self.stores
+            .insert_checkpoint_in_batch(&mut write_batch, &verified_checkpoint)?;
 
         // Write all changes
         write_batch.write()?;

--- a/crates/walrus-service/src/event/event_processor/db.rs
+++ b/crates/walrus-service/src/event/event_processor/db.rs
@@ -8,13 +8,13 @@ use anyhow::Result;
 use sui_types::{
     base_types::ObjectID,
     committee::Committee,
-    messages_checkpoint::TrustedCheckpoint,
+    messages_checkpoint::{TrustedCheckpoint, VerifiedCheckpoint},
     object::Object,
 };
 use typed_store::{
     Map,
     TypedStoreError,
-    rocks::{self, DBMap, MetricConf, ReadWriteOptions, RocksDB},
+    rocks::{self, DBBatch, DBMap, MetricConf, ReadWriteOptions, RocksDB},
 };
 
 use crate::{
@@ -147,6 +147,36 @@ impl EventProcessorStores {
         self.committee_store.schedule_delete_all()?;
         self.event_store.schedule_delete_all()?;
         self.walrus_package_store.schedule_delete_all()?;
+        Ok(())
+    }
+
+    /// Inserts a checkpoint into the checkpoint store in a batch.
+    /// Inv: it should never insert smaller sequence number than the current latest checkpoint
+    /// sequence number.
+    pub fn insert_checkpoint_in_batch(
+        &self,
+        batch: &mut DBBatch,
+        checkpoint: &VerifiedCheckpoint,
+    ) -> Result<(), TypedStoreError> {
+        #[cfg(debug_assertions)]
+        {
+            let current_latest_checkpoint_seq_number = self
+                .checkpoint_store
+                .get(&())?
+                .map(|c| c.inner().sequence_number)
+                .unwrap_or(0);
+            debug_assert!(
+                *checkpoint.sequence_number() > current_latest_checkpoint_seq_number,
+                "attempt to insert checkpoint with sequence number {} which is smaller than the \
+                current latest checkpoint sequence number {}",
+                *checkpoint.sequence_number(),
+                current_latest_checkpoint_seq_number
+            );
+        }
+        batch.insert_batch(
+            &self.checkpoint_store,
+            std::iter::once(((), checkpoint.serializable_ref())),
+        )?;
         Ok(())
     }
 }

--- a/crates/walrus-service/src/event/event_processor/processor.rs
+++ b/crates/walrus-service/src/event/event_processor/processor.rs
@@ -332,7 +332,11 @@ impl EventProcessor {
     /// Tails the full node for new checkpoints and processes them. This method will run until the
     /// cancellation token is cancelled. If the checkpoint processor falls behind the full node, it
     /// will read events from the event blobs so it can catch up.
-    pub async fn start_tailing_checkpoints(&self, cancel_token: CancellationToken) -> Result<()> {
+    pub async fn start_tailing_checkpoints(
+        &self,
+        cancel_token: CancellationToken,
+        coordination_state: Arc<CatchupCoordinationState>,
+    ) -> Result<()> {
         let mut next_event_index = self
             .stores
             .event_store
@@ -364,6 +368,11 @@ impl EventProcessor {
         sui_macros::fail_point_async!("pause_checkpoint_tailing_entry");
 
         while let Some(entry) = rx.recv().await {
+            ensure!(
+                !coordination_state.is_tailing_stopped(),
+                "catchup using event blob is active, this is unexpected when tailing checkpoints \
+                is also active"
+            );
             let Ok(checkpoint) = entry.result else {
                 let error = entry.result.err().unwrap_or(anyhow!("unknown error"));
                 tracing::error!(
@@ -409,9 +418,14 @@ impl EventProcessor {
         coordination_state.mark_tailing_started();
         let coordination_state = coordination_state.clone();
         tokio::spawn(async move {
-            tracing::info!("Starting tailing task");
-            let result = processor.start_tailing_checkpoints(cancel_token).await;
-            tracing::info!("Tailing task exited");
+            tracing::info!("starting tailing task");
+            let result = processor
+                .start_tailing_checkpoints(cancel_token, coordination_state.clone())
+                .await;
+            match &result {
+                Ok(()) => tracing::info!("tailing task exited successfully"),
+                Err(error) => tracing::error!(?error, "tailing task exited with error"),
+            }
             coordination_state.notify_tailing_stopped();
             result
         })

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -1273,6 +1273,8 @@ impl StorageNodeHandleBuilder {
                     200
                 },
                 runtime_catchup_lag_threshold: 200,
+                runtime_lag_check_interval: Duration::from_secs(30),
+                enable_runtime_catchup: true,
                 ..Default::default()
             },
             pending_sliver_cache: Default::default(),


### PR DESCRIPTION
## Description

When trying to use event blob to catchup on events, the catchup manager always waits for checkpoint tailing to stop by
waiting on a notify. However, when starting the node, it always calls `notify_tailing_stopped`, which stores a notify
permit inside it. This causes `wait_for_tailing_stopped` in `catchup_using_event_blobs()` always return immediately,
which results in checkpoint downloading task and event blob catchup run at the same time.

This PR fix the issue by using the combination of notify_waiters and notify to avoid storing the permit. Also, we add
several invariant checks to guard the correctness of the interaction between catchup manager and checkpoint downloading
process.

Fix WAL-1115

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
