### PR TITLE
chore: bump Rust to 1.93 and fix new lint warning

### DIFF
--- a/crates/walrus-core/src/encoding/quilt_encoding.rs
+++ b/crates/walrus-core/src/encoding/quilt_encoding.rs
@@ -1099,21 +1099,15 @@ impl QuiltV1 {
     ///
     /// If the quilt index is not set, it will decode it from the quilt data, and set it.
     fn get_or_decode_quilt_index(&mut self) -> Result<&QuiltIndexV1, QuiltError> {
-        if self.quilt_index.is_some() {
-            return Ok(self
-                .quilt_index
-                .as_ref()
-                .expect("quilt index should be set"));
+        if self.quilt_index.is_none() {
+            let columns_size = self.data.len() / self.row_size * self.symbol_size;
+            let quilt_index = QuiltVersionV1::decode_quilt_index(self, columns_size)?;
+            self.quilt_index = Some(quilt_index);
         }
-
-        let columns_size = self.data.len() / self.row_size * self.symbol_size;
-        let quilt_index = QuiltVersionV1::decode_quilt_index(self, columns_size)?;
-        self.quilt_index = Some(quilt_index);
-
         Ok(self
             .quilt_index
             .as_ref()
-            .expect("quilt index should be set"))
+            .expect("quilt index was either set initially or has been set after decode"))
     }
 }
 

--- a/docker/walrus-antithesis/build-walrus-image-for-antithesis/Dockerfile
+++ b/docker/walrus-antithesis/build-walrus-image-for-antithesis/Dockerfile
@@ -8,7 +8,7 @@
 
 # Stage 1: Base Build Environment + Builder
 # -------------------------------------
-FROM rust:1.92-bookworm AS builder
+FROM rust:1.93-bookworm AS builder
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION
 WORKDIR "$WORKDIR/walrus"

--- a/docker/walrus-orchestrator/Dockerfile
+++ b/docker/walrus-orchestrator/Dockerfile
@@ -3,7 +3,7 @@
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
 
-FROM rust:1.92-bookworm AS builder
+FROM rust:1.93-bookworm AS builder
 
 ARG PROFILE=release
 ARG GIT_REVISION

--- a/docker/walrus-proxy/Dockerfile
+++ b/docker/walrus-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.92-bookworm as builder
+FROM rust:1.93-bookworm as builder
 
 ARG PROFILE=release
 WORKDIR /work

--- a/docker/walrus-service/Dockerfile
+++ b/docker/walrus-service/Dockerfile
@@ -3,7 +3,7 @@
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
 
-FROM rust:1.92-bookworm AS builder
+FROM rust:1.93-bookworm AS builder
 
 ARG PROFILE=release
 ARG GIT_REVISION

--- a/docker/walrus-service/Dockerfile.walrus-backup
+++ b/docker/walrus-service/Dockerfile.walrus-backup
@@ -3,7 +3,7 @@
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
 
-FROM rust:1.92-bookworm AS builder
+FROM rust:1.93-bookworm AS builder
 
 ARG PROFILE=release
 ARG RUST_LOG=info,walrus_service::common::event_blob_downloader=warn

--- a/docker/walrus-stress/Dockerfile
+++ b/docker/walrus-stress/Dockerfile
@@ -3,7 +3,7 @@
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
 
-FROM rust:1.92-bookworm AS builder
+FROM rust:1.93-bookworm AS builder
 
 ARG PROFILE=release
 ARG GIT_REVISION

--- a/docker/walrus-upload-relay/Dockerfile
+++ b/docker/walrus-upload-relay/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.92-bookworm AS builder
+FROM rust:1.93-bookworm AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.92"
+channel = "1.93"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Description

Bumps the Rust toolchain and Docker files to the [latest stable Rust release 1.93](https://blog.rust-lang.org/2026/01/22/Rust-1.93.0/).

## Test plan

CI.