### PR TITLE
perf: offload blocking RocksDB reads from tokio runtime

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -4709,20 +4709,27 @@ impl ServiceState for StorageNodeInner {
         let latest_checkpoint_sequence_number =
             self.event_manager.latest_checkpoint_sequence_number();
 
+        let (node_status, event_progress) = {
+            let storage = self.storage.clone();
+            tokio::task::spawn_blocking(move || {
+                let node_status = storage
+                    .node_status()
+                    .expect("fetching node status should not fail");
+                let event_progress = storage
+                    .get_event_cursor_progress()
+                    .expect("get cursor progress should not fail");
+                (node_status, event_progress)
+            })
+            .await
+            .expect("spawn_blocking task panicked")
+        };
+
         ServiceHealthInfo {
             uptime: self.start_time.elapsed(),
             epoch: self.current_committee_epoch(),
             public_key: self.public_key().clone(),
-            node_status: self
-                .storage
-                .node_status()
-                .expect("fetching node status should not fail")
-                .to_string(),
-            event_progress: self
-                .storage
-                .get_event_cursor_progress()
-                .expect("get cursor progress should not fail")
-                .into(),
+            node_status: node_status.to_string(),
+            event_progress: event_progress.into(),
             shard_detail,
             shard_summary,
             latest_checkpoint_sequence_number,

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -364,10 +364,7 @@ pub trait ServiceState {
     > + Send;
 
     /// Retrieves the blob status for the given `blob_id`.
-    fn blob_status(
-        &self,
-        blob_id: &BlobId,
-    ) -> impl Future<Output = Result<BlobStatus, BlobStatusError>> + Send;
+    fn blob_status(&self, blob_id: &BlobId) -> Result<BlobStatus, BlobStatusError>;
 
     /// Returns the number of shards the node is currently operating with.
     fn n_shards(&self) -> NonZeroU16;
@@ -3325,7 +3322,7 @@ impl StorageNodeInner {
         }
 
         let pending = self.pending_metadata_cache.get(blob_id).await;
-        let is_registered = self.is_blob_registered(blob_id).await?;
+        let is_registered = self.is_blob_registered(blob_id)?;
 
         match (pending, is_registered, allow_pending) {
             (Some(metadata), _, _) => Ok((metadata, false)),
@@ -3482,15 +3479,12 @@ impl StorageNodeInner {
         Ok(())
     }
 
-    async fn is_blob_registered(&self, blob_id: &BlobId) -> Result<bool, anyhow::Error> {
-        let storage = self.storage.clone();
-        let blob_id = *blob_id;
-        let blob_info = tokio::task::spawn_blocking(move || storage.get_blob_info(&blob_id))
-            .map(unwrap_or_resume_unwind)
-            .await
-            .context("could not retrieve blob info")?;
-        let epoch = self.current_committee_epoch();
-        Ok(blob_info.is_some_and(|blob_info| blob_info.is_registered(epoch)))
+    fn is_blob_registered(&self, blob_id: &BlobId) -> Result<bool, anyhow::Error> {
+        Ok(self
+            .storage
+            .get_blob_info(blob_id)
+            .context("could not retrieve blob info")?
+            .is_some_and(|blob_info| blob_info.is_registered(self.current_committee_epoch())))
     }
 
     fn notify_registration(&self, blob_id: &BlobId) {
@@ -3502,13 +3496,13 @@ impl StorageNodeInner {
         // blob scoped, so it can return `true` due to registration of a different object that
         // references the same `BlobId`.
         if timeout.is_zero() {
-            return self.is_blob_registered(blob_id).await.unwrap_or(false);
+            return self.is_blob_registered(blob_id).unwrap_or(false);
         }
 
         let notify = self.registration_notifier.acquire(blob_id);
         let notified = notify.notified();
 
-        if self.is_blob_registered(blob_id).await.unwrap_or(false) {
+        if self.is_blob_registered(blob_id).unwrap_or(false) {
             return true;
         }
 
@@ -3528,7 +3522,7 @@ impl StorageNodeInner {
         }
 
         match tokio::time::timeout(timeout, notified).await {
-            Ok(()) => self.is_blob_registered(blob_id).await.unwrap_or(false),
+            Ok(()) => self.is_blob_registered(blob_id).unwrap_or(false),
             Err(_) => false,
         }
     }
@@ -3575,7 +3569,7 @@ impl StorageNodeInner {
     }
 
     /// Common validation for blob operations
-    async fn validate_blob_access<E>(
+    fn validate_blob_access<E>(
         &self,
         blob_id: &BlobId,
         forbidden_error: E,
@@ -3585,7 +3579,7 @@ impl StorageNodeInner {
         E: From<anyhow::Error>,
     {
         ensure!(!self.is_blocked(blob_id), forbidden_error);
-        ensure!(self.is_blob_registered(blob_id).await?, unavailable_error,);
+        ensure!(self.is_blob_registered(blob_id)?, unavailable_error,);
         Ok(())
     }
 
@@ -3849,7 +3843,7 @@ impl StorageNodeInner {
         blob_id: BlobId,
         defer_duration: std::time::Duration,
     ) -> Result<(), SetRecoveryDeferralError> {
-        let is_registered = self.is_blob_registered(&blob_id).await.map_err(|error| {
+        let is_registered = self.is_blob_registered(&blob_id).map_err(|error| {
             tracing::warn!(
                 walrus.blob_id = %blob_id,
                 ?error,
@@ -4136,10 +4130,7 @@ impl ServiceState for StorageNode {
             .retrieve_multiple_decoding_symbols(blob_id, target_slivers, target_type)
     }
 
-    fn blob_status(
-        &self,
-        blob_id: &BlobId,
-    ) -> impl Future<Output = Result<BlobStatus, BlobStatusError>> + Send {
+    fn blob_status(&self, blob_id: &BlobId) -> Result<BlobStatus, BlobStatusError> {
         self.inner.blob_status(blob_id)
     }
 
@@ -4197,8 +4188,7 @@ impl ServiceState for StorageNodeInner {
             blob_id,
             RetrieveMetadataError::Forbidden,
             RetrieveMetadataError::Unavailable,
-        )
-        .await?;
+        )?;
 
         let storage = self.storage.clone();
         let blob_id = *blob_id;
@@ -4222,13 +4212,10 @@ impl ServiceState for StorageNodeInner {
     ) -> Result<bool, StoreMetadataError> {
         let blob_id = *metadata.blob_id();
 
-        let blob_info = {
-            let storage = self.storage.clone();
-            tokio::task::spawn_blocking(move || storage.get_blob_info(&blob_id))
-                .map(unwrap_or_resume_unwind)
-                .await
-                .context("could not retrieve blob info")?
-        };
+        let blob_info = self
+            .storage
+            .get_blob_info(&blob_id)
+            .context("could not retrieve blob info")?;
 
         if let Some(event) = blob_info
             .as_ref()
@@ -4293,7 +4280,7 @@ impl ServiceState for StorageNodeInner {
             return Ok(false);
         }
 
-        if self.is_blob_registered(&blob_id).await? {
+        if self.is_blob_registered(&blob_id)? {
             // Read the blob info again because registration can race between the initial blob_info
             // check and adding to the cache. Flush immediately in that case so the pending metadata
             // doesn’t linger indefinitely.
@@ -4336,8 +4323,7 @@ impl ServiceState for StorageNodeInner {
             blob_id,
             RetrieveSliverError::Forbidden,
             RetrieveSliverError::Unavailable,
-        )
-        .await?;
+        )?;
 
         self.retrieve_sliver_unchecked(blob_id, sliver_pair_index, sliver_type)
             .await
@@ -4408,7 +4394,7 @@ impl ServiceState for StorageNodeInner {
                     inserted,
                     "store_sliver: buffered sliver in pending cache"
                 );
-                if self.is_blob_registered(&blob_id).await? {
+                if self.is_blob_registered(&blob_id)? {
                     // Registration may arrive between the initial registration check and the point
                     // where we enqueue the sliver. If it does, flush everything immediately so the
                     // data doesn’t stay buffered without another trigger.
@@ -4437,7 +4423,7 @@ impl ServiceState for StorageNodeInner {
         blob_persistence_type: &BlobPersistenceType,
     ) -> Result<StorageConfirmation, ComputeStorageConfirmationError> {
         ensure!(
-            self.is_blob_registered(blob_id).await?,
+            self.is_blob_registered(blob_id)?,
             ComputeStorageConfirmationError::NotCurrentlyRegistered,
         );
 
@@ -4516,14 +4502,11 @@ impl ServiceState for StorageNodeInner {
         self.wait_for_registration_inner(blob_id, timeout)
     }
 
-    async fn blob_status(&self, blob_id: &BlobId) -> Result<BlobStatus, BlobStatusError> {
-        let storage = self.storage.clone();
-        let blob_id = *blob_id;
-        let blob_info = tokio::task::spawn_blocking(move || storage.get_blob_info(&blob_id))
-            .map(unwrap_or_resume_unwind)
-            .await
-            .context("could not retrieve blob info")?;
-        Ok(blob_info
+    fn blob_status(&self, blob_id: &BlobId) -> Result<BlobStatus, BlobStatusError> {
+        Ok(self
+            .storage
+            .get_blob_info(blob_id)
+            .context("could not retrieve blob info")?
             .map(|blob_info| blob_info.to_blob_status(self.current_committee_epoch()))
             .unwrap_or_default())
     }
@@ -4556,7 +4539,6 @@ impl ServiceState for StorageNodeInner {
             RetrieveSliverError::Forbidden,
             RetrieveSliverError::Unavailable,
         )
-        .await
         .map_err(RetrieveSymbolError::RetrieveSliver)?;
 
         let encoding_type = self
@@ -4630,7 +4612,6 @@ impl ServiceState for StorageNodeInner {
             RetrieveSliverError::Forbidden,
             RetrieveSliverError::Unavailable,
         )
-        .await
         .map_err(RetrieveSymbolError::RetrieveSliver)?;
 
         if target_sliver_indexes.is_empty() {
@@ -5415,7 +5396,7 @@ mod tests {
             status_event,
             is_certified,
             ..
-        } = node.as_ref().blob_status(&BLOB_ID).await?
+        } = node.as_ref().blob_status(&BLOB_ID)?
         else {
             panic!("got nonexistent blob status")
         };
@@ -5652,7 +5633,7 @@ mod tests {
             .await?;
 
         assert!(matches!(
-            node.as_ref().blob_status(&BLOB_ID).await,
+            node.as_ref().blob_status(&BLOB_ID),
             Ok(BlobStatus::Nonexistent)
         ));
 
@@ -9940,8 +9921,7 @@ mod tests {
             cluster.nodes[0]
                 .storage_node
                 .inner
-                .is_blob_registered(blob_details.blob_id())
-                .await?
+                .is_blob_registered(blob_details.blob_id())?
         );
 
         Ok(())

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -4709,27 +4709,20 @@ impl ServiceState for StorageNodeInner {
         let latest_checkpoint_sequence_number =
             self.event_manager.latest_checkpoint_sequence_number();
 
-        let (node_status, event_progress) = {
-            let storage = self.storage.clone();
-            tokio::task::spawn_blocking(move || {
-                let node_status = storage
-                    .node_status()
-                    .expect("fetching node status should not fail");
-                let event_progress = storage
-                    .get_event_cursor_progress()
-                    .expect("get cursor progress should not fail");
-                (node_status, event_progress)
-            })
-            .await
-            .expect("spawn_blocking task panicked")
-        };
-
         ServiceHealthInfo {
             uptime: self.start_time.elapsed(),
             epoch: self.current_committee_epoch(),
             public_key: self.public_key().clone(),
-            node_status: node_status.to_string(),
-            event_progress: event_progress.into(),
+            node_status: self
+                .storage
+                .node_status()
+                .expect("fetching node status should not fail")
+                .to_string(),
+            event_progress: self
+                .storage
+                .get_event_cursor_progress()
+                .expect("get cursor progress should not fail")
+                .into(),
             shard_detail,
             shard_summary,
             latest_checkpoint_sequence_number,

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -3464,12 +3464,12 @@ impl StorageNodeInner {
         shard_map_lock: StorageShardLock,
     ) -> Result<(), anyhow::Error> {
         let this = self.clone();
-        tokio::task::spawn_blocking(move || async move {
+        tokio::task::spawn_blocking(move || {
             this.storage
                 .create_storage_for_shards_locked(shard_map_lock, &new_shards)
         })
         .in_current_span()
-        .await?
+        .map(unwrap_or_resume_unwind)
         .await?;
         Ok(())
     }

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -282,7 +282,7 @@ pub trait ServiceState {
     fn retrieve_metadata(
         &self,
         blob_id: &BlobId,
-    ) -> Result<VerifiedBlobMetadataWithId, RetrieveMetadataError>;
+    ) -> impl Future<Output = Result<VerifiedBlobMetadataWithId, RetrieveMetadataError>> + Send;
 
     /// Stores the metadata associated with a blob.
     ///
@@ -297,7 +297,7 @@ pub trait ServiceState {
     fn metadata_status(
         &self,
         blob_id: &BlobId,
-    ) -> Result<StoredOnNodeStatus, RetrieveMetadataError>;
+    ) -> impl Future<Output = Result<StoredOnNodeStatus, RetrieveMetadataError>> + Send;
 
     /// Retrieves a primary or secondary sliver for a blob for a shard held by this storage node.
     fn retrieve_sliver(
@@ -364,7 +364,10 @@ pub trait ServiceState {
     > + Send;
 
     /// Retrieves the blob status for the given `blob_id`.
-    fn blob_status(&self, blob_id: &BlobId) -> Result<BlobStatus, BlobStatusError>;
+    fn blob_status(
+        &self,
+        blob_id: &BlobId,
+    ) -> impl Future<Output = Result<BlobStatus, BlobStatusError>> + Send;
 
     /// Returns the number of shards the node is currently operating with.
     fn n_shards(&self) -> NonZeroU16;
@@ -2629,7 +2632,13 @@ impl StorageNodeInner {
             return;
         }
 
-        let deferral_from_size = match self.storage.get_metadata(&blob_id) {
+        let metadata_result = {
+            let storage = self.storage.clone();
+            tokio::task::spawn_blocking(move || storage.get_metadata(&blob_id))
+                .await
+                .expect("spawn_blocking task panicked")
+        };
+        let deferral_from_size = match metadata_result {
             Ok(Some(metadata)) => {
                 let size = metadata.as_ref().unencoded_length();
                 self.deferral_for_unencoded_size(size).inspect(|&duration| {
@@ -3022,7 +3031,14 @@ impl StorageNodeInner {
     ) -> Result<BlobMetadataWithId<true>, TypedStoreError> {
         tracing::debug!(%blob_id, "check blob metadata existence");
 
-        if let Some(metadata) = self.storage.get_metadata(blob_id)? {
+        let existing = {
+            let storage = self.storage.clone();
+            let blob_id = *blob_id;
+            tokio::task::spawn_blocking(move || storage.get_metadata(&blob_id))
+                .await
+                .expect("spawn_blocking task panicked")?
+        };
+        if let Some(metadata) = existing {
             tracing::debug!(%blob_id, "not syncing metadata: already stored");
             return Ok(metadata);
         }
@@ -3252,11 +3268,15 @@ impl StorageNodeInner {
         blob_id: &BlobId,
         verified: Arc<VerifiedBlobMetadataWithId>,
     ) -> Result<bool, StoreMetadataError> {
-        if self
-            .storage
-            .has_metadata(blob_id)
-            .context("could not check metadata existence")?
-        {
+        let has_metadata = {
+            let storage = self.storage.clone();
+            let blob_id = *blob_id;
+            tokio::task::spawn_blocking(move || storage.has_metadata(&blob_id))
+                .await
+                .expect("spawn_blocking task panicked")
+                .context("could not check metadata existence")?
+        };
+        if has_metadata {
             return Ok(false);
         }
 
@@ -3286,16 +3306,20 @@ impl StorageNodeInner {
         blob_id: &BlobId,
         allow_pending: bool,
     ) -> Result<(Arc<VerifiedBlobMetadataWithId>, bool), StoreSliverError> {
-        let persisted = self
-            .storage
-            .get_metadata(blob_id)
-            .context("database error when storing sliver")?;
+        let persisted = {
+            let storage = self.storage.clone();
+            let blob_id = *blob_id;
+            tokio::task::spawn_blocking(move || storage.get_metadata(&blob_id))
+                .await
+                .expect("spawn_blocking task panicked")
+                .context("database error when storing sliver")?
+        };
         if let Some(metadata) = persisted {
             return Ok((Arc::new(metadata), true));
         }
 
         let pending = self.pending_metadata_cache.get(blob_id).await;
-        let is_registered = self.is_blob_registered(blob_id)?;
+        let is_registered = self.is_blob_registered(blob_id).await?;
 
         match (pending, is_registered, allow_pending) {
             (Some(metadata), _, _) => Ok((metadata, false)),
@@ -3308,11 +3332,15 @@ impl StorageNodeInner {
         &self,
         blob_id: &BlobId,
     ) -> Result<(), StoreMetadataError> {
-        if self
-            .storage
-            .has_metadata(blob_id)
-            .context("could not check metadata existence")?
-        {
+        let has_metadata = {
+            let storage = self.storage.clone();
+            let blob_id = *blob_id;
+            tokio::task::spawn_blocking(move || storage.has_metadata(&blob_id))
+                .await
+                .expect("spawn_blocking task panicked")
+                .context("could not check metadata existence")?
+        };
+        if has_metadata {
             return Ok(());
         }
 
@@ -3379,12 +3407,16 @@ impl StorageNodeInner {
         }
 
         if self.pending_sliver_cache.has_blob(blob_id).await {
-            let metadata = match self
-                .storage
-                .get_metadata(blob_id)
-                .context("unable to fetch metadata while flushing pending slivers")
-                .map_err(|error| PendingCacheError::Sliver(StoreSliverError::Internal(error)))?
-            {
+            let persisted = {
+                let storage = self.storage.clone();
+                let blob_id = *blob_id;
+                tokio::task::spawn_blocking(move || storage.get_metadata(&blob_id))
+                    .await
+                    .expect("spawn_blocking task panicked")
+                    .context("unable to fetch metadata while flushing pending slivers")
+                    .map_err(|error| PendingCacheError::Sliver(StoreSliverError::Internal(error)))?
+            };
+            let metadata = match persisted {
                 Some(metadata) => Arc::new(metadata),
                 None => return Err(PendingCacheError::Sliver(StoreSliverError::MissingMetadata)),
             };
@@ -3442,12 +3474,15 @@ impl StorageNodeInner {
         Ok(())
     }
 
-    fn is_blob_registered(&self, blob_id: &BlobId) -> Result<bool, anyhow::Error> {
-        Ok(self
-            .storage
-            .get_blob_info(blob_id)
-            .context("could not retrieve blob info")?
-            .is_some_and(|blob_info| blob_info.is_registered(self.current_committee_epoch())))
+    async fn is_blob_registered(&self, blob_id: &BlobId) -> Result<bool, anyhow::Error> {
+        let storage = self.storage.clone();
+        let blob_id = *blob_id;
+        let blob_info = tokio::task::spawn_blocking(move || storage.get_blob_info(&blob_id))
+            .await
+            .expect("spawn_blocking task panicked")
+            .context("could not retrieve blob info")?;
+        let epoch = self.current_committee_epoch();
+        Ok(blob_info.is_some_and(|blob_info| blob_info.is_registered(epoch)))
     }
 
     fn notify_registration(&self, blob_id: &BlobId) {
@@ -3459,13 +3494,13 @@ impl StorageNodeInner {
         // blob scoped, so it can return `true` due to registration of a different object that
         // references the same `BlobId`.
         if timeout.is_zero() {
-            return self.is_blob_registered(blob_id).unwrap_or(false);
+            return self.is_blob_registered(blob_id).await.unwrap_or(false);
         }
 
         let notify = self.registration_notifier.acquire(blob_id);
         let notified = notify.notified();
 
-        if self.is_blob_registered(blob_id).unwrap_or(false) {
+        if self.is_blob_registered(blob_id).await.unwrap_or(false) {
             return true;
         }
 
@@ -3485,7 +3520,7 @@ impl StorageNodeInner {
         }
 
         match tokio::time::timeout(timeout, notified).await {
-            Ok(()) => self.is_blob_registered(blob_id).unwrap_or(false),
+            Ok(()) => self.is_blob_registered(blob_id).await.unwrap_or(false),
             Err(_) => false,
         }
     }
@@ -3503,6 +3538,9 @@ impl StorageNodeInner {
     /// If an error occurs while retrieving the blob info, this returns `false`. The intention
     /// is that if this is used to cancel a blob sync or to delete blob data, we need to be *sure*
     /// that the blob is not certified.
+    ///
+    /// Note: This is intentionally kept synchronous because it is called from within rayon
+    /// `par_iter_mut` in `cancel_syncs`, which already runs off the tokio runtime.
     fn is_blob_not_certified(&self, blob_id: &BlobId) -> bool {
         if let Ok(false) = self.is_blob_certified(blob_id) {
             return true;
@@ -3527,7 +3565,7 @@ impl StorageNodeInner {
     }
 
     /// Common validation for blob operations
-    fn validate_blob_access<E>(
+    async fn validate_blob_access<E>(
         &self,
         blob_id: &BlobId,
         forbidden_error: E,
@@ -3537,7 +3575,7 @@ impl StorageNodeInner {
         E: From<anyhow::Error>,
     {
         ensure!(!self.is_blocked(blob_id), forbidden_error);
-        ensure!(self.is_blob_registered(blob_id)?, unavailable_error,);
+        ensure!(self.is_blob_registered(blob_id).await?, unavailable_error,);
         Ok(())
     }
 
@@ -3727,7 +3765,7 @@ impl StorageNodeInner {
         Ok(output)
     }
 
-    fn get_encoding_type_for_blob(
+    async fn get_encoding_type_for_blob(
         &self,
         blob_id: &BlobId,
     ) -> Result<Option<EncodingType>, TypedStoreError> {
@@ -3737,10 +3775,17 @@ impl StorageNodeInner {
             // encoding type from the database. If the metadata is otherwise available, then the
             // encoding type is available there and this function should not be used, otherwise, a
             // database call may be required.
-            _ => self
-                .storage
-                .get_metadata(blob_id)
-                .map(|option| option.map(|metadata| metadata.metadata().encoding_type())),
+            _ => {
+                let storage = self.storage.clone();
+                let blob_id = *blob_id;
+                tokio::task::spawn_blocking(move || {
+                    storage
+                        .get_metadata(&blob_id)
+                        .map(|option| option.map(|metadata| metadata.metadata().encoding_type()))
+                })
+                .await
+                .expect("spawn_blocking task panicked")
+            }
         }
     }
 
@@ -3794,7 +3839,7 @@ impl StorageNodeInner {
         blob_id: BlobId,
         defer_duration: std::time::Duration,
     ) -> Result<(), SetRecoveryDeferralError> {
-        let is_registered = self.is_blob_registered(&blob_id).map_err(|error| {
+        let is_registered = self.is_blob_registered(&blob_id).await.map_err(|error| {
             tracing::warn!(
                 walrus.blob_id = %blob_id,
                 ?error,
@@ -3991,7 +4036,8 @@ impl ServiceState for StorageNode {
     fn retrieve_metadata(
         &self,
         blob_id: &BlobId,
-    ) -> Result<VerifiedBlobMetadataWithId, RetrieveMetadataError> {
+    ) -> impl Future<Output = Result<VerifiedBlobMetadataWithId, RetrieveMetadataError>> + Send
+    {
         self.inner.retrieve_metadata(blob_id)
     }
 
@@ -4006,7 +4052,7 @@ impl ServiceState for StorageNode {
     fn metadata_status(
         &self,
         blob_id: &BlobId,
-    ) -> Result<StoredOnNodeStatus, RetrieveMetadataError> {
+    ) -> impl Future<Output = Result<StoredOnNodeStatus, RetrieveMetadataError>> + Send {
         self.inner.metadata_status(blob_id)
     }
 
@@ -4080,7 +4126,10 @@ impl ServiceState for StorageNode {
             .retrieve_multiple_decoding_symbols(blob_id, target_slivers, target_type)
     }
 
-    fn blob_status(&self, blob_id: &BlobId) -> Result<BlobStatus, BlobStatusError> {
+    fn blob_status(
+        &self,
+        blob_id: &BlobId,
+    ) -> impl Future<Output = Result<BlobStatus, BlobStatusError>> + Send {
         self.inner.blob_status(blob_id)
     }
 
@@ -4118,7 +4167,7 @@ impl ServiceState for StorageNode {
 }
 
 impl ServiceState for StorageNodeInner {
-    fn retrieve_metadata(
+    async fn retrieve_metadata(
         &self,
         blob_id: &BlobId,
     ) -> Result<VerifiedBlobMetadataWithId, RetrieveMetadataError> {
@@ -4138,13 +4187,18 @@ impl ServiceState for StorageNodeInner {
             blob_id,
             RetrieveMetadataError::Forbidden,
             RetrieveMetadataError::Unavailable,
-        )?;
+        )
+        .await?;
 
-        self.storage
-            .get_metadata(blob_id)
+        let storage = self.storage.clone();
+        let blob_id = *blob_id;
+        let metadata = tokio::task::spawn_blocking(move || storage.get_metadata(&blob_id))
+            .await
+            .expect("spawn_blocking task panicked")
             .context("database error when retrieving metadata")?
-            .ok_or(RetrieveMetadataError::Unavailable)
-            .inspect(|_| self.metrics.metadata_retrieved_total.inc())
+            .ok_or(RetrieveMetadataError::Unavailable)?;
+        self.metrics.metadata_retrieved_total.inc();
+        Ok(metadata)
     }
 
     /// Stores metadata for a blob.
@@ -4158,10 +4212,13 @@ impl ServiceState for StorageNodeInner {
     ) -> Result<bool, StoreMetadataError> {
         let blob_id = *metadata.blob_id();
 
-        let blob_info = self
-            .storage
-            .get_blob_info(&blob_id)
-            .context("could not retrieve blob info")?;
+        let blob_info = {
+            let storage = self.storage.clone();
+            tokio::task::spawn_blocking(move || storage.get_blob_info(&blob_id))
+                .await
+                .expect("spawn_blocking task panicked")
+                .context("could not retrieve blob info")?
+        };
 
         if let Some(event) = blob_info
             .as_ref()
@@ -4170,11 +4227,14 @@ impl ServiceState for StorageNodeInner {
             return Err(StoreMetadataError::InvalidBlob(event));
         }
 
-        if self
-            .storage
-            .has_metadata(&blob_id)
-            .context("could not check metadata existence")?
-        {
+        let has_metadata = {
+            let storage = self.storage.clone();
+            tokio::task::spawn_blocking(move || storage.has_metadata(&blob_id))
+                .await
+                .expect("spawn_blocking task panicked")
+                .context("could not check metadata existence")?
+        };
+        if has_metadata {
             return Ok(false);
         }
 
@@ -4223,7 +4283,7 @@ impl ServiceState for StorageNodeInner {
             return Ok(false);
         }
 
-        if self.is_blob_registered(&blob_id)? {
+        if self.is_blob_registered(&blob_id).await? {
             // Read the blob info again because registration can race between the initial blob_info
             // check and adding to the cache. Flush immediately in that case so the pending metadata
             // doesn’t linger indefinitely.
@@ -4238,11 +4298,16 @@ impl ServiceState for StorageNodeInner {
         Ok(true)
     }
 
-    fn metadata_status(
+    async fn metadata_status(
         &self,
         blob_id: &BlobId,
     ) -> Result<StoredOnNodeStatus, RetrieveMetadataError> {
-        match self.storage.has_metadata(blob_id) {
+        let storage = self.storage.clone();
+        let blob_id = *blob_id;
+        match tokio::task::spawn_blocking(move || storage.has_metadata(&blob_id))
+            .await
+            .expect("spawn_blocking task panicked")
+        {
             Ok(true) => Ok(StoredOnNodeStatus::Stored),
             Ok(false) => Ok(StoredOnNodeStatus::Nonexistent),
             Err(err) => Err(RetrieveMetadataError::Internal(err.into())),
@@ -4261,7 +4326,8 @@ impl ServiceState for StorageNodeInner {
             blob_id,
             RetrieveSliverError::Forbidden,
             RetrieveSliverError::Unavailable,
-        )?;
+        )
+        .await?;
 
         self.retrieve_sliver_unchecked(blob_id, sliver_pair_index, sliver_type)
             .await
@@ -4332,7 +4398,7 @@ impl ServiceState for StorageNodeInner {
                     inserted,
                     "store_sliver: buffered sliver in pending cache"
                 );
-                if self.is_blob_registered(&blob_id)? {
+                if self.is_blob_registered(&blob_id).await? {
                     // Registration may arrive between the initial registration check and the point
                     // where we enqueue the sliver. If it does, flush everything immediately so the
                     // data doesn’t stay buffered without another trigger.
@@ -4361,7 +4427,7 @@ impl ServiceState for StorageNodeInner {
         blob_persistence_type: &BlobPersistenceType,
     ) -> Result<StorageConfirmation, ComputeStorageConfirmationError> {
         ensure!(
-            self.is_blob_registered(blob_id)?,
+            self.is_blob_registered(blob_id).await?,
             ComputeStorageConfirmationError::NotCurrentlyRegistered,
         );
 
@@ -4382,31 +4448,47 @@ impl ServiceState for StorageNodeInner {
         );
 
         if let BlobPersistenceType::Deletable { object_id } = blob_persistence_type {
-            let sui_object_id = object_id.into();
+            let sui_object_id: sui_types::base_types::ObjectID = object_id.into();
 
             // Check the regular per-object table first.
-            if let Some(per_object_info) = self
-                .storage
-                .get_per_object_info(&sui_object_id)
-                .context("database error when checking per object info")?
-            {
+            let per_object_info = {
+                let storage = self.storage.clone();
+                let oid = sui_object_id;
+                tokio::task::spawn_blocking(move || storage.get_per_object_info(&oid))
+                    .await
+                    .expect("spawn_blocking task panicked")
+                    .context("database error when checking per object info")?
+            };
+            if let Some(per_object_info) = per_object_info {
                 ensure!(
                     per_object_info.is_registered(self.current_committee_epoch()),
                     ComputeStorageConfirmationError::NotCurrentlyRegistered,
                 );
-            } else if self
-                .storage
-                .get_per_object_pooled_info(&sui_object_id)
-                .context("database error when checking per object pooled info")?
-                .is_some()
-            {
-                // Entry exists in the pooled blob table — the blob is active.
-                // Deleted pooled blobs are removed from the table entirely, so presence implies
-                // the blob is registered.
-                // TODO(WAL-1174): check the expiration of the pool here once the storage pool
-                // end-epoch table is implemented.
             } else {
-                return Err(ComputeStorageConfirmationError::NotCurrentlyRegistered);
+                let has_pooled_info = {
+                    let storage = self.storage.clone();
+                    let oid = sui_object_id;
+                    tokio::task::spawn_blocking(move || {
+                        storage.get_per_object_pooled_info(&oid)
+                    })
+                    .await
+                    .expect("spawn_blocking task panicked")
+                    .context(
+                        "database error when checking per object pooled info",
+                    )?
+                    .is_some()
+                };
+                if has_pooled_info {
+                    // Entry exists in the pooled blob table — the blob is active.
+                    // Deleted pooled blobs are removed from the table entirely, so
+                    // presence implies the blob is registered.
+                    // TODO(WAL-1174): check the expiration of the pool here once the
+                    // storage pool end-epoch table is implemented.
+                } else {
+                    return Err(
+                        ComputeStorageConfirmationError::NotCurrentlyRegistered,
+                    );
+                }
             }
         }
 
@@ -4430,11 +4512,14 @@ impl ServiceState for StorageNodeInner {
         self.wait_for_registration_inner(blob_id, timeout)
     }
 
-    fn blob_status(&self, blob_id: &BlobId) -> Result<BlobStatus, BlobStatusError> {
-        Ok(self
-            .storage
-            .get_blob_info(blob_id)
-            .context("could not retrieve blob info")?
+    async fn blob_status(&self, blob_id: &BlobId) -> Result<BlobStatus, BlobStatusError> {
+        let storage = self.storage.clone();
+        let blob_id = *blob_id;
+        let blob_info = tokio::task::spawn_blocking(move || storage.get_blob_info(&blob_id))
+            .await
+            .expect("spawn_blocking task panicked")
+            .context("could not retrieve blob info")?;
+        Ok(blob_info
             .map(|blob_info| blob_info.to_blob_status(self.current_committee_epoch()))
             .unwrap_or_default())
     }
@@ -4444,7 +4529,7 @@ impl ServiceState for StorageNodeInner {
         blob_id: &BlobId,
         inconsistency_proof: InconsistencyProof,
     ) -> Result<InvalidBlobIdAttestation, InconsistencyProofError> {
-        let metadata = self.retrieve_metadata(blob_id)?;
+        let metadata = self.retrieve_metadata(blob_id).await?;
 
         inconsistency_proof.verify(metadata.as_ref(), &self.encoding_config)?;
 
@@ -4467,10 +4552,12 @@ impl ServiceState for StorageNodeInner {
             RetrieveSliverError::Forbidden,
             RetrieveSliverError::Unavailable,
         )
+        .await
         .map_err(RetrieveSymbolError::RetrieveSliver)?;
 
         let encoding_type = self
             .get_encoding_type_for_blob(blob_id)
+            .await
             .context("could not retrieve blob encoding type")?
             .ok_or_else(|| anyhow!("encoding type unavailable for blob {:?}", blob_id))?;
 
@@ -4539,6 +4626,7 @@ impl ServiceState for StorageNodeInner {
             RetrieveSliverError::Forbidden,
             RetrieveSliverError::Unavailable,
         )
+        .await
         .map_err(RetrieveSymbolError::RetrieveSliver)?;
 
         if target_sliver_indexes.is_empty() {
@@ -5316,7 +5404,7 @@ mod tests {
             status_event,
             is_certified,
             ..
-        } = node.as_ref().blob_status(&BLOB_ID)?
+        } = node.as_ref().blob_status(&BLOB_ID).await?
         else {
             panic!("got nonexistent blob status")
         };
@@ -5537,7 +5625,8 @@ mod tests {
         let metadata_status = storage_node
             .as_ref()
             .inner
-            .metadata_status(metadata.blob_id())?;
+            .metadata_status(metadata.blob_id())
+            .await?;
         assert_eq!(metadata_status, StoredOnNodeStatus::Stored);
         Ok(())
     }
@@ -5552,7 +5641,7 @@ mod tests {
             .await?;
 
         assert!(matches!(
-            node.as_ref().blob_status(&BLOB_ID),
+            node.as_ref().blob_status(&BLOB_ID).await,
             Ok(BlobStatus::Nonexistent)
         ));
 
@@ -8626,6 +8715,7 @@ mod tests {
                     .storage_node
                     .inner
                     .blob_status(&OTHER_BLOB_ID)
+                    .await
                     .expect("getting blob status should succeed"),
                 BlobStatus::Nonexistent
             );
@@ -9839,7 +9929,8 @@ mod tests {
             cluster.nodes[0]
                 .storage_node
                 .inner
-                .is_blob_registered(blob_details.blob_id())?
+                .is_blob_registered(blob_details.blob_id())
+                .await?
         );
 
         Ok(())

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -4468,15 +4468,11 @@ impl ServiceState for StorageNodeInner {
                 let has_pooled_info = {
                     let storage = self.storage.clone();
                     let oid = sui_object_id;
-                    tokio::task::spawn_blocking(move || {
-                        storage.get_per_object_pooled_info(&oid)
-                    })
-                    .map(unwrap_or_resume_unwind)
-                    .await
-                    .context(
-                        "database error when checking per object pooled info",
-                    )?
-                    .is_some()
+                    tokio::task::spawn_blocking(move || storage.get_per_object_pooled_info(&oid))
+                        .map(unwrap_or_resume_unwind)
+                        .await
+                        .context("database error when checking per object pooled info")?
+                        .is_some()
                 };
                 if has_pooled_info {
                     // Entry exists in the pooled blob table — the blob is active.
@@ -4485,9 +4481,7 @@ impl ServiceState for StorageNodeInner {
                     // TODO(WAL-1174): check the expiration of the pool here once the
                     // storage pool end-epoch table is implemented.
                 } else {
-                    return Err(
-                        ComputeStorageConfirmationError::NotCurrentlyRegistered,
-                    );
+                    return Err(ComputeStorageConfirmationError::NotCurrentlyRegistered);
                 }
             }
         }

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -176,7 +176,7 @@ use self::{
     system_events::EventManager,
 };
 use crate::{
-    common::config::SuiConfig,
+    common::{config::SuiConfig, utils::unwrap_or_resume_unwind},
     event::{
         event_blob_downloader::{EventBlobDownloader, LastCertifiedEventBlob},
         event_processor::{
@@ -2635,8 +2635,8 @@ impl StorageNodeInner {
         let metadata_result = {
             let storage = self.storage.clone();
             tokio::task::spawn_blocking(move || storage.get_metadata(&blob_id))
+                .map(unwrap_or_resume_unwind)
                 .await
-                .expect("spawn_blocking task panicked")
         };
         let deferral_from_size = match metadata_result {
             Ok(Some(metadata)) => {
@@ -3035,8 +3035,8 @@ impl StorageNodeInner {
             let storage = self.storage.clone();
             let blob_id = *blob_id;
             tokio::task::spawn_blocking(move || storage.get_metadata(&blob_id))
-                .await
-                .expect("spawn_blocking task panicked")?
+                .map(unwrap_or_resume_unwind)
+                .await?
         };
         if let Some(metadata) = existing {
             tracing::debug!(%blob_id, "not syncing metadata: already stored");
@@ -3272,8 +3272,8 @@ impl StorageNodeInner {
             let storage = self.storage.clone();
             let blob_id = *blob_id;
             tokio::task::spawn_blocking(move || storage.has_metadata(&blob_id))
+                .map(unwrap_or_resume_unwind)
                 .await
-                .expect("spawn_blocking task panicked")
                 .context("could not check metadata existence")?
         };
         if has_metadata {
@@ -3310,8 +3310,8 @@ impl StorageNodeInner {
             let storage = self.storage.clone();
             let blob_id = *blob_id;
             tokio::task::spawn_blocking(move || storage.get_metadata(&blob_id))
+                .map(unwrap_or_resume_unwind)
                 .await
-                .expect("spawn_blocking task panicked")
                 .context("database error when storing sliver")?
         };
         if let Some(metadata) = persisted {
@@ -3336,8 +3336,8 @@ impl StorageNodeInner {
             let storage = self.storage.clone();
             let blob_id = *blob_id;
             tokio::task::spawn_blocking(move || storage.has_metadata(&blob_id))
+                .map(unwrap_or_resume_unwind)
                 .await
-                .expect("spawn_blocking task panicked")
                 .context("could not check metadata existence")?
         };
         if has_metadata {
@@ -3411,8 +3411,8 @@ impl StorageNodeInner {
                 let storage = self.storage.clone();
                 let blob_id = *blob_id;
                 tokio::task::spawn_blocking(move || storage.get_metadata(&blob_id))
+                    .map(unwrap_or_resume_unwind)
                     .await
-                    .expect("spawn_blocking task panicked")
                     .context("unable to fetch metadata while flushing pending slivers")
                     .map_err(|error| PendingCacheError::Sliver(StoreSliverError::Internal(error)))?
             };
@@ -3478,8 +3478,8 @@ impl StorageNodeInner {
         let storage = self.storage.clone();
         let blob_id = *blob_id;
         let blob_info = tokio::task::spawn_blocking(move || storage.get_blob_info(&blob_id))
+            .map(unwrap_or_resume_unwind)
             .await
-            .expect("spawn_blocking task panicked")
             .context("could not retrieve blob info")?;
         let epoch = self.current_committee_epoch();
         Ok(blob_info.is_some_and(|blob_info| blob_info.is_registered(epoch)))
@@ -3783,8 +3783,8 @@ impl StorageNodeInner {
                         .get_metadata(&blob_id)
                         .map(|option| option.map(|metadata| metadata.metadata().encoding_type()))
                 })
+                .map(unwrap_or_resume_unwind)
                 .await
-                .expect("spawn_blocking task panicked")
             }
         }
     }
@@ -4193,8 +4193,8 @@ impl ServiceState for StorageNodeInner {
         let storage = self.storage.clone();
         let blob_id = *blob_id;
         let metadata = tokio::task::spawn_blocking(move || storage.get_metadata(&blob_id))
+            .map(unwrap_or_resume_unwind)
             .await
-            .expect("spawn_blocking task panicked")
             .context("database error when retrieving metadata")?
             .ok_or(RetrieveMetadataError::Unavailable)?;
         self.metrics.metadata_retrieved_total.inc();
@@ -4215,8 +4215,8 @@ impl ServiceState for StorageNodeInner {
         let blob_info = {
             let storage = self.storage.clone();
             tokio::task::spawn_blocking(move || storage.get_blob_info(&blob_id))
+                .map(unwrap_or_resume_unwind)
                 .await
-                .expect("spawn_blocking task panicked")
                 .context("could not retrieve blob info")?
         };
 
@@ -4230,8 +4230,8 @@ impl ServiceState for StorageNodeInner {
         let has_metadata = {
             let storage = self.storage.clone();
             tokio::task::spawn_blocking(move || storage.has_metadata(&blob_id))
+                .map(unwrap_or_resume_unwind)
                 .await
-                .expect("spawn_blocking task panicked")
                 .context("could not check metadata existence")?
         };
         if has_metadata {
@@ -4305,8 +4305,8 @@ impl ServiceState for StorageNodeInner {
         let storage = self.storage.clone();
         let blob_id = *blob_id;
         match tokio::task::spawn_blocking(move || storage.has_metadata(&blob_id))
+            .map(unwrap_or_resume_unwind)
             .await
-            .expect("spawn_blocking task panicked")
         {
             Ok(true) => Ok(StoredOnNodeStatus::Stored),
             Ok(false) => Ok(StoredOnNodeStatus::Nonexistent),
@@ -4455,8 +4455,8 @@ impl ServiceState for StorageNodeInner {
                 let storage = self.storage.clone();
                 let oid = sui_object_id;
                 tokio::task::spawn_blocking(move || storage.get_per_object_info(&oid))
+                    .map(unwrap_or_resume_unwind)
                     .await
-                    .expect("spawn_blocking task panicked")
                     .context("database error when checking per object info")?
             };
             if let Some(per_object_info) = per_object_info {
@@ -4471,8 +4471,8 @@ impl ServiceState for StorageNodeInner {
                     tokio::task::spawn_blocking(move || {
                         storage.get_per_object_pooled_info(&oid)
                     })
+                    .map(unwrap_or_resume_unwind)
                     .await
-                    .expect("spawn_blocking task panicked")
                     .context(
                         "database error when checking per object pooled info",
                     )?
@@ -4516,8 +4516,8 @@ impl ServiceState for StorageNodeInner {
         let storage = self.storage.clone();
         let blob_id = *blob_id;
         let blob_info = tokio::task::spawn_blocking(move || storage.get_blob_info(&blob_id))
+            .map(unwrap_or_resume_unwind)
             .await
-            .expect("spawn_blocking task panicked")
             .context("could not retrieve blob info")?;
         Ok(blob_info
             .map(|blob_info| blob_info.to_blob_status(self.current_committee_epoch()))

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -3527,8 +3527,6 @@ impl StorageNodeInner {
         }
     }
 
-    /// Note: This is intentionally kept synchronous because it is only called from
-    /// `is_blob_not_certified`, which runs from within rayon `par_iter_mut` in `cancel_syncs`.
     fn is_blob_certified(&self, blob_id: &BlobId) -> Result<bool, anyhow::Error> {
         Ok(self
             .storage
@@ -3542,9 +3540,6 @@ impl StorageNodeInner {
     /// If an error occurs while retrieving the blob info, this returns `false`. The intention
     /// is that if this is used to cancel a blob sync or to delete blob data, we need to be *sure*
     /// that the blob is not certified.
-    ///
-    /// Note: This is intentionally kept synchronous because it is called from within rayon
-    /// `par_iter_mut` in `cancel_syncs`, which already runs off the tokio runtime.
     fn is_blob_not_certified(&self, blob_id: &BlobId) -> bool {
         if let Ok(false) = self.is_blob_certified(blob_id) {
             return true;
@@ -4444,41 +4439,31 @@ impl ServiceState for StorageNodeInner {
         );
 
         if let BlobPersistenceType::Deletable { object_id } = blob_persistence_type {
-            let sui_object_id: sui_types::base_types::ObjectID = object_id.into();
+            let sui_object_id = object_id.into();
 
             // Check the regular per-object table first.
-            let per_object_info = {
-                let storage = self.storage.clone();
-                let oid = sui_object_id;
-                tokio::task::spawn_blocking(move || storage.get_per_object_info(&oid))
-                    .map(unwrap_or_resume_unwind)
-                    .await
-                    .context("database error when checking per object info")?
-            };
-            if let Some(per_object_info) = per_object_info {
+            if let Some(per_object_info) = self
+                .storage
+                .get_per_object_info(&sui_object_id)
+                .context("database error when checking per object info")?
+            {
                 ensure!(
                     per_object_info.is_registered(self.current_committee_epoch()),
                     ComputeStorageConfirmationError::NotCurrentlyRegistered,
                 );
+            } else if self
+                .storage
+                .get_per_object_pooled_info(&sui_object_id)
+                .context("database error when checking per object pooled info")?
+                .is_some()
+            {
+                // Entry exists in the pooled blob table — the blob is active.
+                // Deleted pooled blobs are removed from the table entirely, so presence implies
+                // the blob is registered.
+                // TODO(WAL-1174): check the expiration of the pool here once the storage pool
+                // end-epoch table is implemented.
             } else {
-                let has_pooled_info = {
-                    let storage = self.storage.clone();
-                    let oid = sui_object_id;
-                    tokio::task::spawn_blocking(move || storage.get_per_object_pooled_info(&oid))
-                        .map(unwrap_or_resume_unwind)
-                        .await
-                        .context("database error when checking per object pooled info")?
-                        .is_some()
-                };
-                if has_pooled_info {
-                    // Entry exists in the pooled blob table — the blob is active.
-                    // Deleted pooled blobs are removed from the table entirely, so
-                    // presence implies the blob is registered.
-                    // TODO(WAL-1174): check the expiration of the pool here once the
-                    // storage pool end-epoch table is implemented.
-                } else {
-                    return Err(ComputeStorageConfirmationError::NotCurrentlyRegistered);
-                }
+                return Err(ComputeStorageConfirmationError::NotCurrentlyRegistered);
             }
         }
 
@@ -8707,7 +8692,6 @@ mod tests {
                     .storage_node
                     .inner
                     .blob_status(&OTHER_BLOB_ID)
-                    .await
                     .expect("getting blob status should succeed"),
                 BlobStatus::Nonexistent
             );

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -297,7 +297,7 @@ pub trait ServiceState {
     fn metadata_status(
         &self,
         blob_id: &BlobId,
-    ) -> impl Future<Output = Result<StoredOnNodeStatus, RetrieveMetadataError>> + Send;
+    ) -> Result<StoredOnNodeStatus, RetrieveMetadataError>;
 
     /// Retrieves a primary or secondary sliver for a blob for a shard held by this storage node.
     fn retrieve_sliver(
@@ -3271,15 +3271,11 @@ impl StorageNodeInner {
         blob_id: &BlobId,
         verified: Arc<VerifiedBlobMetadataWithId>,
     ) -> Result<bool, StoreMetadataError> {
-        let has_metadata = {
-            let storage = self.storage.clone();
-            let blob_id = *blob_id;
-            tokio::task::spawn_blocking(move || storage.has_metadata(&blob_id))
-                .map(unwrap_or_resume_unwind)
-                .await
-                .context("could not check metadata existence")?
-        };
-        if has_metadata {
+        if self
+            .storage
+            .has_metadata(blob_id)
+            .context("could not check metadata existence")?
+        {
             return Ok(false);
         }
 
@@ -3335,15 +3331,11 @@ impl StorageNodeInner {
         &self,
         blob_id: &BlobId,
     ) -> Result<(), StoreMetadataError> {
-        let has_metadata = {
-            let storage = self.storage.clone();
-            let blob_id = *blob_id;
-            tokio::task::spawn_blocking(move || storage.has_metadata(&blob_id))
-                .map(unwrap_or_resume_unwind)
-                .await
-                .context("could not check metadata existence")?
-        };
-        if has_metadata {
+        if self
+            .storage
+            .has_metadata(blob_id)
+            .context("could not check metadata existence")?
+        {
             return Ok(());
         }
 
@@ -4051,7 +4043,7 @@ impl ServiceState for StorageNode {
     fn metadata_status(
         &self,
         blob_id: &BlobId,
-    ) -> impl Future<Output = Result<StoredOnNodeStatus, RetrieveMetadataError>> + Send {
+    ) -> Result<StoredOnNodeStatus, RetrieveMetadataError> {
         self.inner.metadata_status(blob_id)
     }
 
@@ -4187,13 +4179,12 @@ impl ServiceState for StorageNodeInner {
 
         let storage = self.storage.clone();
         let blob_id = *blob_id;
-        let metadata = tokio::task::spawn_blocking(move || storage.get_metadata(&blob_id))
+        tokio::task::spawn_blocking(move || storage.get_metadata(&blob_id))
             .map(unwrap_or_resume_unwind)
             .await
             .context("database error when retrieving metadata")?
-            .ok_or(RetrieveMetadataError::Unavailable)?;
-        self.metrics.metadata_retrieved_total.inc();
-        Ok(metadata)
+            .ok_or(RetrieveMetadataError::Unavailable)
+            .inspect(|_| self.metrics.metadata_retrieved_total.inc())
     }
 
     /// Stores metadata for a blob.
@@ -4219,14 +4210,11 @@ impl ServiceState for StorageNodeInner {
             return Err(StoreMetadataError::InvalidBlob(event));
         }
 
-        let has_metadata = {
-            let storage = self.storage.clone();
-            tokio::task::spawn_blocking(move || storage.has_metadata(&blob_id))
-                .map(unwrap_or_resume_unwind)
-                .await
-                .context("could not check metadata existence")?
-        };
-        if has_metadata {
+        if self
+            .storage
+            .has_metadata(&blob_id)
+            .context("could not check metadata existence")?
+        {
             return Ok(false);
         }
 
@@ -4290,16 +4278,11 @@ impl ServiceState for StorageNodeInner {
         Ok(true)
     }
 
-    async fn metadata_status(
+    fn metadata_status(
         &self,
         blob_id: &BlobId,
     ) -> Result<StoredOnNodeStatus, RetrieveMetadataError> {
-        let storage = self.storage.clone();
-        let blob_id = *blob_id;
-        match tokio::task::spawn_blocking(move || storage.has_metadata(&blob_id))
-            .map(unwrap_or_resume_unwind)
-            .await
-        {
+        match self.storage.has_metadata(blob_id) {
             Ok(true) => Ok(StoredOnNodeStatus::Stored),
             Ok(false) => Ok(StoredOnNodeStatus::Nonexistent),
             Err(err) => Err(RetrieveMetadataError::Internal(err.into())),
@@ -5602,8 +5585,7 @@ mod tests {
         let metadata_status = storage_node
             .as_ref()
             .inner
-            .metadata_status(metadata.blob_id())
-            .await?;
+            .metadata_status(metadata.blob_id())?;
         assert_eq!(metadata_status, StoredOnNodeStatus::Stored);
         Ok(())
     }

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -3224,10 +3224,16 @@ impl StorageNodeInner {
             );
         }
 
-        if shard_storage
-            .is_sliver_type_stored(metadata.blob_id(), sliver.r#type())
-            .context("database error when checking sliver existence")?
-        {
+        let is_stored = {
+            let shard = shard_storage.clone();
+            let blob_id = *metadata.blob_id();
+            let sliver_type = sliver.r#type();
+            tokio::task::spawn_blocking(move || shard.is_sliver_type_stored(&blob_id, sliver_type))
+                .map(unwrap_or_resume_unwind)
+                .await
+                .context("database error when checking sliver existence")?
+        };
+        if is_stored {
             return Ok(None);
         }
 
@@ -3458,6 +3464,8 @@ impl StorageNodeInner {
         }
     }
 
+    /// Note: if the parent future is dropped, the `spawn_blocking` task runs to completion
+    /// and holds the `StorageShardLock` until shard creation finishes.
     async fn create_storage_for_shards_in_background(
         self: &Arc<Self>,
         new_shards: Vec<ShardIndex>,
@@ -3525,6 +3533,8 @@ impl StorageNodeInner {
         }
     }
 
+    /// Note: This is intentionally kept synchronous because it is only called from
+    /// `is_blob_not_certified`, which runs from within rayon `par_iter_mut` in `cancel_syncs`.
     fn is_blob_certified(&self, blob_id: &BlobId) -> Result<bool, anyhow::Error> {
         Ok(self
             .storage
@@ -4728,7 +4738,14 @@ impl ServiceState for StorageNodeInner {
             .get_shard_for_sliver_pair(sliver_pair_index, blob_id)
             .await?;
 
-        match shard_storage.is_sliver_stored::<A>(blob_id) {
+        let is_stored = {
+            let shard = shard_storage.clone();
+            let blob_id = *blob_id;
+            tokio::task::spawn_blocking(move || shard.is_sliver_stored::<A>(&blob_id))
+                .map(unwrap_or_resume_unwind)
+                .await
+        };
+        match is_stored {
             Ok(true) => Ok(StoredOnNodeStatus::Stored),
             Ok(false) => {
                 if self

--- a/crates/walrus-service/src/node/blob_event_processor.rs
+++ b/crates/walrus-service/src/node/blob_event_processor.rs
@@ -3,7 +3,6 @@
 
 use std::{num::NonZeroUsize, sync::Arc};
 
-use futures::FutureExt as _;
 use sui_macros::fail_point_async;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use walrus_core::{BlobId, Epoch};
@@ -13,7 +12,6 @@ use walrus_utils::metrics::monitored_scope;
 use self::pending_events::{PendingEventCounter, PendingEventGuard};
 use super::{StorageNodeInner, blob_sync::BlobSyncHandler, metrics, system_events::EventHandle};
 use crate::{
-    common::utils::unwrap_or_resume_unwind,
     event::events::CheckpointEventPosition,
     node::{
         storage::blob_info::{BlobInfoApi, CertifiedBlobInfoApi},
@@ -206,15 +204,8 @@ impl BackgroundEventProcessor {
             }
         );
 
-        let is_certified = {
-            let node = self.node.clone();
-            let blob_id = blob_id;
-            tokio::task::spawn_blocking(move || node.is_blob_certified(&blob_id))
-                .map(unwrap_or_resume_unwind)
-                .await?
-        };
         if skip_blob_sync_in_test
-            || !is_certified
+            || !self.node.is_blob_certified(&blob_id)?
             || self.node.storage.node_status()?.is_catching_up()
             || (current_event_epoch.is_some()
                 && self
@@ -274,13 +265,7 @@ impl BackgroundEventProcessor {
         let current_committee_epoch = self.node.current_committee_epoch();
         tracing::Span::current().record("walrus.epoch", current_committee_epoch);
 
-        let blob_info = {
-            let storage = self.node.storage.clone();
-            tokio::task::spawn_blocking(move || storage.get_blob_info(&blob_id))
-                .map(unwrap_or_resume_unwind)
-                .await?
-        };
-        if let Some(blob_info) = blob_info {
+        if let Some(blob_info) = self.node.storage.get_blob_info(&blob_id)? {
             if !blob_info.is_certified(current_committee_epoch) {
                 self.node
                     .blob_retirement_notifier

--- a/crates/walrus-service/src/node/blob_event_processor.rs
+++ b/crates/walrus-service/src/node/blob_event_processor.rs
@@ -3,6 +3,8 @@
 
 use std::{num::NonZeroUsize, sync::Arc};
 
+use anyhow::Context as _;
+use futures::FutureExt as _;
 use sui_macros::fail_point_async;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use walrus_core::{BlobId, Epoch};
@@ -12,6 +14,7 @@ use walrus_utils::metrics::monitored_scope;
 use self::pending_events::{PendingEventCounter, PendingEventGuard};
 use super::{StorageNodeInner, blob_sync::BlobSyncHandler, metrics, system_events::EventHandle};
 use crate::{
+    common::utils::unwrap_or_resume_unwind,
     event::events::CheckpointEventPosition,
     node::{
         storage::blob_info::{BlobInfoApi, CertifiedBlobInfoApi},
@@ -204,9 +207,29 @@ impl BackgroundEventProcessor {
             }
         );
 
+        let is_certified = {
+            let storage = self.node.storage.clone();
+            let blob_id = blob_id;
+            let epoch = self.node.current_committee_epoch();
+            tokio::task::spawn_blocking(move || {
+                storage
+                    .get_blob_info(&blob_id)
+                    .context("could not retrieve blob info")
+                    .map(|info| info.is_some_and(|info| info.is_certified(epoch)))
+            })
+            .map(unwrap_or_resume_unwind)
+            .await?
+        };
+        let is_catching_up = {
+            let storage = self.node.storage.clone();
+            tokio::task::spawn_blocking(move || storage.node_status())
+                .map(unwrap_or_resume_unwind)
+                .await?
+                .is_catching_up()
+        };
         if skip_blob_sync_in_test
-            || !self.node.is_blob_certified(&blob_id)?
-            || self.node.storage.node_status()?.is_catching_up()
+            || !is_certified
+            || is_catching_up
             || (current_event_epoch.is_some()
                 && self
                     .node
@@ -265,7 +288,13 @@ impl BackgroundEventProcessor {
         let current_committee_epoch = self.node.current_committee_epoch();
         tracing::Span::current().record("walrus.epoch", current_committee_epoch);
 
-        if let Some(blob_info) = self.node.storage.get_blob_info(&blob_id)? {
+        let blob_info = {
+            let storage = self.node.storage.clone();
+            tokio::task::spawn_blocking(move || storage.get_blob_info(&blob_id))
+                .map(unwrap_or_resume_unwind)
+                .await?
+        };
+        if let Some(blob_info) = blob_info {
             if !blob_info.is_certified(current_committee_epoch) {
                 self.node
                     .blob_retirement_notifier
@@ -295,21 +324,25 @@ impl BackgroundEventProcessor {
             } else {
                 tracing::debug!("not deleting data for deleted blob");
             }
-        } else if self
-            .node
-            .storage
-            .node_status()?
-            .is_catching_up_with_incomplete_history()
-        {
-            tracing::debug!(
-                "handling a `BlobDeleted` event for an untracked blob while catching up with \
-                incomplete history; not deleting blob data"
-            );
         } else {
-            tracing::debug!(
-                "handling a `BlobDeleted` event for an untracked blob; this can happen when \
-                re-processing events after a node restart"
-            );
+            let is_catching_up_incomplete = {
+                let storage = self.node.storage.clone();
+                tokio::task::spawn_blocking(move || storage.node_status())
+                    .map(unwrap_or_resume_unwind)
+                    .await?
+                    .is_catching_up_with_incomplete_history()
+            };
+            if is_catching_up_incomplete {
+                tracing::debug!(
+                    "handling a `BlobDeleted` event for an untracked blob while catching up \
+                    with incomplete history; not deleting blob data"
+                );
+            } else {
+                tracing::debug!(
+                    "handling a `BlobDeleted` event for an untracked blob; this can happen \
+                    when re-processing events after a node restart"
+                );
+            }
         }
 
         event_handle.mark_as_complete();

--- a/crates/walrus-service/src/node/blob_event_processor.rs
+++ b/crates/walrus-service/src/node/blob_event_processor.rs
@@ -3,7 +3,6 @@
 
 use std::{num::NonZeroUsize, sync::Arc};
 
-use anyhow::Context as _;
 use futures::FutureExt as _;
 use sui_macros::fail_point_async;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
@@ -208,17 +207,11 @@ impl BackgroundEventProcessor {
         );
 
         let is_certified = {
-            let storage = self.node.storage.clone();
+            let node = self.node.clone();
             let blob_id = blob_id;
-            let epoch = self.node.current_committee_epoch();
-            tokio::task::spawn_blocking(move || {
-                storage
-                    .get_blob_info(&blob_id)
-                    .context("could not retrieve blob info")
-                    .map(|info| info.is_some_and(|info| info.is_certified(epoch)))
-            })
-            .map(unwrap_or_resume_unwind)
-            .await?
+            tokio::task::spawn_blocking(move || node.is_blob_certified(&blob_id))
+                .map(unwrap_or_resume_unwind)
+                .await?
         };
         let is_catching_up = {
             let storage = self.node.storage.clone();

--- a/crates/walrus-service/src/node/blob_event_processor.rs
+++ b/crates/walrus-service/src/node/blob_event_processor.rs
@@ -213,16 +213,9 @@ impl BackgroundEventProcessor {
                 .map(unwrap_or_resume_unwind)
                 .await?
         };
-        let is_catching_up = {
-            let storage = self.node.storage.clone();
-            tokio::task::spawn_blocking(move || storage.node_status())
-                .map(unwrap_or_resume_unwind)
-                .await?
-                .is_catching_up()
-        };
         if skip_blob_sync_in_test
             || !is_certified
-            || is_catching_up
+            || self.node.storage.node_status()?.is_catching_up()
             || (current_event_epoch.is_some()
                 && self
                     .node
@@ -317,25 +310,21 @@ impl BackgroundEventProcessor {
             } else {
                 tracing::debug!("not deleting data for deleted blob");
             }
+        } else if self
+            .node
+            .storage
+            .node_status()?
+            .is_catching_up_with_incomplete_history()
+        {
+            tracing::debug!(
+                "handling a `BlobDeleted` event for an untracked blob while catching up \
+                with incomplete history; not deleting blob data"
+            );
         } else {
-            let is_catching_up_incomplete = {
-                let storage = self.node.storage.clone();
-                tokio::task::spawn_blocking(move || storage.node_status())
-                    .map(unwrap_or_resume_unwind)
-                    .await?
-                    .is_catching_up_with_incomplete_history()
-            };
-            if is_catching_up_incomplete {
-                tracing::debug!(
-                    "handling a `BlobDeleted` event for an untracked blob while catching up \
-                    with incomplete history; not deleting blob data"
-                );
-            } else {
-                tracing::debug!(
-                    "handling a `BlobDeleted` event for an untracked blob; this can happen \
-                    when re-processing events after a node restart"
-                );
-            }
+            tracing::debug!(
+                "handling a `BlobDeleted` event for an untracked blob; this can happen \
+                when re-processing events after a node restart"
+            );
         }
 
         event_handle.mark_as_complete();

--- a/crates/walrus-service/src/node/blob_event_processor.rs
+++ b/crates/walrus-service/src/node/blob_event_processor.rs
@@ -302,13 +302,13 @@ impl BackgroundEventProcessor {
             .is_catching_up_with_incomplete_history()
         {
             tracing::debug!(
-                "handling a `BlobDeleted` event for an untracked blob while catching up \
-                with incomplete history; not deleting blob data"
+                "handling a `BlobDeleted` event for an untracked blob while catching up with \
+                incomplete history; not deleting blob data"
             );
         } else {
             tracing::debug!(
-                "handling a `BlobDeleted` event for an untracked blob; this can happen \
-                when re-processing events after a node restart"
+                "handling a `BlobDeleted` event for an untracked blob; this can happen when \
+                re-processing events after a node restart"
             );
         }
 

--- a/crates/walrus-service/src/node/blob_sync.rs
+++ b/crates/walrus-service/src/node/blob_sync.rs
@@ -836,7 +836,14 @@ impl BlobSynchronizer {
     async fn recover_metadata(
         self: Arc<Self>,
     ) -> Result<(bool, VerifiedBlobMetadataWithId), TypedStoreError> {
-        if let Some(metadata) = self.storage().get_metadata(&self.blob_id)? {
+        let existing = {
+            let storage = self.storage().clone();
+            let blob_id = self.blob_id;
+            tokio::task::spawn_blocking(move || storage.get_metadata(&blob_id))
+                .await
+                .expect("spawn_blocking task panicked")?
+        };
+        if let Some(metadata) = existing {
             tracing::debug!("not syncing metadata: already stored");
             return Ok((false, metadata));
         }

--- a/crates/walrus-service/src/node/blob_sync.rs
+++ b/crates/walrus-service/src/node/blob_sync.rs
@@ -50,7 +50,10 @@ use super::{
     storage::Storage,
     system_events::{CompletableHandle, EventHandle},
 };
-use crate::{common::utils::FutureHelpers as _, node::NodeStatus};
+use crate::{
+    common::utils::{self, FutureHelpers as _},
+    node::NodeStatus,
+};
 
 #[derive(Debug, Clone)]
 struct Permits {
@@ -840,8 +843,8 @@ impl BlobSynchronizer {
             let storage = self.storage().clone();
             let blob_id = self.blob_id;
             tokio::task::spawn_blocking(move || storage.get_metadata(&blob_id))
-                .await
-                .expect("spawn_blocking task panicked")?
+                .map(utils::unwrap_or_resume_unwind)
+                .await?
         };
         if let Some(metadata) = existing {
             tracing::debug!("not syncing metadata: already stored");

--- a/crates/walrus-service/src/node/blob_sync.rs
+++ b/crates/walrus-service/src/node/blob_sync.rs
@@ -404,14 +404,12 @@ impl BlobSyncHandler {
         // Note that if the node status is not in recovery catch up, it is safe to start the sync
         // without further status checking since node entering recovery catch up will cancel all
         // the blob syncs, including this one.
-        let node_status = {
-            let storage = synchronizer.node.storage.clone();
-            tokio::task::spawn_blocking(move || storage.node_status())
-                .map(utils::unwrap_or_resume_unwind)
-                .await
-                .expect("node status should be set")
-        };
-        let (label, _guard) = match node_status {
+        let (label, _guard) = match synchronizer
+            .node
+            .storage
+            .node_status()
+            .expect("node status should be set")
+        {
             NodeStatus::RecoveryCatchUp => {
                 tracing::debug!(
                     "about to start blob sync, but node is in recovery catch up, skipping blob sync"

--- a/crates/walrus-service/src/node/blob_sync.rs
+++ b/crates/walrus-service/src/node/blob_sync.rs
@@ -887,7 +887,14 @@ impl BlobSynchronizer {
 
             Span::current().record("walrus.sliver.pair_index", field::display(sliver_id));
 
-            if shard_storage.is_sliver_stored::<A>(&self.blob_id)? {
+            let is_stored = {
+                let shard = shard_storage.clone();
+                let blob_id = self.blob_id;
+                tokio::task::spawn_blocking(move || shard.is_sliver_stored::<A>(&blob_id))
+                    .map(utils::unwrap_or_resume_unwind)
+                    .await?
+            };
+            if is_stored {
                 tracing::debug!("not syncing sliver: already stored");
                 return Ok(false);
             }

--- a/crates/walrus-service/src/node/blob_sync.rs
+++ b/crates/walrus-service/src/node/blob_sync.rs
@@ -404,12 +404,14 @@ impl BlobSyncHandler {
         // Note that if the node status is not in recovery catch up, it is safe to start the sync
         // without further status checking since node entering recovery catch up will cancel all
         // the blob syncs, including this one.
-        let (label, _guard) = match synchronizer
-            .node
-            .storage
-            .node_status()
-            .expect("node status should be set")
-        {
+        let node_status = {
+            let storage = synchronizer.node.storage.clone();
+            tokio::task::spawn_blocking(move || storage.node_status())
+                .map(utils::unwrap_or_resume_unwind)
+                .await
+                .expect("node status should be set")
+        };
+        let (label, _guard) = match node_status {
             NodeStatus::RecoveryCatchUp => {
                 tracing::debug!(
                     "about to start blob sync, but node is in recovery catch up, skipping blob sync"

--- a/crates/walrus-service/src/node/server.rs
+++ b/crates/walrus-service/src/node/server.rs
@@ -644,7 +644,7 @@ mod tests {
             Ok(true)
         }
 
-        async fn metadata_status(
+        fn metadata_status(
             &self,
             blob_id: &BlobId,
         ) -> Result<walrus_storage_node_client::api::StoredOnNodeStatus, RetrieveMetadataError>

--- a/crates/walrus-service/src/node/server.rs
+++ b/crates/walrus-service/src/node/server.rs
@@ -621,7 +621,7 @@ mod tests {
     impl ServiceState for MockServiceState {
         /// Returns a valid response only for blob IDs with the first byte 0, None for those
         /// starting with 1, and otherwise an error.
-        fn retrieve_metadata(
+        async fn retrieve_metadata(
             &self,
             blob_id: &BlobId,
         ) -> Result<VerifiedBlobMetadataWithId, RetrieveMetadataError> {
@@ -644,7 +644,7 @@ mod tests {
             Ok(true)
         }
 
-        fn metadata_status(
+        async fn metadata_status(
             &self,
             blob_id: &BlobId,
         ) -> Result<walrus_storage_node_client::api::StoredOnNodeStatus, RetrieveMetadataError>
@@ -758,7 +758,7 @@ mod tests {
 
         /// Returns a "certified" blob status for blob ID starting with zero, `Nonexistent` when
         /// starting with 1, and otherwise an error.
-        fn blob_status(&self, blob_id: &BlobId) -> Result<BlobStatus, BlobStatusError> {
+        async fn blob_status(&self, blob_id: &BlobId) -> Result<BlobStatus, BlobStatusError> {
             if blob_id.0[0] == 0 {
                 Ok(BlobStatus::Permanent {
                     end_epoch: 3,

--- a/crates/walrus-service/src/node/server.rs
+++ b/crates/walrus-service/src/node/server.rs
@@ -758,7 +758,7 @@ mod tests {
 
         /// Returns a "certified" blob status for blob ID starting with zero, `Nonexistent` when
         /// starting with 1, and otherwise an error.
-        async fn blob_status(&self, blob_id: &BlobId) -> Result<BlobStatus, BlobStatusError> {
+        fn blob_status(&self, blob_id: &BlobId) -> Result<BlobStatus, BlobStatusError> {
             if blob_id.0[0] == 0 {
                 Ok(BlobStatus::Permanent {
                     end_epoch: 3,

--- a/crates/walrus-service/src/node/server/routes.rs
+++ b/crates/walrus-service/src/node/server/routes.rs
@@ -171,9 +171,7 @@ pub async fn get_metadata_status<S: SyncServiceState>(
     State(state): State<RestApiState<S>>,
     Path(BlobIdString(blob_id)): Path<BlobIdString>,
 ) -> Result<ApiSuccess<StoredOnNodeStatus>, RetrieveMetadataError> {
-    Ok(ApiSuccess::ok(
-        state.service.metadata_status(&blob_id).await?,
-    ))
+    Ok(ApiSuccess::ok(state.service.metadata_status(&blob_id)?))
 }
 
 /// Store blob metadata.

--- a/crates/walrus-service/src/node/server/routes.rs
+++ b/crates/walrus-service/src/node/server/routes.rs
@@ -746,7 +746,7 @@ pub async fn get_blob_status<S: SyncServiceState>(
     State(state): State<RestApiState<S>>,
     Path(BlobIdString(blob_id)): Path<BlobIdString>,
 ) -> Result<ApiSuccess<BlobStatus>, BlobStatusError> {
-    Ok(ApiSuccess::ok(state.service.blob_status(&blob_id).await?))
+    Ok(ApiSuccess::ok(state.service.blob_status(&blob_id)?))
 }
 
 #[derive(Debug, Clone, serde::Deserialize, utoipa::IntoParams)]

--- a/crates/walrus-service/src/node/server/routes.rs
+++ b/crates/walrus-service/src/node/server/routes.rs
@@ -148,7 +148,7 @@ pub async fn get_metadata<S: SyncServiceState>(
     State(state): State<RestApiState<S>>,
     Path(BlobIdString(blob_id)): Path<BlobIdString>,
 ) -> Result<Bcs<VerifiedBlobMetadataWithId>, RetrieveMetadataError> {
-    Ok(Bcs(state.service.retrieve_metadata(&blob_id)?))
+    Ok(Bcs(state.service.retrieve_metadata(&blob_id).await?))
 }
 
 /// Check if the metadata for a blob is already stored.
@@ -171,7 +171,9 @@ pub async fn get_metadata_status<S: SyncServiceState>(
     State(state): State<RestApiState<S>>,
     Path(BlobIdString(blob_id)): Path<BlobIdString>,
 ) -> Result<ApiSuccess<StoredOnNodeStatus>, RetrieveMetadataError> {
-    Ok(ApiSuccess::ok(state.service.metadata_status(&blob_id)?))
+    Ok(ApiSuccess::ok(
+        state.service.metadata_status(&blob_id).await?,
+    ))
 }
 
 /// Store blob metadata.
@@ -744,7 +746,7 @@ pub async fn get_blob_status<S: SyncServiceState>(
     State(state): State<RestApiState<S>>,
     Path(BlobIdString(blob_id)): Path<BlobIdString>,
 ) -> Result<ApiSuccess<BlobStatus>, BlobStatusError> {
-    Ok(ApiSuccess::ok(state.service.blob_status(&blob_id)?))
+    Ok(ApiSuccess::ok(state.service.blob_status(&blob_id).await?))
 }
 
 #[derive(Debug, Clone, serde::Deserialize, utoipa::IntoParams)]

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -1142,12 +1142,24 @@ impl Storage {
             .shard_storage(shard)
             .await
             .ok_or(anyhow::anyhow!("shard {shard} does not exist"))?;
-        let blob_id = *blob_id;
-        Ok(
-            tokio::task::spawn_blocking(move || shard_storage.is_sliver_pair_stored(&blob_id))
-                .map(utils::unwrap_or_resume_unwind)
-                .await?,
-        )
+
+        // In msim, the consistency check calls this via futures::executor::block_on
+        // (inside an outer spawn_blocking), where nested spawn_blocking is not
+        // supported. Fall back to a direct call there; the outer spawn_blocking
+        // already keeps the work off the tokio runtime.
+        #[cfg(msim)]
+        {
+            Ok(shard_storage.is_sliver_pair_stored(blob_id)?)
+        }
+        #[cfg(not(msim))]
+        {
+            let blob_id = *blob_id;
+            Ok(
+                tokio::task::spawn_blocking(move || shard_storage.is_sliver_pair_stored(&blob_id))
+                    .map(utils::unwrap_or_resume_unwind)
+                    .await?,
+            )
+        }
     }
 
     /// Returns a list of identifiers of the shards that store their

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -1193,34 +1193,44 @@ impl Storage {
         };
 
         let sliver_count = request.sliver_count();
-        let mut fetched_blobs = Vec::with_capacity(sliver_count);
-        let mut last_fetched_blob_id = None;
-        while fetched_blobs.len() < sliver_count {
-            let remaining_count = sliver_count - fetched_blobs.len();
+        let starting_blob_id = request.starting_blob_id();
+        let sliver_type = request.sliver_type();
+        let blob_info = self.blob_info.clone();
 
-            // Set starting point - either the initial request start or after last fetched blob
-            let starting_blob_id_bound =
-                last_fetched_blob_id.map_or(Included(request.starting_blob_id()), Excluded);
+        let fetched_blobs = tokio::task::spawn_blocking(move || {
+            let mut fetched_blobs = Vec::with_capacity(sliver_count);
+            let mut last_fetched_blob_id = None;
+            while fetched_blobs.len() < sliver_count {
+                let remaining_count = sliver_count - fetched_blobs.len();
 
-            // Scan certified slivers to fetch.
-            let blobs_to_fetch = self
-                .blob_info
-                .certified_blob_info_iter_before_epoch(current_epoch, starting_blob_id_bound)
-                .take(remaining_count)
-                .map_ok(|(blob_id, _)| blob_id)
-                .collect::<Result<Vec<_>, TypedStoreError>>()?;
+                // Set starting point: initial request start or after last fetched blob.
+                let starting_blob_id_bound =
+                    last_fetched_blob_id.map_or(Included(starting_blob_id), Excluded);
 
-            if blobs_to_fetch.is_empty() {
-                // No more blobs to fetch.
-                break;
+                // Scan certified slivers to fetch.
+                let blobs_to_fetch = blob_info
+                    .certified_blob_info_iter_before_epoch(
+                        current_epoch,
+                        starting_blob_id_bound,
+                    )
+                    .take(remaining_count)
+                    .map_ok(|(blob_id, _)| blob_id)
+                    .collect::<Result<Vec<_>, TypedStoreError>>()?;
+
+                if blobs_to_fetch.is_empty() {
+                    break;
+                }
+
+                // Update last fetched ID for next iteration.
+                last_fetched_blob_id = blobs_to_fetch.last().cloned();
+
+                let mut slivers = shard.fetch_slivers(sliver_type, &blobs_to_fetch)?;
+                fetched_blobs.append(&mut slivers);
             }
-
-            // Update last fetched ID for next iteration
-            last_fetched_blob_id = blobs_to_fetch.last().cloned();
-
-            let mut slivers = shard.fetch_slivers(request.sliver_type(), &blobs_to_fetch)?;
-            fetched_blobs.append(&mut slivers);
-        }
+            Ok::<_, TypedStoreError>(fetched_blobs)
+        })
+        .await
+        .expect("spawn_blocking task panicked")?;
 
         Ok(fetched_blobs.into())
     }

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -1209,10 +1209,7 @@ impl Storage {
 
                 // Scan certified slivers to fetch.
                 let blobs_to_fetch = blob_info
-                    .certified_blob_info_iter_before_epoch(
-                        current_epoch,
-                        starting_blob_id_bound,
-                    )
+                    .certified_blob_info_iter_before_epoch(current_epoch, starting_blob_id_bound)
                     .take(remaining_count)
                     .map_ok(|(blob_id, _)| blob_id)
                     .collect::<Result<Vec<_>, TypedStoreError>>()?;

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -1224,7 +1224,7 @@ impl Storage {
             while fetched_blobs.len() < sliver_count {
                 let remaining_count = sliver_count - fetched_blobs.len();
 
-                // Set starting point: initial request start or after last fetched blob.
+                // Set starting point - either the initial request start or after last fetched blob
                 let starting_blob_id_bound =
                     last_fetched_blob_id.map_or(Included(starting_blob_id), Excluded);
 
@@ -1236,10 +1236,11 @@ impl Storage {
                     .collect::<Result<Vec<_>, TypedStoreError>>()?;
 
                 if blobs_to_fetch.is_empty() {
+                    // No more blobs to fetch.
                     break;
                 }
 
-                // Update last fetched ID for next iteration.
+                // Update last fetched ID for next iteration
                 last_fetched_blob_id = blobs_to_fetch.last().cloned();
 
                 let mut slivers = shard.fetch_slivers(sliver_type, &blobs_to_fetch)?;

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -1138,11 +1138,16 @@ impl Storage {
         blob_id: &BlobId,
         shard: ShardIndex,
     ) -> anyhow::Result<bool> {
-        Ok(self
+        let shard_storage = self
             .shard_storage(shard)
             .await
-            .ok_or(anyhow::anyhow!("shard {shard} does not exist"))?
-            .is_sliver_pair_stored(blob_id)?)
+            .ok_or(anyhow::anyhow!("shard {shard} does not exist"))?;
+        let blob_id = *blob_id;
+        Ok(
+            tokio::task::spawn_blocking(move || shard_storage.is_sliver_pair_stored(&blob_id))
+                .map(utils::unwrap_or_resume_unwind)
+                .await?,
+        )
     }
 
     /// Returns a list of identifiers of the shards that store their
@@ -1171,6 +1176,10 @@ impl Storage {
 
     /// Handles a sync shard request. The validity of the request should be checked before calling
     /// this function.
+    ///
+    /// Note: the blocking batch fetch runs inside `spawn_blocking`. If the parent future is
+    /// dropped, the blocking task runs to completion — this is intentional to avoid partial
+    /// iterator state.
     pub async fn handle_sync_shard_request(
         &self,
         request: &SyncShardRequest,

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -1229,8 +1229,8 @@ impl Storage {
             }
             Ok::<_, TypedStoreError>(fetched_blobs)
         })
-        .await
-        .expect("spawn_blocking task panicked")?;
+        .map(utils::unwrap_or_resume_unwind)
+        .await?;
 
         Ok(fetched_blobs.into())
     }


### PR DESCRIPTION
## Description
Close WAL-1140
Offload large RocksDB reads from tokio worker threads to the blocking pool.
- All new `spawn_blocking` wraps are for real value loads from the metadata CF (`get_metadata`), bulk sliver reads (`fetch_slivers`) and `contains_key` on the slivers CF
- Leave synchronous when the underlying read is a small-value `.get()` on a cache-friendly CF. That covers
  `get_blob_info`, `has_metadata`, `node_status`, `get_event_cursor_progress`, and `get_per_object_info` / `get_per_object_pooled_info`.

- fix: `create_storage_for_shards_in_background` had an `async move` block inside `spawn_blocking` that made the closure a no-op. 

## Test plan

Existing tests pass.

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
