### PR TITLE
refactor: cleanup select_coins interface to prepare for grpc migration

### DIFF
--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -2534,12 +2534,12 @@ pub async fn test_select_coins_max_objects() -> TestResult {
     let max_num_coins = 2;
 
     let result = retry_client
-        .select_coins_with_limit(address, None, sui(1).into(), vec![], max_num_coins)
+        .select_coins(address, None, sui(1).into(), vec![], max_num_coins)
         .await;
     assert!(result.is_ok(), "1 SUI can be constructed with <= 2 coins");
 
     let result = retry_client
-        .select_coins_with_limit(address, None, sui(3).into(), vec![], max_num_coins)
+        .select_coins(address, None, sui(3).into(), vec![], max_num_coins)
         .await;
     if let Err(error) = result {
         assert!(
@@ -2551,7 +2551,7 @@ pub async fn test_select_coins_max_objects() -> TestResult {
     }
 
     let result = retry_client
-        .select_coins_with_limit(address, None, sui(5).into(), vec![], max_num_coins)
+        .select_coins(address, None, sui(5).into(), vec![], max_num_coins)
         .await;
     if let Err(error) = result {
         assert!(

--- a/crates/walrus-sui/src/client/read_client.rs
+++ b/crates/walrus-sui/src/client/read_client.rs
@@ -48,6 +48,7 @@ use super::{
     retry_client::RetriableSuiClient,
 };
 use crate::{
+    client::retry_client::retriable_sui_client::MAX_GAS_PAYMENT_OBJECTS,
     coin::Coin,
     contracts::{self, AssociatedContractStruct, AssociatedContractStructWithPkgId, TypeOriginMap},
     types::{
@@ -701,7 +702,13 @@ impl SuiReadClient {
             CoinType::Sui => None,
         };
         self.sui_client
-            .select_coins(owner_address, coin_type_option, min_balance.into(), exclude)
+            .select_coins(
+                owner_address,
+                coin_type_option,
+                min_balance.into(),
+                exclude,
+                MAX_GAS_PAYMENT_OBJECTS,
+            )
             .await
             .map_err(|err| match err {
                 SuiClientError::SuiSdkError(sui_sdk::error::Error::InsufficientFund {

--- a/crates/walrus-sui/src/system_setup.rs
+++ b/crates/walrus-sui/src/system_setup.rs
@@ -41,7 +41,7 @@ use crate::test_utils::system_setup;
 use crate::{
     client::retry_client::{
         RetriableSuiClient,
-        retriable_sui_client::{GasBudgetAndPrice, LazySuiClientBuilder},
+        retriable_sui_client::{GasBudgetAndPrice, LazySuiClientBuilder, MAX_GAS_PAYMENT_OBJECTS},
     },
     contracts,
     utils::get_created_sui_object_ids_by_type,
@@ -278,7 +278,13 @@ pub(crate) async fn publish_package(
         .await?;
 
     let gas_coins = retry_client
-        .select_coins(sender, None, u128::from(gas_budget), vec![])
+        .select_coins(
+            sender,
+            None,
+            u128::from(gas_budget),
+            vec![],
+            MAX_GAS_PAYMENT_OBJECTS,
+        )
         .await?
         .into_iter()
         .map(|coin| coin.object_ref())
@@ -613,7 +619,13 @@ pub async fn create_system_and_staking_objects(
         .await?;
 
     let gas_coins = retry_client
-        .select_coins(address, None, u128::from(gas_budget), vec![])
+        .select_coins(
+            address,
+            None,
+            u128::from(gas_budget),
+            vec![],
+            MAX_GAS_PAYMENT_OBJECTS,
+        )
         .await?
         .into_iter()
         .map(|coin| coin.object_ref())

--- a/crates/walrus-sui/src/utils.rs
+++ b/crates/walrus-sui/src/utils.rs
@@ -44,7 +44,11 @@ use walrus_core::{
 };
 
 use crate::{
-    client::{SuiClientResult, SuiContractClient, retry_client::RetriableSuiClient},
+    client::{
+        SuiClientResult,
+        SuiContractClient,
+        retry_client::{RetriableSuiClient, retriable_sui_client::MAX_GAS_PAYMENT_OBJECTS},
+    },
     config::load_wallet_context_from_path,
     contracts::{AssociatedContractStruct, MoveConversionError},
     wallet::Wallet,
@@ -478,7 +482,13 @@ pub async fn get_sui_from_wallet_or_faucet(
         let ptb = ptb.finish();
         let gas_budget = one_sui / 2;
         let gas_coins = client
-            .select_coins(sender, None, u128::from(gas_budget + one_sui), vec![])
+            .select_coins(
+                sender,
+                None,
+                u128::from(gas_budget + one_sui),
+                vec![],
+                MAX_GAS_PAYMENT_OBJECTS,
+            )
             .await?
             .iter()
             .map(|coin| coin.object_ref())


### PR DESCRIPTION
## Description

This change is a no-op to encapsulate JSON RPC select_coins implementation to prepare for gRPC implementation in next PR.

## Test plan

CI Pipeline.