### PR TITLE
fix: don't create new environment for sui in multisig action

### DIFF
--- a/.github/workflows/create-tx-for-multisig.yml
+++ b/.github/workflows/create-tx-for-multisig.yml
@@ -9,11 +9,6 @@ on:
         options:
           - upgrade-walrus-subsidies
           - set-walrus-subsidy-rates
-      rpc:
-        description: "RPC url"
-        required: true
-        default: "https://fullnode.mainnet.sui.io:443"
-        type: string
       gas_object_id:
         description: "object id to get gas from for multisig transaction"
         required: false
@@ -60,7 +55,6 @@ jobs:
 
       - name: Setup sui client config
         run: |
-          sui client --yes new-env --rpc ${{ inputs.rpc }} --alias mainnet
           sui client switch --env mainnet
 
       - name: Create unsigned transaction for multisig


### PR DESCRIPTION
## Description

Fixes the multisig action (failed due to mainnet environment being created automatically in newer sui version)

## Test plan

Manually run workflow

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
