### PR TITLE
chore: disable GC on mainnet by default

### DIFF
--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -207,7 +207,16 @@ pub struct StorageNodeConfig {
 impl StorageNodeConfig {
     /// Returns the default configuration for the mainnet network.
     pub fn default_mainnet() -> Self {
-        Self::default()
+        Self {
+            // Disable garbage collection by default on mainnet.
+            // TODO(WAL-1105): Enable GC by default on mainnet.
+            garbage_collection: GarbageCollectionConfig {
+                enable_blob_info_cleanup: false,
+                enable_data_deletion: false,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
     }
 
     /// Returns the default configuration for the testnet network.
@@ -264,12 +273,7 @@ impl StorageNodeConfig {
             blob_event_processor_config: BlobEventProcessorConfig {
                 num_workers: NonZeroUsize::new(3).expect("3 is non-zero"),
             },
-            garbage_collection: GarbageCollectionConfig {
-                randomization_time_window: Some(Duration::from_secs(1)),
-                blob_objects_batch_size: 10,
-                data_deletion_batch_size: 5,
-                ..Default::default()
-            },
+            garbage_collection: GarbageCollectionConfig::default_for_test(),
             ..Default::default()
         }
     }
@@ -295,12 +299,7 @@ impl StorageNodeConfig {
                 enable_sliver_data_existence_check: true,
                 ..Default::default()
             },
-            garbage_collection: GarbageCollectionConfig {
-                randomization_time_window: Some(Duration::from_secs(1)),
-                blob_objects_batch_size: 10,
-                data_deletion_batch_size: 5,
-                ..Default::default()
-            },
+            garbage_collection: GarbageCollectionConfig::default_for_test(),
             ..Default::default()
         }
     }


### PR DESCRIPTION
## Description

Disables GC by default on Mainnet but keep it enabled on Testnet.

## Test plan

CI.
