### PR TITLE
chore: implement basic aggregator tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13049,6 +13049,7 @@ dependencies = [
  "prometheus",
  "rand 0.8.5",
  "reqwest",
+ "serde_json",
  "serde_yaml 0.9.34+deprecated",
  "sui-macros",
  "sui-protocol-config",

--- a/crates/walrus-e2e-tests/Cargo.toml
+++ b/crates/walrus-e2e-tests/Cargo.toml
@@ -16,6 +16,7 @@ futures.workspace = true
 hex.workspace = true
 indicatif.workspace = true
 reqwest = { version = "0.12.12", default-features = false, features = ["__internal_proxy_sys_no_cache", "http2", "json", "rustls-tls"] }
+serde_json.workspace = true
 serde_yaml.workspace = true
 sui-macros.workspace = true
 sui-protocol-config.workspace = true

--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -275,7 +275,7 @@ async fn run_store_and_read_with_crash_failures(
 ) -> TestResult {
     walrus_test_utils::init_tracing();
 
-    let (_sui_cluster_handle, mut cluster, client, _) =
+    let (_sui_cluster_handle, mut cluster, client, _, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
     // Stop the nodes in the write failure set.
     failed_shards_write
@@ -311,7 +311,7 @@ async_param_test! {
 async fn test_inconsistency(failed_nodes: &[usize]) -> TestResult {
     walrus_test_utils::init_tracing();
 
-    let (_sui_cluster_handle, mut cluster, mut client, _) =
+    let (_sui_cluster_handle, mut cluster, mut client, _, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
 
     // Store a blob and get confirmations from each node.
@@ -489,7 +489,7 @@ async fn test_store_with_existing_blob_resource(
 ) -> TestResult {
     walrus_test_utils::init_tracing();
 
-    let (_sui_cluster_handle, _cluster, client, _) =
+    let (_sui_cluster_handle, _cluster, client, _, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
 
     let blobs = walrus_test_utils::random_data_list(31415, 4);
@@ -627,7 +627,7 @@ async fn store_blob(
 pub async fn test_store_and_read_duplicate_blobs() -> TestResult {
     walrus_test_utils::init_tracing();
 
-    let (_sui_cluster_handle, _cluster, client, _) =
+    let (_sui_cluster_handle, _cluster, client, _, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
     let client = client.as_ref();
 
@@ -691,7 +691,7 @@ async_param_test! {
 async fn test_store_with_existing_blobs(persistence: BlobPersistence) -> TestResult {
     walrus_test_utils::init_tracing();
 
-    let (_sui_cluster_handle, _cluster, client, _) =
+    let (_sui_cluster_handle, _cluster, client, _, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
 
     let blobs = walrus_test_utils::random_data_list(31415, 5);
@@ -786,7 +786,7 @@ async fn test_store_with_existing_storage_resource(
 ) -> TestResult {
     walrus_test_utils::init_tracing();
 
-    let (_sui_cluster_handle, _cluster, client, _) =
+    let (_sui_cluster_handle, _cluster, client, _, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
 
     let blobs = walrus_test_utils::random_data_list(31415, 4);
@@ -864,7 +864,7 @@ async_param_test! {
 /// Tests blob object deletion.
 async fn test_delete_blob(blobs_to_create: u32) -> TestResult {
     walrus_test_utils::init_tracing();
-    let (_sui_cluster_handle, _cluster, client, _) =
+    let (_sui_cluster_handle, _cluster, client, _, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
     let blobs = walrus_test_utils::random_data_list(314, 1);
 
@@ -923,7 +923,7 @@ async fn test_delete_blob(blobs_to_create: u32) -> TestResult {
 #[walrus_simtest]
 async fn test_storage_nodes_do_not_serve_data_for_deleted_blobs() -> TestResult {
     walrus_test_utils::init_tracing();
-    let (_sui_cluster_handle, _cluster, client, _) =
+    let (_sui_cluster_handle, _cluster, client, _, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
     let client = client.as_ref();
     let blob = walrus_test_utils::random_data(314);
@@ -956,7 +956,7 @@ async fn test_storage_nodes_do_not_serve_data_for_deleted_blobs() -> TestResult 
 async fn test_storage_nodes_do_not_serve_data_for_expired_deletable_blobs() -> TestResult {
     walrus_test_utils::init_tracing();
     let epoch_duration = Duration::from_secs(15);
-    let (_sui_cluster_handle, cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
+    let (_sui_cluster_handle, cluster, client, _, _) = test_cluster::E2eTestSetupBuilder::new()
         .with_epoch_duration(epoch_duration)
         .build()
         .await?;
@@ -1129,7 +1129,7 @@ async fn test_store_quilt(blobs_to_create: u32) -> TestResult {
         .build();
     let test_cluster_builder =
         test_cluster::E2eTestSetupBuilder::new().with_test_nodes_config(test_nodes_config);
-    let (_sui_cluster_handle, _cluster, client, _) = test_cluster_builder.build().await?;
+    let (_sui_cluster_handle, _cluster, client, _, _) = test_cluster_builder.build().await?;
     let client = client.as_ref();
     let blobs = walrus_test_utils::random_data_list(314, blobs_to_create as usize);
     let encoding_type = DEFAULT_ENCODING;
@@ -1257,7 +1257,7 @@ async fn test_store_quilt(blobs_to_create: u32) -> TestResult {
 async fn test_blocklist() -> TestResult {
     walrus_test_utils::init_tracing();
     let blocklist_dir = tempfile::tempdir().expect("temporary directory creation must succeed");
-    let (_sui_cluster_handle, _cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
+    let (_sui_cluster_handle, _cluster, client, _, _) = test_cluster::E2eTestSetupBuilder::new()
         .with_test_nodes_config(
             TestNodesConfig::builder()
                 .with_blocklist_dir(blocklist_dir.path().to_path_buf())
@@ -1347,7 +1347,7 @@ async fn test_blocklist() -> TestResult {
 #[walrus_simtest]
 async fn test_blob_operations_with_credits() -> TestResult {
     walrus_test_utils::init_tracing();
-    let (_sui_cluster_handle, _cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
+    let (_sui_cluster_handle, _cluster, client, _, _) = test_cluster::E2eTestSetupBuilder::new()
         .with_credits()
         .build()
         .await?;
@@ -1413,7 +1413,7 @@ async fn test_blob_operations_with_credits() -> TestResult {
 async fn test_walrus_subsidies_get_called_by_node() -> TestResult {
     walrus_test_utils::init_tracing();
 
-    let (_sui_cluster_handle, cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
+    let (_sui_cluster_handle, cluster, client, _, _) = test_cluster::E2eTestSetupBuilder::new()
         .with_epoch_duration(Duration::from_secs(20))
         .build()
         .await?;
@@ -1457,7 +1457,7 @@ async fn test_walrus_subsidies_get_called_by_node() -> TestResult {
 #[walrus_simtest]
 async fn test_multiple_stores_same_blob() -> TestResult {
     walrus_test_utils::init_tracing();
-    let (_sui_cluster_handle, _cluster, client, _) =
+    let (_sui_cluster_handle, _cluster, client, _, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
     let client = client.as_ref();
     let blobs = walrus_test_utils::random_data_list(314, 1);
@@ -1596,15 +1596,16 @@ async fn test_multiple_stores_same_blob() -> TestResult {
 #[walrus_simtest]
 async fn test_repeated_shard_move() -> TestResult {
     walrus_test_utils::init_tracing();
-    let (_sui_cluster_handle, walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
-        .with_epoch_duration(Duration::from_secs(20))
-        .with_test_nodes_config(
-            TestNodesConfig::builder()
-                .with_node_weights(&[1, 1])
-                .build(),
-        )
-        .build()
-        .await?;
+    let (_sui_cluster_handle, walrus_cluster, client, _, _) =
+        test_cluster::E2eTestSetupBuilder::new()
+            .with_epoch_duration(Duration::from_secs(20))
+            .with_test_nodes_config(
+                TestNodesConfig::builder()
+                    .with_node_weights(&[1, 1])
+                    .build(),
+            )
+            .build()
+            .await?;
 
     client
         .as_ref()
@@ -1676,7 +1677,7 @@ async fn test_burn_blobs() -> TestResult {
     const N_TO_DELETE: usize = 2;
     walrus_test_utils::init_tracing();
 
-    let (_sui_cluster_handle, _cluster, client, _) =
+    let (_sui_cluster_handle, _cluster, client, _, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
 
     let mut blob_object_ids = vec![];
@@ -1726,7 +1727,7 @@ async fn test_burn_blobs() -> TestResult {
 #[walrus_simtest]
 async fn test_extend_owned_blobs() -> TestResult {
     walrus_test_utils::init_tracing();
-    let (_sui_cluster_handle, _cluster, client, _) =
+    let (_sui_cluster_handle, _cluster, client, _, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
 
     let current_epoch = client.as_ref().sui_client().current_epoch().await?;
@@ -1790,7 +1791,7 @@ async fn test_share_blobs() -> TestResult {
     const INITIAL_FUNDS: u64 = 1000000000;
     walrus_test_utils::init_tracing();
 
-    let (_sui_cluster_handle, _cluster, client, _) =
+    let (_sui_cluster_handle, _cluster, client, _, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
 
     let blobs = walrus_test_utils::random_data_list(314, 1);
@@ -1887,7 +1888,7 @@ async fn test_post_store_action(
     n_target_blobs: usize,
 ) -> TestResult {
     walrus_test_utils::init_tracing();
-    let (_sui_cluster_handle, _cluster, client, _) =
+    let (_sui_cluster_handle, _cluster, client, _, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
     let target_address: SuiAddress = SuiAddress::from_bytes(TARGET_ADDRESS).expect("valid address");
 
@@ -1957,7 +1958,7 @@ async fn test_post_store_action(
 async fn test_store_blob_with_random_attributes() -> TestResult {
     walrus_test_utils::init_tracing();
 
-    let (_sui_cluster_handle, _cluster, client, _) =
+    let (_sui_cluster_handle, _cluster, client, _, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
 
     let num_attributes = thread_rng().gen_range(0..=10);
@@ -2186,7 +2187,7 @@ impl<'a> BlobAttributeTestContext<'a> {
 async fn test_blob_attribute_add_and_remove() -> TestResult {
     walrus_test_utils::init_tracing();
 
-    let (_sui_cluster_handle, _cluster, mut client, _) =
+    let (_sui_cluster_handle, _cluster, mut client, _, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
     let mut test_context = BlobAttributeTestContext::new(&mut client).await?;
 
@@ -2242,7 +2243,7 @@ async fn test_blob_attribute_add_and_remove() -> TestResult {
 async fn test_blob_attribute_fields_operations() -> TestResult {
     walrus_test_utils::init_tracing();
 
-    let (_sui_cluster_handle, _cluster, mut client, _) =
+    let (_sui_cluster_handle, _cluster, mut client, _, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
     let mut test_context = BlobAttributeTestContext::new(&mut client).await?;
 
@@ -2340,15 +2341,16 @@ async fn test_blob_attribute_fields_operations() -> TestResult {
 #[walrus_simtest]
 async fn test_shard_move_out_and_back_in_immediately() -> TestResult {
     walrus_test_utils::init_tracing();
-    let (_sui_cluster_handle, walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
-        .with_epoch_duration(Duration::from_secs(20))
-        .with_test_nodes_config(
-            TestNodesConfig::builder()
-                .with_node_weights(&[1, 1])
-                .build(),
-        )
-        .build()
-        .await?;
+    let (_sui_cluster_handle, walrus_cluster, client, _, _) =
+        test_cluster::E2eTestSetupBuilder::new()
+            .with_epoch_duration(Duration::from_secs(20))
+            .with_test_nodes_config(
+                TestNodesConfig::builder()
+                    .with_node_weights(&[1, 1])
+                    .build(),
+            )
+            .build()
+            .await?;
 
     walrus_cluster.wait_for_nodes_to_reach_epoch(2).await;
 
@@ -2444,7 +2446,7 @@ async fn test_shard_move_out_and_back_in_immediately() -> TestResult {
 #[walrus_simtest]
 async fn test_ptb_retriable_error() -> TestResult {
     // Set up test environment with cluster and client
-    let (_sui_cluster_handle, cluster, client, _) =
+    let (_sui_cluster_handle, cluster, client, _, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
 
     // Create an atomic counter to track number of failure attempts
@@ -2485,7 +2487,7 @@ async fn test_ptb_retriable_error() -> TestResult {
 #[walrus_simtest]
 pub async fn test_select_coins_max_objects() -> TestResult {
     walrus_test_utils::init_tracing();
-    let (sui_cluster_handle, _, _, _) = test_cluster::E2eTestSetupBuilder::new().build().await?;
+    let (sui_cluster_handle, _, _, _, _) = test_cluster::E2eTestSetupBuilder::new().build().await?;
 
     // Create a new wallet on the cluster.
     let mut cluster_wallet = walrus_sui::config::load_wallet_context_from_path(
@@ -2564,7 +2566,7 @@ async fn test_store_with_upload_relay_no_tip() {
     walrus_test_utils::init_tracing();
 
     // Start the Sui and Walrus clusters.
-    let (sui_cluster_handle, _cluster, cluster_client, _) =
+    let (sui_cluster_handle, _cluster, cluster_client, _, _) =
         test_cluster::E2eTestSetupBuilder::new()
             .build()
             .await
@@ -2685,7 +2687,7 @@ async fn test_store_with_upload_relay_with_tip() {
     walrus_test_utils::init_tracing();
 
     // Start the Sui and Walrus clusters.
-    let (sui_cluster_handle, _cluster, cluster_client, _system_context) =
+    let (sui_cluster_handle, _cluster, cluster_client, _system_context, _) =
         test_cluster::E2eTestSetupBuilder::new()
             .build()
             .await
@@ -2865,7 +2867,7 @@ async fn test_byte_range_read_client() -> TestResult {
         .build();
     let test_cluster_builder =
         test_cluster::E2eTestSetupBuilder::new().with_test_nodes_config(test_nodes_config);
-    let (_sui_cluster_handle, _cluster, client, _) = test_cluster_builder.build().await?;
+    let (_sui_cluster_handle, _cluster, client, _, _) = test_cluster_builder.build().await?;
     let client = client.as_ref();
 
     // Generate a non zero blob size.
@@ -2927,7 +2929,7 @@ async fn test_byte_range_read_size_too_large() -> TestResult {
         .build();
     let test_cluster_builder =
         test_cluster::E2eTestSetupBuilder::new().with_test_nodes_config(test_nodes_config);
-    let (_sui_cluster_handle, _cluster, mut client, _) = test_cluster_builder.build().await?;
+    let (_sui_cluster_handle, _cluster, mut client, _, _) = test_cluster_builder.build().await?;
     client.as_mut().set_max_blob_size(Some(1000));
     let client = client.as_ref();
 
@@ -3000,7 +3002,7 @@ async fn test_streaming_blob() -> TestResult {
     walrus_test_utils::init_tracing();
 
     // Setup test cluster
-    let (_sui_cluster_handle, _cluster, client, _) =
+    let (_sui_cluster_handle, _cluster, client, _, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
 
     // Generate and store a test blob (~100KB to span multiple slivers)
@@ -3066,5 +3068,354 @@ async fn test_streaming_blob() -> TestResult {
         "streamed data should match original blob"
     );
 
+    Ok(())
+}
+
+/// Tests that the aggregator returns the content-type header from blob attributes.
+#[ignore = "ignore E2E tests by default"]
+#[walrus_simtest]
+async fn test_aggregator_get_blob_by_object_id_content_type() -> TestResult {
+    walrus_test_utils::init_tracing();
+
+    let (_sui_cluster_handle, _cluster, client, _, aggregator_handle) =
+        test_cluster::E2eTestSetupBuilder::new()
+            .with_aggregator()
+            .with_aggregator_allowed_headers(vec!["Content-Type".to_string()])
+            .build()
+            .await?;
+
+    let aggregator = aggregator_handle.expect("aggregator should be started");
+
+    // Create test data
+    let test_content = b"Hello, Walrus!".to_vec();
+    let content_type = "text/plain";
+
+    // Create attribute with content-type
+    let mut attribute = BlobAttribute::default();
+    attribute.insert("Content-Type".to_string(), content_type.to_string());
+
+    // Store the blob with attributes
+    let store_args = StoreArgs::default_with_epochs(1);
+    let results = client
+        .as_ref()
+        .reserve_and_store_blobs_retry_committees(
+            vec![test_content.clone()],
+            vec![attribute],
+            &store_args,
+        )
+        .await?;
+
+    let blob_object = match &results[0] {
+        BlobStoreResult::NewlyCreated { blob_object, .. } => blob_object,
+        _ => panic!("Expected newly created blob"),
+    };
+
+    // Make HTTP request to the aggregator endpoint
+    let http_client = reqwest::Client::new();
+    let url = format!(
+        "{}/v1/blobs/by-object-id/{}",
+        aggregator.base_url(),
+        blob_object.id
+    );
+
+    let response = http_client
+        .get(&url)
+        .send()
+        .await
+        .expect("HTTP request should succeed");
+
+    // Verify status code
+    assert_eq!(response.status(), 200);
+
+    // Verify content-type header
+    let response_content_type = response
+        .headers()
+        .get("content-type")
+        .expect("Content-Type header should be present");
+    assert_eq!(response_content_type.to_str().unwrap(), content_type);
+
+    // Verify the body matches
+    let body = response.bytes().await?;
+    assert_eq!(body.as_ref(), test_content.as_slice());
+
+    // Test that Accept header overrides the stored Content-Type
+    let response_with_accept = http_client
+        .get(&url)
+        .header("Accept", "text/markdown")
+        .send()
+        .await
+        .expect("HTTP request with Accept header should succeed");
+
+    assert_eq!(response_with_accept.status(), 200);
+
+    // Accept header should override the stored content-type
+    let overridden_content_type = response_with_accept
+        .headers()
+        .get("content-type")
+        .expect("Content-Type header should be present");
+    assert_eq!(overridden_content_type.to_str().unwrap(), "text/markdown");
+
+    // Cleanup
+    aggregator.shutdown().await?;
+
+    Ok(())
+}
+
+/// Tests that headers not in allowed_headers are filtered from the response.
+#[ignore = "ignore E2E tests by default"]
+#[walrus_simtest]
+async fn test_aggregator_filters_disallowed_headers() -> TestResult {
+    walrus_test_utils::init_tracing();
+
+    let (_sui_cluster_handle, _cluster, client, _, aggregator_handle) =
+        test_cluster::E2eTestSetupBuilder::new()
+            .with_aggregator()
+            .with_aggregator_allowed_headers(vec!["Content-Type".to_string()])
+            .build()
+            .await?;
+
+    let aggregator = aggregator_handle.expect("aggregator should be started");
+
+    let test_content = b"Test content".to_vec();
+
+    // Create attribute with both allowed and disallowed headers
+    let mut attribute = BlobAttribute::default();
+    attribute.insert("Content-Type".to_string(), "text/plain".to_string());
+    attribute.insert("X-Secret-Header".to_string(), "secret-value".to_string());
+
+    let store_args = StoreArgs::default_with_epochs(1);
+    let results = client
+        .as_ref()
+        .reserve_and_store_blobs_retry_committees(vec![test_content], vec![attribute], &store_args)
+        .await?;
+
+    let blob_object = match &results[0] {
+        BlobStoreResult::NewlyCreated { blob_object, .. } => blob_object,
+        _ => panic!("Expected newly created blob"),
+    };
+
+    let http_client = reqwest::Client::new();
+    let url = format!(
+        "{}/v1/blobs/by-object-id/{}",
+        aggregator.base_url(),
+        blob_object.id
+    );
+
+    let response = http_client.get(&url).send().await?;
+
+    // Content-Type should be present (allowed)
+    assert!(response.headers().get("content-type").is_some());
+
+    // X-Secret-Header should NOT be present (not in allowed list)
+    assert!(response.headers().get("x-secret-header").is_none());
+
+    aggregator.shutdown().await?;
+
+    Ok(())
+}
+
+/// Tests getting a quilt patch by QuiltPatchId and listing patches in a quilt.
+#[ignore = "ignore E2E tests by default"]
+#[walrus_simtest]
+async fn test_aggregator_get_quilt_patch_by_id() -> TestResult {
+    walrus_test_utils::init_tracing();
+
+    let (_sui_cluster_handle, _cluster, client, _, aggregator_handle) =
+        test_cluster::E2eTestSetupBuilder::new()
+            .with_aggregator()
+            .build()
+            .await?;
+
+    let aggregator = aggregator_handle.expect("aggregator should be started");
+
+    // Create test blobs for quilt
+    let blob1 = b"Hello from patch 1".to_vec();
+    let blob2 = b"Hello from patch 2".to_vec();
+
+    let quilt_store_blobs = vec![
+        QuiltStoreBlob::new(&blob1, "patch-1.txt").expect("create blob 1"),
+        QuiltStoreBlob::new(&blob2, "patch-2.txt").expect("create blob 2"),
+    ];
+
+    // Store the quilt
+    let quilt_client = client.as_ref().quilt_client();
+    let quilt = quilt_client
+        .construct_quilt::<QuiltVersionV1>(&quilt_store_blobs, DEFAULT_ENCODING)
+        .await?;
+    let store_args = StoreArgs::default_with_epochs(1);
+    let QuiltStoreResult {
+        blob_store_result,
+        stored_quilt_blobs,
+    } = quilt_client
+        .reserve_and_store_quilt::<QuiltVersionV1>(quilt, &store_args)
+        .await?;
+
+    let quilt_blob_id = match &blob_store_result {
+        BlobStoreResult::NewlyCreated { blob_object, .. } => blob_object.blob_id,
+        _ => panic!("Expected newly created quilt"),
+    };
+
+    // Get first patch by QuiltPatchId
+    let patch_id = &stored_quilt_blobs[0].quilt_patch_id;
+    let http_client = reqwest::Client::new();
+    let url = format!(
+        "{}/v1/blobs/by-quilt-patch-id/{}",
+        aggregator.base_url(),
+        patch_id
+    );
+
+    let response = http_client.get(&url).send().await?;
+    assert_eq!(response.status(), 200);
+
+    let body = response.bytes().await?;
+    assert_eq!(body.as_ref(), blob1.as_slice());
+
+    // Test Accept header override on quilt patch endpoint
+    let response_with_accept = http_client
+        .get(&url)
+        .header("Accept", "text/markdown")
+        .send()
+        .await?;
+
+    let content_type = response_with_accept
+        .headers()
+        .get("content-type")
+        .expect("Content-Type should be present");
+    assert_eq!(content_type.to_str().unwrap(), "text/markdown");
+
+    // Test listing all patches in the quilt
+    let list_url = format!(
+        "{}/v1/quilts/{}/patches",
+        aggregator.base_url(),
+        quilt_blob_id
+    );
+
+    let list_response = http_client.get(&list_url).send().await?;
+    assert_eq!(list_response.status(), 200);
+
+    // Response should be JSON array of patches
+    let patches: serde_json::Value = list_response.json().await?;
+    let patches_array = patches.as_array().expect("response should be array");
+    assert_eq!(patches_array.len(), 2);
+
+    // Verify patch identifiers are present
+    let identifiers: Vec<&str> = patches_array
+        .iter()
+        .map(|p| p["identifier"].as_str().unwrap())
+        .collect();
+    assert!(identifiers.contains(&"patch-1.txt"));
+    assert!(identifiers.contains(&"patch-2.txt"));
+
+    aggregator.shutdown().await?;
+    Ok(())
+}
+
+/// Tests retrieving a byte range from a blob.
+#[ignore = "ignore E2E tests by default"]
+#[walrus_simtest]
+async fn test_aggregator_get_blob_byte_range() -> TestResult {
+    walrus_test_utils::init_tracing();
+
+    let (_sui_cluster_handle, _cluster, client, _, aggregator_handle) =
+        test_cluster::E2eTestSetupBuilder::new()
+            .with_aggregator()
+            .build()
+            .await?;
+
+    let aggregator = aggregator_handle.expect("aggregator should be started");
+
+    // Create a 100KB blob with known content
+    #[allow(clippy::cast_possible_truncation)]
+    let test_content: Vec<u8> = (0..100_000u32).map(|i| (i % 256) as u8).collect();
+
+    let store_args = StoreArgs::default_with_epochs(1);
+    let results = client
+        .as_ref()
+        .reserve_and_store_blobs_retry_committees(
+            vec![test_content.clone()],
+            vec![BlobAttribute::default()],
+            &store_args,
+        )
+        .await?;
+
+    let blob_id = match &results[0] {
+        BlobStoreResult::NewlyCreated { blob_object, .. } => blob_object.blob_id,
+        _ => panic!("Expected newly created blob"),
+    };
+
+    // Request byte range 20000-30000 (10KB)
+    let http_client = reqwest::Client::new();
+    let url = format!(
+        "{}/v1/blobs/{}/byte-range?start=20000&length=10000",
+        aggregator.base_url(),
+        blob_id
+    );
+
+    let response = http_client.get(&url).send().await?;
+    assert_eq!(response.status(), 200);
+
+    let body = response.bytes().await?;
+    assert_eq!(body.len(), 10000);
+    assert_eq!(body.as_ref(), &test_content[20000..30000]);
+
+    aggregator.shutdown().await?;
+    Ok(())
+}
+
+/// Tests getting a blob by blob_id (not object_id) with Accept header override.
+#[ignore = "ignore E2E tests by default"]
+#[walrus_simtest]
+async fn test_aggregator_get_blob_by_blob_id() -> TestResult {
+    walrus_test_utils::init_tracing();
+
+    let (_sui_cluster_handle, _cluster, client, _, aggregator_handle) =
+        test_cluster::E2eTestSetupBuilder::new()
+            .with_aggregator()
+            .build()
+            .await?;
+
+    let aggregator = aggregator_handle.expect("aggregator should be started");
+
+    let test_content = b"Hello, Walrus! Basic blob test.".to_vec();
+
+    let store_args = StoreArgs::default_with_epochs(1);
+    let results = client
+        .as_ref()
+        .reserve_and_store_blobs_retry_committees(
+            vec![test_content.clone()],
+            vec![BlobAttribute::default()],
+            &store_args,
+        )
+        .await?;
+
+    let blob_id = match &results[0] {
+        BlobStoreResult::NewlyCreated { blob_object, .. } => blob_object.blob_id,
+        _ => panic!("Expected newly created blob"),
+    };
+
+    // Get blob by blob_id (not object_id)
+    let http_client = reqwest::Client::new();
+    let url = format!("{}/v1/blobs/{}", aggregator.base_url(), blob_id);
+
+    let response = http_client.get(&url).send().await?;
+    assert_eq!(response.status(), 200);
+
+    let body = response.bytes().await?;
+    assert_eq!(body.as_ref(), test_content.as_slice());
+
+    // Also test Accept header
+    let response_with_accept = http_client
+        .get(&url)
+        .header("Accept", "application/json")
+        .send()
+        .await?;
+
+    let content_type = response_with_accept
+        .headers()
+        .get("content-type")
+        .expect("Content-Type should be present");
+    assert_eq!(content_type.to_str().unwrap(), "application/json");
+
+    aggregator.shutdown().await?;
     Ok(())
 }

--- a/crates/walrus-e2e-tests/tests/test_event_blobs.rs
+++ b/crates/walrus-e2e-tests/tests/test_event_blobs.rs
@@ -19,7 +19,7 @@ use walrus_sui::client::ReadClient;
 #[tokio::test]
 #[ignore = "ignore E2E tests by default"]
 async fn test_event_blobs() -> anyhow::Result<()> {
-    let (_sui_cluster, _cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
+    let (_sui_cluster, _cluster, client, _, _) = test_cluster::E2eTestSetupBuilder::new()
         .with_test_nodes_config(
             TestNodesConfig::builder()
                 .with_node_weights(&[2, 2])
@@ -80,7 +80,7 @@ async fn test_event_blobs() -> anyhow::Result<()> {
 #[tokio::test]
 #[ignore = "ignore E2E tests by default"]
 async fn test_disabled_event_blob_writer() -> anyhow::Result<()> {
-    let (_sui_cluster, _cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
+    let (_sui_cluster, _cluster, client, _, _) = test_cluster::E2eTestSetupBuilder::new()
         .with_test_nodes_config(
             TestNodesConfig::builder()
                 .with_node_weights(&[1, 1])

--- a/crates/walrus-service/tests/epoch_change.rs
+++ b/crates/walrus-service/tests/epoch_change.rs
@@ -15,7 +15,7 @@ async fn nodes_drive_epoch_change() -> walrus_test_utils::Result {
 
     walrus_test_utils::init_tracing();
     let epoch_duration = Duration::from_secs(5);
-    let (_sui, storage_nodes, _, _) = test_cluster::E2eTestSetupBuilder::new()
+    let (_sui, storage_nodes, _, _, _) = test_cluster::E2eTestSetupBuilder::new()
         .with_epoch_duration(epoch_duration)
         .with_test_nodes_config(
             TestNodesConfig::builder()

--- a/crates/walrus-simtest/tests/simtest.rs
+++ b/crates/walrus-simtest/tests/simtest.rs
@@ -103,7 +103,7 @@ mod tests {
 
         let blob_info_consistency_check = BlobInfoConsistencyCheck::new();
 
-        let (_sui_cluster, _cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
+        let (_sui_cluster, _cluster, client, _, _) = test_cluster::E2eTestSetupBuilder::new()
             .with_test_nodes_config(
                 TestNodesConfig::builder()
                     .with_node_weights(&[1, 2, 3, 3, 4])
@@ -165,7 +165,7 @@ mod tests {
         // We use a very short epoch duration of 60 seconds so that we can exercise more epoch
         // changes in the test.
         let mut node_weights = vec![2, 2, 3, 3, 3];
-        let (_sui_cluster, walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
+        let (_sui_cluster, walrus_cluster, client, _, _) = test_cluster::E2eTestSetupBuilder::new()
             .with_epoch_duration(Duration::from_secs(30))
             .with_test_nodes_config(
                 TestNodesConfig::builder()
@@ -286,7 +286,7 @@ mod tests {
                 max_concurrent_blob_syncs_during_recovery;
         }
 
-        let (_sui_cluster, mut walrus_cluster, client, _) =
+        let (_sui_cluster, mut walrus_cluster, client, _, _) =
             test_cluster::E2eTestSetupBuilder::new()
                 .with_epoch_duration(Duration::from_secs(30))
                 .with_test_nodes_config(
@@ -503,7 +503,7 @@ mod tests {
             });
         }
 
-        let (_sui_cluster, mut walrus_cluster, client, _) =
+        let (_sui_cluster, mut walrus_cluster, client, _, _) =
             test_cluster::E2eTestSetupBuilder::new()
                 .with_epoch_duration(EPOCH_DURATION)
                 .with_max_epochs_ahead(MAX_EPOCHS_AHEAD)
@@ -672,7 +672,7 @@ mod tests {
         blob_2_deletable: bool,
     ) {
         const EPOCH_DURATION: Duration = Duration::from_secs(30);
-        let (_sui_cluster, walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
+        let (_sui_cluster, walrus_cluster, client, _, _) = test_cluster::E2eTestSetupBuilder::new()
             .with_epoch_duration(EPOCH_DURATION)
             .with_test_nodes_config(
                 TestNodesConfig::builder()
@@ -794,7 +794,7 @@ mod tests {
                 max_concurrent_blob_syncs_during_recovery;
         }
 
-        let (_sui_cluster, walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
+        let (_sui_cluster, walrus_cluster, client, _, _) = test_cluster::E2eTestSetupBuilder::new()
             .with_epoch_duration(Duration::from_secs(30))
             .with_test_nodes_config(
                 TestNodesConfig::builder()
@@ -895,7 +895,7 @@ mod tests {
             .await;
         });
 
-        let (_sui_cluster, walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
+        let (_sui_cluster, walrus_cluster, client, _, _) = test_cluster::E2eTestSetupBuilder::new()
             .with_test_nodes_config(
                 TestNodesConfig::builder()
                     .with_node_weights(&[1, 2, 3, 3, 4])
@@ -959,7 +959,7 @@ mod tests {
     #[ignore = "ignore integration simtests by default"]
     #[walrus_simtest]
     async fn test_recovery_in_progress_with_node_restart() {
-        let (_sui_cluster, walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
+        let (_sui_cluster, walrus_cluster, client, _, _) = test_cluster::E2eTestSetupBuilder::new()
             .with_epoch_duration(Duration::from_secs(30))
             .with_test_nodes_config(
                 TestNodesConfig::builder()
@@ -1089,7 +1089,7 @@ mod tests {
         walrus_test_utils::init_tracing();
         let deploy_dir = tempfile::TempDir::new().unwrap();
         let epoch_duration = Duration::from_secs(30);
-        let (_sui_cluster_handle, mut walrus_cluster, client, system_ctx) =
+        let (_sui_cluster_handle, mut walrus_cluster, client, system_ctx, _) =
             test_cluster::E2eTestSetupBuilder::new()
                 .with_deploy_directory(deploy_dir.path().to_path_buf())
                 .with_delegate_governance_to_admin_wallet()
@@ -1336,7 +1336,7 @@ mod tests {
             ))
         };
 
-        let (_sui_cluster, cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
+        let (_sui_cluster, cluster, client, _, _) = test_cluster::E2eTestSetupBuilder::new()
             .with_test_nodes_config(
                 TestNodesConfig::builder()
                     .with_node_weights(&[10; 7])
@@ -1444,7 +1444,7 @@ mod tests {
     async fn test_single_client_workload() {
         let blob_info_consistency_check = BlobInfoConsistencyCheck::new();
 
-        let (_sui_cluster, _cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
+        let (_sui_cluster, _cluster, client, _, _) = test_cluster::E2eTestSetupBuilder::new()
             .with_test_nodes_config(
                 TestNodesConfig::builder()
                     .with_node_weights(&[1, 2, 3, 3, 4])

--- a/crates/walrus-simtest/tests/simtest_event_blob.rs
+++ b/crates/walrus-simtest/tests/simtest_event_blob.rs
@@ -192,7 +192,7 @@ mod tests {
     //#[ignore = "ignore integration simtests by default"]
     #[walrus_simtest]
     async fn test_event_blob_fork_recovery() {
-        let (_sui_cluster, mut walrus_cluster, client, _) =
+        let (_sui_cluster, mut walrus_cluster, client, _, _) =
             test_cluster::E2eTestSetupBuilder::new()
                 .with_epoch_duration(Duration::from_secs(15))
                 .with_test_nodes_config(
@@ -248,7 +248,7 @@ mod tests {
     #[ignore = "ignore integration simtests by default"]
     #[walrus_simtest]
     async fn test_event_blob_local_fork_recovery() {
-        let (_sui_cluster, mut walrus_cluster, client, _) =
+        let (_sui_cluster, mut walrus_cluster, client, _, _) =
             test_cluster::E2eTestSetupBuilder::new()
                 .with_epoch_duration(Duration::from_secs(15))
                 .with_test_nodes_config(
@@ -302,7 +302,7 @@ mod tests {
     async fn test_runtime_catchup_triggers_on_tailing_pause() {
         use walrus_service::client::ClientCommunicationConfig;
 
-        let (_sui_cluster, mut walrus_cluster, client, _) =
+        let (_sui_cluster, mut walrus_cluster, client, _, _) =
             test_cluster::E2eTestSetupBuilder::new()
                 .with_epoch_duration(Duration::from_secs(15))
                 .with_num_checkpoints_per_blob(20)

--- a/crates/walrus-simtest/tests/simtest_failure.rs
+++ b/crates/walrus-simtest/tests/simtest_failure.rs
@@ -40,7 +40,7 @@ mod tests {
     #[ignore = "ignore integration simtests by default"]
     #[walrus_simtest]
     async fn test_walrus_with_single_node_crash_and_restart() {
-        let (sui_cluster, _walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
+        let (sui_cluster, _walrus_cluster, client, _, _) = test_cluster::E2eTestSetupBuilder::new()
             .with_test_nodes_config(
                 TestNodesConfig::builder()
                     .with_node_weights(&[1, 2, 3, 3, 4])
@@ -216,7 +216,7 @@ mod tests {
                 max_concurrent_blob_syncs_during_recovery;
         }
 
-        let (_sui_cluster, walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
+        let (_sui_cluster, walrus_cluster, client, _, _) = test_cluster::E2eTestSetupBuilder::new()
             .with_epoch_duration(Duration::from_secs(30))
             .with_test_nodes_config(
                 TestNodesConfig::builder()
@@ -345,7 +345,7 @@ mod tests {
     async fn test_repeated_node_crash() {
         // We use a very short epoch duration of 10 seconds so that we can exercise more epoch
         // changes in the test.
-        let (_sui_cluster, walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
+        let (_sui_cluster, walrus_cluster, client, _, _) = test_cluster::E2eTestSetupBuilder::new()
             .with_epoch_duration(Duration::from_secs(10))
             .with_test_nodes_config(
                 TestNodesConfig::builder()
@@ -510,7 +510,7 @@ mod tests {
     async fn test_checkpoint_lag_error() {
         // We use a very short epoch duration of 10 seconds so that we can exercise more epoch
         // changes in the test.
-        let (_sui_cluster, walrus_cluster, _, _) = test_cluster::E2eTestSetupBuilder::new()
+        let (_sui_cluster, walrus_cluster, _, _, _) = test_cluster::E2eTestSetupBuilder::new()
             .with_epoch_duration(Duration::from_secs(10))
             .with_test_nodes_config(
                 TestNodesConfig::builder()
@@ -603,7 +603,7 @@ mod tests {
                 max_concurrent_blob_syncs_during_recovery;
         }
 
-        let (_sui_cluster, walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
+        let (_sui_cluster, walrus_cluster, client, _, _) = test_cluster::E2eTestSetupBuilder::new()
             .with_epoch_duration(Duration::from_secs(30))
             .with_test_nodes_config(
                 TestNodesConfig::builder()
@@ -776,24 +776,25 @@ mod tests {
     #[walrus_simtest]
     async fn test_checkpoint_downloader_with_additional_fullnodes() {
         let checkpoints_per_event_blob = 20;
-        let (sui_cluster, mut walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
-            .with_epoch_duration(Duration::from_secs(15))
-            .with_test_nodes_config(
-                TestNodesConfig::builder()
-                    .with_node_weights(&[2, 2, 3, 3, 3])
-                    .with_enable_event_blob_writer()
-                    .build(),
-            )
-            .with_num_checkpoints_per_blob(checkpoints_per_event_blob)
-            .with_communication_config(
-                ClientCommunicationConfig::default_for_test_with_reqwest_timeout(
-                    Duration::from_secs(2),
-                ),
-            )
-            .with_additional_fullnodes(4)
-            .build_generic::<SimStorageNodeHandle>()
-            .await
-            .unwrap();
+        let (sui_cluster, mut walrus_cluster, client, _, _) =
+            test_cluster::E2eTestSetupBuilder::new()
+                .with_epoch_duration(Duration::from_secs(15))
+                .with_test_nodes_config(
+                    TestNodesConfig::builder()
+                        .with_node_weights(&[2, 2, 3, 3, 3])
+                        .with_enable_event_blob_writer()
+                        .build(),
+                )
+                .with_num_checkpoints_per_blob(checkpoints_per_event_blob)
+                .with_communication_config(
+                    ClientCommunicationConfig::default_for_test_with_reqwest_timeout(
+                        Duration::from_secs(2),
+                    ),
+                )
+                .with_additional_fullnodes(4)
+                .build_generic::<SimStorageNodeHandle>()
+                .await
+                .unwrap();
 
         // Register a fail point that will fail the first attempt.
         sui_macros::register_fail_point_if("fallback_client_inject_error", move || true);

--- a/crates/walrus-simtest/tests/simtest_param_sync.rs
+++ b/crates/walrus-simtest/tests/simtest_param_sync.rs
@@ -213,7 +213,7 @@ mod tests {
     #[ignore = "ignore integration simtests by default"]
     #[walrus_simtest]
     async fn test_sync_node_config_params_basic() {
-        let (_sui_cluster, mut walrus_cluster, client, _) =
+        let (_sui_cluster, mut walrus_cluster, client, _, _) =
             test_cluster::E2eTestSetupBuilder::new()
                 .with_epoch_duration(Duration::from_secs(30))
                 .with_test_nodes_config(
@@ -404,7 +404,7 @@ mod tests {
     #[ignore = "ignore integration simtests by default"]
     #[walrus_simtest]
     async fn test_registered_node_update_protocol_key() {
-        let (_sui_cluster, walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
+        let (_sui_cluster, walrus_cluster, client, _, _) = test_cluster::E2eTestSetupBuilder::new()
             .with_epoch_duration(Duration::from_secs(10))
             .with_test_nodes_config(
                 TestNodesConfig::builder()
@@ -483,7 +483,7 @@ mod tests {
     #[ignore = "ignore integration simtests by default"]
     #[walrus_simtest]
     async fn test_node_config_synchronizer() {
-        let (_sui_cluster, mut walrus_cluster, client, _) =
+        let (_sui_cluster, mut walrus_cluster, client, _, _) =
             test_cluster::E2eTestSetupBuilder::new()
                 .with_epoch_duration(Duration::from_secs(30))
                 .with_test_nodes_config(
@@ -729,7 +729,7 @@ mod tests {
         ]
     }
     async fn test_sync_node_params(update_params: &TestUpdateParams) {
-        let (_sui_cluster, walrus_cluster, client, _) = test_cluster::E2eTestSetupBuilder::new()
+        let (_sui_cluster, walrus_cluster, client, _, _) = test_cluster::E2eTestSetupBuilder::new()
             .with_epoch_duration(Duration::from_secs(10))
             .with_test_nodes_config(
                 TestNodesConfig::builder()

--- a/crates/walrus-simtest/tests/simtest_pending_uploads.rs
+++ b/crates/walrus-simtest/tests/simtest_pending_uploads.rs
@@ -48,7 +48,7 @@ mod tests {
             .backoff_config
             .max_backoff = Duration::from_millis(100);
 
-        let (_sui_cluster, mut walrus_cluster, client, _) =
+        let (_sui_cluster, mut walrus_cluster, client, _, _) =
             test_cluster::E2eTestSetupBuilder::new()
                 .with_test_nodes_config(
                     TestNodesConfig::builder()


### PR DESCRIPTION
## Description

### Add E2E tests for aggregator HTTP endpoints

This PR adds substantial E2E tests for the aggregator's HTTP API:

  - test_aggregator_get_blob_by_object_id_content_type - Verifies Content-Type header from blob attributes and Accept header override behavior
  - test_aggregator_filters_disallowed_headers - Ensures headers not in the allowed list are filtered from responses
  - test_aggregator_get_quilt_patch_by_id - Tests quilt patch retrieval by QuiltPatchId and listing patches via /v1/quilts/{id}/patches
  - test_aggregator_get_blob_byte_range - Tests partial blob retrieval with byte range queries
  - test_aggregator_get_blob_by_blob_id - Tests basic blob retrieval by blob_id with Accept header support

Also includes infrastructure changes to support aggregator testing in the E2E test setup.

## Test plan

CI Pipeline, local test run.