### PR TITLE
fix: fix republishing in local testbed

### DIFF
--- a/crates/walrus-sui/src/system_setup.rs
+++ b/crates/walrus-sui/src/system_setup.rs
@@ -398,7 +398,16 @@ pub(crate) async fn publish_coin_and_system_package(
                 "clearing deploy directory {:?} before copying to it",
                 deploy_directory
             );
-            std::fs::remove_dir_all(&deploy_directory)?;
+            // Clear all contents inside the directory without removing the directory itself
+            for entry in std::fs::read_dir(&deploy_directory)? {
+                let entry = entry?;
+                let path = entry.path();
+                if path.is_dir() {
+                    std::fs::remove_dir_all(path)?;
+                } else {
+                    std::fs::remove_file(path)?;
+                }
+            }
         }
         copy_recursively(&contract_dir, &deploy_directory).await?;
         deploy_directory


### PR DESCRIPTION
## Description

Republishing the same contract in local testbed currently doesn't work due to the hack to work around ephemeral contract
publishing. We need to clear the contract dir before the next publishing.

Related to WAL-1126

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
