### PR TITLE
feat: Add long poll client side changes

### DIFF
--- a/crates/walrus-sdk/client_config_example.yaml
+++ b/crates/walrus-sdk/client_config_example.yaml
@@ -46,6 +46,8 @@ communication_config:
     min_blob_size_bytes: 52428800
   upload_mode: balanced
   pending_uploads_enabled: false
+  pending_upload_grace_millis: 0
+  confirmation_long_poll_millis: 0
   optimistic_upload_max_blob_bytes: 4194304
   registration_delay_millis: 200
   max_total_blob_size: 1073741824

--- a/crates/walrus-sdk/src/client/communication/factory.rs
+++ b/crates/walrus-sdk/src/client/communication/factory.rs
@@ -285,6 +285,7 @@ impl NodeCommunicationFactory {
             Arc::clone(&self.encoding_config),
             self.config.request_rate_config.clone(),
             self.config.sliver_status_check_threshold,
+            self.config.confirmation_long_poll,
         ))
     }
 

--- a/crates/walrus-sdk/src/client/communication/node.rs
+++ b/crates/walrus-sdk/src/client/communication/node.rs
@@ -60,6 +60,7 @@ pub struct NodeResult<T, E> {
 }
 
 impl<T, E> NodeResult<T, E> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         committee_epoch: Epoch,
         weight: usize,
@@ -99,6 +100,7 @@ pub struct NodeCommunication<W = ()> {
     pub client: StorageNodeClient,
     pub config: RequestRateConfig,
     pub sliver_status_check_threshold: usize,
+    pub confirmation_long_poll: Duration,
     pub(crate) auto_tune_handle: Option<AutoTuneHandle>,
     pub(crate) throughput_stats: Arc<Mutex<NodeThroughputStats>>,
     pub node_write_limit: W,
@@ -120,6 +122,7 @@ impl NodeReadCommunication {
     /// Creates a new [`NodeCommunication`].
     ///
     /// Returns `None` if the `node` has no shards.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         node_index: NodeIndex,
         committee_epoch: Epoch,
@@ -128,6 +131,7 @@ impl NodeReadCommunication {
         encoding_config: Arc<EncodingConfig>,
         config: RequestRateConfig,
         sliver_status_check_threshold: usize,
+        confirmation_long_poll: Duration,
     ) -> Option<Self> {
         if node.shard_ids.is_empty() {
             tracing::debug!("do not create NodeCommunication for node without shards");
@@ -156,6 +160,7 @@ impl NodeReadCommunication {
             config,
             auto_tune_handle: None,
             sliver_status_check_threshold,
+            confirmation_long_poll,
             throughput_stats: Arc::new(Mutex::new(NodeThroughputStats::default())),
             node_write_limit: (),
             sliver_write_limit: (),
@@ -177,6 +182,7 @@ impl NodeReadCommunication {
             client,
             config,
             sliver_status_check_threshold,
+            confirmation_long_poll,
             throughput_stats,
             ..
         } = self;
@@ -190,6 +196,7 @@ impl NodeReadCommunication {
             config,
             auto_tune_handle,
             sliver_status_check_threshold,
+            confirmation_long_poll,
             throughput_stats,
             node_write_limit,
             sliver_write_limit,
@@ -293,8 +300,12 @@ impl<W> NodeCommunication<W> {
         epoch: Epoch,
         blob_persistence_type: &BlobPersistenceType,
     ) -> Result<SignedStorageConfirmation, NodeError> {
-        let confirmation = backoff::retry(self.backoff_strategy(), || {
-            self.client.get_confirmation(blob_id, blob_persistence_type)
+        let wait_for_registration =
+            (!self.confirmation_long_poll.is_zero()).then_some(self.confirmation_long_poll);
+        let confirmation = backoff::retry(self.backoff_strategy(), || async {
+            self.client
+                .get_confirmation(blob_id, blob_persistence_type, wait_for_registration)
+                .await
         })
         .await
         .map_err(|error| {

--- a/crates/walrus-sdk/src/config/communication_config.rs
+++ b/crates/walrus-sdk/src/config/communication_config.rs
@@ -204,6 +204,20 @@ pub struct ClientCommunicationConfig {
     /// Allow pending (optimistic) uploads before registration is seen by storage nodes.
     #[serde(default)]
     pub pending_uploads_enabled: bool,
+    /// Grace period to allow pending uploads to continue after registration completes.
+    ///
+    /// Set to 0 to cancel immediately once registration finishes.
+    #[serde(default)]
+    #[serde(rename = "pending_upload_grace_millis")]
+    #[serde_as(as = "DurationMilliSeconds")]
+    pub pending_upload_grace: Duration,
+    /// Maximum time to long-poll confirmation requests for registration events.
+    ///
+    /// Set to 0 to disable long polling.
+    #[serde(default)]
+    #[serde(rename = "confirmation_long_poll_millis")]
+    #[serde_as(as = "DurationMilliSeconds")]
+    pub confirmation_long_poll: Duration,
     /// Maximum unencoded blob size (in bytes) to consider for optimistic uploads.
     #[serde(default = "default_optimistic_upload_max_blob_bytes")]
     pub optimistic_upload_max_blob_bytes: u64,
@@ -241,6 +255,8 @@ impl Default for ClientCommunicationConfig {
             data_in_flight_auto_tune: Default::default(),
             upload_mode: default_upload_mode(),
             pending_uploads_enabled: false,
+            pending_upload_grace: Duration::from_millis(0),
+            confirmation_long_poll: Duration::from_millis(0),
             optimistic_upload_max_blob_bytes: DEFAULT_OPTIMISTIC_UPLOAD_MAX_BLOB_BYTES,
             registration_delay: Duration::from_millis(200),
             max_total_blob_size: 1024 * 1024 * 1024, // 1GiB

--- a/crates/walrus-service/src/node/server.rs
+++ b/crates/walrus-service/src/node/server.rs
@@ -1107,7 +1107,7 @@ mod tests {
 
         let blob_id = blob_id_for_valid_response();
         let _confirmation = client
-            .get_confirmation(&blob_id, &BlobPersistenceType::Permanent)
+            .get_confirmation(&blob_id, &BlobPersistenceType::Permanent, None)
             .await
             .expect("should return a signed confirmation");
     }
@@ -1123,7 +1123,7 @@ mod tests {
         let client = storage_node_client(config.as_ref());
 
         let err = client
-            .get_confirmation(&blob_id, &BlobPersistenceType::Permanent)
+            .get_confirmation(&blob_id, &BlobPersistenceType::Permanent, None)
             .await
             .expect_err("confirmation request should fail");
 


### PR DESCRIPTION
## Description

The changes in this PR are for:
1. Client side changes to use long poll time duration while getting storage confirmations
2. Adding a cancel token to soft cancel pending uploads so we don't terminate in-flight sliver uploads