### PR TITLE
feat: Use ref counted notify instead of weak<notify>

### DIFF
--- a/crates/walrus-service/src/node/blob_retirement_notifier.rs
+++ b/crates/walrus-service/src/node/blob_retirement_notifier.rs
@@ -71,6 +71,9 @@ impl BlobRetirementNotifier {
                 }
                 Ok(false)
             })?;
+        self.metrics
+            .blob_retirement_notifier_registered_blobs
+            .set(i64::try_from(self.registered_blobs.len()).unwrap_or(i64::MAX));
         Ok(())
     }
 


### PR DESCRIPTION
## Description

Fix race condition in RefCountedNotifyMap by using explicit ref counting. 
Here is how the bug manifests:
1. thread A calls `acquire()` which returns `RefCountedNotify` at `T0`
2. thread B calls `notify()` which returns `Arc<Notify>` at `T1`
3. thread A runs `drop` on `RefCountedNotify` but `Arc::strong_count` is `2` (because of the notify() at T1) and hence it won't remove the key from the map at `T2`
4. thread B drops the `Arc<Notify>`, strong count is now 1 but there is no way to run the cleanup

The previous implementation stored `Weak<Notify>` in the map and relied on `Arc::strong_count` in Drop to decide when to clean up entries. 
The fix reverts the Weak<Notify> logic to ref counted logic that existed before. 
## Test plan

How did you test the new or updated feature?

`cargo nextest run test_randomized_concurrent_operations --no-capture --stress-count=20` passes.