### PR TITLE
feat(cli): add --file option to read-quilt for offline quilt inspection

### DIFF
--- a/crates/walrus-service/src/client/cli.rs
+++ b/crates/walrus-service/src/client/cli.rs
@@ -37,6 +37,7 @@ pub use args::{
     Commands,
     DaemonCommands,
     HealthSortBy,
+    LocalFileQuiltQuery,
     NodeSelection,
     NodeSortBy,
     PublisherArgs,

--- a/crates/walrus-service/src/client/cli/args.rs
+++ b/crates/walrus-service/src/client/cli/args.rs
@@ -1297,14 +1297,15 @@ impl FromStr for QuiltBlobInput {
 pub struct QuiltPatchQuery {
     /// The quilt ID, which is the BlobID of the quilt.
     ///
-    /// It is required unless `--quilt-patch-id` is used.
+    /// It is required unless `--quilt-patch-id` or `--file` is used.
     #[serde_as(as = "Option<DisplayFromStr>")]
     #[arg(
         long,
         allow_hyphen_values = true,
         value_parser = parse_blob_id,
         conflicts_with = "quilt_patch_ids",
-        required_unless_present = "quilt_patch_ids",
+        conflicts_with = "file",
+        required_unless_present_any = ["quilt_patch_ids", "file"],
         help_heading = "Arguments",
     )]
     quilt_id: Option<BlobId>,
@@ -1352,6 +1353,21 @@ pub struct QuiltPatchQuery {
     )]
     #[serde(default)]
     quilt_patch_ids: Vec<QuiltPatchId>,
+
+    /// Path to a local quilt file to read from.
+    /// When provided, the quilt is read from disk instead of fetching from the network.
+    #[arg(long, help_heading = "Arguments")]
+    #[serde(
+        default,
+        deserialize_with = "walrus_utils::config::resolve_home_dir_option"
+    )]
+    pub file: Option<PathBuf>,
+
+    /// The number of shards (required when using --file for fully offline operation,
+    /// otherwise read from chain).
+    #[arg(long, requires = "file")]
+    #[serde(default)]
+    pub n_shards: Option<NonZeroU16>,
 }
 
 impl QuiltPatchQuery {
@@ -1408,6 +1424,56 @@ impl QuiltPatchQuery {
             - quiltPatchIds: {{\"quiltPatchIds\": [\"<PATCH_ID>\", ...]}}\n\
             - quiltId only: {{\"quiltId\": \"<ID>\"}}"
         )
+    }
+
+    /// Converts the query to a `LocalFileQuiltQuery` for reading from a local file.
+    ///
+    /// This method is used when reading from a local file instead of fetching from the network.
+    pub fn into_local_file_query(mut self) -> Result<LocalFileQuiltQuery> {
+        // quilt_id should not be provided when using --file
+        if self.quilt_id.is_some() {
+            return Err(anyhow!(
+                "--quilt-id cannot be used with --file. \
+                The quilt data is read from the file directly."
+            ));
+        }
+
+        match (
+            !self.identifiers.is_empty(),
+            !self.tag.is_empty(),
+            !self.quilt_patch_ids.is_empty(),
+        ) {
+            // identifiers provided
+            (true, false, false) => Ok(LocalFileQuiltQuery::ByIdentifiers(self.identifiers)),
+
+            // tag provided
+            (false, true, false) => {
+                if self.tag.len() != 2 {
+                    return Err(anyhow!("Only one tag is supported for now."));
+                }
+                let value = self.tag.pop().expect("value should be present");
+                let tag = self.tag.pop().expect("tag should be present");
+                Ok(LocalFileQuiltQuery::ByTag { tag, value })
+            }
+
+            // quilt_patch_ids provided - extract patch_id_bytes for local lookup
+            (false, false, true) => {
+                let patch_ids = self
+                    .quilt_patch_ids
+                    .into_iter()
+                    .map(|qpi| qpi.patch_id_bytes)
+                    .collect();
+                Ok(LocalFileQuiltQuery::ByPatchIds(patch_ids))
+            }
+
+            // nothing provided - get all blobs
+            (false, false, false) => Ok(LocalFileQuiltQuery::All),
+
+            // multiple query types provided - invalid
+            _ => Err(anyhow!(
+                "Only one of --identifiers, --tag, or --quilt-patch-ids can be used with --file."
+            )),
+        }
     }
 }
 
@@ -1486,6 +1552,24 @@ pub enum QuiltPatchSelector {
     ByPatchId(QuiltPatchByPatchId),
     /// Read 'em all.
     All(BlobId),
+}
+
+/// Selector for quilt patches when reading from a local file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LocalFileQuiltQuery {
+    /// Query by identifiers.
+    ByIdentifiers(Vec<String>),
+    /// Query by tag key and value.
+    ByTag {
+        /// The tag key.
+        tag: String,
+        /// The tag value.
+        value: String,
+    },
+    /// Query by patch internal IDs (extracted from QuiltPatchIds).
+    ByPatchIds(Vec<Vec<u8>>),
+    /// Get all blobs.
+    All,
 }
 
 #[serde_as]


### PR DESCRIPTION
## Description

  Add support for reading quilt patches from a local file instead of fetching from the Walrus network. This enables offline inspection of quilt blobs that were previously downloaded via `walrus read <quilt_id>`.

New CLI options for `read-quilt`:
  - `--file <path>`: Read quilt data from a local file
  - `--n-shards <n>`: Specify shard count for fully offline operation (otherwise fetched from chain)

When using --file, patches can be queried by:
  - `--identifiers`: Select specific patches by identifier
  - `--tag`: Select patches matching a tag key/value pair
  - No filter: Extract all patches from the quilt

Note: --quilt-patch-ids is not supported with --file since patch IDs depend on the quilt's blob ID which requires on-chain storage.

## Test plan

Manual testing.
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [x] CLI: Add support for reading/writing quilt patches from/to a local file instead of to the Walrus network.
