### PR TITLE
fix: Minor fix to drain pending events

### DIFF
--- a/crates/walrus-sdk/src/client.rs
+++ b/crates/walrus-sdk/src/client.rs
@@ -1198,7 +1198,9 @@ impl WalrusNodeClient<SuiContractClient> {
             pending_blobs = pending_blobs.len(),
             "starting pending upload task"
         );
-        let (tx, _rx) = tokio::sync::mpsc::channel(pending_blobs.len().max(1));
+        let (tx, mut rx) = tokio::sync::mpsc::channel(pending_blobs.len().max(1));
+        tokio::spawn(async move { while rx.recv().await.is_some() {} });
+
         let cancel = CancellationToken::new();
         let future = Box::pin(self.distributed_upload_without_confirmation(
             pending_blobs,


### PR DESCRIPTION
## Description

We need to drain because the pending‑upload path creates a progress‑event channel for the uploader, but it used to drop the receiver immediately. So, keeping the receiver alive and draining it stops the errors
## Test plan

Running locally
