### PR TITLE
ci: Update walrus-docs-ci to use the walrus-sites-deploy action

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -98,5 +98,3 @@ jobs:
           EPOCHS: "10"
           GAS_BUDGET: "1000000000"
           SITE_BUILDER_VERSION: v2
-          OBJECT_ID: "${{ vars.WALRUS_SITE_OBJECT_DOCS }}"
-          GITHUB_TOKEN: "${{ !vars.WALRUS_SITE_OBJECT_DOCS && secrets.GITHUB_TOKEN || '' }}"

--- a/docs/site/ws-resources.json
+++ b/docs/site/ws-resources.json
@@ -64,6 +64,7 @@
     "/docs/operator-guide/upload-relay": "/docs/operator-guide/upload-relay.html",
     "/docs/snippets/blob-object-id": "/docs/snippets/blob-object-id.html",
     "/docs/snippets/blog-note-edit": "/docs/snippets/blog-note-edit.html",
+    "/docs/tusky-migration-guide": "/docs/tusky-migration-guide.html",
     "/docs/usage/client-cli": "/docs/usage/client-cli.html",
     "/docs/usage/examples": "/docs/usage/examples.html",
     "/docs/usage/glossary": "/docs/usage/glossary.html",
@@ -96,7 +97,6 @@
     "/docs/walrus-sites/tutorial-install": "/docs/walrus-sites/tutorial-install.html",
     "/docs/walrus-sites/tutorial-publish": "/docs/walrus-sites/tutorial-publish.html",
     "/docs/walrus-sites/tutorial-suins": "/docs/walrus-sites/tutorial-suins.html",
-    "/docs/tusky-migration-guide": "/docs/tusky-migration-guide.html",
     "/index": "/index.html",
     "/intro": "/intro.html",
     "/intro.html": "/intro/index.html",
@@ -187,5 +187,6 @@
     "/walrus-sites/tutorial-suins/index": "/walrus-sites/tutorial-suins/index.html",
     "/walrus-sites/tutorial.html": "/walrus-sites/tutorial/index.html",
     "/walrus-sites/tutorial/index": "/walrus-sites/tutorial/index.html"
-  }
+  },
+  "object_id": "0xbd6014d74e37d94a299c932e70e0b009979d9c6dc6d941eb4afe4995b8df242c"
 }


### PR DESCRIPTION
## Description

Updates walrus-docs-ci to use the [walrus-sites-deploy action ](https://github.com/MystenLabs/walrus-sites-github-actions/blob/main/deploy/action.yml). 


## Test plan

Executed the [publish docs job](https://github.com/MystenLabs/walrus/actions/runs/20852837509/job/59911811518)

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
