### PR TITLE
feat: adding client interface to fetch decoding symbols

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13342,7 +13342,6 @@ dependencies = [
  "tower 0.5.2",
  "tracing",
  "tracing-opentelemetry",
- "tracing-subscriber",
  "utoipa",
  "walrus-core",
  "walrus-test-utils",

--- a/crates/walrus-service/src/node/server.rs
+++ b/crates/walrus-service/src/node/server.rs
@@ -651,6 +651,8 @@ mod tests {
         }
 
         // A mock implementation returning a single decoding symbol for each target sliver.
+        // The returned symbols are also used to test the query sent to the server can be
+        // parsed correctly.
         async fn retrieve_multiple_decoding_symbols(
             &self,
             _blob_id: &BlobId,
@@ -1410,6 +1412,7 @@ mod tests {
         Ok(())
     }
 
+    // Test the query sent to the server can be parsed correctly.
     async_param_test! {
         list_decoding_symbols: [
             primary: (SliverType::Primary),
@@ -1419,7 +1422,8 @@ mod tests {
     async fn list_decoding_symbols(sliver_type: SliverType) {
         let _ = tracing_subscriber::fmt::try_init();
         let (config, _handle) = start_rest_api_with_test_config().await;
-        println!("config: {:?}", config.as_ref());
+
+        tracing::debug!("config: {:?}", config.as_ref());
         let client = storage_node_client(config.as_ref());
         let blob_id = walrus_core::test_utils::random_blob_id();
 
@@ -1432,6 +1436,7 @@ mod tests {
             .list_decoding_symbols(&blob_id, &filter)
             .await
             .expect("request should succeed");
+
         assert_eq!(result.len(), 2);
         assert_eq!(result.get(&SliverIndex(17)).unwrap().len(), 1);
         assert_eq!(result.get(&SliverIndex(28)).unwrap().len(), 1);

--- a/crates/walrus-storage-node-client/Cargo.toml
+++ b/crates/walrus-storage-node-client/Cargo.toml
@@ -33,7 +33,6 @@ tokio.workspace = true
 tower = { workspace = true, features = ["util"] }
 tracing.workspace = true
 tracing-opentelemetry.workspace = true
-tracing-subscriber.workspace = true
 utoipa.workspace = true
 walrus-core = { workspace = true, features = ["sui-types"] }
 walrus-utils = { workspace = true, features = ["http", "metrics"] }


### PR DESCRIPTION
## Description

This PR add client side interface to call ListDecodingSymbols endpoint to fetch symbols to reconstruct slivers on client side.

Contribute to WAL-1120

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
