### PR TITLE
docs: remove reference to old subsidies package

### DIFF
--- a/docs/content/system-overview/available-networks.mdx
+++ b/docs/content/system-overview/available-networks.mdx
@@ -33,8 +33,6 @@ In case you wish to explore the Walrus contracts, their package IDs are:
 
 - Walrus package: `0xfdc88f7d7cf30afab2f82e8380d11ee8f70efb90e863d1de8616fae1bb09ea77`
 
-- Subsidies package: `0xd843c37d213ea683ec3519abe4646fd618f52d7fce1c4e9875a4144d53e21ebc`
-
 As these are inferred automatically from the object IDs above, there is no need to manually input them into the Walrus client configuration file. The latest published package IDs can also be found in the `Move.lock` files in the subdirectories of the [`contracts` directory on GitHub](https://github.com/MystenLabs/walrus/tree/main/contracts).
 
 The configuration file described on the [setup page](/docs/getting-started) includes both Mainnet and Testnet configuration.


### PR DESCRIPTION
## Description

Removes a reference to the old subsidies package that was missed in the cleanup last year after the change to the new subsidies.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
