### PR TITLE
fix: Fix racing notification b/w catchup and checkpoint tailing

### DIFF
--- a/crates/walrus-service/src/event/event_processor/catchup.rs
+++ b/crates/walrus-service/src/event/event_processor/catchup.rs
@@ -3,7 +3,12 @@
 
 //! Catchup module for catching up the event processor with the network.
 
-use std::{fs, path::PathBuf, sync::Arc, time::Duration};
+use std::{
+    fs,
+    path::PathBuf,
+    sync::{Arc, atomic::Ordering},
+    time::Duration,
+};
 
 use sui_types::{
     committee::Committee,
@@ -133,7 +138,11 @@ impl EventBlobCatchupManager {
         let current_lag = self.get_current_lag().await?;
 
         if current_lag > lag_threshold {
-            tracing::info!(lag_threshold, "performing catchup - lag is above threshold");
+            tracing::info!(
+                lag_threshold,
+                current_lag,
+                "performing catchup - lag is above threshold"
+            );
             match self.perform_catchup().await {
                 Ok(()) => {}
                 Err(CatchupError::Recoverable(error)) => {
@@ -144,7 +153,11 @@ impl EventBlobCatchupManager {
                 }
             }
         } else {
-            tracing::info!(lag_threshold, "skipping catchup - lag is below threshold");
+            tracing::info!(
+                lag_threshold,
+                current_lag,
+                "skipping catchup - lag is below threshold"
+            );
         }
 
         Ok(())
@@ -318,6 +331,17 @@ impl EventBlobCatchupManager {
         let next_event_index = self
             .get_next_event_index()
             .map_err(|error| CatchupError::NonRecoverable(anyhow::Error::from(error)))?;
+
+        // Inv: when process_event_blob is running, checkpoint tailing should definitely be stopped.
+        if !coordination_state
+            .is_tailing_stopped
+            .load(Ordering::Acquire)
+        {
+            return Err(CatchupError::Recoverable(anyhow::anyhow!(
+                "checkpoint tailing should be stopped when process_event_blob is running"
+            )));
+        }
+
         let processing_result = tokio::time::timeout(
             self.catchup_runtime_config.processing_timeout,
             self.process_event_blobs(blobs, next_event_index),
@@ -582,11 +606,8 @@ impl EventBlobCatchupManager {
             .await?;
         let verified_checkpoint = VerifiedCheckpoint::new_unchecked(checkpoint_summary.clone());
 
-        batch.insert_batch(
-            &self.stores.checkpoint_store,
-            [((), verified_checkpoint.serializable_ref())],
-        )?;
-
+        self.stores
+            .insert_checkpoint_in_batch(batch, &verified_checkpoint)?;
         let next_committee = self.get_next_committee(&checkpoint_summary).await?;
         batch.insert_batch(
             &self.stores.committee_store,

--- a/crates/walrus-service/src/event/event_processor/checkpoint.rs
+++ b/crates/walrus-service/src/event/event_processor/checkpoint.rs
@@ -232,10 +232,8 @@ impl CheckpointProcessor {
         }
 
         // Update checkpoint store
-        write_batch.insert_batch(
-            &self.stores.checkpoint_store,
-            std::iter::once(((), verified_checkpoint.serializable_ref())),
-        )?;
+        self.stores
+            .insert_checkpoint_in_batch(&mut write_batch, &verified_checkpoint)?;
 
         // Write all changes
         write_batch.write()?;

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -1273,6 +1273,8 @@ impl StorageNodeHandleBuilder {
                     200
                 },
                 runtime_catchup_lag_threshold: 200,
+                runtime_lag_check_interval: Duration::from_secs(30),
+                enable_runtime_catchup: true,
                 ..Default::default()
             },
             pending_sliver_cache: Default::default(),

--- a/crates/walrus-simtest/tests/simtest_event_blob.rs
+++ b/crates/walrus-simtest/tests/simtest_event_blob.rs
@@ -306,7 +306,7 @@ mod tests {
             test_cluster::E2eTestSetupBuilder::new()
                 .with_epoch_duration(Duration::from_secs(15))
                 .with_num_checkpoints_per_blob(20)
-                //.with_event_stream_catchup_min_checkpoint_lag(Some(u64::MAX))
+                .with_event_stream_catchup_min_checkpoint_lag(Some(2000))
                 .with_test_nodes_config(
                     TestNodesConfig::builder()
                         .with_node_weights(&[2, 2, 3, 3, 3])
@@ -347,7 +347,7 @@ mod tests {
                     .await;
             if latest_certified_blob.is_some() {
                 tracing::info!(
-                    "Latest certified blob: {:?}",
+                    "latest certified blob: {:?}",
                     latest_certified_blob.clone().unwrap()
                 );
                 break;
@@ -404,7 +404,13 @@ mod tests {
         let latest_seq = node_health_info[0]
             .latest_checkpoint_sequence_number
             .unwrap();
-        assert!(latest_seq > prev_seq);
+        assert!(
+            latest_seq > prev_seq,
+            "latest checkpoint sequence number should advance after the pause window, \
+            prev_seq: {}, latest_seq: {}",
+            prev_seq,
+            latest_seq
+        );
 
         // Verify event-blob catchup ran
         assert!(saw_event_blob_catchup.load(Ordering::SeqCst));


### PR DESCRIPTION
## Description

This PR fixes the following race condition:
1.The catchup and tailing coordination uses a Notify to wait for “tailing has stopped” before catchup writes checkpoints. 
2.On startup we call `notify_tailing_stopped()` to mark the initial idle state. If that notification is sent when no one is waiting, it remains queued. Later, when runtime catchup starts and calls `wait_for_tailing_stopped()`, it consumes that old notification immediately and assumes tailing is stopped even though tailing is actually running. 
3.As a result, catchup proceeds in parallel with tailing: the catchup path writes new checkpoints, but the still-running tailing loop quickly overwrites checkpoint_store with its older value, so the restart sees a stale checkpoint.
4. **The fix is quite simple**: Only use `is_tailing_stopped` as the source of truth and avoid spurious notification wake ups. Just wait until `is_tailing_stopped` is set to true. Startup `notify_tailing_stopped()` still sets `is_tailing_stopped = true` so the first catchup returns immediately but a stale stored permit just causes one extra wake, then we keep waiting until the flag flips back to true.
5. 
## Test plan

Re-run the simtest
