### PR TITLE
fix(docs): <Card> href links should omit the .mdx postfix

### DIFF
--- a/docs/content/walrus-sites/ci-cd.mdx
+++ b/docs/content/walrus-sites/ci-cd.mdx
@@ -6,11 +6,11 @@ keywords: ["walrus sites", "ci/cd", "github actions", "automation", "deployment"
 
 If you need to automate the deployment of your Walrus Sites, you can use a CI/CD pipeline.
 
-<Card title="Preparing Your Deployment Credentials" href="/walrus-sites/ci-cd-gh-secrets-vars.mdx">
+<Card title="Preparing Your Deployment Credentials" href="/docs/walrus-sites/ci-cd-gh-secrets-vars">
 Set up the necessary secrets and variables in your GitHub repository.
 </Card>
 
-<Card title="Writing Your Workflow" href="/walrus-sites/ci-cd-gh-workflow.mdx">
+<Card title="Writing Your Workflow" href="/docs/walrus-sites/ci-cd-gh-workflow">
 Create and configure your GitHub Actions workflow file.
 </Card>
 

--- a/docs/content/walrus-sites/tutorial.mdx
+++ b/docs/content/walrus-sites/tutorial.mdx
@@ -7,14 +7,14 @@ keywords: ["walrus sites", "tutorial", "first site", "publishing", "site builder
 This tutorial walks you through the steps necessary to publish a Walrus Site. We also provide the
 instructions on how to add a SuiNS name to it for convenient browsing.
 
-<Card title="Installing the Site Builder" href="/docs/walrus-sites/tutorial-install.mdx">
+<Card title="Installing the Site Builder" href="/docs/walrus-sites/tutorial-install">
 Install and setup the Walrus Sites `site-builder` tool for development.
 </Card>
 
-<Card title="Publishing a Walrus Site" href="/docs/walrus-sites/tutorial-publish.mdx">
+<Card title="Publishing a Walrus Site" href="/docs/walrus-sites/tutorial-publish">
 Publish your first Walrus Site using the `site-builder` tool.
 </Card>
 
-<Card title="Set a SuiNS Name" href="/docs/walrus-sites/tutorial-suins.mdx">
+<Card title="Set a SuiNS Name" href="/docs/walrus-sites/tutorial-suins">
 Setup SuiNS names for human-readable Walrus Sites domain names and portal browsing.
 </Card>


### PR DESCRIPTION
## Description

Broken links inside Card components in walrus docs inside walrus-sites section.

## Test plan

Locally run docusaurus via `yarn start`