### PR TITLE
fix: fix tracing subscriber initialization in cli

### DIFF
--- a/crates/walrus-service/src/client/cli/runner.rs
+++ b/crates/walrus-service/src/client/cli/runner.rs
@@ -228,7 +228,7 @@ impl ClientCommandRunner {
                 None => (),
             }
             // Since we may export OTLP, this needs to be initialised in an async context.
-            let _guard = subscriber_builder.init()?;
+            let _guard = subscriber_builder.init_scoped()?;
 
             self.run_cli_app_inner(command).await
         };


### PR DESCRIPTION
## Description

When upgrading to sui 1.63, it appears that it turns on the `tracing-log` feature of tracing subscriber.

Before, the CLI initialize tracing subscriber twice: once uses scoped one and once uses the global one. However, when setting the global subscriber, it requires that no logger is set when `tracing-log` feature is enabled, so sui 1.63 breaks the old code.

The fix is to also use scoped subscriber instead of the global subscriber, with more relaxed logger checks.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
