### PR TITLE
fix: commission rate updates for nodes not in the committee

### DIFF
--- a/contracts/walrus/sources/staking/pending_values.move
+++ b/contracts/walrus/sources/staking/pending_values.move
@@ -60,6 +60,23 @@ public(package) fun value_at(self: &PendingValues, epoch: u32): u64 {
     })
 }
 
+/// Returns the value of the pending entry with the largest epoch that is
+/// less than or equal to `to_epoch`, or `none` if no such entry exists.
+/// Useful for "override" semantics (unlike `value_at`, which sums entries).
+public(package) fun latest_value_at(self: &PendingValues, to_epoch: u32): Option<u64> {
+    let mut latest_epoch: Option<u32> = option::none();
+    self.0.keys().do!(|epoch| if (epoch <= to_epoch) {
+        if (latest_epoch.is_none() || *latest_epoch.borrow() < epoch) {
+            latest_epoch = option::some(epoch);
+        }
+    });
+    if (latest_epoch.is_some()) {
+        option::some(self.0[latest_epoch.borrow()])
+    } else {
+        option::none()
+    }
+}
+
 /// Reduce the pending values to the given epoch. This method removes all the
 /// values that are pending for epochs less than or equal to the given epoch.
 public(package) fun flush(self: &mut PendingValues, to_epoch: u32): u64 {

--- a/contracts/walrus/sources/staking/staking_pool.move
+++ b/contracts/walrus/sources/staking/staking_pool.move
@@ -430,13 +430,18 @@ public(package) fun advance_epoch(
     // Block the commission for collection until `voting_end`.
     pool.add_commission(commission, true);
 
-    // Update the commission_rate for the new epoch if there's a pending value.
+    // Update the commission_rate for the new epoch if there's a pending value
+    // whose target epoch has already been reached. Using `latest_value_at`
+    // (rather than an exact-epoch lookup) ensures that if the pool was out of
+    // the committee when a scheduled rate became effective, the scheduled rate
+    // is still applied the next time advance_epoch runs. Stale pending entries
+    // are always flushed, even when no match is found.
     // Note that pending commission rates are set 2 epochs ahead, so users are
     // aware of the rate change in advance.
-    pool.pending_commission_rate.inner().try_get(&current_epoch).do!(|commission_rate| {
+    pool.pending_commission_rate.latest_value_at(current_epoch).do!(|commission_rate| {
         pool.commission_rate = commission_rate as u16;
-        pool.pending_commission_rate.flush(current_epoch);
     });
+    pool.pending_commission_rate.flush(current_epoch);
 
     // Add rewards to the pool and update the `wal_balance`.
     let rewards_amount = rewards.value();

--- a/contracts/walrus/tests/staking/staking_pool/pool_commission_tests.move
+++ b/contracts/walrus/tests/staking/staking_pool/pool_commission_tests.move
@@ -156,6 +156,45 @@ fun commission_setting_at_different_epochs() {
     pool.destroy_empty();
 }
 
+#[test]
+// A node schedules multiple commission rates before joining the committee,
+// skipping each rate's target epoch entirely (because advance_epoch is not
+// called while out of committee), then finally joins. The most recent
+// scheduled rate whose target epoch has already arrived should take effect
+// on the first advance_epoch, and stale entries must be flushed so they
+// cannot re-apply in later epochs.
+fun pending_commission_applied_after_skipped_epochs() {
+    let mut test = context_runner();
+    let (wctx, ctx) = test.current(); // E0
+    let mut pool = pool().commission_rate(0).build(&wctx, ctx);
+
+    // E0: schedule 10% → pending[E+2] = 10_00
+    pool.set_next_commission(10_00, &wctx);
+
+    // E+1: schedule 20% → pending[E+3] = 20_00
+    let (wctx, _) = test.next_epoch();
+    pool.set_next_commission(20_00, &wctx);
+
+    // Simulate being out of committee: skip E+2 and E+3 entirely so that
+    // both scheduled target epochs pass without advance_epoch being called.
+    let (_wctx, _) = test.next_epoch(); // E+2
+    let (_wctx, _) = test.next_epoch(); // E+3
+    let (wctx, _) = test.next_epoch(); // E+4 <- node joins committee
+
+    pool.advance_epoch(mint_wal_balance(0), &wctx);
+    // The latest scheduled rate whose target was reached is 20_00 (E+3),
+    // not 10_00 (E+2) and not the initial 0.
+    assert_eq!(pool.commission_rate(), 20_00);
+
+    // A subsequent advance_epoch with no new schedules must not re-apply
+    // any stale pending entry: the rate stays at 20_00.
+    let (wctx, _) = test.next_epoch(); // E+5
+    pool.advance_epoch(mint_wal_balance(0), &wctx);
+    assert_eq!(pool.commission_rate(), 20_00);
+
+    pool.destroy_empty();
+}
+
 #[test, expected_failure(abort_code = ::walrus::staking_pool::EIncorrectCommissionRate)]
 fun set_incorrect_commission_rate_fail() {
     let mut test = context_runner();


### PR DESCRIPTION
## Description

This PR fixes the bug where commission updates may be skipped if the node has been in the committee yet.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
