### PR TITLE
feat(cli): add --file option to quilt commands for offline workflows

### DIFF
--- a/crates/walrus-service/src/client/cli.rs
+++ b/crates/walrus-service/src/client/cli.rs
@@ -37,6 +37,7 @@ pub use args::{
     Commands,
     DaemonCommands,
     HealthSortBy,
+    LocalFileQuiltQuery,
     NodeSelection,
     NodeSortBy,
     PublisherArgs,

--- a/crates/walrus-service/src/client/cli/cli_output.rs
+++ b/crates/walrus-service/src/client/cli/cli_output.rs
@@ -68,6 +68,7 @@ use crate::client::{
         StakeOutput,
         StorageNodeInfo,
         StoreQuiltDryRunOutput,
+        StoreQuiltToFileOutput,
         WalletOutput,
     },
 };
@@ -324,6 +325,27 @@ impl CliOutput for StoreQuiltDryRunOutput {
         construct_stored_quilt_patch_table(&client_types::get_stored_quilt_patches(
             &self.quilt_index,
             self.quilt_blob_output.blob_id,
+        ))
+        .printstd();
+    }
+}
+
+impl CliOutput for StoreQuiltToFileOutput {
+    fn print_cli_output(&self) {
+        printdoc!(
+            "{} Quilt written to file
+            Quilt blob ID: {}
+            Unencoded size: {}
+            Written to: {}
+            ",
+            success(),
+            self.blob_id,
+            HumanReadableBytes(self.unencoded_size),
+            self.file.display(),
+        );
+        construct_stored_quilt_patch_table(&client_types::get_stored_quilt_patches(
+            &self.quilt_index,
+            self.blob_id,
         ))
         .printstd();
     }

--- a/crates/walrus-service/src/client/responses.rs
+++ b/crates/walrus-service/src/client/responses.rs
@@ -150,6 +150,22 @@ pub(crate) struct StoreQuiltDryRunOutput {
     pub(crate) quilt_index: QuiltIndex,
 }
 
+/// The output of the `store-quilt --file` command.
+#[serde_as]
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct StoreQuiltToFileOutput {
+    /// The file path to which the quilt was written.
+    pub(crate) file: PathBuf,
+    /// The blob ID.
+    #[serde_as(as = "DisplayFromStr")]
+    pub(crate) blob_id: BlobId,
+    /// The size of the unencoded blob (in bytes).
+    pub(crate) unencoded_size: u64,
+    /// The quilt index containing patch information.
+    pub(crate) quilt_index: QuiltIndex,
+}
+
 /// The output of the `blob-status` command.
 #[serde_as]
 #[derive(Debug, Clone, Serialize)]


### PR DESCRIPTION
# Description

Add support for fully offline quilt debugging operations by enabling local file I/O across all quilt commands. This allows constructing, inspecting, and extracting quilt data without network access to Walrus.

New --file options:
- store-quilt --file: Write constructed quilt to disk instead of uploading
- read-quilt --file: Read quilt patches from a local file
- list-patches-in-quilt --file: Inspect quilt metadata from a local file

Common options when using --file:
- --n-shards: Specify shard count for fully offline operation
- --rpc-url: Fetch n_shards from chain when not provided locally

When using read-quilt --file, patches can be queried by:
- --identifiers: Select specific patches by identifier
- --tag: Select patches matching a tag key/value pair
- --quilt-patch-id: Select patches by patch ID
- No filter: Extract all patches from the quilt

Example workflow:
walrus store-quilt --paths ./files/ --file quilt.bin --n-shards 1000
walrus list-patches-in-quilt --file quilt.bin --n-shards 1000
walrus read-quilt --file quilt.bin --n-shards 1000 --identifier README.md

## Test plan

Manual testing, CI Pipeline.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [x] CLI: Add support for fully offline quilt operations by enabling local file I/O across all quilt commands. This allows constructing, inspecting, and extracting quilt data without network access to Walrus.
