### PR TITLE
test: add cross-node invariant checks

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -239,8 +239,8 @@ pub use garbage_collector::GarbageCollectionConfig;
 
 // The number of events are dominated by the checkpoints, as we don't expect all checkpoints
 // contain Walrus events. 2K events per recording is roughly 1 recording per 9 minutes, which
-// gives a 3-hour Antithesis test ~20 recordings to cross-check across nodes while keeping the
-// metric label cardinality bounded at 10 rotating buckets.
+// gives a 3-hour Antithesis test ~20 recordings to cross-check across nodes. Label cardinality
+// is bounded by NUM_DIGEST_BUCKETS below.
 #[cfg(not(msim))]
 const NUM_EVENTS_PER_DIGEST_RECORDING: u64 = 2_000;
 

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -238,9 +238,11 @@ pub use config_synchronizer::{ConfigLoader, ConfigSynchronizer, StorageNodeConfi
 pub use garbage_collector::GarbageCollectionConfig;
 
 // The number of events are dominated by the checkpoints, as we don't expect all checkpoints
-// contain Walrus events. 20K events per recording is roughly 1 recording per 1.5 hours.
+// contain Walrus events. 2K events per recording is roughly 1 recording per 9 minutes, which
+// gives a 3-hour Antithesis test ~20 recordings to cross-check across nodes while keeping the
+// metric label cardinality bounded at 10 rotating buckets.
 #[cfg(not(msim))]
-const NUM_EVENTS_PER_DIGEST_RECORDING: u64 = 20_000;
+const NUM_EVENTS_PER_DIGEST_RECORDING: u64 = 2_000;
 
 // In simtest, we record event source for events to make event index consistency checking more
 // accurate.
@@ -2486,8 +2488,8 @@ impl StorageNode {
         event_source: &CheckpointEventPosition,
     ) -> Result<(), TypedStoreError> {
         // Only record every Nth event.
-        // `NUM_EVENTS_PER_DIGEST_RECORDING` is chosen in a way that a node produces a recording
-        // every few hours.
+        // `NUM_EVENTS_PER_DIGEST_RECORDING` is chosen so a node produces a recording roughly
+        // every ~9 minutes, giving a 3-hour Antithesis test ~20 recordings to cross-check.
 
         if !event_index.is_multiple_of(NUM_EVENTS_PER_DIGEST_RECORDING) {
             return Ok(());

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -249,7 +249,17 @@ const NUM_EVENTS_PER_DIGEST_RECORDING: u64 = 2_000;
 #[cfg(msim)]
 const NUM_EVENTS_PER_DIGEST_RECORDING: u64 = 1;
 
-const NUM_DIGEST_BUCKETS: u64 = 10;
+// Number of distinct buckets for the `periodic_event_source_for_deterministic_events`
+// metric. The bucket label is `(event_index / NUM_EVENTS_PER_DIGEST_RECORDING) %
+// NUM_DIGEST_BUCKETS`, so buckets are reused every
+// `NUM_DIGEST_BUCKETS * NUM_EVENTS_PER_DIGEST_RECORDING` events.
+//
+// With 1000 buckets and the non-msim recording interval of 2_000 events, reuse only
+// happens after 2_000_000 events (tens of hours of cluster runtime), which keeps the
+// cross-node observer from seeing two different recordings collide in the same bucket
+// and flagging it as a spurious divergence. Analogous to `EPOCH_BUCKET_COUNT` in
+// consistency_check.rs.
+const NUM_DIGEST_BUCKETS: u64 = 1_000;
 const CHECKPOINT_EVENT_POSITION_SCALE: u64 = 100;
 
 /// Indicates how the node should treat uploads.

--- a/crates/walrus-service/src/node/consistency_check.rs
+++ b/crates/walrus-service/src/node/consistency_check.rs
@@ -159,8 +159,20 @@ pub(super) async fn schedule_background_consistency_check(
     Ok(())
 }
 
+/// Number of distinct epoch buckets used for consistency-check Prometheus labels.
+///
+/// Metrics like `walrus_blob_info_consistency_check{epoch="N"}` use `epoch % EPOCH_BUCKET_COUNT`
+/// as the label so that Prometheus label cardinality stays bounded. A bucket is reused (and its
+/// old value overwritten) every `EPOCH_BUCKET_COUNT` epochs.
+///
+/// The cross-node observer in Antithesis tests compares these labels across nodes. If a node
+/// misses an epoch update, a stale value in a reused bucket looks like a data divergence. Setting
+/// the count high enough (1 000) ensures buckets are never reused within any realistic test
+/// duration, while the memory cost remains negligible.
+const EPOCH_BUCKET_COUNT: u64 = 1_000;
+
 fn get_epoch_bucket(epoch: Epoch) -> String {
-    (epoch % 100).to_string()
+    (epoch % EPOCH_BUCKET_COUNT).to_string()
 }
 
 fn handle_existence_check_result(

--- a/crates/walrus-service/src/node/consistency_check.rs
+++ b/crates/walrus-service/src/node/consistency_check.rs
@@ -167,9 +167,9 @@ pub(super) async fn schedule_background_consistency_check(
 ///
 /// The cross-node observer in Antithesis tests compares these labels across nodes. If a node
 /// misses an epoch update, a stale value in a reused bucket looks like a data divergence. Setting
-/// the count high enough (1 000) ensures buckets are never reused within any realistic test
+/// the count high enough (1000) ensures buckets are never reused within any realistic test
 /// duration, while the memory cost remains negligible.
-const EPOCH_BUCKET_COUNT: u64 = 1_000;
+const EPOCH_BUCKET_COUNT: u32 = 1_000;
 
 fn get_epoch_bucket(epoch: Epoch) -> String {
     (epoch % EPOCH_BUCKET_COUNT).to_string()

--- a/crates/walrus-service/src/node/metrics.rs
+++ b/crates/walrus-service/src/node/metrics.rs
@@ -176,7 +176,7 @@ walrus_utils::metrics::define_metric_set! {
         periodic_event_source_for_deterministic_events: IntGaugeVec["bucket"],
 
         #[help = "The hash of the list of certified blobs at the beginning of the epoch. Note that \
-        the label is the last two digits of the epoch number."]
+        the label is epoch % EPOCH_BUCKET_COUNT (see consistency_check.rs)."]
         blob_info_consistency_check: IntGaugeVec["epoch"],
 
         #[help = "The number of errors occurred when checking the consistency of the blob info \
@@ -187,7 +187,7 @@ walrus_utils::metrics::define_metric_set! {
         blob_info_consistency_check_certified_scanned: IntCounterVec["epoch"],
 
         #[help = "The hash of the list of certified per-object blobs at the beginning of the \
-        epoch. Note that the label is the last two digits of the epoch number."]
+        epoch. Note that the label is epoch % EPOCH_BUCKET_COUNT (see consistency_check.rs)."]
         per_object_blob_info_consistency_check: IntGaugeVec["epoch"],
 
         #[help = "The number of errors occurred when checking the consistency of the per-object \

--- a/docker/walrus-antithesis/build-test-config-image/docker-compose.yaml
+++ b/docker/walrus-antithesis/build-test-config-image/docker-compose.yaml
@@ -194,6 +194,7 @@ services:
       - INITIAL_WAIT=180
       - EVENT_SOURCE_PATIENCE=3
       - FULLY_STORED_PATIENCE=3
+      - EVENT_SOURCE_WARN_AFTER=120
     volumes:
       - ./files/run-observer.sh:/root/run-observer.sh
     command: >

--- a/docker/walrus-antithesis/build-test-config-image/docker-compose.yaml
+++ b/docker/walrus-antithesis/build-test-config-image/docker-compose.yaml
@@ -195,6 +195,7 @@ services:
       - EVENT_SOURCE_PATIENCE=3
       - FULLY_STORED_PATIENCE=3
       - EVENT_SOURCE_WARN_AFTER=120
+      - MAX_EPOCH_BUCKETS=1000
     volumes:
       - ./files/run-observer.sh:/root/run-observer.sh
     command: >

--- a/docker/walrus-antithesis/build-test-config-image/docker-compose.yaml
+++ b/docker/walrus-antithesis/build-test-config-image/docker-compose.yaml
@@ -7,6 +7,7 @@
 # - A setup completion service
 # - 4 Walrus nodes for testing
 # - 1 stress client for testing
+# - 1 cross-node invariant observer
 services:
   # Runs a local Sui network with a single validator
   sui-localnet:
@@ -172,6 +173,31 @@ services:
       - ./files/run-staking.sh:/root/run-staking.sh
     command: >
       /bin/bash -c "sleep 15 && /root/run-staking.sh"
+
+  # Cross-node invariant observer — scrapes Prometheus metrics from all storage
+  # nodes and verifies data consistency across the cluster. Crashes on violation,
+  # which Antithesis surfaces as a test failure.
+  walrus-observer:
+    depends_on:
+      walrus-deploy:
+        condition: service_completed_successfully
+    networks:
+      testbed-network:
+        ipv4_address: 10.0.0.40
+    image: ${WALRUS_IMAGE_NAME}
+    platform: ${WALRUS_PLATFORM:-linux/amd64}
+    hostname: walrus-observer
+    container_name: walrus-observer
+    environment:
+      - NO_COLOR=1
+      - CHECK_INTERVAL=60
+      - INITIAL_WAIT=180
+      - EVENT_SOURCE_PATIENCE=3
+      - FULLY_STORED_PATIENCE=3
+    volumes:
+      - ./files/run-observer.sh:/root/run-observer.sh
+    command: >
+      /bin/bash -c "/root/run-observer.sh"
 
 # Persistent volumes for sharing data between containers
 volumes:

--- a/docker/walrus-antithesis/build-test-config-image/docker-compose.yaml
+++ b/docker/walrus-antithesis/build-test-config-image/docker-compose.yaml
@@ -191,7 +191,6 @@ services:
     environment:
       - NO_COLOR=1
       - CHECK_INTERVAL=60
-      - INITIAL_WAIT=180
       - EVENT_SOURCE_PATIENCE=3
       - FULLY_STORED_PATIENCE=3
       - EVENT_SOURCE_WARN_AFTER=120

--- a/docker/walrus-antithesis/build-test-config-image/docker-compose.yaml
+++ b/docker/walrus-antithesis/build-test-config-image/docker-compose.yaml
@@ -194,6 +194,7 @@ services:
       - EVENT_SOURCE_PATIENCE=3
       - FULLY_STORED_PATIENCE=3
       - MAX_EPOCH_BUCKETS=1000
+      - MAX_DIGEST_BUCKETS=1000
     volumes:
       - ./files/run-observer.sh:/root/run-observer.sh
     command: >

--- a/docker/walrus-antithesis/build-test-config-image/docker-compose.yaml
+++ b/docker/walrus-antithesis/build-test-config-image/docker-compose.yaml
@@ -193,7 +193,6 @@ services:
       - CHECK_INTERVAL=60
       - EVENT_SOURCE_PATIENCE=3
       - FULLY_STORED_PATIENCE=3
-      - EVENT_SOURCE_WARN_AFTER=120
       - MAX_EPOCH_BUCKETS=1000
     volumes:
       - ./files/run-observer.sh:/root/run-observer.sh

--- a/docker/walrus-antithesis/build-test-config-image/docker-compose.yaml
+++ b/docker/walrus-antithesis/build-test-config-image/docker-compose.yaml
@@ -191,7 +191,6 @@ services:
     environment:
       - NO_COLOR=1
       - CHECK_INTERVAL=60
-      - EVENT_SOURCE_PATIENCE=3
       - FULLY_STORED_PATIENCE=3
       - MAX_EPOCH_BUCKETS=1000
       - MAX_DIGEST_BUCKETS=1000

--- a/docker/walrus-antithesis/build-test-config-image/files/run-observer.sh
+++ b/docker/walrus-antithesis/build-test-config-image/files/run-observer.sh
@@ -38,6 +38,20 @@ mkdir -p "$WORK_DIR"
 log()  { echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] [observer] $*"; }
 die()  { log "FATAL: $*" >&2; exit 1; }
 
+# Print per-node metric values for a labelled gauge.
+# Arguments: metric_name  label_name
+print_metric_values() {
+    local metric="$1" label="$2"
+    for i in "${!NODES[@]}"; do
+        local vals=""
+        while IFS="$(printf '\t')" read -r lbl val; do
+            [ -z "$lbl" ] && continue
+            vals="${vals} ${label}=${lbl}:${val}"
+        done < <(extract_metric "$WORK_DIR/raw_${NODES[$i]}.prom" "$metric" "$label")
+        log "  node-${i} (${NODES[$i]}):${vals:- (none)}"
+    done
+}
+
 # Scrape the /metrics endpoint of a storage node.
 scrape_node() {
     local ip="$1" out="$2"
@@ -80,6 +94,12 @@ check_cross_node_metric() {
         cut -f1 "$WORK_DIR/chk_${i}.tsv"
     done | sort | uniq -c | awk -v n="$num_nodes" '$1 == n { print $2 }' \
         > "$WORK_DIR/chk_common.txt"
+
+    if [ ! -s "$WORK_DIR/chk_common.txt" ]; then
+        log "  ${metric}: no common ${label} values across nodes, skipping comparison"
+        echo "0"
+        return
+    fi
 
     while IFS= read -r lbl; do
         [ -z "$lbl" ] && continue
@@ -187,9 +207,11 @@ while true; do
     if [ "$v" -gt 0 ]; then
         log "INVARIANT VIOLATION — blob_info_consistency_check (${v} epoch(s)):"
         cat "$WORK_DIR/details_blob_info.txt"
+        print_metric_values "walrus_blob_info_consistency_check" "epoch"
         die "blob_info_consistency_check: mismatched digests across nodes"
     fi
     log "walrus_blob_info_consistency_check: OK"
+    print_metric_values "walrus_blob_info_consistency_check" "epoch"
 
     # ------------------------------------------------------------------
     # Hard invariant 2: per-object blob digest must match across nodes.
@@ -200,9 +222,11 @@ while true; do
     if [ "$v" -gt 0 ]; then
         log "INVARIANT VIOLATION — per_object_blob_info_consistency_check (${v} epoch(s)):"
         cat "$WORK_DIR/details_per_object.txt"
+        print_metric_values "walrus_per_object_blob_info_consistency_check" "epoch"
         die "per_object_blob_info_consistency_check: mismatched digests across nodes"
     fi
     log "walrus_per_object_blob_info_consistency_check: OK"
+    print_metric_values "walrus_per_object_blob_info_consistency_check" "epoch"
 
     # ------------------------------------------------------------------
     # Soft invariant 1: event source consistency (tolerate transient lag).
@@ -217,12 +241,14 @@ while true; do
         event_source_streak=$((event_source_streak + 1))
         log "Event source mismatch (streak: ${event_source_streak}/${EVENT_SOURCE_PATIENCE}):"
         cat "$WORK_DIR/details_event_source.txt"
+        print_metric_values "walrus_periodic_event_source_for_deterministic_events" "bucket"
         if [ "$event_source_streak" -ge "$EVENT_SOURCE_PATIENCE" ]; then
             die "periodic_event_source: persistent mismatch for ${EVENT_SOURCE_PATIENCE} consecutive rounds"
         fi
     else
         event_source_streak=0
         log "walrus_periodic_event_source_for_deterministic_events: OK"
+        print_metric_values "walrus_periodic_event_source_for_deterministic_events" "bucket"
     fi
 
     # ------------------------------------------------------------------
@@ -235,12 +261,14 @@ while true; do
         fully_stored_streak=$((fully_stored_streak + 1))
         log "Fully-stored-ratio violation (streak: ${fully_stored_streak}/${FULLY_STORED_PATIENCE}):"
         cat "$WORK_DIR/details_fully_stored.txt"
+        print_metric_values "walrus_node_blob_data_fully_stored_ratio" "epoch"
         if [ "$fully_stored_streak" -ge "$FULLY_STORED_PATIENCE" ]; then
             die "node_blob_data_fully_stored_ratio: persistent violation for ${FULLY_STORED_PATIENCE} consecutive rounds"
         fi
     else
         fully_stored_streak=0
         log "walrus_node_blob_data_fully_stored_ratio: OK"
+        print_metric_values "walrus_node_blob_data_fully_stored_ratio" "epoch"
     fi
 
     log "All checks passed for round ${round}"

--- a/docker/walrus-antithesis/build-test-config-image/files/run-observer.sh
+++ b/docker/walrus-antithesis/build-test-config-image/files/run-observer.sh
@@ -117,14 +117,17 @@ check_cross_node_metric() {
 # ---------------------------------------------------------------------------
 check_fully_stored_ratio() {
     local metric="walrus_node_blob_data_fully_stored_ratio"
+    local details_file="$1"
     local violations=0
+
+    : > "$details_file"
 
     for i in "${!NODES[@]}"; do
         while IFS="$(printf '\t')" read -r epoch ratio; do
             [ -z "$epoch" ] && continue
             # Numeric comparison: ratio must equal 1.
             if ! awk -v r="$ratio" 'BEGIN { exit (r == 1) ? 0 : 1 }'; then
-                log "  node-${i} (${NODES[$i]}) epoch=${epoch} ratio=${ratio}" >&2
+                echo "  node-${i} (${NODES[$i]}) epoch=${epoch} ratio=${ratio}" >> "$details_file"
                 violations=$((violations + 1))
             fi
         done < <(extract_metric "$WORK_DIR/raw_${NODES[$i]}.prom" "$metric" "epoch")
@@ -167,6 +170,10 @@ while true; do
         fi
     done
     if [ "$all_ok" = false ]; then
+        # Reset streak counters so that non-consecutive violations separated
+        # by unreachable rounds do not accumulate toward the patience threshold.
+        event_source_streak=0
+        fully_stored_streak=0
         sleep "$CHECK_INTERVAL"
         continue
     fi
@@ -223,10 +230,11 @@ while true; do
     # A node that just recovered may briefly report < 1 while syncing
     # completes.  Crash only after FULLY_STORED_PATIENCE rounds.
     # ------------------------------------------------------------------
-    v=$(check_fully_stored_ratio)
+    v=$(check_fully_stored_ratio "$WORK_DIR/details_fully_stored.txt")
     if [ "$v" -gt 0 ]; then
         fully_stored_streak=$((fully_stored_streak + 1))
-        log "Fully-stored-ratio violation (streak: ${fully_stored_streak}/${FULLY_STORED_PATIENCE})"
+        log "Fully-stored-ratio violation (streak: ${fully_stored_streak}/${FULLY_STORED_PATIENCE}):"
+        cat "$WORK_DIR/details_fully_stored.txt"
         if [ "$fully_stored_streak" -ge "$FULLY_STORED_PATIENCE" ]; then
             die "node_blob_data_fully_stored_ratio: persistent violation for ${FULLY_STORED_PATIENCE} consecutive rounds"
         fi

--- a/docker/walrus-antithesis/build-test-config-image/files/run-observer.sh
+++ b/docker/walrus-antithesis/build-test-config-image/files/run-observer.sh
@@ -11,9 +11,9 @@
 # Hard invariants (crash on first confirmed violation):
 #   - walrus_blob_info_consistency_check           — same digest per epoch across all nodes
 #   - walrus_per_object_blob_info_consistency_check — same digest per epoch across all nodes
+#   - walrus_periodic_event_source_for_deterministic_events — same per bucket across all nodes
 #
 # Soft invariants (crash after persistent violation):
-#   - walrus_periodic_event_source_for_deterministic_events — same per bucket across all nodes
 #   - walrus_node_blob_data_fully_stored_ratio               — must equal 1 on every node/epoch
 #
 # Epoch bucket design:
@@ -36,7 +36,6 @@ METRICS_PORT="${METRICS_PORT:-9184}"
 CHECK_INTERVAL="${CHECK_INTERVAL:-60}"
 INITIAL_WAIT="${INITIAL_WAIT:-180}"
 # Consecutive rounds a soft-invariant violation must persist before crashing.
-EVENT_SOURCE_PATIENCE="${EVENT_SOURCE_PATIENCE:-3}"
 FULLY_STORED_PATIENCE="${FULLY_STORED_PATIENCE:-3}"
 # Rounds before we escalate "no event source data" from info to warning.
 # Event source metric requires 20k events (~1.5h). With 60s intervals,
@@ -239,14 +238,12 @@ check_fully_stored_ratio() {
 log "Cross-node invariant observer starting"
 log "Nodes: ${NODES[*]}, port: ${METRICS_PORT}"
 log "Check interval: ${CHECK_INTERVAL}s, initial wait: ${INITIAL_WAIT}s"
-log "Event source patience: ${EVENT_SOURCE_PATIENCE} rounds"
 log "Fully stored patience: ${FULLY_STORED_PATIENCE} rounds"
 log "Max epoch buckets: ${MAX_EPOCH_BUCKETS}"
 
 log "Waiting ${INITIAL_WAIT}s for cluster stabilization..."
 sleep "$INITIAL_WAIT"
 
-event_source_streak=0
 fully_stored_streak=0
 round=0
 
@@ -268,9 +265,8 @@ while true; do
         fi
     done
     if [ "$all_ok" = false ]; then
-        # Reset streak counters so that non-consecutive violations separated
+        # Reset streak counter so that non-consecutive violations separated
         # by unreachable rounds do not accumulate toward the patience threshold.
-        event_source_streak=0
         fully_stored_streak=0
         sleep "$CHECK_INTERVAL"
         continue
@@ -324,17 +320,17 @@ while true; do
     fi
 
     # ------------------------------------------------------------------
-    # Soft invariant 1: event source consistency (tolerate transient lag).
-    # Nodes may be at different event-processing positions, so bucket
-    # values can temporarily diverge. Crash only after a persistent
-    # mismatch across EVENT_SOURCE_PATIENCE consecutive rounds.
+    # Hard invariant 3: event source must match across nodes.
+    # The metric is recorded every fixed batch of events. For a given
+    # bucket, either a node hasn't reached that batch (no data) or it
+    # has the final hash. check_cross_node_metric only compares labels
+    # present on ALL nodes, so lagging nodes are excluded automatically.
     # ------------------------------------------------------------------
     v=$(check_cross_node_metric \
         "$EVENT_SOURCE" "bucket" \
         "$WORK_DIR/details_event_source.txt")
     if [ "$v" -eq -1 ]; then
         # No data yet — the metric is recorded every 20k events (~1.5h).
-        event_source_streak=0
         if [ "$round" -lt "$EVENT_SOURCE_WARN_AFTER" ]; then
             log "${EVENT_SOURCE}: no data yet" \
                 "(expected — metric requires ~20k events, round ${round}/${EVENT_SOURCE_WARN_AFTER})"
@@ -344,21 +340,17 @@ while true; do
         fi
         print_metric_values "$EVENT_SOURCE" "bucket"
     elif [ "$v" -gt 0 ]; then
-        event_source_streak=$((event_source_streak + 1))
-        log "Event source mismatch (streak: ${event_source_streak}/${EVENT_SOURCE_PATIENCE}):"
+        log "INVARIANT VIOLATION — ${EVENT_SOURCE} (${v} bucket(s)):"
         cat "$WORK_DIR/details_event_source.txt"
         print_metric_values "$EVENT_SOURCE" "bucket"
-        if [ "$event_source_streak" -ge "$EVENT_SOURCE_PATIENCE" ]; then
-            die "${EVENT_SOURCE}: persistent mismatch for ${EVENT_SOURCE_PATIENCE} consecutive rounds"
-        fi
+        die "${EVENT_SOURCE}: mismatched values across nodes"
     else
-        event_source_streak=0
         log "${EVENT_SOURCE}: OK"
         print_metric_values "$EVENT_SOURCE" "bucket"
     fi
 
     # ------------------------------------------------------------------
-    # Soft invariant 2: all blobs fully stored (tolerate recovery lag).
+    # Soft invariant 1: all blobs fully stored (tolerate recovery lag).
     # A node that just recovered may briefly report < 1 while syncing
     # completes.  Crash only after FULLY_STORED_PATIENCE rounds.
     # Only the latest (highest) epoch bucket per node is checked — see

--- a/docker/walrus-antithesis/build-test-config-image/files/run-observer.sh
+++ b/docker/walrus-antithesis/build-test-config-image/files/run-observer.sh
@@ -15,6 +15,16 @@
 # Soft invariants (crash after persistent violation):
 #   - walrus_periodic_event_source_for_deterministic_events — same per bucket across all nodes
 #   - walrus_node_blob_data_fully_stored_ratio               — must equal 1 on every node/epoch
+#
+# Epoch bucket design:
+#   Storage nodes label consistency-check metrics with `epoch % 1000` (see
+#   EPOCH_BUCKET_COUNT in consistency_check.rs). This bounds Prometheus label
+#   cardinality while ensuring buckets are never reused within any realistic
+#   test duration. The observer compares all common epoch labels across nodes.
+#   If any node has more epoch labels than MAX_EPOCH_BUCKETS, we stop comparing
+#   and log a warning, because bucket reuse could cause false positives — a
+#   stale value from epoch N in the same bucket as epoch N+1000 looks like a
+#   data divergence even though the node simply hasn't updated yet.
 
 set -euo pipefail
 
@@ -32,6 +42,10 @@ FULLY_STORED_PATIENCE="${FULLY_STORED_PATIENCE:-3}"
 # Event source metric requires 20k events (~1.5h). With 60s intervals,
 # 120 rounds ≈ 2 hours — enough time for the metric to appear.
 EVENT_SOURCE_WARN_AFTER="${EVENT_SOURCE_WARN_AFTER:-120}"
+# Must match EPOCH_BUCKET_COUNT in consistency_check.rs. When a node has this
+# many epoch labels, buckets will start being reused and comparisons become
+# unreliable.
+MAX_EPOCH_BUCKETS="${MAX_EPOCH_BUCKETS:-1000}"
 
 WORK_DIR="/tmp/observer"
 mkdir -p "$WORK_DIR"
@@ -72,17 +86,23 @@ extract_metric() {
         | sort -t"$(printf '\t')" -k1,1
 }
 
+
 # ---------------------------------------------------------------------------
 # Cross-node comparison for a labelled gauge metric.
 #
 # For every label value present in ALL scraped nodes, assert that the metric
 # value is identical.  Writes per-violation details to a file.
 #
-# Arguments: metric_name  label_name  details_file
-# Echoes the number of mismatched label values (0 = clean).
+# Arguments: metric_name  label_name  details_file  [max_labels]
+# Echoes:
+#   -2  if any node has >= max_labels labels (bucket saturation)
+#   -1  if no common labels exist
+#    0  if all common labels match
+#   >0  number of mismatched label values
 # ---------------------------------------------------------------------------
 check_cross_node_metric() {
     local metric="$1" label="$2" details_file="$3"
+    local max_labels="${4:-0}"
     local num_nodes=${#NODES[@]}
     local violations=0
 
@@ -92,6 +112,21 @@ check_cross_node_metric() {
         extract_metric "$WORK_DIR/raw_${NODES[$i]}.prom" "$metric" "$label" \
             > "$WORK_DIR/chk_${i}.tsv"
     done
+
+    # Check for approaching bucket saturation: if any node has an epoch label
+    # >= 90% of the bucket count, we're close to wraparound and comparisons
+    # may become unreliable.
+    if [ "$max_labels" -gt 0 ]; then
+        local threshold=$((max_labels * 9 / 10))
+        for i in "${!NODES[@]}"; do
+            local highest
+            highest=$(cut -f1 "$WORK_DIR/chk_${i}.tsv" | sort -n | tail -1)
+            if [ -n "$highest" ] && [ "$highest" -ge "$threshold" ]; then
+                echo "-2"
+                return
+            fi
+        done
+    fi
 
     # Labels that appear in every node's output.
     for i in "${!NODES[@]}"; do
@@ -136,7 +171,11 @@ check_cross_node_metric() {
 }
 
 # ---------------------------------------------------------------------------
-# Check walrus_node_blob_data_fully_stored_ratio == 1 for all nodes/epochs.
+# Check walrus_node_blob_data_fully_stored_ratio == 1 for each node's latest
+# epoch bucket.  With EPOCH_BUCKET_COUNT = 1_000, buckets map 1:1 to real
+# epochs for any realistic test duration.  We only check the latest (highest)
+# epoch per node because older epochs are immutable snapshots — if the latest
+# epoch is healthy, earlier ones are too.
 # Echoes the number of violations.
 # ---------------------------------------------------------------------------
 check_fully_stored_ratio() {
@@ -147,14 +186,18 @@ check_fully_stored_ratio() {
     : > "$details_file"
 
     for i in "${!NODES[@]}"; do
-        while IFS="$(printf '\t')" read -r epoch ratio; do
-            [ -z "$epoch" ] && continue
-            # Numeric comparison: ratio must equal 1.
-            if ! awk -v r="$ratio" 'BEGIN { exit (r == 1) ? 0 : 1 }'; then
-                echo "  node-${i} (${NODES[$i]}) epoch=${epoch} ratio=${ratio}" >> "$details_file"
-                violations=$((violations + 1))
-            fi
-        done < <(extract_metric "$WORK_DIR/raw_${NODES[$i]}.prom" "$metric" "epoch")
+        # Only check the highest epoch bucket (most recent consistency check).
+        local latest=""
+        latest=$(extract_metric "$WORK_DIR/raw_${NODES[$i]}.prom" "$metric" "epoch" \
+            | sort -t"$(printf '\t')" -k1,1n | tail -1)
+        [ -z "$latest" ] && continue
+        local epoch ratio
+        epoch=$(echo "$latest" | cut -f1)
+        ratio=$(echo "$latest" | cut -f2)
+        if ! awk -v r="$ratio" 'BEGIN { exit (r == 1) ? 0 : 1 }'; then
+            echo "  node-${i} (${NODES[$i]}) epoch=${epoch} ratio=${ratio}" >> "$details_file"
+            violations=$((violations + 1))
+        fi
     done
 
     echo "$violations"
@@ -168,6 +211,7 @@ log "Nodes: ${NODES[*]}, port: ${METRICS_PORT}"
 log "Check interval: ${CHECK_INTERVAL}s, initial wait: ${INITIAL_WAIT}s"
 log "Event source patience: ${EVENT_SOURCE_PATIENCE} rounds"
 log "Fully stored patience: ${FULLY_STORED_PATIENCE} rounds"
+log "Max epoch buckets: ${MAX_EPOCH_BUCKETS}"
 
 log "Waiting ${INITIAL_WAIT}s for cluster stabilization..."
 sleep "$INITIAL_WAIT"
@@ -204,33 +248,50 @@ while true; do
 
     # ------------------------------------------------------------------
     # Hard invariant 1: certified blob digest must match across nodes.
+    #
+    # The epoch label is `epoch % 1_000` (EPOCH_BUCKET_COUNT in
+    # consistency_check.rs). With 1000 buckets, reuse cannot happen in any
+    # realistic test duration. We pass MAX_EPOCH_BUCKETS so that if a test
+    # ever runs long enough to saturate the buckets, we stop comparing
+    # rather than risk false positives from stale collisions.
     # ------------------------------------------------------------------
     v=$(check_cross_node_metric \
         "walrus_blob_info_consistency_check" "epoch" \
-        "$WORK_DIR/details_blob_info.txt")
-    if [ "$v" -gt 0 ]; then
+        "$WORK_DIR/details_blob_info.txt" "$MAX_EPOCH_BUCKETS")
+    if [ "$v" -eq -2 ]; then
+        log "WARNING: walrus_blob_info_consistency_check: epoch bucket capacity reached" \
+            "(${MAX_EPOCH_BUCKETS}), skipping comparison to avoid false positives from bucket reuse"
+        print_metric_values "walrus_blob_info_consistency_check" "epoch"
+    elif [ "$v" -gt 0 ]; then
         log "INVARIANT VIOLATION — blob_info_consistency_check (${v} epoch(s)):"
         cat "$WORK_DIR/details_blob_info.txt"
         print_metric_values "walrus_blob_info_consistency_check" "epoch"
         die "blob_info_consistency_check: mismatched digests across nodes"
+    else
+        log "walrus_blob_info_consistency_check: OK"
+        print_metric_values "walrus_blob_info_consistency_check" "epoch"
     fi
-    log "walrus_blob_info_consistency_check: OK"
-    print_metric_values "walrus_blob_info_consistency_check" "epoch"
 
     # ------------------------------------------------------------------
     # Hard invariant 2: per-object blob digest must match across nodes.
+    # Same epoch bucket design as invariant 1; see comment above.
     # ------------------------------------------------------------------
     v=$(check_cross_node_metric \
         "walrus_per_object_blob_info_consistency_check" "epoch" \
-        "$WORK_DIR/details_per_object.txt")
-    if [ "$v" -gt 0 ]; then
+        "$WORK_DIR/details_per_object.txt" "$MAX_EPOCH_BUCKETS")
+    if [ "$v" -eq -2 ]; then
+        log "WARNING: walrus_per_object_blob_info_consistency_check: epoch bucket capacity reached" \
+            "(${MAX_EPOCH_BUCKETS}), skipping comparison to avoid false positives from bucket reuse"
+        print_metric_values "walrus_per_object_blob_info_consistency_check" "epoch"
+    elif [ "$v" -gt 0 ]; then
         log "INVARIANT VIOLATION — per_object_blob_info_consistency_check (${v} epoch(s)):"
         cat "$WORK_DIR/details_per_object.txt"
         print_metric_values "walrus_per_object_blob_info_consistency_check" "epoch"
         die "per_object_blob_info_consistency_check: mismatched digests across nodes"
+    else
+        log "walrus_per_object_blob_info_consistency_check: OK"
+        print_metric_values "walrus_per_object_blob_info_consistency_check" "epoch"
     fi
-    log "walrus_per_object_blob_info_consistency_check: OK"
-    print_metric_values "walrus_per_object_blob_info_consistency_check" "epoch"
 
     # ------------------------------------------------------------------
     # Soft invariant 1: event source consistency (tolerate transient lag).
@@ -270,6 +331,8 @@ while true; do
     # Soft invariant 2: all blobs fully stored (tolerate recovery lag).
     # A node that just recovered may briefly report < 1 while syncing
     # completes.  Crash only after FULLY_STORED_PATIENCE rounds.
+    # Only the latest (highest) epoch bucket per node is checked — see
+    # check_fully_stored_ratio for rationale.
     # ------------------------------------------------------------------
     v=$(check_fully_stored_ratio "$WORK_DIR/details_fully_stored.txt")
     if [ "$v" -gt 0 ]; then

--- a/docker/walrus-antithesis/build-test-config-image/files/run-observer.sh
+++ b/docker/walrus-antithesis/build-test-config-image/files/run-observer.sh
@@ -79,8 +79,16 @@ scrape_node() {
 
 # Extract (label_value, metric_value) pairs from a Prometheus scrape file.
 # Outputs: label_value<TAB>metric_value  (sorted by label).
+#
+# Example input line:
+#   walrus_blob_info_consistency_check{epoch="5"} 3965707792766453120
+# With metric="walrus_blob_info_consistency_check" label="epoch", outputs:
+#   5	3965707792766453120
 extract_metric() {
     local file="$1" metric="$2" label="$3"
+    # 1. grep: find lines starting with the metric name
+    # 2. sed:  extract the label value and numeric value
+    # 3. sort: order by label value for consistent comparison
     { grep "^${metric}{" "$file" 2>/dev/null || true; } \
         | sed -n "s/^${metric}{.*${label}=\"\([^\"]*\)\".*} \([^ ]*\).*/\1\t\2/p" \
         | sort -t"$(printf '\t')" -k1,1
@@ -108,14 +116,17 @@ check_cross_node_metric() {
 
     : > "$details_file"
 
+    # Step 1: Extract label→value pairs from each node's scrape into TSV files.
+    #   chk_0.tsv, chk_1.tsv, ... each contain lines like: "5\t3965707792766453120"
     for i in "${!NODES[@]}"; do
         extract_metric "$WORK_DIR/raw_${NODES[$i]}.prom" "$metric" "$label" \
             > "$WORK_DIR/chk_${i}.tsv"
     done
 
-    # Check for approaching bucket saturation: if any node has an epoch label
-    # >= 90% of the bucket count, we're close to wraparound and comparisons
-    # may become unreliable.
+    # Step 2: Bail out if epoch labels are approaching bucket reuse.
+    #   Labels are `epoch % EPOCH_BUCKET_COUNT`. If the highest label on any node
+    #   is >= 90% of max_labels, we're nearing wraparound where new epochs overwrite
+    #   old ones in the same bucket, making cross-node comparison unreliable.
     if [ "$max_labels" -gt 0 ]; then
         local threshold=$((max_labels * 9 / 10))
         for i in "${!NODES[@]}"; do
@@ -128,22 +139,27 @@ check_cross_node_metric() {
         done
     fi
 
-    # Labels that appear in every node's output.
+    # Step 3: Find labels present on ALL nodes (intersection).
+    #   We only compare a label if every node has reported it. This avoids false
+    #   positives when a node is lagging and hasn't computed a recent epoch yet.
+    #   Example: if nodes report epochs {1,2,3}, {1,2,3}, {1,2}, {1,2,3},
+    #   only epochs 1 and 2 are compared (present on all 4 nodes).
     for i in "${!NODES[@]}"; do
         cut -f1 "$WORK_DIR/chk_${i}.tsv"
     done | sort | uniq -c | awk -v n="$num_nodes" '$1 == n { print $2 }' \
         > "$WORK_DIR/chk_common.txt"
 
     if [ ! -s "$WORK_DIR/chk_common.txt" ]; then
-        # Signal "no data" with -1 so callers can distinguish from "0 violations".
-        echo "-1"
+        echo "-1"  # no common labels — nothing to compare
         return
     fi
 
+    # Step 4: For each common label, verify all nodes report the same value.
     while IFS= read -r lbl; do
         [ -z "$lbl" ] && continue
         local ref_val="" mismatch=false
 
+        # Collect the value for this label from each node; compare to first node's value.
         for i in "${!NODES[@]}"; do
             local val
             val=$(awk -F'\t' -v l="$lbl" '$1 == l { print $2 }' "$WORK_DIR/chk_${i}.tsv")
@@ -154,6 +170,7 @@ check_cross_node_metric() {
             fi
         done
 
+        # Record the mismatch with per-node details for debugging.
         if [ "$mismatch" = true ]; then
             {
                 echo "  ${metric}{${label}=\"${lbl}\"}:"
@@ -186,14 +203,21 @@ check_fully_stored_ratio() {
     : > "$details_file"
 
     for i in "${!NODES[@]}"; do
-        # Only check the highest epoch bucket (most recent consistency check).
+        # Find the highest epoch bucket on this node (numerically sorted).
+        # This is the most recent consistency check result. Older epochs are
+        # immutable — they can't degrade, so only the latest matters.
         local latest=""
         latest=$(extract_metric "$WORK_DIR/raw_${NODES[$i]}.prom" "$metric" "epoch" \
             | sort -t"$(printf '\t')" -k1,1n | tail -1)
         [ -z "$latest" ] && continue
+
+        # Split "epoch_label\tratio_value" into separate variables.
         local epoch ratio
         epoch=$(echo "$latest" | cut -f1)
         ratio=$(echo "$latest" | cut -f2)
+
+        # Ratio must be exactly 1.0 (all sampled blobs fully stored).
+        # Use awk for float comparison since bash can't compare decimals.
         if ! awk -v r="$ratio" 'BEGIN { exit (r == 1) ? 0 : 1 }'; then
             echo "  node-${i} (${NODES[$i]}) epoch=${epoch} ratio=${ratio}" >> "$details_file"
             violations=$((violations + 1))

--- a/docker/walrus-antithesis/build-test-config-image/files/run-observer.sh
+++ b/docker/walrus-antithesis/build-test-config-image/files/run-observer.sh
@@ -1,0 +1,240 @@
+#!/bin/bash
+# Copyright (c) Walrus Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+# Cross-node invariant observer for Antithesis testing.
+#
+# Periodically scrapes Prometheus metrics from all storage nodes and verifies
+# cross-node data consistency invariants. Crashes (exits non-zero) when an
+# invariant violation is detected, which Antithesis surfaces as a test failure.
+#
+# Hard invariants (crash on first confirmed violation):
+#   - walrus_blob_info_consistency_check           — same digest per epoch across all nodes
+#   - walrus_per_object_blob_info_consistency_check — same digest per epoch across all nodes
+#
+# Soft invariants (crash after persistent violation):
+#   - walrus_periodic_event_source_for_deterministic_events — same per bucket across all nodes
+#   - walrus_node_blob_data_fully_stored_ratio               — must equal 1 on every node/epoch
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration (override via environment variables)
+# ---------------------------------------------------------------------------
+NODES=("10.0.0.10" "10.0.0.11" "10.0.0.12" "10.0.0.13")
+METRICS_PORT="${METRICS_PORT:-9184}"
+CHECK_INTERVAL="${CHECK_INTERVAL:-60}"
+INITIAL_WAIT="${INITIAL_WAIT:-180}"
+# Consecutive rounds a soft-invariant violation must persist before crashing.
+EVENT_SOURCE_PATIENCE="${EVENT_SOURCE_PATIENCE:-3}"
+FULLY_STORED_PATIENCE="${FULLY_STORED_PATIENCE:-3}"
+
+WORK_DIR="/tmp/observer"
+mkdir -p "$WORK_DIR"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+log()  { echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] [observer] $*"; }
+die()  { log "FATAL: $*" >&2; exit 1; }
+
+# Scrape the /metrics endpoint of a storage node.
+scrape_node() {
+    local ip="$1" out="$2"
+    curl -sf --connect-timeout 5 --max-time 10 \
+        "http://${ip}:${METRICS_PORT}/metrics" > "$out" 2>/dev/null
+}
+
+# Extract (label_value, metric_value) pairs from a Prometheus scrape file.
+# Outputs: label_value<TAB>metric_value  (sorted by label).
+extract_metric() {
+    local file="$1" metric="$2" label="$3"
+    { grep "^${metric}{" "$file" 2>/dev/null || true; } \
+        | sed -n "s/^${metric}{.*${label}=\"\([^\"]*\)\".*} \([^ ]*\).*/\1\t\2/p" \
+        | sort -t"$(printf '\t')" -k1,1
+}
+
+# ---------------------------------------------------------------------------
+# Cross-node comparison for a labelled gauge metric.
+#
+# For every label value present in ALL scraped nodes, assert that the metric
+# value is identical.  Writes per-violation details to a file.
+#
+# Arguments: metric_name  label_name  details_file
+# Echoes the number of mismatched label values (0 = clean).
+# ---------------------------------------------------------------------------
+check_cross_node_metric() {
+    local metric="$1" label="$2" details_file="$3"
+    local num_nodes=${#NODES[@]}
+    local violations=0
+
+    : > "$details_file"
+
+    for i in "${!NODES[@]}"; do
+        extract_metric "$WORK_DIR/raw_${NODES[$i]}.prom" "$metric" "$label" \
+            > "$WORK_DIR/chk_${i}.tsv"
+    done
+
+    # Labels that appear in every node's output.
+    for i in "${!NODES[@]}"; do
+        cut -f1 "$WORK_DIR/chk_${i}.tsv"
+    done | sort | uniq -c | awk -v n="$num_nodes" '$1 == n { print $2 }' \
+        > "$WORK_DIR/chk_common.txt"
+
+    while IFS= read -r lbl; do
+        [ -z "$lbl" ] && continue
+        local ref_val="" mismatch=false
+
+        for i in "${!NODES[@]}"; do
+            local val
+            val=$(awk -F'\t' -v l="$lbl" '$1 == l { print $2 }' "$WORK_DIR/chk_${i}.tsv")
+            if [ -z "$ref_val" ]; then
+                ref_val="$val"
+            elif [ "$val" != "$ref_val" ]; then
+                mismatch=true
+            fi
+        done
+
+        if [ "$mismatch" = true ]; then
+            {
+                echo "  ${metric}{${label}=\"${lbl}\"}:"
+                for i in "${!NODES[@]}"; do
+                    local val
+                    val=$(awk -F'\t' -v l="$lbl" '$1 == l { print $2 }' "$WORK_DIR/chk_${i}.tsv")
+                    echo "    node-${i} (${NODES[$i]}): ${val}"
+                done
+            } >> "$details_file"
+            violations=$((violations + 1))
+        fi
+    done < "$WORK_DIR/chk_common.txt"
+
+    echo "$violations"
+}
+
+# ---------------------------------------------------------------------------
+# Check walrus_node_blob_data_fully_stored_ratio == 1 for all nodes/epochs.
+# Echoes the number of violations.
+# ---------------------------------------------------------------------------
+check_fully_stored_ratio() {
+    local metric="walrus_node_blob_data_fully_stored_ratio"
+    local violations=0
+
+    for i in "${!NODES[@]}"; do
+        while IFS="$(printf '\t')" read -r epoch ratio; do
+            [ -z "$epoch" ] && continue
+            # Numeric comparison: ratio must equal 1.
+            if ! awk -v r="$ratio" 'BEGIN { exit (r == 1) ? 0 : 1 }'; then
+                log "  node-${i} (${NODES[$i]}) epoch=${epoch} ratio=${ratio}" >&2
+                violations=$((violations + 1))
+            fi
+        done < <(extract_metric "$WORK_DIR/raw_${NODES[$i]}.prom" "$metric" "epoch")
+    done
+
+    echo "$violations"
+}
+
+# ---------------------------------------------------------------------------
+# Main loop
+# ---------------------------------------------------------------------------
+log "Cross-node invariant observer starting"
+log "Nodes: ${NODES[*]}, port: ${METRICS_PORT}"
+log "Check interval: ${CHECK_INTERVAL}s, initial wait: ${INITIAL_WAIT}s"
+log "Event source patience: ${EVENT_SOURCE_PATIENCE} rounds"
+log "Fully stored patience: ${FULLY_STORED_PATIENCE} rounds"
+
+log "Waiting ${INITIAL_WAIT}s for cluster stabilization..."
+sleep "$INITIAL_WAIT"
+
+event_source_streak=0
+fully_stored_streak=0
+round=0
+
+while true; do
+    round=$((round + 1))
+    log "=== Round ${round} ==="
+
+    # ------------------------------------------------------------------
+    # Scrape all nodes; skip the round if any node is unreachable.
+    # ------------------------------------------------------------------
+    all_ok=true
+    for i in "${!NODES[@]}"; do
+        if scrape_node "${NODES[$i]}" "$WORK_DIR/raw_${NODES[$i]}.prom"; then
+            log "Scraped node-${i} (${NODES[$i]})"
+        else
+            log "Cannot reach node-${i} (${NODES[$i]}), skipping round"
+            all_ok=false
+            break
+        fi
+    done
+    if [ "$all_ok" = false ]; then
+        sleep "$CHECK_INTERVAL"
+        continue
+    fi
+
+    # ------------------------------------------------------------------
+    # Hard invariant 1: certified blob digest must match across nodes.
+    # ------------------------------------------------------------------
+    v=$(check_cross_node_metric \
+        "walrus_blob_info_consistency_check" "epoch" \
+        "$WORK_DIR/details_blob_info.txt")
+    if [ "$v" -gt 0 ]; then
+        log "INVARIANT VIOLATION — blob_info_consistency_check (${v} epoch(s)):"
+        cat "$WORK_DIR/details_blob_info.txt"
+        die "blob_info_consistency_check: mismatched digests across nodes"
+    fi
+    log "walrus_blob_info_consistency_check: OK"
+
+    # ------------------------------------------------------------------
+    # Hard invariant 2: per-object blob digest must match across nodes.
+    # ------------------------------------------------------------------
+    v=$(check_cross_node_metric \
+        "walrus_per_object_blob_info_consistency_check" "epoch" \
+        "$WORK_DIR/details_per_object.txt")
+    if [ "$v" -gt 0 ]; then
+        log "INVARIANT VIOLATION — per_object_blob_info_consistency_check (${v} epoch(s)):"
+        cat "$WORK_DIR/details_per_object.txt"
+        die "per_object_blob_info_consistency_check: mismatched digests across nodes"
+    fi
+    log "walrus_per_object_blob_info_consistency_check: OK"
+
+    # ------------------------------------------------------------------
+    # Soft invariant 1: event source consistency (tolerate transient lag).
+    # Nodes may be at different event-processing positions, so bucket
+    # values can temporarily diverge. Crash only after a persistent
+    # mismatch across EVENT_SOURCE_PATIENCE consecutive rounds.
+    # ------------------------------------------------------------------
+    v=$(check_cross_node_metric \
+        "walrus_periodic_event_source_for_deterministic_events" "bucket" \
+        "$WORK_DIR/details_event_source.txt")
+    if [ "$v" -gt 0 ]; then
+        event_source_streak=$((event_source_streak + 1))
+        log "Event source mismatch (streak: ${event_source_streak}/${EVENT_SOURCE_PATIENCE}):"
+        cat "$WORK_DIR/details_event_source.txt"
+        if [ "$event_source_streak" -ge "$EVENT_SOURCE_PATIENCE" ]; then
+            die "periodic_event_source: persistent mismatch for ${EVENT_SOURCE_PATIENCE} consecutive rounds"
+        fi
+    else
+        event_source_streak=0
+        log "walrus_periodic_event_source_for_deterministic_events: OK"
+    fi
+
+    # ------------------------------------------------------------------
+    # Soft invariant 2: all blobs fully stored (tolerate recovery lag).
+    # A node that just recovered may briefly report < 1 while syncing
+    # completes.  Crash only after FULLY_STORED_PATIENCE rounds.
+    # ------------------------------------------------------------------
+    v=$(check_fully_stored_ratio)
+    if [ "$v" -gt 0 ]; then
+        fully_stored_streak=$((fully_stored_streak + 1))
+        log "Fully-stored-ratio violation (streak: ${fully_stored_streak}/${FULLY_STORED_PATIENCE})"
+        if [ "$fully_stored_streak" -ge "$FULLY_STORED_PATIENCE" ]; then
+            die "node_blob_data_fully_stored_ratio: persistent violation for ${FULLY_STORED_PATIENCE} consecutive rounds"
+        fi
+    else
+        fully_stored_streak=0
+        log "walrus_node_blob_data_fully_stored_ratio: OK"
+    fi
+
+    log "All checks passed for round ${round}"
+    sleep "$CHECK_INTERVAL"
+done

--- a/docker/walrus-antithesis/build-test-config-image/files/run-observer.sh
+++ b/docker/walrus-antithesis/build-test-config-image/files/run-observer.sh
@@ -28,6 +28,10 @@ INITIAL_WAIT="${INITIAL_WAIT:-180}"
 # Consecutive rounds a soft-invariant violation must persist before crashing.
 EVENT_SOURCE_PATIENCE="${EVENT_SOURCE_PATIENCE:-3}"
 FULLY_STORED_PATIENCE="${FULLY_STORED_PATIENCE:-3}"
+# Rounds before we escalate "no event source data" from info to warning.
+# Event source metric requires 20k events (~1.5h). With 60s intervals,
+# 120 rounds ≈ 2 hours — enough time for the metric to appear.
+EVENT_SOURCE_WARN_AFTER="${EVENT_SOURCE_WARN_AFTER:-120}"
 
 WORK_DIR="/tmp/observer"
 mkdir -p "$WORK_DIR"
@@ -48,7 +52,7 @@ print_metric_values() {
             [ -z "$lbl" ] && continue
             vals="${vals} ${label}=${lbl}:${val}"
         done < <(extract_metric "$WORK_DIR/raw_${NODES[$i]}.prom" "$metric" "$label")
-        log "  node-${i} (${NODES[$i]}):${vals:- (none)}"
+        log "  node-${i} (${NODES[$i]}):${vals:- (no data — not enough events processed yet)}"
     done
 }
 
@@ -96,8 +100,8 @@ check_cross_node_metric() {
         > "$WORK_DIR/chk_common.txt"
 
     if [ ! -s "$WORK_DIR/chk_common.txt" ]; then
-        log "  ${metric}: no common ${label} values across nodes, skipping comparison"
-        echo "0"
+        # Signal "no data" with -1 so callers can distinguish from "0 violations".
+        echo "-1"
         return
     fi
 
@@ -237,7 +241,18 @@ while true; do
     v=$(check_cross_node_metric \
         "walrus_periodic_event_source_for_deterministic_events" "bucket" \
         "$WORK_DIR/details_event_source.txt")
-    if [ "$v" -gt 0 ]; then
+    if [ "$v" -eq -1 ]; then
+        # No data yet — the metric is recorded every 20k events (~1.5h).
+        event_source_streak=0
+        if [ "$round" -lt "$EVENT_SOURCE_WARN_AFTER" ]; then
+            log "walrus_periodic_event_source_for_deterministic_events: no data yet" \
+                "(expected — metric requires ~20k events, round ${round}/${EVENT_SOURCE_WARN_AFTER})"
+        else
+            log "WARNING: walrus_periodic_event_source_for_deterministic_events: still no data" \
+                "after ${round} rounds — expected by now, check event processing"
+        fi
+        print_metric_values "walrus_periodic_event_source_for_deterministic_events" "bucket"
+    elif [ "$v" -gt 0 ]; then
         event_source_streak=$((event_source_streak + 1))
         log "Event source mismatch (streak: ${event_source_streak}/${EVENT_SOURCE_PATIENCE}):"
         cat "$WORK_DIR/details_event_source.txt"

--- a/docker/walrus-antithesis/build-test-config-image/files/run-observer.sh
+++ b/docker/walrus-antithesis/build-test-config-image/files/run-observer.sh
@@ -50,6 +50,12 @@ MAX_EPOCH_BUCKETS="${MAX_EPOCH_BUCKETS:-1000}"
 WORK_DIR="/tmp/observer"
 mkdir -p "$WORK_DIR"
 
+# Short aliases for long metric names (used in checks and log messages).
+BLOB_INFO="walrus_blob_info_consistency_check"
+PER_OBJECT_INFO="walrus_per_object_blob_info_consistency_check"
+EVENT_SOURCE="walrus_periodic_event_source_for_deterministic_events"
+FULLY_STORED_RATIO="walrus_node_blob_data_fully_stored_ratio"
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -82,7 +88,7 @@ scrape_node() {
 #
 # Example input line:
 #   walrus_blob_info_consistency_check{epoch="5"} 3965707792766453120
-# With metric="walrus_blob_info_consistency_check" label="epoch", outputs:
+# With metric="$BLOB_INFO" label="epoch", outputs:
 #   5	3965707792766453120
 extract_metric() {
     local file="$1" metric="$2" label="$3"
@@ -103,7 +109,7 @@ extract_metric() {
 #
 # Arguments: metric_name  label_name  details_file  [max_labels]
 # Echoes:
-#   -2  if any node has >= max_labels labels (bucket saturation)
+#   -2  if labels are nearing bucket saturation
 #   -1  if no common labels exist
 #    0  if all common labels match
 #   >0  number of mismatched label values
@@ -196,7 +202,7 @@ check_cross_node_metric() {
 # Echoes the number of violations.
 # ---------------------------------------------------------------------------
 check_fully_stored_ratio() {
-    local metric="walrus_node_blob_data_fully_stored_ratio"
+    local metric="$FULLY_STORED_RATIO"
     local details_file="$1"
     local violations=0
 
@@ -280,20 +286,20 @@ while true; do
     # rather than risk false positives from stale collisions.
     # ------------------------------------------------------------------
     v=$(check_cross_node_metric \
-        "walrus_blob_info_consistency_check" "epoch" \
+        "$BLOB_INFO" "epoch" \
         "$WORK_DIR/details_blob_info.txt" "$MAX_EPOCH_BUCKETS")
     if [ "$v" -eq -2 ]; then
-        log "WARNING: walrus_blob_info_consistency_check: epoch bucket capacity reached" \
+        log "WARNING: ${BLOB_INFO}: epoch bucket capacity reached" \
             "(${MAX_EPOCH_BUCKETS}), skipping comparison to avoid false positives from bucket reuse"
-        print_metric_values "walrus_blob_info_consistency_check" "epoch"
+        print_metric_values "$BLOB_INFO" "epoch"
     elif [ "$v" -gt 0 ]; then
-        log "INVARIANT VIOLATION — blob_info_consistency_check (${v} epoch(s)):"
+        log "INVARIANT VIOLATION — ${BLOB_INFO} (${v} epoch(s)):"
         cat "$WORK_DIR/details_blob_info.txt"
-        print_metric_values "walrus_blob_info_consistency_check" "epoch"
-        die "blob_info_consistency_check: mismatched digests across nodes"
+        print_metric_values "$BLOB_INFO" "epoch"
+        die "${BLOB_INFO}: mismatched digests across nodes"
     else
-        log "walrus_blob_info_consistency_check: OK"
-        print_metric_values "walrus_blob_info_consistency_check" "epoch"
+        log "${BLOB_INFO}: OK"
+        print_metric_values "$BLOB_INFO" "epoch"
     fi
 
     # ------------------------------------------------------------------
@@ -301,20 +307,20 @@ while true; do
     # Same epoch bucket design as invariant 1; see comment above.
     # ------------------------------------------------------------------
     v=$(check_cross_node_metric \
-        "walrus_per_object_blob_info_consistency_check" "epoch" \
+        "$PER_OBJECT_INFO" "epoch" \
         "$WORK_DIR/details_per_object.txt" "$MAX_EPOCH_BUCKETS")
     if [ "$v" -eq -2 ]; then
-        log "WARNING: walrus_per_object_blob_info_consistency_check: epoch bucket capacity reached" \
+        log "WARNING: ${PER_OBJECT_INFO}: epoch bucket capacity reached" \
             "(${MAX_EPOCH_BUCKETS}), skipping comparison to avoid false positives from bucket reuse"
-        print_metric_values "walrus_per_object_blob_info_consistency_check" "epoch"
+        print_metric_values "$PER_OBJECT_INFO" "epoch"
     elif [ "$v" -gt 0 ]; then
-        log "INVARIANT VIOLATION — per_object_blob_info_consistency_check (${v} epoch(s)):"
+        log "INVARIANT VIOLATION — ${PER_OBJECT_INFO} (${v} epoch(s)):"
         cat "$WORK_DIR/details_per_object.txt"
-        print_metric_values "walrus_per_object_blob_info_consistency_check" "epoch"
-        die "per_object_blob_info_consistency_check: mismatched digests across nodes"
+        print_metric_values "$PER_OBJECT_INFO" "epoch"
+        die "${PER_OBJECT_INFO}: mismatched digests across nodes"
     else
-        log "walrus_per_object_blob_info_consistency_check: OK"
-        print_metric_values "walrus_per_object_blob_info_consistency_check" "epoch"
+        log "${PER_OBJECT_INFO}: OK"
+        print_metric_values "$PER_OBJECT_INFO" "epoch"
     fi
 
     # ------------------------------------------------------------------
@@ -324,31 +330,31 @@ while true; do
     # mismatch across EVENT_SOURCE_PATIENCE consecutive rounds.
     # ------------------------------------------------------------------
     v=$(check_cross_node_metric \
-        "walrus_periodic_event_source_for_deterministic_events" "bucket" \
+        "$EVENT_SOURCE" "bucket" \
         "$WORK_DIR/details_event_source.txt")
     if [ "$v" -eq -1 ]; then
         # No data yet — the metric is recorded every 20k events (~1.5h).
         event_source_streak=0
         if [ "$round" -lt "$EVENT_SOURCE_WARN_AFTER" ]; then
-            log "walrus_periodic_event_source_for_deterministic_events: no data yet" \
+            log "${EVENT_SOURCE}: no data yet" \
                 "(expected — metric requires ~20k events, round ${round}/${EVENT_SOURCE_WARN_AFTER})"
         else
-            log "WARNING: walrus_periodic_event_source_for_deterministic_events: still no data" \
+            log "WARNING: ${EVENT_SOURCE}: still no data" \
                 "after ${round} rounds — expected by now, check event processing"
         fi
-        print_metric_values "walrus_periodic_event_source_for_deterministic_events" "bucket"
+        print_metric_values "$EVENT_SOURCE" "bucket"
     elif [ "$v" -gt 0 ]; then
         event_source_streak=$((event_source_streak + 1))
         log "Event source mismatch (streak: ${event_source_streak}/${EVENT_SOURCE_PATIENCE}):"
         cat "$WORK_DIR/details_event_source.txt"
-        print_metric_values "walrus_periodic_event_source_for_deterministic_events" "bucket"
+        print_metric_values "$EVENT_SOURCE" "bucket"
         if [ "$event_source_streak" -ge "$EVENT_SOURCE_PATIENCE" ]; then
-            die "periodic_event_source: persistent mismatch for ${EVENT_SOURCE_PATIENCE} consecutive rounds"
+            die "${EVENT_SOURCE}: persistent mismatch for ${EVENT_SOURCE_PATIENCE} consecutive rounds"
         fi
     else
         event_source_streak=0
-        log "walrus_periodic_event_source_for_deterministic_events: OK"
-        print_metric_values "walrus_periodic_event_source_for_deterministic_events" "bucket"
+        log "${EVENT_SOURCE}: OK"
+        print_metric_values "$EVENT_SOURCE" "bucket"
     fi
 
     # ------------------------------------------------------------------
@@ -363,14 +369,14 @@ while true; do
         fully_stored_streak=$((fully_stored_streak + 1))
         log "Fully-stored-ratio violation (streak: ${fully_stored_streak}/${FULLY_STORED_PATIENCE}):"
         cat "$WORK_DIR/details_fully_stored.txt"
-        print_metric_values "walrus_node_blob_data_fully_stored_ratio" "epoch"
+        print_metric_values "$FULLY_STORED_RATIO" "epoch"
         if [ "$fully_stored_streak" -ge "$FULLY_STORED_PATIENCE" ]; then
-            die "node_blob_data_fully_stored_ratio: persistent violation for ${FULLY_STORED_PATIENCE} consecutive rounds"
+            die "${FULLY_STORED_RATIO}: persistent violation for ${FULLY_STORED_PATIENCE} consecutive rounds"
         fi
     else
         fully_stored_streak=0
-        log "walrus_node_blob_data_fully_stored_ratio: OK"
-        print_metric_values "walrus_node_blob_data_fully_stored_ratio" "epoch"
+        log "${FULLY_STORED_RATIO}: OK"
+        print_metric_values "$FULLY_STORED_RATIO" "epoch"
     fi
 
     log "All checks passed for round ${round}"

--- a/docker/walrus-antithesis/build-test-config-image/files/run-observer.sh
+++ b/docker/walrus-antithesis/build-test-config-image/files/run-observer.sh
@@ -144,30 +144,29 @@ check_cross_node_metric() {
         done
     fi
 
-    # Step 3: Find labels present on ALL nodes (intersection).
-    #   We only compare a label if every node has reported it. This avoids false
-    #   positives when a node is lagging and hasn't computed a recent epoch yet.
-    #   Example: if nodes report epochs {1,2,3}, {1,2,3}, {1,2}, {1,2,3},
-    #   only epochs 1 and 2 are compared (present on all 4 nodes).
+    # Step 3: Find labels present on 2+ nodes.
+    #   A label is comparable as long as at least two nodes have reported it.
+    #   Nodes that haven't computed a given epoch yet are simply excluded from
+    #   that label's comparison.
     for i in "${!NODES[@]}"; do
         cut -f1 "$WORK_DIR/chk_${i}.tsv"
-    done | sort | uniq -c | awk -v n="$num_nodes" '$1 == n { print $2 }' \
+    done | sort | uniq -c | awk '$1 >= 2 { print $2 }' \
         > "$WORK_DIR/chk_common.txt"
 
     if [ ! -s "$WORK_DIR/chk_common.txt" ]; then
-        echo "-1"  # no common labels — nothing to compare
+        echo "-1"  # no label on 2+ nodes — nothing to compare
         return
     fi
 
-    # Step 4: For each common label, verify all nodes report the same value.
+    # Step 4: For each label, verify all nodes that have it report the same value.
     while IFS= read -r lbl; do
         [ -z "$lbl" ] && continue
         local ref_val="" mismatch=false
 
-        # Collect the value for this label from each node; compare to first node's value.
         for i in "${!NODES[@]}"; do
             local val
             val=$(awk -F'\t' -v l="$lbl" '$1 == l { print $2 }' "$WORK_DIR/chk_${i}.tsv")
+            [ -z "$val" ] && continue  # node doesn't have this label, skip
             if [ -z "$ref_val" ]; then
                 ref_val="$val"
             elif [ "$val" != "$ref_val" ]; then
@@ -175,14 +174,13 @@ check_cross_node_metric() {
             fi
         done
 
-        # Record the mismatch with per-node details for debugging.
         if [ "$mismatch" = true ]; then
             {
                 echo "  ${metric}{${label}=\"${lbl}\"}:"
                 for i in "${!NODES[@]}"; do
                     local val
                     val=$(awk -F'\t' -v l="$lbl" '$1 == l { print $2 }' "$WORK_DIR/chk_${i}.tsv")
-                    echo "    node-${i} (${NODES[$i]}): ${val}"
+                    echo "    node-${i} (${NODES[$i]}): ${val:-(absent)}"
                 done
             } >> "$details_file"
             violations=$((violations + 1))
@@ -288,6 +286,9 @@ while true; do
         log "WARNING: ${BLOB_INFO}: epoch bucket capacity reached" \
             "(${MAX_EPOCH_BUCKETS}), skipping comparison to avoid false positives from bucket reuse"
         print_metric_values "$BLOB_INFO" "epoch"
+    elif [ "$v" -eq -1 ]; then
+        log "${BLOB_INFO}: no common data across nodes, skipping comparison"
+        print_metric_values "$BLOB_INFO" "epoch"
     elif [ "$v" -gt 0 ]; then
         log "INVARIANT VIOLATION — ${BLOB_INFO} (${v} epoch(s)):"
         cat "$WORK_DIR/details_blob_info.txt"
@@ -308,6 +309,9 @@ while true; do
     if [ "$v" -eq -2 ]; then
         log "WARNING: ${PER_OBJECT_INFO}: epoch bucket capacity reached" \
             "(${MAX_EPOCH_BUCKETS}), skipping comparison to avoid false positives from bucket reuse"
+        print_metric_values "$PER_OBJECT_INFO" "epoch"
+    elif [ "$v" -eq -1 ]; then
+        log "${PER_OBJECT_INFO}: no common data across nodes, skipping comparison"
         print_metric_values "$PER_OBJECT_INFO" "epoch"
     elif [ "$v" -gt 0 ]; then
         log "INVARIANT VIOLATION — ${PER_OBJECT_INFO} (${v} epoch(s)):"

--- a/docker/walrus-antithesis/build-test-config-image/files/run-observer.sh
+++ b/docker/walrus-antithesis/build-test-config-image/files/run-observer.sh
@@ -16,15 +16,17 @@
 # Soft invariants (crash after persistent violation):
 #   - walrus_node_blob_data_fully_stored_ratio               — must equal 1 on every node/epoch
 #
-# Epoch bucket design:
-#   Storage nodes label consistency-check metrics with `epoch % 1000` (see
-#   EPOCH_BUCKET_COUNT in consistency_check.rs). This bounds Prometheus label
-#   cardinality while ensuring buckets are never reused within any realistic
-#   test duration. The observer compares all common epoch labels across nodes.
-#   If any node has more epoch labels than MAX_EPOCH_BUCKETS, we stop comparing
-#   and log a warning, because bucket reuse could cause false positives — a
-#   stale value from epoch N in the same bucket as epoch N+1000 looks like a
-#   data divergence even though the node simply hasn't updated yet.
+# Bucket design (same idea, two independent dimensions):
+#   - Per-epoch metrics (blob_info, per_object_blob_info, fully_stored_ratio) are
+#     labelled with `epoch % EPOCH_BUCKET_COUNT` (1000, in consistency_check.rs).
+#   - The event-source metric is labelled with
+#     `(event_index / NUM_EVENTS_PER_DIGEST_RECORDING) % NUM_DIGEST_BUCKETS`
+#     (1000, in node.rs) so recent recordings are retained per bucket.
+#   Both schemes bound Prometheus label cardinality. The observer compares all
+#   common labels across nodes. If any node exceeds MAX_EPOCH_BUCKETS or
+#   MAX_DIGEST_BUCKETS, we stop comparing and log a warning, because bucket
+#   reuse could cause false positives — a stale value in the same bucket as a
+#   newer one would look like a data divergence.
 
 set -euo pipefail
 
@@ -40,6 +42,10 @@ FULLY_STORED_PATIENCE="${FULLY_STORED_PATIENCE:-3}"
 # many epoch labels, buckets will start being reused and comparisons become
 # unreliable.
 MAX_EPOCH_BUCKETS="${MAX_EPOCH_BUCKETS:-1000}"
+# Must match NUM_DIGEST_BUCKETS in node.rs. When a node has this many event-source
+# bucket labels, the bucket counter is about to wrap and old recordings get
+# overwritten by new ones, which would look like cross-node divergence.
+MAX_DIGEST_BUCKETS="${MAX_DIGEST_BUCKETS:-1000}"
 
 WORK_DIR="/tmp/observer"
 mkdir -p "$WORK_DIR"
@@ -232,7 +238,7 @@ log "Cross-node invariant observer starting"
 log "Nodes: ${NODES[*]}, port: ${METRICS_PORT}"
 log "Check interval: ${CHECK_INTERVAL}s"
 log "Fully stored patience: ${FULLY_STORED_PATIENCE} rounds"
-log "Max epoch buckets: ${MAX_EPOCH_BUCKETS}"
+log "Max epoch buckets: ${MAX_EPOCH_BUCKETS}, max digest buckets: ${MAX_DIGEST_BUCKETS}"
 
 fully_stored_streak=0
 round=0
@@ -317,15 +323,22 @@ while true; do
 
     # ------------------------------------------------------------------
     # Hard invariant 3: event source must match across nodes.
-    # The metric is recorded every fixed batch of events. For a given
-    # bucket, either a node hasn't reached that batch (no data) or it
-    # has the final hash. check_cross_node_metric only compares labels
-    # present on ALL nodes, so lagging nodes are excluded automatically.
+    # The metric is recorded every NUM_EVENTS_PER_DIGEST_RECORDING events
+    # and stored under `bucket = (event_index / N_PER_RECORDING) %
+    # NUM_DIGEST_BUCKETS`. Within a single bucket generation, either a
+    # node hasn't reached that batch (no data) or it has the final hash,
+    # so common labels must match. We pass MAX_DIGEST_BUCKETS so that if
+    # nodes ever drift far enough for a bucket to wrap, we stop comparing
+    # rather than flag the stale collision as divergence.
     # ------------------------------------------------------------------
     v=$(check_cross_node_metric \
         "$EVENT_SOURCE" "bucket" \
-        "$WORK_DIR/details_event_source.txt")
-    if [ "$v" -eq -1 ]; then
+        "$WORK_DIR/details_event_source.txt" "$MAX_DIGEST_BUCKETS")
+    if [ "$v" -eq -2 ]; then
+        log "WARNING: ${EVENT_SOURCE}: bucket capacity reached" \
+            "(${MAX_DIGEST_BUCKETS}), skipping comparison to avoid false positives from bucket reuse"
+        print_metric_values "$EVENT_SOURCE" "bucket"
+    elif [ "$v" -eq -1 ]; then
         # No data yet — the metric is recorded every NUM_EVENTS_PER_DIGEST_RECORDING
         # events, which can take tens of minutes of cluster runtime. The observer
         # has no reliable way to know when "long enough" has elapsed (its own

--- a/docker/walrus-antithesis/build-test-config-image/files/run-observer.sh
+++ b/docker/walrus-antithesis/build-test-config-image/files/run-observer.sh
@@ -36,10 +36,6 @@ METRICS_PORT="${METRICS_PORT:-9184}"
 CHECK_INTERVAL="${CHECK_INTERVAL:-60}"
 # Consecutive rounds a soft-invariant violation must persist before crashing.
 FULLY_STORED_PATIENCE="${FULLY_STORED_PATIENCE:-3}"
-# Rounds before we escalate "no event source data" from info to warning.
-# Event source metric requires 2k events (~9 min). With 60s intervals,
-# 20 rounds ≈ 20 minutes — enough time for the metric to appear.
-EVENT_SOURCE_WARN_AFTER="${EVENT_SOURCE_WARN_AFTER:-20}"
 # Must match EPOCH_BUCKET_COUNT in consistency_check.rs. When a node has this
 # many epoch labels, buckets will start being reused and comparisons become
 # unreliable.
@@ -330,14 +326,11 @@ while true; do
         "$EVENT_SOURCE" "bucket" \
         "$WORK_DIR/details_event_source.txt")
     if [ "$v" -eq -1 ]; then
-        # No data yet — the metric is recorded every 2k events (~9 min).
-        if [ "$round" -lt "$EVENT_SOURCE_WARN_AFTER" ]; then
-            log "${EVENT_SOURCE}: no data yet" \
-                "(expected — metric requires ~2k events, round ${round}/${EVENT_SOURCE_WARN_AFTER})"
-        else
-            log "WARNING: ${EVENT_SOURCE}: still no data" \
-                "after ${round} rounds — expected by now, check event processing"
-        fi
+        # No data yet — the metric is recorded every NUM_EVENTS_PER_DIGEST_RECORDING
+        # events, which can take tens of minutes of cluster runtime. The observer
+        # has no reliable way to know when "long enough" has elapsed (its own
+        # lifetime resets on restart), so we just log absence and move on.
+        log "${EVENT_SOURCE}: no data yet"
         print_metric_values "$EVENT_SOURCE" "bucket"
     elif [ "$v" -gt 0 ]; then
         log "INVARIANT VIOLATION — ${EVENT_SOURCE} (${v} bucket(s)):"

--- a/docker/walrus-antithesis/build-test-config-image/files/run-observer.sh
+++ b/docker/walrus-antithesis/build-test-config-image/files/run-observer.sh
@@ -38,6 +38,12 @@ METRICS_PORT="${METRICS_PORT:-9184}"
 CHECK_INTERVAL="${CHECK_INTERVAL:-60}"
 # Consecutive rounds a soft-invariant violation must persist before crashing.
 FULLY_STORED_PATIENCE="${FULLY_STORED_PATIENCE:-3}"
+# Consecutive rounds a hard invariant can return "no common data across nodes"
+# before we treat it as a silent regression and fail. Without this, a bug that
+# stops the consistency-check metrics from being emitted would leave the observer
+# reporting success forever. The default is loose enough to tolerate cluster
+# warmup and the event-source metric's naturally long recording cadence.
+NO_DATA_PATIENCE="${NO_DATA_PATIENCE:-60}"
 # Must match EPOCH_BUCKET_COUNT in consistency_check.rs. When a node has this
 # many epoch labels, buckets will start being reused and comparisons become
 # unreliable.
@@ -197,14 +203,37 @@ check_cross_node_metric() {
 # epochs for any realistic test duration.  We only check the latest (highest)
 # epoch per node because older epochs are immutable snapshots — if the latest
 # epoch is healthy, earlier ones are too.
-# Echoes the number of violations.
+#
+# Arguments: details_file  [max_labels]
+# Echoes:
+#   -2  if any node's highest epoch label is nearing bucket wrap
+#    0  if all nodes' latest ratio is 1
+#   >0  number of nodes whose latest ratio is below 1
 # ---------------------------------------------------------------------------
 check_fully_stored_ratio() {
     local metric="$FULLY_STORED_RATIO"
     local details_file="$1"
+    local max_labels="${2:-0}"
     local violations=0
 
     : > "$details_file"
+
+    # Bail out if epoch labels are approaching bucket wraparound. After
+    # `epoch % EPOCH_BUCKET_COUNT` wraps, `sort -n | tail -1` no longer
+    # picks the latest real epoch — a stale value in a high-numbered bucket
+    # could be flagged repeatedly and trip the patience counter.
+    if [ "$max_labels" -gt 0 ]; then
+        local threshold=$((max_labels * 9 / 10))
+        for i in "${!NODES[@]}"; do
+            local highest
+            highest=$(extract_metric "$WORK_DIR/raw_${NODES[$i]}.prom" "$metric" "epoch" \
+                | cut -f1 | sort -n | tail -1)
+            if [ -n "$highest" ] && [ "$highest" -ge "$threshold" ]; then
+                echo "-2"
+                return
+            fi
+        done
+    fi
 
     for i in "${!NODES[@]}"; do
         # Find the highest epoch bucket on this node (numerically sorted).
@@ -238,9 +267,13 @@ log "Cross-node invariant observer starting"
 log "Nodes: ${NODES[*]}, port: ${METRICS_PORT}"
 log "Check interval: ${CHECK_INTERVAL}s"
 log "Fully stored patience: ${FULLY_STORED_PATIENCE} rounds"
+log "No-data patience (hard invariants): ${NO_DATA_PATIENCE} rounds"
 log "Max epoch buckets: ${MAX_EPOCH_BUCKETS}, max digest buckets: ${MAX_DIGEST_BUCKETS}"
 
 fully_stored_streak=0
+blob_info_no_data_streak=0
+per_object_no_data_streak=0
+event_source_no_data_streak=0
 round=0
 
 while true; do
@@ -285,14 +318,20 @@ while true; do
             "(${MAX_EPOCH_BUCKETS}), skipping comparison to avoid false positives from bucket reuse"
         print_metric_values "$BLOB_INFO" "epoch"
     elif [ "$v" -eq -1 ]; then
-        log "${BLOB_INFO}: no common data across nodes, skipping comparison"
+        blob_info_no_data_streak=$((blob_info_no_data_streak + 1))
+        log "${BLOB_INFO}: no common data across nodes" \
+            "(streak: ${blob_info_no_data_streak}/${NO_DATA_PATIENCE})"
         print_metric_values "$BLOB_INFO" "epoch"
+        if [ "$blob_info_no_data_streak" -ge "$NO_DATA_PATIENCE" ]; then
+            die "${BLOB_INFO}: no common data for ${NO_DATA_PATIENCE} consecutive rounds — likely silent regression"
+        fi
     elif [ "$v" -gt 0 ]; then
         log "INVARIANT VIOLATION — ${BLOB_INFO} (${v} epoch(s)):"
         cat "$WORK_DIR/details_blob_info.txt"
         print_metric_values "$BLOB_INFO" "epoch"
         die "${BLOB_INFO}: mismatched digests across nodes"
     else
+        blob_info_no_data_streak=0
         log "${BLOB_INFO}: OK"
         print_metric_values "$BLOB_INFO" "epoch"
     fi
@@ -309,14 +348,20 @@ while true; do
             "(${MAX_EPOCH_BUCKETS}), skipping comparison to avoid false positives from bucket reuse"
         print_metric_values "$PER_OBJECT_INFO" "epoch"
     elif [ "$v" -eq -1 ]; then
-        log "${PER_OBJECT_INFO}: no common data across nodes, skipping comparison"
+        per_object_no_data_streak=$((per_object_no_data_streak + 1))
+        log "${PER_OBJECT_INFO}: no common data across nodes" \
+            "(streak: ${per_object_no_data_streak}/${NO_DATA_PATIENCE})"
         print_metric_values "$PER_OBJECT_INFO" "epoch"
+        if [ "$per_object_no_data_streak" -ge "$NO_DATA_PATIENCE" ]; then
+            die "${PER_OBJECT_INFO}: no common data for ${NO_DATA_PATIENCE} consecutive rounds — likely silent regression"
+        fi
     elif [ "$v" -gt 0 ]; then
         log "INVARIANT VIOLATION — ${PER_OBJECT_INFO} (${v} epoch(s)):"
         cat "$WORK_DIR/details_per_object.txt"
         print_metric_values "$PER_OBJECT_INFO" "epoch"
         die "${PER_OBJECT_INFO}: mismatched digests across nodes"
     else
+        per_object_no_data_streak=0
         log "${PER_OBJECT_INFO}: OK"
         print_metric_values "$PER_OBJECT_INFO" "epoch"
     fi
@@ -342,15 +387,22 @@ while true; do
         # No data yet — the metric is recorded every NUM_EVENTS_PER_DIGEST_RECORDING
         # events, which can take tens of minutes of cluster runtime. The observer
         # has no reliable way to know when "long enough" has elapsed (its own
-        # lifetime resets on restart), so we just log absence and move on.
-        log "${EVENT_SOURCE}: no data yet"
+        # lifetime resets on restart), so we just log absence. If this persists
+        # for NO_DATA_PATIENCE rounds, treat it as a silent regression and die.
+        event_source_no_data_streak=$((event_source_no_data_streak + 1))
+        log "${EVENT_SOURCE}: no data yet" \
+            "(streak: ${event_source_no_data_streak}/${NO_DATA_PATIENCE})"
         print_metric_values "$EVENT_SOURCE" "bucket"
+        if [ "$event_source_no_data_streak" -ge "$NO_DATA_PATIENCE" ]; then
+            die "${EVENT_SOURCE}: no common data for ${NO_DATA_PATIENCE} consecutive rounds — likely silent regression"
+        fi
     elif [ "$v" -gt 0 ]; then
         log "INVARIANT VIOLATION — ${EVENT_SOURCE} (${v} bucket(s)):"
         cat "$WORK_DIR/details_event_source.txt"
         print_metric_values "$EVENT_SOURCE" "bucket"
         die "${EVENT_SOURCE}: mismatched values across nodes"
     else
+        event_source_no_data_streak=0
         log "${EVENT_SOURCE}: OK"
         print_metric_values "$EVENT_SOURCE" "bucket"
     fi
@@ -362,8 +414,13 @@ while true; do
     # Only the latest (highest) epoch bucket per node is checked — see
     # check_fully_stored_ratio for rationale.
     # ------------------------------------------------------------------
-    v=$(check_fully_stored_ratio "$WORK_DIR/details_fully_stored.txt")
-    if [ "$v" -gt 0 ]; then
+    v=$(check_fully_stored_ratio "$WORK_DIR/details_fully_stored.txt" "$MAX_EPOCH_BUCKETS")
+    if [ "$v" -eq -2 ]; then
+        log "WARNING: ${FULLY_STORED_RATIO}: epoch bucket capacity reached" \
+            "(${MAX_EPOCH_BUCKETS}), skipping check — latest-epoch heuristic is unreliable after wrap"
+        fully_stored_streak=0
+        print_metric_values "$FULLY_STORED_RATIO" "epoch"
+    elif [ "$v" -gt 0 ]; then
         fully_stored_streak=$((fully_stored_streak + 1))
         log "Fully-stored-ratio violation (streak: ${fully_stored_streak}/${FULLY_STORED_PATIENCE}):"
         cat "$WORK_DIR/details_fully_stored.txt"

--- a/docker/walrus-antithesis/build-test-config-image/files/run-observer.sh
+++ b/docker/walrus-antithesis/build-test-config-image/files/run-observer.sh
@@ -34,7 +34,6 @@ set -euo pipefail
 NODES=("10.0.0.10" "10.0.0.11" "10.0.0.12" "10.0.0.13")
 METRICS_PORT="${METRICS_PORT:-9184}"
 CHECK_INTERVAL="${CHECK_INTERVAL:-60}"
-INITIAL_WAIT="${INITIAL_WAIT:-180}"
 # Consecutive rounds a soft-invariant violation must persist before crashing.
 FULLY_STORED_PATIENCE="${FULLY_STORED_PATIENCE:-3}"
 # Rounds before we escalate "no event source data" from info to warning.
@@ -235,12 +234,9 @@ check_fully_stored_ratio() {
 # ---------------------------------------------------------------------------
 log "Cross-node invariant observer starting"
 log "Nodes: ${NODES[*]}, port: ${METRICS_PORT}"
-log "Check interval: ${CHECK_INTERVAL}s, initial wait: ${INITIAL_WAIT}s"
+log "Check interval: ${CHECK_INTERVAL}s"
 log "Fully stored patience: ${FULLY_STORED_PATIENCE} rounds"
 log "Max epoch buckets: ${MAX_EPOCH_BUCKETS}"
-
-log "Waiting ${INITIAL_WAIT}s for cluster stabilization..."
-sleep "$INITIAL_WAIT"
 
 fully_stored_streak=0
 round=0

--- a/docker/walrus-antithesis/build-test-config-image/files/run-observer.sh
+++ b/docker/walrus-antithesis/build-test-config-image/files/run-observer.sh
@@ -303,9 +303,6 @@ while true; do
         fi
     done
     if [ "$all_ok" = false ]; then
-        # Reset streak counter so that non-consecutive violations separated
-        # by unreachable rounds do not accumulate toward the patience threshold.
-        fully_stored_streak=0
         sleep "$CHECK_INTERVAL"
         continue
     fi

--- a/docker/walrus-antithesis/build-test-config-image/files/run-observer.sh
+++ b/docker/walrus-antithesis/build-test-config-image/files/run-observer.sh
@@ -38,9 +38,9 @@ INITIAL_WAIT="${INITIAL_WAIT:-180}"
 # Consecutive rounds a soft-invariant violation must persist before crashing.
 FULLY_STORED_PATIENCE="${FULLY_STORED_PATIENCE:-3}"
 # Rounds before we escalate "no event source data" from info to warning.
-# Event source metric requires 20k events (~1.5h). With 60s intervals,
-# 120 rounds ≈ 2 hours — enough time for the metric to appear.
-EVENT_SOURCE_WARN_AFTER="${EVENT_SOURCE_WARN_AFTER:-120}"
+# Event source metric requires 2k events (~9 min). With 60s intervals,
+# 20 rounds ≈ 20 minutes — enough time for the metric to appear.
+EVENT_SOURCE_WARN_AFTER="${EVENT_SOURCE_WARN_AFTER:-20}"
 # Must match EPOCH_BUCKET_COUNT in consistency_check.rs. When a node has this
 # many epoch labels, buckets will start being reused and comparisons become
 # unreliable.
@@ -334,10 +334,10 @@ while true; do
         "$EVENT_SOURCE" "bucket" \
         "$WORK_DIR/details_event_source.txt")
     if [ "$v" -eq -1 ]; then
-        # No data yet — the metric is recorded every 20k events (~1.5h).
+        # No data yet — the metric is recorded every 2k events (~9 min).
         if [ "$round" -lt "$EVENT_SOURCE_WARN_AFTER" ]; then
             log "${EVENT_SOURCE}: no data yet" \
-                "(expected — metric requires ~20k events, round ${round}/${EVENT_SOURCE_WARN_AFTER})"
+                "(expected — metric requires ~2k events, round ${round}/${EVENT_SOURCE_WARN_AFTER})"
         else
             log "WARNING: ${EVENT_SOURCE}: still no data" \
                 "after ${round} rounds — expected by now, check event processing"

--- a/docker/walrus-antithesis/build-test-config-image/files/run-observer.sh
+++ b/docker/walrus-antithesis/build-test-config-image/files/run-observer.sh
@@ -294,8 +294,8 @@ while true; do
         if scrape_node "${NODES[$i]}" "$WORK_DIR/raw_${NODES[$i]}.prom"; then
             log "Scraped node-${i} (${NODES[$i]})"
         else
-            local err_file="$WORK_DIR/raw_${NODES[$i]}.prom.err"
-            local err_msg=""
+            err_file="$WORK_DIR/raw_${NODES[$i]}.prom.err"
+            err_msg=""
             [ -s "$err_file" ] && err_msg=": $(tr '\n' ' ' <"$err_file" | head -c 200)"
             log "Cannot reach node-${i} (${NODES[$i]}), skipping round${err_msg}"
             all_ok=false

--- a/docker/walrus-antithesis/build-test-config-image/files/run-observer.sh
+++ b/docker/walrus-antithesis/build-test-config-image/files/run-observer.sh
@@ -82,11 +82,13 @@ print_metric_values() {
     done
 }
 
-# Scrape the /metrics endpoint of a storage node.
+# Scrape the /metrics endpoint of a storage node. On failure, curl's stderr
+# is captured into <out>.err so the caller can surface it for root-cause of a
+# skipped round (connection refused vs. timeout vs. DNS, etc.).
 scrape_node() {
     local ip="$1" out="$2"
     curl -sf --connect-timeout 5 --max-time 10 \
-        "http://${ip}:${METRICS_PORT}/metrics" > "$out" 2>/dev/null
+        "http://${ip}:${METRICS_PORT}/metrics" > "$out" 2>"${out}.err"
 }
 
 # Extract (label_value, metric_value) pairs from a Prometheus scrape file.
@@ -114,11 +116,15 @@ extract_metric() {
 # value is identical.  Writes per-violation details to a file.
 #
 # Arguments: metric_name  label_name  details_file  [max_labels]
-# Echoes:
+# Echoes (stdout, consumed by $(...) in caller):
 #   -2  if labels are nearing bucket saturation
 #   -1  if no common labels exist
 #    0  if all common labels match
 #   >0  number of mismatched label values
+#
+# Note: status is communicated via stdout echo rather than exit code because
+# callers use `v=$(...)` + `[ "$v" -eq N ]` comparisons. Don't add nonzero
+# `return` codes here without also updating every caller.
 # ---------------------------------------------------------------------------
 check_cross_node_metric() {
     local metric="$1" label="$2" details_file="$3"
@@ -288,7 +294,10 @@ while true; do
         if scrape_node "${NODES[$i]}" "$WORK_DIR/raw_${NODES[$i]}.prom"; then
             log "Scraped node-${i} (${NODES[$i]})"
         else
-            log "Cannot reach node-${i} (${NODES[$i]}), skipping round"
+            local err_file="$WORK_DIR/raw_${NODES[$i]}.prom.err"
+            local err_msg=""
+            [ -s "$err_file" ] && err_msg=": $(tr '\n' ' ' <"$err_file" | head -c 200)"
+            log "Cannot reach node-${i} (${NODES[$i]}), skipping round${err_msg}"
             all_ok=false
             break
         fi


### PR DESCRIPTION
## Description
Close WAL-1149

Adds a cross-node invariant observer container to Antithesis tests. It periodically scrapes Prometheus metrics from all storage nodes and crashes on data consistency violations, which Antithesis surfaces as test failures.

  Checks:
  - Blob info and per-object blob info digests match across nodes (hard invariant — crash immediately)
  - Event source position matches across nodes (hard invariant — crash immediately)
  - Fully-stored ratio equals 1.0 on each node's latest epoch (soft invariant — crash after 3 consecutive rounds)

Node-side changes

  - `NUM_EVENTS_PER_DIGEST_RECORDING`: 20_000 → 2_000. One event-source recording per ~9 min so a 3-hour test gets ~20 cross-check samples. Per-event overhead is a single modulo + occasional gauge write.
  - `NUM_DIGEST_BUCKETS`: 10 → 1_000. Prevents bucket reuse.
  - `EPOCH_BUCKET_COUNT`: 100 → 1_000 (in consistency_check.rs). Same rationale.

## Test plan
- Ran locally with pipeline.sh, all checks pass across multiple rounds
- Run in Antithesis and logs show checks work as expected

---
## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
