### PR TITLE
chore: bump Rust to 1.92 and fix new lint warnings

### DIFF
--- a/crates/checkpoint-downloader/src/downloader.rs
+++ b/crates/checkpoint-downloader/src/downloader.rs
@@ -543,8 +543,11 @@ impl ParallelCheckpointDownloaderInner {
                     }
 
                     // Note that we only return error in test mode.
-                    assert!(cfg!(test));
-                    return CheckpointEntry::new(sequence_number, Err(err.into()));
+                    if cfg!(test) {
+                        return CheckpointEntry::new(sequence_number, Err(err.into()));
+                    } else {
+                        unreachable!("we retry indefinitely in production");
+                    }
                 }
             }
         }

--- a/crates/walrus-service/src/common/config.rs
+++ b/crates/walrus-service/src/common/config.rs
@@ -6,7 +6,7 @@
 use std::{sync::Arc, time::Duration};
 
 use serde::{Deserialize, Serialize};
-use serde_with::{DurationMilliSeconds, serde_as};
+use serde_with::DurationMilliSeconds;
 use walrus_sdk::config::combine_rpc_urls;
 use walrus_sui::{
     client::{

--- a/crates/walrus-service/src/node/thread_pool.rs
+++ b/crates/walrus-service/src/node/thread_pool.rs
@@ -175,10 +175,9 @@ impl RayonThreadPool {
         // Note that in simtest, we cannot use Rayon thread pool due to that it causes simtest to be
         // non-deterministic. This is because Rayon threads are actually run in different threads
         // than the tokio main threads, and not controlled by the tokio runtime.
-        debug_assert!(
-            !cfg!(msim),
-            "`RayonThreadPool` cannot be used in msim and so must not be constructed"
-        );
+        if cfg!(msim) {
+            panic!("`RayonThreadPool` cannot be used in msim and so must not be constructed");
+        }
         Self { inner: pool }
     }
 }

--- a/docker/walrus-antithesis/build-walrus-image-for-antithesis/Dockerfile
+++ b/docker/walrus-antithesis/build-walrus-image-for-antithesis/Dockerfile
@@ -8,7 +8,7 @@
 
 # Stage 1: Base Build Environment + Builder
 # -------------------------------------
-FROM rust:1.91-bookworm AS builder
+FROM rust:1.92-bookworm AS builder
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION
 WORKDIR "$WORKDIR/walrus"

--- a/docker/walrus-orchestrator/Dockerfile
+++ b/docker/walrus-orchestrator/Dockerfile
@@ -3,7 +3,7 @@
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
 
-FROM rust:1.91-bookworm AS builder
+FROM rust:1.92-bookworm AS builder
 
 ARG PROFILE=release
 ARG GIT_REVISION

--- a/docker/walrus-proxy/Dockerfile
+++ b/docker/walrus-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.91-bookworm as builder
+FROM rust:1.92-bookworm as builder
 
 ARG PROFILE=release
 WORKDIR /work

--- a/docker/walrus-service/Dockerfile
+++ b/docker/walrus-service/Dockerfile
@@ -3,7 +3,7 @@
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
 
-FROM rust:1.91-bookworm AS builder
+FROM rust:1.92-bookworm AS builder
 
 ARG PROFILE=release
 ARG GIT_REVISION

--- a/docker/walrus-service/Dockerfile.walrus-backup
+++ b/docker/walrus-service/Dockerfile.walrus-backup
@@ -3,7 +3,7 @@
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
 
-FROM rust:1.91-bookworm AS builder
+FROM rust:1.92-bookworm AS builder
 
 ARG PROFILE=release
 ARG RUST_LOG=info,walrus_service::common::event_blob_downloader=warn

--- a/docker/walrus-stress/Dockerfile
+++ b/docker/walrus-stress/Dockerfile
@@ -3,7 +3,7 @@
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
 
-FROM rust:1.91-bookworm AS builder
+FROM rust:1.92-bookworm AS builder
 
 ARG PROFILE=release
 ARG GIT_REVISION

--- a/docker/walrus-upload-relay/Dockerfile
+++ b/docker/walrus-upload-relay/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.91-bookworm AS builder
+FROM rust:1.92-bookworm AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.91"
+channel = "1.92"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Description

Bumps Rust to the [latest stable release 1.92](https://blog.rust-lang.org/2025/12/11/Rust-1.92.0/) and fixes the few new lint warnings.

## Test plan

CI.