### PR TITLE
feat(sdk): expose get_certificate_standalone for re-registration flows

### DIFF
--- a/crates/walrus-sdk/src/node_client.rs
+++ b/crates/walrus-sdk/src/node_client.rs
@@ -2081,8 +2081,32 @@ impl<T> WalrusNodeClient<T> {
         })
     }
 
-    /// Fetches confirmations for a blob from a quorum of nodes and returns the certificate.
-    async fn get_certificate_standalone(
+    /// Fetches storage confirmations from a quorum of nodes and aggregates them into a
+    /// [`ConfirmationCertificate`] without uploading any slivers.
+    ///
+    /// Unlike the regular certification flow ([`send_blob_data_and_get_certificate`]), this
+    /// assumes the storage nodes already hold all slivers for `blob_id` — either because the blob
+    /// was previously certified on chain (and we are registering a new on-chain [`Blob`] pointing
+    /// at the same content) or because nothing has changed since an earlier upload. The caller is
+    /// responsible for having already registered the new on-chain [`Blob`] object it wants to
+    /// certify; pass the resulting `ObjectID` via
+    /// [`BlobPersistenceType::Deletable { object_id }`] (or use
+    /// [`BlobPersistenceType::Permanent`] for permanent blobs) so that storage nodes sign the
+    /// confirmation against the correct on-chain identity.
+    ///
+    /// Storage nodes sign confirmations for the **current** epoch regardless of
+    /// `certified_epoch`; that argument is only used to route the request to the correct
+    /// historical committee when the blob was first certified in a past epoch.
+    ///
+    /// Typical caller pattern:
+    /// 1. Fetch source `BlobObjectMetadata` (for example via [`Self::retrieve_metadata`]).
+    /// 2. Build a PTB: `reserve_space` → `register_blob` → submit; extract the new `ObjectID`.
+    /// 3. Call this method with the new `ObjectID` inside `blob_persistence_type`.
+    /// 4. Build a PTB: `certify_blob` → submit.
+    ///
+    /// [`send_blob_data_and_get_certificate`]: Self::send_blob_data_and_get_certificate
+    /// [`Blob`]: walrus_sui::types::Blob
+    pub async fn get_certificate_standalone(
         &self,
         blob_id: &BlobId,
         certified_epoch: Epoch,


### PR DESCRIPTION
## Description

Make `WalrusNodeClient::get_certificate_standalone` `pub` and expand its
docstring. No behavior change — the method was already used internally by
`store_pipeline::certify_with_nodes` when storage nodes already hold the
data; this PR only widens the visibility so SDK users can reuse the same
zero-bandwidth path.

**Motivation.** External SDK users (e.g. a hosted-API gateway that wants
to re-register an existing Walrus blob under a new on-chain `Blob` object
without re-uploading slivers) need a way to fetch a fresh confirmation
certificate from the storage-node quorum, given:

1. a `blob_id` the nodes already hold,
2. a `certified_epoch` from the source `Blob`, and
3. a new on-chain `ObjectID` (`BlobPersistenceType::Deletable { object_id }`)
   that the nodes should sign against.

Today, the only public path is `send_blob_data_and_get_certificate`, which
requires re-uploading the slivers. Exposing `get_certificate_standalone`
unlocks the following caller pattern without re-uploading bytes:

1. Fetch source `BlobObjectMetadata` (e.g. via `retrieve_metadata`).
2. PTB: `reserve_space` → `register_blob` → submit; extract new `ObjectID`.
3. `get_certificate_standalone(blob_id, source_certified_epoch,
   BlobPersistenceType::Deletable { object_id: new })`.
4. PTB: `certify_blob` → submit.

**Downstream consumer.** Oyster (Walrus-backed hosted API gateway) needs
this to implement a duplicate-blob endpoint — reifying a second reference
to an already-stored blob under a new `(bucket, key)` pair without paying
sliver-upload bandwidth for content that is already on the network.

## Test plan

- `cargo build -p walrus-sdk` passes (pure visibility change + docstring).
- `cargo test -p walrus-sdk` — existing internal callers of
  `get_certificate_standalone` continue to compile and pass (only one
  internal caller: `store_pipeline::certify_with_nodes`).
- End-to-end validation of the new caller path will land downstream in
  Oyster once this PR merges and a new `testnet-v1.45.x` tag is cut.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI: