### PR TITLE
test: various test improvements (#2759)

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -128,7 +128,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libssl-dev pkg-config zlib1g-dev libpq-dev build-essential cmake
       - name: Run tests
-        run: cargo nextest run --workspace --features "walrus-service/backup" --profile ci --run-ignored all
+        run: cargo nextest run --workspace --features "walrus-service/backup" --profile ci --run-ignored all --cargo-profile
+          test-opt
       - name: Run all unit tests and doctests with `cargo test`
         run: cargo test
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,15 +190,16 @@ panic = 'abort'
 [profile.dev]
 panic = 'abort'
 
-[profile.test]
+[profile.test-opt]
+inherits = "test"
+# the small extra compilation time for opt-level 1 is worth it to give >5x speedup for simulator
+# tests and major speedup for other tests.
 opt-level = 1
 
 [profile.simulator]
 debug = true
 debug-assertions = true
-inherits = "test"
-# opt-level 1 gives >5x speedup for simulator tests without slowing down build times very much.
-opt-level = 1
+inherits = "test-opt"
 overflow-checks = true
 panic = 'abort'
 

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -4360,7 +4360,7 @@ mod tests {
             move_structs::EpochState,
         },
     };
-    use walrus_test_utils::{Result as TestResult, WithTempDir, async_param_test, random_data};
+    use walrus_test_utils::{Result as TestResult, WithTempDir, async_param_test};
 
     use super::*;
     use crate::test_utils::{
@@ -4658,117 +4658,6 @@ mod tests {
         inner
             .check_does_not_store_metadata_or_slivers_for_blob(&BLOB_ID)
             .await?;
-        Ok(())
-    }
-
-    async_param_test! {
-        correctly_handles_blob_deletions_with_concurrent_instances -> TestResult: [
-            same_epoch_deletable: (true, 1),
-            same_epoch_permanent: (false, 1),
-            later_epoch_deletable: (true, 2),
-            later_epoch_permanent: (false, 2),
-        ]
-    }
-    async fn correctly_handles_blob_deletions_with_concurrent_instances(
-        blob_2_deletable: bool,
-        current_epoch: Epoch,
-    ) -> TestResult {
-        walrus_test_utils::init_tracing();
-
-        tracing::info!("setting up cluster at epoch 1");
-        let (cluster, events) =
-            cluster_at_epoch1_without_blobs_waiting_for_active_nodes(&[&[0, 1, 2, 3]], None)
-                .await?;
-        let node = &cluster.nodes[0];
-        let mut current_events_processed_count = node
-            .storage_node
-            .inner
-            .storage
-            .get_sequentially_processed_event_count()?;
-
-        tracing::info!("generating random blob");
-        let blob = random_data(100);
-        let blob_details = EncodedBlob::new(&blob, cluster.encoding_config());
-        let blob_id = *blob_details.blob_id();
-
-        let blob_1_registration_event = BlobRegistered {
-            epoch: 1,
-            deletable: true,
-            end_epoch: 2,
-            ..BlobRegistered::for_testing_with_random_object_id(blob_id)
-        };
-        let blob_2_registration_event = BlobRegistered {
-            epoch: 1,
-            deletable: blob_2_deletable,
-            end_epoch: 2,
-            ..BlobRegistered::for_testing_with_random_object_id(blob_id)
-        };
-
-        tracing::info!("storing blob at all shards");
-        events.send(blob_1_registration_event.clone().into())?;
-        store_at_shards(&blob_details, &cluster, |_, _| true).await?;
-        current_events_processed_count =
-            wait_until_events_processed_exact(node, current_events_processed_count + 1).await?;
-
-        if current_epoch > 1 {
-            tracing::info!("advancing cluster to epoch {current_epoch}");
-            advance_cluster_to_epoch(&cluster, &[&events], current_epoch).await?;
-
-            tracing::info!("sending first blob registration event again");
-            events.send(blob_1_registration_event.clone().into())?;
-            current_events_processed_count = wait_until_events_processed_exact(
-                node,
-                current_events_processed_count + 2 * (u64::from(current_epoch) - 1) + 1,
-            )
-            .await?;
-        }
-
-        tracing::info!(
-            "current epoch: {}",
-            node.storage_node.inner.current_committee_epoch()
-        );
-        tracing::info!("current events processed count: {current_events_processed_count}");
-
-        tracing::info!("registering same blob again");
-        events.send(blob_2_registration_event.clone().into())?;
-        current_events_processed_count =
-            wait_until_events_processed_exact(node, current_events_processed_count + 1).await?;
-
-        tracing::info!("certifying and deleting first blob");
-        events.send(
-            blob_1_registration_event
-                .clone()
-                .into_corresponding_certified_event_for_testing()
-                .into(),
-        )?;
-        events.send(
-            blob_1_registration_event
-                .into_corresponding_deleted_event_for_testing(true)
-                .into(),
-        )?;
-        current_events_processed_count =
-            wait_until_events_processed_exact(node, current_events_processed_count + 2).await?;
-
-        tracing::info!("certifying second blob");
-        events.send(
-            blob_2_registration_event
-                .clone()
-                .into_corresponding_certified_event_for_testing()
-                .into(),
-        )?;
-        current_events_processed_count =
-            wait_until_events_processed_exact(node, current_events_processed_count + 1).await?;
-
-        if blob_2_deletable {
-            tracing::info!("deleting second blob");
-            events.send(
-                blob_2_registration_event
-                    .into_corresponding_deleted_event_for_testing(true)
-                    .into(),
-            )?;
-            wait_until_events_processed_exact(node, current_events_processed_count + 1).await?;
-        }
-
         Ok(())
     }
 
@@ -5487,6 +5376,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "ignore long-running test by default"]
     async fn recovers_all_shards_for_multi_shard_node() -> TestResult {
         let shards: &[&[u16]] = &[&[0, 1], &[2, 3]];
 
@@ -5645,6 +5535,7 @@ mod tests {
     }
 
     #[walrus_simtest]
+    #[ignore = "ignore long-running test by default"]
     async fn deletes_expired_blob_data() -> TestResult {
         walrus_test_utils::init_tracing();
 

--- a/crates/walrus-service/src/node/garbage_collector.rs
+++ b/crates/walrus-service/src/node/garbage_collector.rs
@@ -71,8 +71,8 @@ impl GarbageCollectionConfig {
             enable_data_deletion: true,
             enable_random_delay: true,
             randomization_time_window: Some(Duration::from_secs(1)),
-            blob_objects_batch_size: 1000,
-            data_deletion_batch_size: 1000,
+            blob_objects_batch_size: 10,
+            data_deletion_batch_size: 10,
         }
     }
 }

--- a/crates/walrus-simtest/tests/simtest.rs
+++ b/crates/walrus-simtest/tests/simtest.rs
@@ -67,7 +67,12 @@ mod tests {
         test_utils::system_setup::{development_contract_dir, testnet_contract_dir},
         types::{Blob, move_structs::EventBlob},
     };
-    use walrus_test_utils::{WithTempDir, random_data_from_rng};
+    use walrus_test_utils::{
+        WithTempDir,
+        async_param_test,
+        random_data_from_rng,
+        simtest_param_test,
+    };
 
     /// Returns a simulator configuration that adds random network latency between nodes.
     ///
@@ -651,6 +656,124 @@ mod tests {
         // );
         clear_fail_point("fail_point_recovery_with_incomplete_history");
         clear_fail_point("fail_point_catchup_using_event_blobs_start");
+    }
+
+    simtest_param_test! {
+        #[ignore = "ignore integration simtests by default"]
+        correctly_handles_blob_deletions_with_concurrent_instances: [
+            same_epoch_deletable: (true, true),
+            same_epoch_permanent: (true, false),
+            later_epoch_deletable: (false, true),
+            later_epoch_permanent: (false, false),
+        ]
+    }
+    async fn correctly_handles_blob_deletions_with_concurrent_instances(
+        process_in_same_epoch: bool,
+        blob_2_deletable: bool,
+    ) {
+        const EPOCH_DURATION: Duration = Duration::from_secs(30);
+        let (_sui_cluster, walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
+            .with_epoch_duration(EPOCH_DURATION)
+            .with_test_nodes_config(
+                TestNodesConfig::builder()
+                    .with_node_weights(&[1, 2, 3, 3, 4])
+                    .build(),
+            )
+            .with_communication_config(
+                ClientCommunicationConfig::default_for_test_with_reqwest_timeout(
+                    Duration::from_secs(2),
+                ),
+            )
+            .build_generic::<SimStorageNodeHandle>()
+            .await
+            .unwrap();
+
+        let target_epoch_for_processing = if process_in_same_epoch { 1 } else { 2 };
+        let target_cluster_epoch = target_epoch_for_processing + 1;
+
+        let blob_info_consistency_check = BlobInfoConsistencyCheck::new();
+        let client = Arc::new(client);
+
+        let maybe_delayed_node_id = walrus_cluster.nodes[0]
+            .node_id
+            .expect("node ID should be set");
+
+        let allow_processing = Arc::new(AtomicBool::new(process_in_same_epoch));
+        register_fail_point_async("before-process-event-impl", {
+            let allow_processing = allow_processing.clone();
+            move || {
+                let target_node_id = maybe_delayed_node_id;
+                let allow_processing = allow_processing.clone();
+                async move {
+                    if sui_simulator::current_simnode_id() == target_node_id {
+                        while !allow_processing.load(Ordering::SeqCst) {
+                            tokio::time::sleep(Duration::from_millis(100)).await;
+                        }
+                    }
+                }
+            }
+        });
+
+        let blob = walrus_test_utils::random_data(256);
+        let blob_1_store_args = StoreArgs::default_with_epochs(1)
+            .with_persistence(BlobPersistence::Deletable)
+            .no_store_optimizations();
+        let blob_2_store_args = blob_1_store_args
+            .clone()
+            .with_persistence(BlobPersistence::from_deletable(blob_2_deletable));
+
+        let mut blob_ids = Vec::new();
+        let mut object_ids_to_delete = Vec::new();
+        for (i, store_args) in [blob_1_store_args, blob_2_store_args].iter().enumerate() {
+            let results = client
+                .inner
+                .reserve_and_store_blobs_retry_committees(vec![blob.clone()], vec![], store_args)
+                .await
+                .expect("store should succeed");
+            let BlobStoreResult::NewlyCreated {
+                blob_object: Blob { blob_id, id, .. },
+                ..
+            } = results.first().expect("expected result for store")
+            else {
+                panic!("unexpected store result {results:?} for store {i}");
+            };
+            blob_ids.push(*blob_id);
+            if store_args.persistence.is_deletable() {
+                object_ids_to_delete.push(*id);
+            }
+        }
+        assert_eq!(blob_ids[0], blob_ids[1]);
+        if object_ids_to_delete.len() == 2 {
+            assert!(object_ids_to_delete[0] != object_ids_to_delete[1]);
+        }
+
+        for object_id in object_ids_to_delete.into_iter() {
+            client
+                .as_ref()
+                .as_ref()
+                .delete_owned_blob_by_object(object_id)
+                .await
+                .expect("delete should succeed for deletable blob");
+        }
+
+        simtest_utils::wait_for_nodes_to_reach_epoch(
+            &walrus_cluster.nodes[1..],
+            target_epoch_for_processing,
+            2 * EPOCH_DURATION,
+        )
+        .await;
+        allow_processing.store(true, Ordering::SeqCst);
+
+        simtest_utils::wait_for_nodes_to_reach_epoch(
+            &walrus_cluster.nodes[..],
+            target_cluster_epoch,
+            2 * EPOCH_DURATION,
+        )
+        .await;
+
+        blob_info_consistency_check.check_storage_node_consistency();
+
+        clear_fail_point("before-process-event-impl");
     }
 
     // The node recovery process is artificially prolonged to be longer than 1 epoch.

--- a/crates/walrus-test-utils/src/lib.rs
+++ b/crates/walrus-test-utils/src/lib.rs
@@ -212,11 +212,9 @@ macro_rules! simtest_param_test {
             $func_name -> (): [ $( #[walrus_simtest] $case_name: ($($args),+) ),* ]
         );
     };
-    ($func_name:ident -> $return_ty:ty: [
-        $( $case_name:ident: ( $($args:expr),+ ) ),+$(,)?
-    ]) => {
+    ($(#[$outer:meta])* $func_name:ident $(-> $return_ty:ty)?: $cases:tt) => {
         async_param_test!(
-            $func_name -> $return_ty: [ $( #[walrus_simtest] $case_name: ( $($args),+ ) ),* ]
+            $(#[$outer])* #[walrus_simtest] $func_name $(-> $return_ty)?: $cases
         );
     };
     (#[tokio::test(start_paused = true)] $func_name:ident -> $return_ty:ty: [

--- a/deny.toml
+++ b/deny.toml
@@ -20,11 +20,11 @@ ignore = [
   "RUSTSEC-2025-0012",
   # Crash due to uncontrolled recursion in `protobuf` crate.
   "RUSTSEC-2024-0437",
-  # fxhash is unmaintained; it is used in `sui-config`.
+  # `fxhash` is unmaintained; it is used in `sui-config`.
   "RUSTSEC-2025-0057",
-  # number_prefix is unmaintained; it is a dependency of many sui crates.
+  # `number_prefix` is unmaintained; it is a dependency of many sui crates.
   "RUSTSEC-2025-0119",
-  # rustls-pemfile is unmaintained; it is a dependency of `sui-types` crate.
+  # `rustls-pemfile` is unmaintained; it is an indirect dependency through various crates.
   "RUSTSEC-2025-0134",
 ]
 


### PR DESCRIPTION
* Disable optimization for tests by default; enable for E2E tests in CI.
* Improve some test parameters.
* Ignore some long-running tests by default.
* Improve `simtest_param_test` macro.
* Re-implement the previously problematic test `correctly_handles_blob_deletions_with_concurrent_instances` as a simtest.

