### PR TITLE
docs: re-add static setup files that were removed in docs migration

### DIFF
--- a/docs/site/static/setup/client_config.yaml
+++ b/docs/site/static/setup/client_config.yaml
@@ -1,0 +1,1 @@
+../../../../setup/client_config.yaml

--- a/docs/site/static/setup/client_config_example.yaml
+++ b/docs/site/static/setup/client_config_example.yaml
@@ -1,0 +1,1 @@
+../../../../crates/walrus-sdk/client_config_example.yaml

--- a/docs/site/static/setup/client_config_mainnet.yaml
+++ b/docs/site/static/setup/client_config_mainnet.yaml
@@ -1,0 +1,1 @@
+../../../../setup/client_config_mainnet.yaml

--- a/docs/site/static/setup/client_config_testnet.yaml
+++ b/docs/site/static/setup/client_config_testnet.yaml
@@ -1,0 +1,1 @@
+../../../../setup/client_config_testnet.yaml

--- a/docs/site/static/setup/walrus-install.sh
+++ b/docs/site/static/setup/walrus-install.sh
@@ -1,0 +1,1 @@
+../../../../setup/walrus-install.sh

--- a/docs/site/static/setup/walrus_upload_relay_config_example.yaml
+++ b/docs/site/static/setup/walrus_upload_relay_config_example.yaml
@@ -1,0 +1,1 @@
+../../../../crates/walrus-upload-relay/walrus_upload_relay_config_example.yaml


### PR DESCRIPTION
## Description

Some static files were removed in #2751. This PR adds them again in the correct location.

## Test plan

Inspect preview.
