### PR TITLE
ci(docker): add build cache for antithesis local pipeline

### DIFF
--- a/docker/walrus-antithesis/build-test-config-image/pipeline.sh
+++ b/docker/walrus-antithesis/build-test-config-image/pipeline.sh
@@ -45,7 +45,7 @@ run-pipeline() {
   local_walrus_image="walrus-antithesis:$sui_version"
 
   export WALRUS_IMAGE_NAME="$local_walrus_image"
-  export SUI_IMAGE_NAME="mysten/sui-tools:$sui_version"
+  export SUI_IMAGE_NAME="$local_sui_image_name"
 
   export SUI_PLATFORM=linux/"$(uname -m)"
   export WALRUS_PLATFORM=linux/"$(uname -m)"

--- a/docker/walrus-antithesis/build-walrus-image-for-antithesis/Dockerfile
+++ b/docker/walrus-antithesis/build-walrus-image-for-antithesis/Dockerfile
@@ -11,7 +11,7 @@
 FROM rust:1.93-bookworm AS builder
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION
-WORKDIR "$WORKDIR/walrus"
+WORKDIR "/walrus"
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y cmake clang
@@ -48,24 +48,40 @@ ENV RUSTFLAGS="$RUSTFLAGS"
 # Build all binaries with Antithesis instrumentation
 ARG LD_LIBRARY_PATH="/usr/lib/libvoidstar.so"
 ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH"
-RUN LD_LIBRARY_PATH=$LD_LIBRARY_PATH \
+# Persist cargo registry, git deps, and target across docker build runs so repeat builds are incremental.
+# Cargo uses /usr/local/cargo/registry (crates.io) and /usr/local/cargo/git (git deps) by default during
+# `cargo build`; mounting them keeps downloaded deps across builds. /walrus/target holds the build output.
+# Cache mounts are NOT part of the image: their contents live in BuildKit's cache and are not
+# committed to any layer. So the next stage cannot COPY from /walrus/target (it would be empty).
+# We must copy binaries out of the mount into a normal directory in this same RUN:
+# - `cp` runs inside the container and can read from the mounted cache and write to /opt/walrus-binaries.
+# - /opt/walrus-binaries is a normal path, so it becomes part of this layer.
+# - The next stage uses COPY --from=builder /opt/walrus-binaries/... which reads from the image
+#   filesystem; COPY cannot see cache mount contents, only content that was written into the image.
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/walrus/target \
     cargo build \
     --profile release-antithesis \
     --target-dir=/walrus/target \
     --bin walrus \
     --bin walrus-node \
     --bin walrus-deploy \
-    --bin walrus-stress
-RUN find /walrus/target
+    --bin walrus-stress \
+    && mkdir -p /opt/walrus-binaries \
+    && cp /walrus/target/release-antithesis/walrus /walrus/target/release-antithesis/walrus-node \
+        /walrus/target/release-antithesis/walrus-deploy /walrus/target/release-antithesis/walrus-stress \
+        /opt/walrus-binaries/
 
 FROM debian:bookworm-slim AS setup
 
 RUN apt-get update && apt-get install -y ca-certificates curl git
-WORKDIR "$WORKDIR/walrus"
-COPY --from=builder /walrus/target/release-antithesis/walrus /opt/walrus/bin/walrus
-COPY --from=builder /walrus/target/release-antithesis/walrus-node /opt/walrus/bin/walrus-node
-COPY --from=builder /walrus/target/release-antithesis/walrus-deploy /opt/walrus/bin/walrus-deploy
-COPY --from=builder /walrus/target/release-antithesis/walrus-stress /opt/walrus/bin/walrus-stress
+WORKDIR "/walrus"
+# Copy binaries from the path we populated with `cp` in the builder (not from /walrus/target, which was a cache mount).
+COPY --from=builder /opt/walrus-binaries/walrus /opt/walrus/bin/walrus
+COPY --from=builder /opt/walrus-binaries/walrus-node /opt/walrus/bin/walrus-node
+COPY --from=builder /opt/walrus-binaries/walrus-deploy /opt/walrus/bin/walrus-deploy
+COPY --from=builder /opt/walrus-binaries/walrus-stress /opt/walrus/bin/walrus-stress
 RUN mkdir -p /symbols
 RUN ln -s /opt/walrus/bin/walrus /symbols/walrus
 RUN ln -s /opt/walrus/bin/walrus-node /symbols/walrus-node


### PR DESCRIPTION
## Description

Add cache mounts to the walrus-antithesis image build so that running the antithesis pipeline locally (`docker/walrus-antithesis/build-test-config-image/pipeline.sh`) does incremental rebuilds instead of a full `cargo build` every time. On my local machine, it reduces build time from 20 minutes to 2 minutes.

This is very helpful for verifying changes to antithesis test quickly while I am verifying the changes in https://github.com/MystenLabs/walrus/pull/3055.

## Test plan

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
