### PR TITLE
feat(walrus-sui): skip JSON-RPC client when fully migrated to gRPC

### DIFF
--- a/crates/walrus-sui/src/client/dual_client.rs
+++ b/crates/walrus-sui/src/client/dual_client.rs
@@ -36,7 +36,7 @@ use tonic::service::interceptor::InterceptedService;
 use walrus_core::ensure;
 
 use crate::{
-    client::SuiClientError,
+    client::{SuiClientError, retry_client::retriable_sui_client::GrpcMigrationLevel},
     coin::Coin,
     contracts::{AssociatedContractStruct, TypeOriginMap},
 };
@@ -96,17 +96,26 @@ pub(crate) struct CoinBatch {
 
 impl DualClient {
     /// Create a new DualClient with the given RPC URL and optional request timeout.
+    ///
+    /// When `WALRUS_GRPC_MIGRATION_LEVEL` is at its maximum, the JSON-RPC SuiClient is not
+    /// created. This allows connecting to gRPC-only nodes (e.g. sui-forking).
     pub async fn new(
         rpc_url: impl AsRef<str>,
         request_timeout: Option<Duration>,
     ) -> Result<Self, SuiClientError> {
-        let mut client_builder = SuiClientBuilder::default();
-        if let Some(request_timeout) = request_timeout {
-            client_builder = client_builder.request_timeout(request_timeout);
-        }
         let rpc_url = rpc_url.as_ref();
-        let sui_client = Some(client_builder.build(rpc_url).await?);
         let grpc_client = GrpcClient::new(rpc_url).context("unable to create grpc client")?;
+
+        let sui_client = if GrpcMigrationLevel::default().is_fully_migrated() {
+            None
+        } else {
+            let mut client_builder = SuiClientBuilder::default();
+            if let Some(request_timeout) = request_timeout {
+                client_builder = client_builder.request_timeout(request_timeout);
+            }
+            Some(client_builder.build(rpc_url).await?)
+        };
+
         Ok(Self {
             sui_client,
             grpc_client,

--- a/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
@@ -212,6 +212,14 @@ const GRPC_MIGRATION_LEVEL_BATCH_OBJECTS: GrpcMigrationLevel = GrpcMigrationLeve
 const GRPC_MIGRATION_LEVEL_SELECT_COINS: GrpcMigrationLevel = GrpcMigrationLevel(3);
 const GRPC_MIGRATION_LEVEL_GET_BALANCE: GrpcMigrationLevel = GrpcMigrationLevel(4);
 
+impl GrpcMigrationLevel {
+    /// Returns true if the migration level is high enough that all RPC calls use gRPC
+    /// and the JSON-RPC SuiClient is not needed.
+    pub fn is_fully_migrated(&self) -> bool {
+        *self >= GRPC_MIGRATION_LEVEL_GET_BALANCE
+    }
+}
+
 impl Default for GrpcMigrationLevel {
     fn default() -> Self {
         static VALUE: LazyLock<u32> = LazyLock::new(|| {


### PR DESCRIPTION
## Summary

Skip JSON-RPC `SuiClient` creation in `DualClient::new()` when `WALRUS_GRPC_MIGRATION_LEVEL >= 4`. Add `GrpcMigrationLevel::is_fully_migrated()` helper.

## Motivation

`sui-forking` only exposes gRPC — no JSON-RPC. `DualClient::new()` always calls `SuiClientBuilder::build()` which probes with `rpc.discover`, failing with 404 on gRPC-only nodes. This blocks using `site-builder` against forked networks.

The infrastructure was designed for this — the existing comment on `sui_client()` says: *"when the migration is complete, we will not create SuiClients."* This PR implements that.

Needed by: https://github.com/MystenLabs/walrus-sites/pull/690

## Test plan

- `WALRUS_GRPC_MIGRATION_LEVEL=4 site-builder publish` against `sui-forking` succeeds (previously 404)
- No behavior change when unset or < 4 (default is 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)