### PR TITLE
feat: fully enable storage pool support in storage node

### DIFF
--- a/crates/walrus-service/node_config_example.yaml
+++ b/crates/walrus-service/node_config_example.yaml
@@ -196,7 +196,6 @@ pending_metadata_cache:
   max_cached_entries: 1024
   cache_ttl: 60
 disable_event_blob_writer: false
-enable_storage_pool: true
 commission_rate: 6000
 voting_params:
   currency: FROST

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -751,7 +751,6 @@ impl StorageNode {
                 config.db_config.clone(),
                 MetricConf::new("storage"),
                 registry.clone(),
-                config.enable_storage_pool,
             )?
         };
         tracing::info!("successfully opened the node database");

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -287,12 +287,6 @@ pub struct StorageNodeConfig {
     /// Disable the event-blob writer
     #[serde(default, skip_serializing_if = "defaults::is_default")]
     pub disable_event_blob_writer: bool,
-    /// Whether to enable the per-object pooled blob info table for tracking pooled blobs.
-    // TODO(WAL-1184): this is a temporary configuration to enable the storage pool. Since in
-    // RocksDB, once a column family is created, it is hard to delete it. So adding this config
-    // during development to give us more flexibility in making changes.
-    #[serde(default, skip_serializing_if = "defaults::is_default")]
-    pub enable_storage_pool: bool,
     /// The commission rate of the storage node, in basis points.
     #[serde(default = "defaults::commission_rate")]
     pub commission_rate: u16,
@@ -373,7 +367,6 @@ impl StorageNodeConfig {
                 ..Default::default()
             },
             db_config: DatabaseConfig::default_mainnet(),
-            enable_storage_pool: false,
             ..Default::default()
         }
     }
@@ -381,7 +374,6 @@ impl StorageNodeConfig {
     /// Returns the default configuration for the testnet network.
     pub fn default_testnet() -> Self {
         Self {
-            enable_storage_pool: false,
             ..Default::default()
         }
     }
@@ -535,7 +527,6 @@ impl Default for StorageNodeConfig {
                 max_checkpoint_lag: 1500,
             },
             disable_event_blob_writer: Default::default(),
-            enable_storage_pool: true,
             commission_rate: defaults::commission_rate(),
             voting_params: VotingParamsConfig {
                 voting_prices: VotingPrices {
@@ -617,16 +608,6 @@ impl StorageNodeConfig {
         let config: StorageNodeConfig = serde_yaml::from_value(merged_value.clone())
             .with_context(|| format!("unable to deserialize merged config: {merged_value:?}",))?;
         config.validate()?;
-
-        // TODO(WAL-1184): remove this check when rolling out storage pool.
-        if config.enable_storage_pool
-            && matches!(network_kind, NetworkKind::Mainnet | NetworkKind::Testnet)
-        {
-            anyhow::bail!(
-                "enable_storage_pool cannot be set to true on {network_kind:?}; \
-                storage pool DB tables are still under development and subject to change"
-            );
-        }
 
         Ok(LoadedConfig {
             config_path: path.to_path_buf(),
@@ -2324,31 +2305,6 @@ mod tests {
                 loaded_config.config.live_upload_deferral.enabled,
                 expected_defaults.live_upload_deferral.enabled,
                 "default-only values are preserved"
-            );
-        }
-        Ok(())
-    }
-
-    #[test]
-    fn load_config_rejects_storage_pool_on_mainnet_and_testnet() -> TestResult {
-        let mainnet_ids = contract_ids_from_yaml(MAINNET_CLIENT_CONFIG_YAML);
-        let testnet_ids = contract_ids_from_yaml(TESTNET_CLIENT_CONFIG_YAML);
-
-        let dir = TempDir::new()?;
-        for (label, ids) in [("mainnet", mainnet_ids), ("testnet", testnet_ids)] {
-            let yaml = base_user_yaml_with_sui(
-                ids.system_object,
-                ids.staking_object,
-                "enable_storage_pool: true",
-            );
-            let config_path = dir.path().join(format!("node-{label}.yaml"));
-            std::fs::write(&config_path, &yaml)?;
-
-            let err = StorageNodeConfig::load_config(&config_path)
-                .expect_err("should reject enable_storage_pool on {label}");
-            assert!(
-                err.to_string().contains("enable_storage_pool"),
-                "error message should mention enable_storage_pool, got: {err}"
             );
         }
         Ok(())

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -214,7 +214,6 @@ impl Storage {
         db_config: DatabaseConfig,
         metrics_config: MetricConf,
         metrics_registry: Registry,
-        enable_storage_pool: bool,
     ) -> Result<Self, anyhow::Error> {
         let mut db_opts = Options::from(&db_config.global);
         db_opts.create_missing_column_families(true);
@@ -263,8 +262,7 @@ impl Storage {
         let node_status_options = db_table_opts_factory.node_status();
         let metadata_options = db_table_opts_factory.metadata();
         let metadata_cf_name = metadata_cf_name();
-        let blob_info_column_families =
-            BlobInfoTable::options(&db_table_opts_factory, enable_storage_pool);
+        let blob_info_column_families = BlobInfoTable::options(&db_table_opts_factory);
         let (event_cursor_cf_name, event_cursor_options) =
             EventCursorTable::options(&db_table_opts_factory);
         let garbage_collector_table_cf_name = garbage_collector_table_cf_name();
@@ -342,7 +340,7 @@ impl Storage {
         )?;
 
         let event_cursor = EventCursorTable::reopen(&database)?;
-        let blob_info = BlobInfoTable::reopen(&database, enable_storage_pool)?;
+        let blob_info = BlobInfoTable::reopen(&database)?;
         let shards = Arc::new(RwLock::new(
             existing_shards_ids
                 .into_iter()
@@ -1794,7 +1792,6 @@ pub(crate) mod tests {
                 DatabaseConfig::default(),
                 MetricConf::default(),
                 Registry::default(),
-                true,
             )?;
 
             for shard_id in [SHARD_INDEX, OTHER_SHARD_INDEX] {
@@ -1834,7 +1831,6 @@ pub(crate) mod tests {
                 DatabaseConfig::default(),
                 MetricConf::default(),
                 Registry::default(),
-                true,
             )?;
 
             // Check that the shard status is restored correctly.
@@ -1961,7 +1957,6 @@ pub(crate) mod tests {
                 DatabaseConfig::default(),
                 MetricConf::default(),
                 Registry::default(),
-                true,
             )?;
 
             // Check shard files exist.
@@ -1981,7 +1976,6 @@ pub(crate) mod tests {
                 DatabaseConfig::default(),
                 MetricConf::default(),
                 Registry::default(),
-                true,
             )?;
 
             // Reload storage and the shard should not exist.

--- a/crates/walrus-service/src/node/storage/blob_info.rs
+++ b/crates/walrus-service/src/node/storage/blob_info.rs
@@ -79,10 +79,8 @@ pub type PerObjectBlobInfoIterator<'a> = BlobInfoIter<
 pub(super) struct BlobInfoTable {
     aggregate_blob_info: DBMap<BlobId, BlobInfo>,
     per_object_blob_info: DBMap<ObjectID, PerObjectBlobInfo>,
-    // TODO(WAL-1184): make this non-optional.
-    per_object_pooled_blob_info: Option<DBMap<ObjectID, PerObjectPooledBlobInfo>>,
-    // TODO(WAL-1184): make this non-optional.
-    storage_pool_info: Option<DBMap<ObjectID, StoragePoolInfo>>,
+    per_object_pooled_blob_info: DBMap<ObjectID, PerObjectPooledBlobInfo>,
+    storage_pool_info: DBMap<ObjectID, StoragePoolInfo>,
     latest_handled_event_index: Arc<Mutex<DBMap<(), u64>>>,
 }
 
@@ -135,10 +133,7 @@ pub(crate) fn storage_pool_info_cf_options(
 }
 
 impl BlobInfoTable {
-    pub fn reopen(
-        database: &Arc<RocksDB>,
-        enable_storage_pool: bool,
-    ) -> Result<Self, TypedStoreError> {
+    pub fn reopen(database: &Arc<RocksDB>) -> Result<Self, TypedStoreError> {
         let aggregate_blob_info = DBMap::reopen(
             database,
             Some(constants::aggregate_blob_info_cf_name()),
@@ -151,26 +146,18 @@ impl BlobInfoTable {
             &ReadWriteOptions::default(),
             false,
         )?;
-        let per_object_pooled_blob_info = if enable_storage_pool {
-            Some(DBMap::reopen(
-                database,
-                Some(constants::per_object_pooled_blob_info_cf_name()),
-                &ReadWriteOptions::default(),
-                false,
-            )?)
-        } else {
-            None
-        };
-        let storage_pool_info = if enable_storage_pool {
-            Some(DBMap::reopen(
-                database,
-                Some(constants::storage_pool_info_cf_name()),
-                &ReadWriteOptions::default(),
-                false,
-            )?)
-        } else {
-            None
-        };
+        let per_object_pooled_blob_info = DBMap::reopen(
+            database,
+            Some(constants::per_object_pooled_blob_info_cf_name()),
+            &ReadWriteOptions::default(),
+            false,
+        )?;
+        let storage_pool_info = DBMap::reopen(
+            database,
+            Some(constants::storage_pool_info_cf_name()),
+            &ReadWriteOptions::default(),
+            false,
+        )?;
         let latest_handled_event_index = Arc::new(Mutex::new(DBMap::reopen(
             database,
             Some(constants::event_index_cf_name()),
@@ -190,12 +177,8 @@ impl BlobInfoTable {
     pub fn clear(&self) -> Result<(), TypedStoreError> {
         self.aggregate_blob_info.schedule_delete_all()?;
         self.per_object_blob_info.schedule_delete_all()?;
-        if let Some(pooled) = &self.per_object_pooled_blob_info {
-            pooled.schedule_delete_all()?;
-        }
-        if let Some(pool_info) = &self.storage_pool_info {
-            pool_info.schedule_delete_all()?;
-        }
+        self.per_object_pooled_blob_info.schedule_delete_all()?;
+        self.storage_pool_info.schedule_delete_all()?;
         self.latest_handled_event_index
             .lock()
             .expect("mutex should not be poisoned")
@@ -206,9 +189,8 @@ impl BlobInfoTable {
 
     pub fn options(
         db_table_opts_factory: &DatabaseTableOptionsFactory,
-        enable_storage_pool: bool,
     ) -> Vec<(&'static str, Options)> {
-        let mut cfs = vec![
+        vec![
             (
                 constants::aggregate_blob_info_cf_name(),
                 blob_info_cf_options(db_table_opts_factory),
@@ -223,18 +205,15 @@ impl BlobInfoTable {
                 // value.
                 db_table_opts_factory.standard(),
             ),
-        ];
-        if enable_storage_pool {
-            cfs.push((
+            (
                 constants::per_object_pooled_blob_info_cf_name(),
                 per_object_pooled_blob_info_cf_options(db_table_opts_factory),
-            ));
-            cfs.push((
+            ),
+            (
                 constants::storage_pool_info_cf_name(),
                 storage_pool_info_cf_options(db_table_opts_factory),
-            ));
-        }
-        cfs
+            ),
+        ]
     }
 
     /// Updates the blob info for a blob based on the [`BlobEvent`].
@@ -295,34 +274,22 @@ impl BlobInfoTable {
                 batch.delete_batch(&self.per_object_blob_info, [(object_id)])?;
             }
 
-            // Pooled blob events update the per-object pooled blob info table.
-            //
-            // The table must exist (i.e., storage pools must be enabled) when processing these
-            // events. Receiving a pooled blob event without the table means the node
-            // configuration is inconsistent with the on-chain state, so we panic to avoid
-            // silently dropping events.
             BlobEvent::PooledBlobRegistered(e) => {
-                let table = self.per_object_pooled_blob_info.as_ref().expect(
-                    "received a pooled blob event but the per-object pooled blob info table \
-                    is not enabled",
-                );
                 let operand = PerObjectPooledBlobInfoMergeOperand::from(e);
-                batch.partial_merge_batch(table, [(&e.object_id, operand.to_bytes())])?;
+                batch.partial_merge_batch(
+                    &self.per_object_pooled_blob_info,
+                    [(&e.object_id, operand.to_bytes())],
+                )?;
             }
             BlobEvent::PooledBlobCertified(e) => {
-                let table = self.per_object_pooled_blob_info.as_ref().expect(
-                    "received a pooled blob event but the per-object pooled blob info table \
-                    is not enabled",
-                );
                 let operand = PerObjectPooledBlobInfoMergeOperand::from(e);
-                batch.partial_merge_batch(table, [(&e.object_id, operand.to_bytes())])?;
+                batch.partial_merge_batch(
+                    &self.per_object_pooled_blob_info,
+                    [(&e.object_id, operand.to_bytes())],
+                )?;
             }
             BlobEvent::PooledBlobDeleted(e) => {
-                let table = self.per_object_pooled_blob_info.as_ref().expect(
-                    "received a pooled blob event but the per-object pooled blob info table \
-                    is not enabled",
-                );
-                batch.delete_batch(table, [(&e.object_id)])?;
+                batch.delete_batch(&self.per_object_pooled_blob_info, [(&e.object_id)])?;
             }
 
             BlobEvent::InvalidBlobID(_) | BlobEvent::DenyListBlobDeleted(_) => {}
@@ -568,10 +535,7 @@ impl BlobInfoTable {
         &self,
         object_id: &ObjectID,
     ) -> Result<Option<PerObjectPooledBlobInfo>, TypedStoreError> {
-        match &self.per_object_pooled_blob_info {
-            Some(table) => table.get(object_id),
-            None => Ok(None),
-        }
+        self.per_object_pooled_blob_info.get(object_id)
     }
 
     /// Updates the storage pool info based on a [`StoragePoolEvent`].
@@ -592,33 +556,27 @@ impl BlobInfoTable {
             return Ok(());
         }
 
-        if let Some(table) = &self.storage_pool_info {
-            let (storage_pool_id, operand) = match event {
-                StoragePoolEvent::StoragePoolCreated(created) => (
-                    &created.storage_pool_id,
-                    StoragePoolInfoMergeOperand::Create {
-                        start_epoch: created.start_epoch,
-                        end_epoch: created.end_epoch,
-                    },
-                ),
-                StoragePoolEvent::StoragePoolExtended(extended) => (
-                    &extended.storage_pool_id,
-                    StoragePoolInfoMergeOperand::Extend {
-                        end_epoch: extended.new_end_epoch,
-                    },
-                ),
-            };
+        let (storage_pool_id, operand) = match event {
+            StoragePoolEvent::StoragePoolCreated(created) => (
+                &created.storage_pool_id,
+                StoragePoolInfoMergeOperand::Create {
+                    start_epoch: created.start_epoch,
+                    end_epoch: created.end_epoch,
+                },
+            ),
+            StoragePoolEvent::StoragePoolExtended(extended) => (
+                &extended.storage_pool_id,
+                StoragePoolInfoMergeOperand::Extend {
+                    end_epoch: extended.new_end_epoch,
+                },
+            ),
+        };
 
-            let mut batch = table.batch();
-            batch.partial_merge_batch(table, [(storage_pool_id, operand.to_bytes())])?;
-            batch.insert_batch(&latest_handled_event_index, [(&(), event_index)])?;
-            batch.write()?;
-        } else {
-            panic!(
-                "we received a storage pool event but the storage pool info table is not enabled: \
-                {event:?}"
-            );
-        }
+        let table = &self.storage_pool_info;
+        let mut batch = table.batch();
+        batch.partial_merge_batch(table, [(storage_pool_id, operand.to_bytes())])?;
+        batch.insert_batch(&latest_handled_event_index, [(&(), event_index)])?;
+        batch.write()?;
         Ok(())
     }
 
@@ -647,10 +605,6 @@ impl BlobInfoTable {
         node_metrics: &NodeMetricSet,
         batch_size: usize,
     ) -> anyhow::Result<()> {
-        if self.storage_pool_info.is_none() {
-            return Ok(());
-        }
-
         tracing::info!("starting to garbage collect expired storage pool info");
         let start_time = Instant::now();
 
@@ -689,10 +643,7 @@ impl BlobInfoTable {
         current_epoch: Epoch,
         node_metrics: &NodeMetricSet,
     ) -> anyhow::Result<utils::BatchProcessingResult<ObjectID>> {
-        let table = self
-            .storage_pool_info
-            .as_ref()
-            .context("storage pool info table is not enabled")?;
+        let table = &self.storage_pool_info;
 
         let mut modified_count = 0;
         let mut total_count = 0;
@@ -917,10 +868,6 @@ impl BlobInfoTable {
         node_metrics: &NodeMetricSet,
         batch_size: usize,
     ) -> anyhow::Result<()> {
-        if self.per_object_pooled_blob_info.is_none() {
-            return Ok(());
-        }
-
         tracing::info!("starting to garbage collect expired pooled blob objects");
         let start_time = Instant::now();
 
@@ -964,14 +911,8 @@ impl BlobInfoTable {
         node_metrics: &NodeMetricSet,
         pool_expired_cache: &mut HashMap<ObjectID, bool>,
     ) -> anyhow::Result<utils::BatchProcessingResult<ObjectID>> {
-        let pooled_table = self
-            .per_object_pooled_blob_info
-            .as_ref()
-            .context("per-object pooled blob info table is not enabled")?;
-        let pool_info_table = self
-            .storage_pool_info
-            .as_ref()
-            .context("storage pool info table is not enabled")?;
+        let pooled_table = &self.per_object_pooled_blob_info;
+        let pool_info_table = &self.storage_pool_info;
 
         let mut modified_count = 0;
         let mut total_count = 0;
@@ -1180,8 +1121,9 @@ impl BlobInfoTable {
 
         // Also collect blob IDs from the pooled table, tracking per-blob-id counts.
         let mut pooled_counts: HashMap<BlobId, (u32, u32)> = HashMap::new();
-        if let Some(pooled_table) = &self.per_object_pooled_blob_info {
-            for result in pooled_table
+        {
+            for result in self
+                .per_object_pooled_blob_info
                 .safe_iter_with_snapshot(&snapshot)
                 .context("failed to create per-object pooled blob info snapshot iterator")?
             {
@@ -1338,10 +1280,7 @@ impl BlobInfoTable {
         &self,
         storage_pool_id: &ObjectID,
     ) -> Result<Option<StoragePoolInfo>, TypedStoreError> {
-        match &self.storage_pool_info {
-            Some(table) => table.get(storage_pool_id),
-            None => Ok(None),
-        }
+        self.storage_pool_info.get(storage_pool_id)
     }
 }
 

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -3306,7 +3306,6 @@ pub fn storage_node_config() -> WithTempDir<StorageNodeConfig> {
             event_processor_config: Default::default(),
             pending_sliver_cache: Default::default(),
             disable_event_blob_writer: false,
-            enable_storage_pool: true,
             commission_rate: 0,
             voting_params: VotingParamsConfig {
                 voting_prices: VotingPrices {
@@ -3372,7 +3371,6 @@ pub async fn empty_storage_with_shards(shards: &[ShardIndex]) -> WithTempDir<Sto
         db_config,
         MetricConf::default(),
         Registry::default(),
-        true,
     )
     .expect("storage creation must succeed");
 

--- a/crates/walrus-service/src/testbed.rs
+++ b/crates/walrus-service/src/testbed.rs
@@ -735,7 +735,6 @@ pub async fn create_storage_node_configs(
             pending_sliver_cache: Default::default(),
             pending_metadata_cache: Default::default(),
             disable_event_blob_writer,
-            enable_storage_pool: true,
             commission_rate: node.commission_rate,
             voting_params: VotingParamsConfig {
                 voting_prices: VotingPrices {


### PR DESCRIPTION
## Description

This PR fully enables storage pool support in storage node, which includes on disk state changes that may not be easily
reversable:

- Remove the enable_storage_pool configuration option entirely so storage nodes can never disable storage pool DB tables once deployed
- Make per_object_pooled_blob_info and storage_pool_info fields in BlobInfoTable non-optional (DBMap instead of Option<DBMap>), simplifying all access sites
- Remove the mainnet/testnet guard that rejected enable_storage_pool: true and its corresponding test

Close WAL-1184

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [x] Storage node: enable storage pool support in storage node
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
