### PR TITLE
feat: add storage pool SDK methods

### DIFF
--- a/crates/walrus-sui/src/client.rs
+++ b/crates/walrus-sui/src/client.rs
@@ -79,7 +79,6 @@ use crate::{
             EpochState,
             SharedBlob,
             StorageNode,
-            StoragePoolResource,
         },
     },
     utils::get_created_sui_object_ids_by_type,
@@ -2697,17 +2696,13 @@ impl SuiContractClientInner {
         storage_pool_id: ObjectID,
         extended_epochs: EpochCount,
     ) -> SuiClientResult<()> {
-        let pool: StoragePoolResource = self
-            .read_client
-            .retriable_sui_client()
-            .get_sui_object(storage_pool_id)
-            .await?;
+        let pool = self.read_client.get_storage_pool(storage_pool_id).await?;
         let mut pt_builder = self.transaction_builder();
         pt_builder
             .extend_storage_pool(
                 storage_pool_id.into(),
                 extended_epochs,
-                pool.reserved_encoded_capacity_bytes,
+                pool.reserved_encoded_capacity_bytes(),
             )
             .await?;
         let transaction = pt_builder.build_transaction_data(self.gas_budget).await?;
@@ -2724,13 +2719,9 @@ impl SuiContractClientInner {
         storage_pool_id: ObjectID,
         additional_encoded_capacity_bytes: u64,
     ) -> SuiClientResult<()> {
-        let pool: StoragePoolResource = self
-            .read_client
-            .retriable_sui_client()
-            .get_sui_object(storage_pool_id)
-            .await?;
+        let pool = self.read_client.get_storage_pool(storage_pool_id).await?;
         let current_epoch = self.read_client.current_epoch().await?;
-        let remaining_epochs = pool.end_epoch.saturating_sub(current_epoch);
+        let remaining_epochs = pool.end_epoch().saturating_sub(current_epoch);
         let mut pt_builder = self.transaction_builder();
         pt_builder
             .increase_storage_pool_capacity(

--- a/crates/walrus-sui/src/client.rs
+++ b/crates/walrus-sui/src/client.rs
@@ -79,6 +79,7 @@ use crate::{
             EpochState,
             SharedBlob,
             StorageNode,
+            StoragePoolResource,
         },
     },
     utils::get_created_sui_object_ids_by_type,
@@ -1117,6 +1118,123 @@ impl SuiContractClient {
             .await?
             .filter(|storage| selection_policy.matches(storage.end_epoch, current_epoch))
             .collect())
+    }
+
+    // ---- Storage Pool operations ----
+
+    /// Creates a new storage pool with the specified capacity and duration.
+    /// Returns the object ID of the created `StoragePool`.
+    pub async fn create_storage_pool(
+        &self,
+        reserved_encoded_capacity_bytes: u64,
+        epochs_ahead: EpochCount,
+    ) -> SuiClientResult<ObjectID> {
+        self.retry_on_wrong_version(|| async {
+            self.inner
+                .lock()
+                .await
+                .create_storage_pool(reserved_encoded_capacity_bytes, epochs_ahead)
+                .await
+        })
+        .await
+    }
+
+    /// Registers a pooled blob in the given storage pool.
+    /// Returns the object ID of the created `PooledBlob`.
+    pub async fn register_pooled_blob(
+        &self,
+        storage_pool_id: ObjectID,
+        blob_metadata: BlobObjectMetadata,
+        deletable: bool,
+    ) -> SuiClientResult<ObjectID> {
+        self.retry_on_wrong_version(|| async {
+            self.inner
+                .lock()
+                .await
+                .register_pooled_blob(storage_pool_id, blob_metadata.clone(), deletable)
+                .await
+        })
+        .await
+    }
+
+    /// Certifies a pooled blob using a confirmation certificate from storage nodes.
+    pub async fn certify_pooled_blob(
+        &self,
+        storage_pool_id: ObjectID,
+        blob_id: &BlobId,
+        certificate: &ConfirmationCertificate,
+    ) -> SuiClientResult<()> {
+        self.retry_on_wrong_version(|| async {
+            self.inner
+                .lock()
+                .await
+                .certify_pooled_blob(storage_pool_id, blob_id, certificate)
+                .await
+        })
+        .await
+    }
+
+    /// Deletes a pooled blob from the storage pool, freeing its capacity.
+    pub async fn delete_pooled_blob(
+        &self,
+        storage_pool_id: ObjectID,
+        blob_id: &BlobId,
+    ) -> SuiClientResult<()> {
+        self.retry_on_wrong_version(|| async {
+            self.inner
+                .lock()
+                .await
+                .delete_pooled_blob(storage_pool_id, blob_id)
+                .await
+        })
+        .await
+    }
+
+    /// Extends the lifetime of a storage pool by `extended_epochs` epochs.
+    pub async fn extend_storage_pool(
+        &self,
+        storage_pool_id: ObjectID,
+        extended_epochs: EpochCount,
+    ) -> SuiClientResult<()> {
+        self.retry_on_wrong_version(|| async {
+            self.inner
+                .lock()
+                .await
+                .extend_storage_pool(storage_pool_id, extended_epochs)
+                .await
+        })
+        .await
+    }
+
+    /// Increases the reserved capacity of a storage pool by
+    /// `additional_encoded_capacity_bytes` for the remainder of its lifetime.
+    pub async fn increase_storage_pool_capacity(
+        &self,
+        storage_pool_id: ObjectID,
+        additional_encoded_capacity_bytes: u64,
+    ) -> SuiClientResult<()> {
+        self.retry_on_wrong_version(|| async {
+            self.inner
+                .lock()
+                .await
+                .increase_storage_pool_capacity(storage_pool_id, additional_encoded_capacity_bytes)
+                .await
+        })
+        .await
+    }
+
+    /// Destroys an empty storage pool. The recovered `Storage` reservation is
+    /// auto-transferred to the sender's wallet by the transaction builder, mirroring
+    /// the [`Self::delete_blob`] flow.
+    pub async fn destroy_storage_pool(&self, storage_pool_id: ObjectID) -> SuiClientResult<()> {
+        self.retry_on_wrong_version(|| async {
+            self.inner
+                .lock()
+                .await
+                .destroy_storage_pool(storage_pool_id)
+                .await
+        })
+        .await
     }
 
     /// Deletes the specified blob from the wallet's storage.
@@ -2478,6 +2596,165 @@ impl SuiContractClientInner {
         pt_builder.delete_blob(blob_object_id.into()).await?;
         let transaction = pt_builder.build_transaction_data(self.gas_budget).await?;
         self.sign_and_send_transaction(transaction, "delete_blob")
+            .await?;
+        Ok(())
+    }
+
+    // ---- Storage Pool operations ----
+
+    /// Creates a new storage pool and returns its object ID.
+    pub async fn create_storage_pool(
+        &mut self,
+        reserved_encoded_capacity_bytes: u64,
+        epochs_ahead: EpochCount,
+    ) -> SuiClientResult<ObjectID> {
+        let mut pt_builder = self.transaction_builder();
+        pt_builder
+            .create_storage_pool(reserved_encoded_capacity_bytes, epochs_ahead)
+            .await?;
+        let transaction = pt_builder.build_transaction_data(self.gas_budget).await?;
+        let res = self
+            .sign_and_send_transaction(transaction, "create_storage_pool")
+            .await?;
+        let pool_ids = get_created_sui_object_ids_by_type(
+            &res,
+            &contracts::storage_pool::StoragePool
+                .to_move_struct_tag_with_type_map(&self.read_client.type_origin_map(), &[])?,
+        )?;
+        ensure!(
+            pool_ids.len() == 1,
+            "expected 1 storage pool object, got {}",
+            pool_ids.len()
+        );
+        Ok(pool_ids[0])
+    }
+
+    /// Registers a pooled blob in the given storage pool.
+    /// Returns the object ID of the created `PooledBlob`.
+    pub async fn register_pooled_blob(
+        &mut self,
+        storage_pool_id: ObjectID,
+        blob_metadata: BlobObjectMetadata,
+        deletable: bool,
+    ) -> SuiClientResult<ObjectID> {
+        let mut pt_builder = self.transaction_builder();
+        pt_builder
+            .register_pooled_blob(storage_pool_id.into(), blob_metadata, deletable)
+            .await?;
+        let transaction = pt_builder.build_transaction_data(self.gas_budget).await?;
+        let res = self
+            .sign_and_send_transaction(transaction, "register_pooled_blob")
+            .await?;
+        let pooled_blob_ids = get_created_sui_object_ids_by_type(
+            &res,
+            &contracts::storage_pool::PooledBlob
+                .to_move_struct_tag_with_type_map(&self.read_client.type_origin_map(), &[])?,
+        )?;
+        ensure!(
+            pooled_blob_ids.len() == 1,
+            "expected 1 PooledBlob object, got {}",
+            pooled_blob_ids.len()
+        );
+        Ok(pooled_blob_ids[0])
+    }
+
+    /// Certifies a pooled blob.
+    pub async fn certify_pooled_blob(
+        &mut self,
+        storage_pool_id: ObjectID,
+        blob_id: &BlobId,
+        certificate: &ConfirmationCertificate,
+    ) -> SuiClientResult<()> {
+        let mut pt_builder = self.transaction_builder();
+        pt_builder
+            .certify_pooled_blob(storage_pool_id.into(), blob_id, certificate)
+            .await?;
+        let transaction = pt_builder.build_transaction_data(self.gas_budget).await?;
+        self.sign_and_send_transaction(transaction, "certify_pooled_blob")
+            .await?;
+        Ok(())
+    }
+
+    /// Deletes a pooled blob from the storage pool.
+    pub async fn delete_pooled_blob(
+        &mut self,
+        storage_pool_id: ObjectID,
+        blob_id: &BlobId,
+    ) -> SuiClientResult<()> {
+        let mut pt_builder = self.transaction_builder();
+        pt_builder
+            .delete_pooled_blob(storage_pool_id.into(), blob_id)
+            .await?;
+        let transaction = pt_builder.build_transaction_data(self.gas_budget).await?;
+        self.sign_and_send_transaction(transaction, "delete_pooled_blob")
+            .await?;
+        Ok(())
+    }
+
+    /// Extends a storage pool's lifetime.
+    pub async fn extend_storage_pool(
+        &mut self,
+        storage_pool_id: ObjectID,
+        extended_epochs: EpochCount,
+    ) -> SuiClientResult<()> {
+        let pool: StoragePoolResource = self
+            .read_client
+            .retriable_sui_client()
+            .get_sui_object(storage_pool_id)
+            .await?;
+        let mut pt_builder = self.transaction_builder();
+        pt_builder
+            .extend_storage_pool(
+                storage_pool_id.into(),
+                extended_epochs,
+                pool.reserved_encoded_capacity_bytes,
+            )
+            .await?;
+        let transaction = pt_builder.build_transaction_data(self.gas_budget).await?;
+        self.sign_and_send_transaction(transaction, "extend_storage_pool")
+            .await?;
+        Ok(())
+    }
+
+    /// Increases the reserved capacity of a storage pool for the remainder of its
+    /// lifetime. Fetches the pool object and the current system epoch to derive
+    /// `remaining_epochs` for price computation.
+    pub async fn increase_storage_pool_capacity(
+        &mut self,
+        storage_pool_id: ObjectID,
+        additional_encoded_capacity_bytes: u64,
+    ) -> SuiClientResult<()> {
+        let pool: StoragePoolResource = self
+            .read_client
+            .retriable_sui_client()
+            .get_sui_object(storage_pool_id)
+            .await?;
+        let current_epoch = self.read_client.current_epoch().await?;
+        let remaining_epochs = pool.end_epoch.saturating_sub(current_epoch);
+        let mut pt_builder = self.transaction_builder();
+        pt_builder
+            .increase_storage_pool_capacity(
+                storage_pool_id.into(),
+                additional_encoded_capacity_bytes,
+                remaining_epochs,
+            )
+            .await?;
+        let transaction = pt_builder.build_transaction_data(self.gas_budget).await?;
+        self.sign_and_send_transaction(transaction, "increase_storage_pool_capacity")
+            .await?;
+        Ok(())
+    }
+
+    /// Destroys an empty storage pool. The recovered `Storage` reservation is auto-
+    /// transferred to the sender's wallet by `transfer_remaining_outputs` at build
+    /// time, mirroring `delete_blob`.
+    pub async fn destroy_storage_pool(&mut self, storage_pool_id: ObjectID) -> SuiClientResult<()> {
+        let mut pt_builder = self.transaction_builder();
+        pt_builder
+            .destroy_storage_pool(storage_pool_id.into())
+            .await?;
+        let transaction = pt_builder.build_transaction_data(self.gas_budget).await?;
+        self.sign_and_send_transaction(transaction, "destroy_storage_pool")
             .await?;
         Ok(())
     }

--- a/crates/walrus-sui/src/client/read_client.rs
+++ b/crates/walrus-sui/src/client/read_client.rs
@@ -70,6 +70,9 @@ use crate::{
             StakingInnerV1,
             StakingObjectForDeserialization,
             StakingPool,
+            StoragePoolForDeserialization,
+            StoragePoolInnerV1,
+            StoragePoolResource,
             SubsidiesInnerKey,
             SystemObjectForDeserialization,
             SystemStateInnerV1,
@@ -477,6 +480,29 @@ impl SuiReadClient {
     /// Flushes the cached system and staking objects.
     pub async fn flush_cache(&self) {
         *self.cached_walrus_objects.write().await = None;
+    }
+
+    /// Fetches a storage pool by id, returning the combined outer + inner state.
+    ///
+    /// The outer `StoragePool` Sui object only carries `id` and `version`; the rest of
+    /// the pool state lives in a dynamic field keyed by `version`. This helper performs
+    /// both reads and assembles them into a [`StoragePoolResource`], mirroring how
+    /// `get_full_system_object` handles the system object.
+    #[tracing::instrument(skip(self), level = Level::DEBUG)]
+    pub async fn get_storage_pool(
+        &self,
+        pool_id: ObjectID,
+    ) -> SuiClientResult<StoragePoolResource> {
+        let outer: StoragePoolForDeserialization = self.sui_client.get_sui_object(pool_id).await?;
+        let inner = self
+            .sui_client
+            .get_dynamic_field::<u64, StoragePoolInnerV1>(outer.id, TypeTag::U64, outer.version)
+            .await?;
+        Ok(StoragePoolResource {
+            id: outer.id,
+            version: outer.version,
+            inner,
+        })
     }
 
     pub(crate) async fn object_arg_for_shared_obj(

--- a/crates/walrus-sui/src/client/transaction_builder.rs
+++ b/crates/walrus-sui/src/client/transaction_builder.rs
@@ -468,6 +468,183 @@ impl WalrusPtbBuilder {
         Ok(bitmap)
     }
 
+    // ---- Storage Pool operations ----
+
+    /// Adds a call to `create_storage_pool` to the `pt_builder` and returns the result
+    /// [`Argument`] representing the created `StoragePool`.
+    #[tracing::instrument(skip(self), level = Level::DEBUG)]
+    pub async fn create_storage_pool(
+        &mut self,
+        reserved_encoded_capacity_bytes: u64,
+        epochs_ahead: EpochCount,
+    ) -> SuiClientResult<Argument> {
+        let price = self
+            .storage_price_for_encoded_length(reserved_encoded_capacity_bytes, epochs_ahead, false)
+            .await?;
+        self.fill_wal_balance(price).await?;
+
+        let arguments = vec![
+            self.system_arg(SharedObjectMutability::Mutable)?,
+            self.pt_builder.pure(reserved_encoded_capacity_bytes)?,
+            self.pt_builder.pure(epochs_ahead)?,
+            self.wal_coin_arg()?,
+        ];
+        let result_arg =
+            self.walrus_move_call(contracts::system::create_storage_pool, arguments)?;
+        self.reduce_wal_balance(price)?;
+        self.add_result_to_be_consumed(result_arg);
+        Ok(result_arg)
+    }
+
+    /// Adds a call to `register_pooled_blob` to the `pt_builder`.
+    #[tracing::instrument(skip(self, blob_metadata), level = Level::DEBUG)]
+    pub async fn register_pooled_blob(
+        &mut self,
+        storage_pool: ArgumentOrOwnedObject,
+        blob_metadata: BlobObjectMetadata,
+        deletable: bool,
+    ) -> SuiClientResult<()> {
+        let price = self
+            .write_price_for_encoded_length(blob_metadata.encoded_size, false)
+            .await?;
+        self.fill_wal_balance(price).await?;
+
+        let storage_pool_arg = self.argument_from_arg_or_obj(storage_pool).await?;
+
+        let arguments = vec![
+            self.system_arg(SharedObjectMutability::Mutable)?,
+            storage_pool_arg,
+            self.pt_builder.pure(blob_metadata.blob_id)?,
+            self.pt_builder.pure(blob_metadata.root_hash.bytes())?,
+            self.pt_builder.pure(blob_metadata.unencoded_size)?,
+            self.pt_builder
+                .pure(u8::from(blob_metadata.encoding_type))?,
+            self.pt_builder.pure(deletable)?,
+            self.wal_coin_arg()?,
+        ];
+        self.walrus_move_call(contracts::system::register_pooled_blob, arguments)?;
+        self.reduce_wal_balance(price)?;
+        Ok(())
+    }
+
+    /// Adds a call to `certify_pooled_blob` to the `pt_builder`.
+    #[tracing::instrument(skip(self, certificate), level = Level::DEBUG)]
+    pub async fn certify_pooled_blob(
+        &mut self,
+        storage_pool: ArgumentOrOwnedObject,
+        blob_id: &walrus_core::BlobId,
+        certificate: &ConfirmationCertificate,
+    ) -> SuiClientResult<()> {
+        let signers = self.signers_to_bitmap(&certificate.signers).await?;
+
+        let arguments = vec![
+            self.system_arg(SharedObjectMutability::Immutable)?,
+            self.argument_from_arg_or_obj(storage_pool).await?,
+            self.pt_builder.pure(blob_id)?,
+            self.pt_builder.pure(certificate.signature.as_bytes())?,
+            self.pt_builder.pure(&signers)?,
+            self.pt_builder.pure(&certificate.serialized_message)?,
+        ];
+        self.walrus_move_call(contracts::system::certify_pooled_blob, arguments)?;
+        Ok(())
+    }
+
+    /// Adds a call to `delete_pooled_blob` to the `pt_builder`.
+    #[tracing::instrument(skip(self), level = Level::DEBUG)]
+    pub async fn delete_pooled_blob(
+        &mut self,
+        storage_pool: ArgumentOrOwnedObject,
+        blob_id: &walrus_core::BlobId,
+    ) -> SuiClientResult<()> {
+        let arguments = vec![
+            self.system_arg(SharedObjectMutability::Immutable)?,
+            self.argument_from_arg_or_obj(storage_pool).await?,
+            self.pt_builder.pure(blob_id)?,
+        ];
+        self.walrus_move_call(contracts::system::delete_pooled_blob, arguments)?;
+        Ok(())
+    }
+
+    /// Adds a call to `extend_storage_pool` to the `pt_builder`.
+    ///
+    /// `pool_encoded_capacity` must equal the pool's current
+    /// `reserved_encoded_capacity_bytes` — it is used to compute the WAL coin amount to
+    /// pre-fund. Higher-level callers should fetch the pool object and read the field
+    /// rather than passing a guessed value.
+    #[tracing::instrument(skip(self), level = Level::DEBUG)]
+    pub async fn extend_storage_pool(
+        &mut self,
+        storage_pool: ArgumentOrOwnedObject,
+        extended_epochs: EpochCount,
+        pool_encoded_capacity: u64,
+    ) -> SuiClientResult<()> {
+        let price = self
+            .storage_price_for_encoded_length(pool_encoded_capacity, extended_epochs, false)
+            .await?;
+        self.fill_wal_balance(price).await?;
+
+        let arguments = vec![
+            self.system_arg(SharedObjectMutability::Mutable)?,
+            self.argument_from_arg_or_obj(storage_pool).await?,
+            self.pt_builder.pure(extended_epochs)?,
+            self.wal_coin_arg()?,
+        ];
+        self.walrus_move_call(contracts::system::extend_storage_pool, arguments)?;
+        self.reduce_wal_balance(price)?;
+        Ok(())
+    }
+
+    /// Adds a call to `increase_storage_pool_capacity` to the `pt_builder`.
+    ///
+    /// `remaining_epochs` must equal `pool.end_epoch - current_epoch` — it is used to
+    /// compute the WAL coin amount to pre-fund. Higher-level callers should derive this
+    /// from the pool object and the current system epoch rather than passing a guessed
+    /// value.
+    #[tracing::instrument(skip(self), level = Level::DEBUG)]
+    pub async fn increase_storage_pool_capacity(
+        &mut self,
+        storage_pool: ArgumentOrOwnedObject,
+        additional_encoded_capacity_bytes: u64,
+        remaining_epochs: EpochCount,
+    ) -> SuiClientResult<()> {
+        let price = self
+            .storage_price_for_encoded_length(
+                additional_encoded_capacity_bytes,
+                remaining_epochs,
+                false,
+            )
+            .await?;
+        self.fill_wal_balance(price).await?;
+
+        let arguments = vec![
+            self.system_arg(SharedObjectMutability::Mutable)?,
+            self.argument_from_arg_or_obj(storage_pool).await?,
+            self.pt_builder.pure(additional_encoded_capacity_bytes)?,
+            self.wal_coin_arg()?,
+        ];
+        self.walrus_move_call(contracts::system::increase_storage_pool_capacity, arguments)?;
+        self.reduce_wal_balance(price)?;
+        Ok(())
+    }
+
+    /// Adds a call to `storage_pool::destroy` to the `pt_builder`.
+    ///
+    /// The pool must have `blob_count == 0`. The input pool argument is consumed
+    /// (taken by value by the Move function). Returns the recovered `Storage` object
+    /// argument, which is added to the builder's "to be consumed" set — the caller
+    /// must transfer, share, or further use it before building the transaction.
+    #[tracing::instrument(skip(self), level = Level::DEBUG)]
+    pub async fn destroy_storage_pool(
+        &mut self,
+        storage_pool: ArgumentOrOwnedObject,
+    ) -> SuiClientResult<Argument> {
+        let pool_arg = self.argument_from_arg_or_obj(storage_pool).await?;
+        let result_arg = self.walrus_move_call(contracts::storage_pool::destroy, vec![pool_arg])?;
+        self.mark_arg_as_consumed(&pool_arg);
+        self.add_result_to_be_consumed(result_arg);
+        Ok(result_arg)
+    }
+
     /// Adds a call to `certify_event_blob` to the `pt_builder`.
     pub async fn certify_event_blob(
         &mut self,

--- a/crates/walrus-sui/src/contracts.rs
+++ b/crates/walrus-sui/src/contracts.rs
@@ -239,6 +239,7 @@ pub mod storage_pool {
 
     contract_ident!(struct storage_pool::StoragePool);
     contract_ident!(struct storage_pool::PooledBlob);
+    contract_ident!(fn storage_pool::destroy);
 }
 
 /// Module for tags corresponding to the Move module `system_state_inner`.

--- a/crates/walrus-sui/src/test_utils.rs
+++ b/crates/walrus-sui/src/test_utils.rs
@@ -848,6 +848,27 @@ impl TestNodeKeys {
         self.certificate_for_signers(&confirmation, signers)
     }
 
+    /// Returns a storage confirmation certificate on the provided `blob_id` and `epoch` from
+    /// the test committee, signed by the nodes with indices in `signers`.
+    ///
+    /// The blob is certified as deletable with the given `object_id`.
+    pub fn deletable_blob_certificate_for_signers(
+        &self,
+        signers: &[u16],
+        blob_id: BlobId,
+        epoch: Epoch,
+        object_id: ObjectID,
+    ) -> anyhow::Result<ConfirmationCertificate> {
+        let confirmation = Confirmation::new(
+            epoch,
+            blob_id,
+            BlobPersistenceType::Deletable {
+                object_id: object_id.into(),
+            },
+        );
+        self.certificate_for_signers(&confirmation, signers)
+    }
+
     /// Returns a certificate from the test committee that marks `blob_id` as invalid, signed
     /// by the nodes with indices in `signers`.
     pub fn invalid_blob_certificate_for_signers(

--- a/crates/walrus-sui/src/types/move_structs.rs
+++ b/crates/walrus-sui/src/types/move_structs.rs
@@ -64,17 +64,27 @@ impl AssociatedContractStruct for StorageResource {
     const CONTRACT_STRUCT: StructTag<'static> = contracts::storage_resource::Storage;
 }
 
-/// Sui object for a storage pool.
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
-pub struct StoragePoolResource {
-    /// Object ID of the Sui object.
-    pub id: ObjectID,
-    /// The start epoch of the pool (inclusive).
-    pub start_epoch: Epoch,
-    /// The end epoch of the pool (exclusive).
-    pub end_epoch: Epoch,
-    /// The total reserved capacity in encoded bytes.
-    pub reserved_encoded_capacity_bytes: u64,
+/// Sui type for the outer storage pool object. Used for deserialization.
+///
+/// The outer object only contains `id` and `version`; the rest of the pool state lives
+/// in the dynamic-field-backed [`StoragePoolInnerV1`], keyed by `version`. Use
+/// `SuiReadClient::get_storage_pool` to fetch the combined [`StoragePoolResource`].
+#[derive(Debug, Deserialize)]
+pub struct StoragePoolForDeserialization {
+    pub(crate) id: ObjectID,
+    pub(crate) version: u64,
+}
+
+impl AssociatedContractStruct for StoragePoolForDeserialization {
+    const CONTRACT_STRUCT: StructTag<'static> = contracts::storage_pool::StoragePool;
+}
+
+/// Sui type for the inner storage pool state. Stored as a dynamic field on the outer
+/// `StoragePool` object, keyed by the pool's `version`.
+#[derive(Debug, PartialEq, Eq, Clone, Deserialize)]
+pub struct StoragePoolInnerV1 {
+    /// The storage reservation backing the pool.
+    pub storage: StorageResource,
     /// Sum of all active blobs' encoded sizes.
     pub used_encoded_bytes: u64,
     /// Number of blobs in the table.
@@ -84,8 +94,43 @@ pub struct StoragePoolResource {
     pub blobs: ObjectID,
 }
 
-impl AssociatedContractStruct for StoragePoolResource {
-    const CONTRACT_STRUCT: StructTag<'static> = contracts::storage_pool::StoragePool;
+/// Combined view of a storage pool: the outer object plus its dynamic-field-backed
+/// inner state. Constructed by `SuiReadClient::get_storage_pool`.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct StoragePoolResource {
+    /// Object id of the Sui object.
+    pub id: ObjectID,
+    /// The version of the storage pool.
+    pub version: u64,
+    /// The inner pool state.
+    pub inner: StoragePoolInnerV1,
+}
+
+impl StoragePoolResource {
+    /// Returns the start epoch of the pool (inclusive).
+    pub fn start_epoch(&self) -> Epoch {
+        self.inner.storage.start_epoch
+    }
+
+    /// Returns the end epoch of the pool (exclusive).
+    pub fn end_epoch(&self) -> Epoch {
+        self.inner.storage.end_epoch
+    }
+
+    /// Returns the total reserved capacity in encoded bytes.
+    pub fn reserved_encoded_capacity_bytes(&self) -> u64 {
+        self.inner.storage.storage_size
+    }
+
+    /// Returns the sum of all active blobs' encoded sizes.
+    pub fn used_encoded_bytes(&self) -> u64 {
+        self.inner.used_encoded_bytes
+    }
+
+    /// Returns the number of blobs currently in the pool.
+    pub fn blob_count(&self) -> u64 {
+        self.inner.blob_count
+    }
 }
 
 /// Sui object for a blob.

--- a/crates/walrus-sui/tests/test_walrus_sui.rs
+++ b/crates/walrus-sui/tests/test_walrus_sui.rs
@@ -663,3 +663,140 @@ async fn test_automatic_wal_coin_squashing(
     );
     Ok(())
 }
+
+#[tokio::test]
+#[ignore = "ignore integration tests by default"]
+async fn test_storage_pool_lifecycle() -> anyhow::Result<()> {
+    walrus_test_utils::init_tracing();
+    let encoding_type = EncodingType::RS2;
+
+    let (_sui_cluster_handle, walrus_client, _, _) =
+        initialize_contract_and_wallet_with_single_node().await?;
+
+    let encoding_config = EncodingConfig::new(NonZeroU16::new(1000).unwrap());
+    let capacity = encoding_config
+        .get_for_type(encoding_type)
+        .encoded_blob_length(10_000)
+        .unwrap();
+    let epochs_ahead = 3;
+
+    let pool_id = walrus_client
+        .as_ref()
+        .create_storage_pool(capacity, epochs_ahead)
+        .await?;
+
+    // Exercises the two-step dynamic-field fetch.
+    let pool = walrus_client
+        .as_ref()
+        .read_client
+        .get_storage_pool(pool_id)
+        .await?;
+    assert_eq!(pool.id, pool_id);
+    assert_eq!(pool.reserved_encoded_capacity_bytes(), capacity);
+    assert_eq!(pool.start_epoch(), 1);
+    assert_eq!(pool.end_epoch(), 1 + epochs_ahead);
+    assert_eq!(pool.used_encoded_bytes(), 0);
+    assert_eq!(pool.blob_count(), 0);
+
+    let additional_capacity = capacity;
+    walrus_client
+        .as_ref()
+        .increase_storage_pool_capacity(pool_id, additional_capacity)
+        .await?;
+
+    let extend_epochs = 2;
+    walrus_client
+        .as_ref()
+        .extend_storage_pool(pool_id, extend_epochs)
+        .await?;
+
+    let pool = walrus_client
+        .as_ref()
+        .read_client
+        .get_storage_pool(pool_id)
+        .await?;
+    assert_eq!(
+        pool.reserved_encoded_capacity_bytes(),
+        capacity + additional_capacity
+    );
+    assert_eq!(pool.end_epoch(), 1 + epochs_ahead + extend_epochs);
+
+    walrus_client.as_ref().destroy_storage_pool(pool_id).await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "ignore integration tests by default"]
+async fn test_register_certify_delete_pooled_blob() -> anyhow::Result<()> {
+    walrus_test_utils::init_tracing();
+    let encoding_type = EncodingType::RS2;
+
+    let (_sui_cluster_handle, walrus_client, _, test_node_keys) =
+        initialize_contract_and_wallet_with_single_node().await?;
+
+    let encoding_config = EncodingConfig::new(NonZeroU16::new(1000).unwrap());
+    let size = 10_000;
+    let encoded_size = encoding_config
+        .get_for_type(encoding_type)
+        .encoded_blob_length(size)
+        .unwrap();
+
+    let pool_id = walrus_client
+        .as_ref()
+        .create_storage_pool(encoded_size, 3)
+        .await?;
+
+    #[rustfmt::skip]
+    let root_hash = [
+        9, 8, 7, 6, 5, 4, 3, 2,
+        9, 8, 7, 6, 5, 4, 3, 2,
+        9, 8, 7, 6, 5, 4, 3, 2,
+        9, 8, 7, 6, 5, 4, 3, 2,
+    ];
+    let blob_id = BlobId::from_metadata(Node::from(root_hash), encoding_type, size);
+    let blob_metadata = BlobObjectMetadata {
+        blob_id,
+        root_hash: Node::from(root_hash),
+        unencoded_size: size,
+        encoded_size,
+        encoding_type,
+    };
+
+    let pooled_blob_id = walrus_client
+        .as_ref()
+        .register_pooled_blob(pool_id, blob_metadata, true)
+        .await?;
+
+    let pool = walrus_client
+        .as_ref()
+        .read_client
+        .get_storage_pool(pool_id)
+        .await?;
+    assert_eq!(pool.blob_count(), 1);
+    assert_eq!(pool.used_encoded_bytes(), encoded_size);
+
+    // Deletable certificate must embed the pooled blob's object id; the contract asserts
+    // both the persistence type and the object id match the registration.
+    let certificate =
+        test_node_keys.deletable_blob_certificate_for_signers(&[0], blob_id, 1, pooled_blob_id)?;
+    walrus_client
+        .as_ref()
+        .certify_pooled_blob(pool_id, &blob_id, &certificate)
+        .await?;
+
+    walrus_client
+        .as_ref()
+        .delete_pooled_blob(pool_id, &blob_id)
+        .await?;
+
+    let pool = walrus_client
+        .as_ref()
+        .read_client
+        .get_storage_pool(pool_id)
+        .await?;
+    assert_eq!(pool.blob_count(), 0);
+    assert_eq!(pool.used_encoded_bytes(), 0);
+
+    walrus_client.as_ref().destroy_storage_pool(pool_id).await?;
+    Ok(())
+}


### PR DESCRIPTION
## Description

- Add StoragePool SDK methods in walrus-sui: create / register / certify / delete pooled blob, extend, increase capacity, destroy.
 - Fix StoragePool deserialization: outer object only carries id + version; inner state lives in a dynamic field keyed by version.
 - Add integration tests covering the full pool lifecycle and the register/certify/delete/destroy path.

## Test plan

Add  `test_storage_pool_lifecycle` and `test_register_certify_delete_pooled_blob`

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
