### PR TITLE
feat(cli): add --file option to store-quilt for offline quilt construction

### DIFF
--- a/crates/walrus-service/src/client/cli/args.rs
+++ b/crates/walrus-service/src/client/cli/args.rs
@@ -260,6 +260,23 @@ pub enum CliCommands {
         #[arg(long, num_args = 0.., conflicts_with = "paths")]
         #[serde(default)]
         blobs: Vec<QuiltBlobInput>,
+        /// Path to write the quilt blob to a local file.
+        /// When provided, the quilt is written to disk instead of uploading to Walrus.
+        #[arg(long)]
+        #[serde(
+            default,
+            deserialize_with = "walrus_utils::config::resolve_home_dir_option"
+        )]
+        file: Option<PathBuf>,
+        /// The number of shards (required when using --file for fully offline operation,
+        /// otherwise read from chain).
+        #[arg(long)]
+        #[serde(default)]
+        n_shards: Option<NonZeroU16>,
+        /// The URL of the Sui RPC node to use (only needed when using --file without --n-shards).
+        #[command(flatten)]
+        #[serde(flatten)]
+        rpc_arg: RpcArg,
         /// Common options shared between store and store-quilt commands.
         #[command(flatten)]
         #[serde(flatten)]

--- a/crates/walrus-service/src/client/cli/cli_output.rs
+++ b/crates/walrus-service/src/client/cli/cli_output.rs
@@ -68,6 +68,7 @@ use crate::client::{
         StakeOutput,
         StorageNodeInfo,
         StoreQuiltDryRunOutput,
+        StoreQuiltToFileOutput,
         WalletOutput,
     },
 };
@@ -324,6 +325,27 @@ impl CliOutput for StoreQuiltDryRunOutput {
         construct_stored_quilt_patch_table(&client_types::get_stored_quilt_patches(
             &self.quilt_index,
             self.quilt_blob_output.blob_id,
+        ))
+        .printstd();
+    }
+}
+
+impl CliOutput for StoreQuiltToFileOutput {
+    fn print_cli_output(&self) {
+        printdoc!(
+            "{} Quilt written to file
+            Quilt blob ID: {}
+            Unencoded size: {}
+            Written to: {}
+            ",
+            success(),
+            self.blob_id,
+            HumanReadableBytes(self.unencoded_size),
+            self.file.display(),
+        );
+        construct_stored_quilt_patch_table(&client_types::get_stored_quilt_patches(
+            &self.quilt_index,
+            self.blob_id,
         ))
         .printstd();
     }

--- a/crates/walrus-service/src/client/responses.rs
+++ b/crates/walrus-service/src/client/responses.rs
@@ -150,6 +150,22 @@ pub(crate) struct StoreQuiltDryRunOutput {
     pub(crate) quilt_index: QuiltIndex,
 }
 
+/// The output of the `store-quilt --file` command.
+#[serde_as]
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct StoreQuiltToFileOutput {
+    /// The file path to which the quilt was written.
+    pub(crate) file: PathBuf,
+    /// The blob ID.
+    #[serde_as(as = "DisplayFromStr")]
+    pub(crate) blob_id: BlobId,
+    /// The size of the unencoded blob (in bytes).
+    pub(crate) unencoded_size: u64,
+    /// The quilt index containing patch information.
+    pub(crate) quilt_index: QuiltIndex,
+}
+
 /// The output of the `blob-status` command.
 #[serde_as]
 #[derive(Debug, Clone, Serialize)]


### PR DESCRIPTION
## Description

Add the ability to write a constructed quilt to a local file instead of uploading to the Walrus network. This is the dual to the existing read-quilt --file feature.

New options:
- --file: Path to write the quilt blob to disk
- --n-shards: Number of shards (for fully offline operation)
- --rpc-url: RPC URL to fetch n_shards when not provided

When --file is provided, the quilt is constructed locally and written to disk with the computed blob_id printed for later reference.

Usage examples:
walrus store-quilt --paths ./files/ --file quilt.bin --n-shards 1000 walrus store-quilt --paths ./files/ --file quilt.bin --rpc-url <url>


## Test plan

Manual testing, CI Pipeline.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [x] CLI:Add the ability to write a constructed quilt to a local file instead of uploading to the Walrus network.
