### PR TITLE
feat: create a public function to extract unused storage from storage pool

### DIFF
--- a/contracts/walrus/sources/system.move
+++ b/contracts/walrus/sources/system.move
@@ -304,6 +304,16 @@ public fun increase_storage_pool_capacity_with_storage(
     self.inner().increase_storage_pool_capacity_with_storage(storage_pool, storage)
 }
 
+/// Reduces the pool's capacity by extracting a `Storage` object of the given size.
+public fun decrease_storage_pool_capacity_by_size(
+    self: &System,
+    storage_pool: &mut StoragePool,
+    size: u64,
+    ctx: &mut TxContext,
+): Storage {
+    self.inner().decrease_storage_pool_capacity_by_size(storage_pool, size, ctx)
+}
+
 /// Certifies a blob within a storage pool.
 public fun certify_pooled_blob(
     self: &System,

--- a/contracts/walrus/sources/system.move
+++ b/contracts/walrus/sources/system.move
@@ -314,6 +314,17 @@ public fun decrease_storage_pool_capacity_by_size(
     self.inner().decrease_storage_pool_capacity_by_size(storage_pool, size, ctx)
 }
 
+/// Reduces the pool's capacity by extracting `percent` of the unused capacity as a `Storage`
+/// object. Returns `none` when the computed extract size is zero.
+public fun decrease_storage_pool_unused_capacity_by_percent(
+    self: &System,
+    storage_pool: &mut StoragePool,
+    percent: u8,
+    ctx: &mut TxContext,
+): Option<Storage> {
+    self.inner().decrease_storage_pool_unused_capacity_by_percent(storage_pool, percent, ctx)
+}
+
 /// Certifies a blob within a storage pool.
 public fun certify_pooled_blob(
     self: &System,

--- a/contracts/walrus/sources/system.move
+++ b/contracts/walrus/sources/system.move
@@ -24,6 +24,8 @@ use walrus::{
 const EInvalidMigration: u64 = 0;
 /// The package version is not compatible with the system object.
 const EWrongVersion: u64 = 1;
+/// The extracted storage size is zero (nothing to extract).
+const EZeroExtractSize: u64 = 2;
 
 /// Flag to indicate the version of the system.
 const VERSION: u64 = 3;
@@ -305,24 +307,32 @@ public fun increase_storage_pool_capacity_with_storage(
 }
 
 /// Reduces the pool's capacity by extracting a `Storage` object of the given size.
+/// Aborts with `EZeroExtractSize` if `size` is zero.
 public fun decrease_storage_pool_capacity_by_size(
     self: &System,
     storage_pool: &mut StoragePool,
     size: u64,
     ctx: &mut TxContext,
 ): Storage {
-    self.inner().decrease_storage_pool_capacity_by_size(storage_pool, size, ctx)
+    let result = self.inner().decrease_storage_pool_capacity_by_size(storage_pool, size, ctx);
+    assert!(result.is_some(), EZeroExtractSize);
+    result.destroy_some()
 }
 
 /// Reduces the pool's capacity by extracting `percent` of the unused capacity as a `Storage`
-/// object. Returns `none` when the computed extract size is zero.
+/// object. Aborts with `EZeroExtractSize` if the computed extract size is zero (for example
+/// from rounding or zero unused capacity).
 public fun decrease_storage_pool_unused_capacity_by_percent(
     self: &System,
     storage_pool: &mut StoragePool,
     percent: u8,
     ctx: &mut TxContext,
-): Option<Storage> {
-    self.inner().decrease_storage_pool_unused_capacity_by_percent(storage_pool, percent, ctx)
+): Storage {
+    let result = self
+        .inner()
+        .decrease_storage_pool_unused_capacity_by_percent(storage_pool, percent, ctx);
+    assert!(result.is_some(), EZeroExtractSize);
+    result.destroy_some()
 }
 
 /// Certifies a blob within a storage pool.

--- a/contracts/walrus/sources/system/storage_pool.move
+++ b/contracts/walrus/sources/system/storage_pool.move
@@ -247,6 +247,23 @@ public(package) fun increase_capacity_with_storage(
     other.destroy();
 }
 
+/// Reduces the pool's capacity by splitting off a `Storage` object of the given size.
+/// The remaining capacity in the pool must be sufficient to cover `used_encoded_bytes`,
+/// ensuring all active blobs remain backed by storage.
+public(package) fun decrease_capacity_by_size(
+    self: &mut StoragePool,
+    extract_size: u64,
+    ctx: &mut TxContext,
+): Storage {
+    let inner = self.inner_mut();
+    // Ensure there is enough unused capacity to extract.
+    assert!(inner.storage.size() - inner.used_encoded_bytes >= extract_size, EInsufficientCapacity);
+    // split_by_size keeps `keep_size` in the pool's storage and returns a new Storage with the
+    // remainder.
+    let keep_size = inner.storage.size() - extract_size;
+    inner.storage.split_by_size(keep_size, ctx)
+}
+
 /// Destroys the pool and returns the embedded `Storage` reservation.
 /// Asserts the blobs table is empty and `blob_count == 0`.
 public fun destroy(self: StoragePool): Storage {

--- a/contracts/walrus/sources/system/storage_pool.move
+++ b/contracts/walrus/sources/system/storage_pool.move
@@ -251,19 +251,23 @@ public(package) fun increase_capacity_with_storage(
 
 /// Reduces the pool's capacity by splitting off a `Storage` object of the given size.
 /// The remaining capacity in the pool must be sufficient to cover `used_encoded_bytes`,
-/// ensuring all active blobs remain backed by storage.
+/// ensuring all active blobs remain backed by storage. Returns `none` when `extract_size`
+/// is zero.
 public(package) fun decrease_capacity_by_size(
     self: &mut StoragePool,
     extract_size: u64,
     ctx: &mut TxContext,
-): Storage {
+): Option<Storage> {
+    if (extract_size == 0) {
+        return option::none()
+    };
     let inner = self.inner_mut();
     // Ensure there is enough unused capacity to extract.
     assert!(inner.storage.size() - inner.used_encoded_bytes >= extract_size, EInsufficientCapacity);
     // split_by_size keeps `keep_size` in the pool's storage and returns a new Storage with the
     // remainder.
     let keep_size = inner.storage.size() - extract_size;
-    inner.storage.split_by_size(keep_size, ctx)
+    option::some(inner.storage.split_by_size(keep_size, ctx))
 }
 
 /// Reduces the pool's capacity by extracting `percent` of the currently unused capacity as a
@@ -277,12 +281,8 @@ public(package) fun decrease_unused_capacity_by_percent(
     assert!(percent <= 100, EInvalidPercent);
     let inner = self.inner();
     let unused = inner.storage.size() - inner.used_encoded_bytes;
-    let extract_size = (unused * (percent as u64)) / 100;
-    if (extract_size == 0) {
-        option::none()
-    } else {
-        option::some(self.decrease_capacity_by_size(extract_size, ctx))
-    }
+    let extract_size = ((unused as u128) * (percent as u128) / 100 as u64);
+    self.decrease_capacity_by_size(extract_size, ctx)
 }
 
 /// Destroys the pool and returns the embedded `Storage` reservation.

--- a/contracts/walrus/sources/system/storage_pool.move
+++ b/contracts/walrus/sources/system/storage_pool.move
@@ -47,6 +47,8 @@ const EIncompatibleEndEpoch: u64 = 11;
 const EDuplicateMetadata: u64 = 12;
 /// The blob does not have any metadata.
 const EMissingMetadata: u64 = 13;
+/// The percent value is out of the allowed 0..=100 range.
+const EInvalidPercent: u64 = 14;
 
 /// Version of the pool outer object.
 const VERSION: u64 = 1;
@@ -262,6 +264,25 @@ public(package) fun decrease_capacity_by_size(
     // remainder.
     let keep_size = inner.storage.size() - extract_size;
     inner.storage.split_by_size(keep_size, ctx)
+}
+
+/// Reduces the pool's capacity by extracting `percent` of the currently unused capacity as a
+/// `Storage` object. `percent` must be in the range `0..=100`. Returns `none` when the computed
+/// extract size is zero (for example when `percent == 0` or there is no unused capacity).
+public(package) fun decrease_unused_capacity_by_percent(
+    self: &mut StoragePool,
+    percent: u8,
+    ctx: &mut TxContext,
+): Option<Storage> {
+    assert!(percent <= 100, EInvalidPercent);
+    let inner = self.inner();
+    let unused = inner.storage.size() - inner.used_encoded_bytes;
+    let extract_size = (unused * (percent as u64)) / 100;
+    if (extract_size == 0) {
+        option::none()
+    } else {
+        option::some(self.decrease_capacity_by_size(extract_size, ctx))
+    }
 }
 
 /// Destroys the pool and returns the embedded `Storage` reservation.

--- a/contracts/walrus/sources/system/system_state_inner.move
+++ b/contracts/walrus/sources/system/system_state_inner.move
@@ -988,6 +988,17 @@ public(package) fun increase_storage_pool_capacity_with_storage(
     storage_pool.increase_capacity_with_storage(storage, self.epoch());
 }
 
+/// Reduces the pool's capacity by extracting a `Storage` object of the given size.
+public(package) fun decrease_storage_pool_capacity_by_size(
+    self: &SystemStateInnerV1,
+    storage_pool: &mut StoragePool,
+    size: u64,
+    ctx: &mut TxContext,
+): Storage {
+    assert!(storage_pool.end_epoch() > self.epoch(), EInvalidEpochsAhead);
+    storage_pool.decrease_capacity_by_size(size, ctx)
+}
+
 /// Certifies a blob within a `StoragePool`.
 public(package) fun certify_pooled_blob(
     self: &SystemStateInnerV1,

--- a/contracts/walrus/sources/system/system_state_inner.move
+++ b/contracts/walrus/sources/system/system_state_inner.move
@@ -999,6 +999,18 @@ public(package) fun decrease_storage_pool_capacity_by_size(
     storage_pool.decrease_capacity_by_size(size, ctx)
 }
 
+/// Reduces the pool's capacity by extracting `percent` of the unused capacity as a `Storage`
+/// object. Returns `none` when the computed extract size is zero.
+public(package) fun decrease_storage_pool_unused_capacity_by_percent(
+    self: &SystemStateInnerV1,
+    storage_pool: &mut StoragePool,
+    percent: u8,
+    ctx: &mut TxContext,
+): Option<Storage> {
+    assert!(storage_pool.end_epoch() > self.epoch(), EInvalidEpochsAhead);
+    storage_pool.decrease_unused_capacity_by_percent(percent, ctx)
+}
+
 /// Certifies a blob within a `StoragePool`.
 public(package) fun certify_pooled_blob(
     self: &SystemStateInnerV1,

--- a/contracts/walrus/sources/system/system_state_inner.move
+++ b/contracts/walrus/sources/system/system_state_inner.move
@@ -989,12 +989,13 @@ public(package) fun increase_storage_pool_capacity_with_storage(
 }
 
 /// Reduces the pool's capacity by extracting a `Storage` object of the given size.
+/// Returns `none` when `size` is zero.
 public(package) fun decrease_storage_pool_capacity_by_size(
     self: &SystemStateInnerV1,
     storage_pool: &mut StoragePool,
     size: u64,
     ctx: &mut TxContext,
-): Storage {
+): Option<Storage> {
     assert!(storage_pool.end_epoch() > self.epoch(), EInvalidEpochsAhead);
     storage_pool.decrease_capacity_by_size(size, ctx)
 }

--- a/contracts/walrus/tests/system/storage_pool_tests.move
+++ b/contracts/walrus/tests/system/storage_pool_tests.move
@@ -820,6 +820,77 @@ fun increase_capacity_with_storage_expired_pool() {
     abort
 }
 
+// === decrease_capacity_by_size tests ===
+
+/// Extract capacity from a pool with blobs; verify sizes, epochs, and available drops correctly.
+#[test]
+fun decrease_capacity_by_size_happy_path() {
+    let ctx = &mut tx_context::dummy();
+    let mut system = system::new_for_testing(ctx);
+    let capacity = encoded_size(&system, SIZE);
+    let mut fake_coin = test_utils::mint_frost(N_COINS * 10, ctx);
+    // Pool has 3x capacity, register a blob that uses 1x.
+    let mut pool = system.create_storage_pool(capacity * 3, 3, &mut fake_coin, ctx);
+    register_blob_in_pool(&mut system, &mut pool, default_blob_id(), SIZE, false, ctx);
+
+    // Extract exactly all unused capacity (2x).
+    let extracted = pool.decrease_capacity_by_size(capacity * 2, ctx);
+    assert_eq!(pool.reserved_encoded_capacity_bytes(), capacity);
+    assert_eq!(pool.available_encoded_bytes(), 0);
+    assert_eq!(extracted.size(), capacity * 2);
+    assert_eq!(extracted.start_epoch(), pool.start_epoch());
+    assert_eq!(extracted.end_epoch(), pool.end_epoch());
+
+    fake_coin.burn_for_testing();
+    extracted.destroy();
+    pool.destroy_for_testing();
+    system.destroy_for_testing();
+}
+
+/// Cannot extract more than unused capacity — blobs must remain backed.
+#[test, expected_failure(abort_code = storage_pool::EInsufficientCapacity)]
+fun decrease_capacity_by_size_exceeds_available() {
+    let ctx = &mut tx_context::dummy();
+    let mut system = system::new_for_testing(ctx);
+    let capacity = encoded_size(&system, SIZE);
+    let mut fake_coin = test_utils::mint_frost(N_COINS * 10, ctx);
+    let mut pool = system.create_storage_pool(capacity, 3, &mut fake_coin, ctx);
+    register_blob_in_pool(&mut system, &mut pool, default_blob_id(), SIZE, false, ctx);
+
+    // Pool is fully used — even 1 byte should fail.
+    let _storage = pool.decrease_capacity_by_size(1, ctx);
+    abort
+}
+
+/// Cannot extract more than total capacity.
+#[test, expected_failure(abort_code = storage_pool::EInsufficientCapacity)]
+fun decrease_capacity_by_size_exceeds_total() {
+    let ctx = &mut tx_context::dummy();
+    let mut system = system::new_for_testing(ctx);
+    let capacity = encoded_size(&system, SIZE);
+    let mut fake_coin = test_utils::mint_frost(N_COINS * 10, ctx);
+    let mut pool = system.create_storage_pool(capacity, 3, &mut fake_coin, ctx);
+
+    let _storage = pool.decrease_capacity_by_size(capacity + 1, ctx);
+    abort
+}
+
+/// After splitting, the reduced pool correctly enforces its new capacity limit.
+#[test, expected_failure(abort_code = storage_pool::EInsufficientCapacity)]
+fun decrease_capacity_by_size_then_register_blob_fails() {
+    let ctx = &mut tx_context::dummy();
+    let mut system = system::new_for_testing(ctx);
+    let capacity = encoded_size(&system, SIZE);
+    let mut fake_coin = test_utils::mint_frost(N_COINS * 10, ctx);
+    let mut pool = system.create_storage_pool(capacity * 2, 3, &mut fake_coin, ctx);
+
+    // Leave less than 1x capacity.
+    let _extracted = pool.decrease_capacity_by_size(capacity + 1, ctx);
+    // Blob needs 1x — should fail.
+    register_blob_in_pool(&mut system, &mut pool, default_blob_id(), SIZE, false, ctx);
+    abort
+}
+
 // === Capacity accounting and reward distribution tests ===
 
 // Test that the capacity and rewards are accounted for the correct epochs when creating and

--- a/contracts/walrus/tests/system/storage_pool_tests.move
+++ b/contracts/walrus/tests/system/storage_pool_tests.move
@@ -834,7 +834,7 @@ fun decrease_capacity_by_size_happy_path() {
     register_blob_in_pool(&mut system, &mut pool, default_blob_id(), SIZE, false, ctx);
 
     // Extract exactly all unused capacity (2x).
-    let extracted = pool.decrease_capacity_by_size(capacity * 2, ctx);
+    let extracted = pool.decrease_capacity_by_size(capacity * 2, ctx).destroy_some();
     assert_eq!(pool.reserved_encoded_capacity_bytes(), capacity);
     assert_eq!(pool.available_encoded_bytes(), 0);
     assert_eq!(extracted.size(), capacity * 2);
@@ -888,6 +888,92 @@ fun decrease_capacity_by_size_then_register_blob_fails() {
     let _extracted = pool.decrease_capacity_by_size(capacity + 1, ctx);
     // Blob needs 1x — should fail.
     register_blob_in_pool(&mut system, &mut pool, default_blob_id(), SIZE, false, ctx);
+    abort
+}
+
+// === decrease_storage_pool_unused_capacity_by_percent tests ===
+
+/// 50% with rounding (available=99, extracts 49 not 50), then 100% of remainder; verifies
+/// no overdrawing with blob present.
+#[test]
+fun decrease_unused_by_percent_happy_path() {
+    use walrus::storage_resource;
+    let ctx = &mut tx_context::dummy();
+    let mut system = system::new_for_testing(ctx);
+    let capacity = encoded_size(&system, SIZE);
+    // Pool with capacity + 99: blob uses capacity, leaving 99 available (odd, for rounding).
+    let storage = storage_resource::create_for_test(0, 3, capacity + 99, ctx);
+    let mut pool = system.create_storage_pool_with_storage(storage, ctx);
+    register_blob_in_pool(&mut system, &mut pool, default_blob_id(), SIZE, false, ctx);
+
+    // 50% of 99 = 49 (floor, not 50).
+    let first = system.decrease_storage_pool_unused_capacity_by_percent(&mut pool, 50, ctx);
+    assert_eq!(first.size(), 49);
+    assert_eq!(pool.available_encoded_bytes(), 50);
+
+    // 100% of remaining 50.
+    let second = system.decrease_storage_pool_unused_capacity_by_percent(&mut pool, 100, ctx);
+    assert_eq!(second.size(), 50);
+    assert_eq!(pool.available_encoded_bytes(), 0);
+
+    first.destroy();
+    second.destroy();
+    pool.destroy_for_testing();
+    system.destroy_for_testing();
+}
+
+/// Rounding to zero (available=99, 1% → 0) aborts with EZeroExtractSize.
+#[test, expected_failure(abort_code = system::EZeroExtractSize)]
+fun decrease_unused_by_percent_rounds_to_zero() {
+    let ctx = &mut tx_context::dummy();
+    let mut system = system::new_for_testing(ctx);
+    let mut fake_coin = test_utils::mint_frost(N_COINS * 10, ctx);
+    let mut pool = system.create_storage_pool(99, 3, &mut fake_coin, ctx);
+
+    let _s = system.decrease_storage_pool_unused_capacity_by_percent(&mut pool, 1, ctx);
+    abort
+}
+
+/// Percentage > 100 is rejected.
+#[test, expected_failure(abort_code = storage_pool::EInvalidPercent)]
+fun decrease_unused_by_percent_over_100() {
+    let ctx = &mut tx_context::dummy();
+    let mut system = system::new_for_testing(ctx);
+    let mut fake_coin = test_utils::mint_frost(N_COINS * 10, ctx);
+    let mut pool = system.create_storage_pool(99, 3, &mut fake_coin, ctx);
+
+    let _s = system.decrease_storage_pool_unused_capacity_by_percent(&mut pool, 101, ctx);
+    abort
+}
+
+/// No overflow: near-u64::MAX available × 100 computed safely via u128.
+#[test]
+fun decrease_unused_by_percent_large_available() {
+    use walrus::storage_resource;
+    let ctx = &mut tx_context::dummy();
+    let system = system::new_for_testing(ctx);
+    let large: u64 = 18_446_744_073_709_551_000;
+    let storage = storage_resource::create_for_test(0, 3, large, ctx);
+    let mut pool = system.create_storage_pool_with_storage(storage, ctx);
+
+    let extracted = system.decrease_storage_pool_unused_capacity_by_percent(&mut pool, 100, ctx);
+    assert_eq!(extracted.size(), large);
+
+    extracted.destroy();
+    pool.destroy_for_testing();
+    system.destroy_for_testing();
+}
+
+/// Expired pool is rejected.
+#[test, expected_failure(abort_code = system_state_inner::EInvalidEpochsAhead)]
+fun decrease_unused_by_percent_expired_pool() {
+    let ctx = &mut tx_context::dummy();
+    let mut system = system::new_for_testing(ctx);
+    let mut fake_coin = test_utils::mint_frost(N_COINS * 10, ctx);
+    let mut pool = system.create_storage_pool(99, 1, &mut fake_coin, ctx);
+
+    advance_epoch(&mut system);
+    let _s = system.decrease_storage_pool_unused_capacity_by_percent(&mut pool, 50, ctx);
     abort
 }
 


### PR DESCRIPTION
## Description

This can be used to shrink storage pool size and extract storage resource that the pool owner doesn't want to extend anymore.

This function currently requires specifying exact storage amount to be extracted.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
