### PR TITLE
chore(ci): bump taiki-e/install-action to v2.75.16

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
-      - uses: taiki-e/install-action@970d55e3ce02a46d60ffae7b4fab3dedace6e769 # pin@v2.49.13
+      - uses: taiki-e/install-action@a2352fc6ce487f030a3aa709482d57823eadfb37 # pin@v2.75.16
         with:
           tool: cargo-deny@0.18.4
       - name: Check dependencies
@@ -119,7 +119,7 @@ jobs:
       OPENSSL_NO_VENDOR: "0"
       WALRUS_GRPC_MIGRATION_LEVEL: "${{ matrix.grpc_migration_level }}"
     steps:
-      - uses: taiki-e/install-action@970d55e3ce02a46d60ffae7b4fab3dedace6e769 # pin@v2.49.13
+      - uses: taiki-e/install-action@a2352fc6ce487f030a3aa709482d57823eadfb37 # pin@v2.75.16
         with:
           tool: cargo-nextest
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
@@ -149,7 +149,7 @@ jobs:
       SIMTEST_REDUCED: ${{ github.event_name != 'push' && contains(github.event.pull_request.labels.*.name, 'ci:less-simtest-seeds')
         }}
     steps:
-      - uses: taiki-e/install-action@970d55e3ce02a46d60ffae7b4fab3dedace6e769 # pin@v2.49.13
+      - uses: taiki-e/install-action@a2352fc6ce487f030a3aa709482d57823eadfb37 # pin@v2.75.16
         with:
           tool: cargo-nextest
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
@@ -179,7 +179,7 @@ jobs:
     if: false
     runs-on: ubuntu-ghcloud
     steps:
-      - uses: taiki-e/install-action@970d55e3ce02a46d60ffae7b4fab3dedace6e769 # pin@v2.49.13
+      - uses: taiki-e/install-action@a2352fc6ce487f030a3aa709482d57823eadfb37 # pin@v2.75.16
         with:
           tool: cargo-nextest
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -99,7 +99,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
       - name: Install licensesnip
-        uses: taiki-e/install-action@970d55e3ce02a46d60ffae7b4fab3dedace6e769 # pin@v2.49.13
+        uses: taiki-e/install-action@a2352fc6ce487f030a3aa709482d57823eadfb37 # pin@v2.75.16
         with:
           tool: licensesnip@1.7.0
       - run: licensesnip check


### PR DESCRIPTION
## Description

Bump `taiki-e/install-action` from **v2.49.13** (commit `970d55e3`) to
**v2.75.16** (commit `a2352fc6`) across the two workflows that pin it by
SHA.

### Why

Our current pin is v2.49.13, which pre-dates the fix in v2.53.2 (shipped
2025-06-18) for a flaky crates.io lookup that `install-action` performs
when resolving an unpinned `cargo-nextest` version. That lookup started
returning **403** again today, around 2026-04-16 23:30 UTC, breaking the
Code and Lint workflows on in-flight PRs:

- My PR #3294 (SDK visibility change) — 22 identical `curl: (22) ... error: 403` lines in the `taiki-e/install-action` step.
- `shuo/antithesis_test_invariant_check` — same symptom, 22 occurrences.

The last green `code.yml` run on `main` (24536876876 at 2026-04-16 22:17 UTC)
ran before the upstream crates.io behavior changed. `install-action`'s
own CI is fully green today using its latest releases, which confirms
the fix is carried forward in v2.53.2+.

Relevant upstream reference: [`taiki-e/install-action` #1005](https://github.com/taiki-e/install-action/issues/1005).

### Scope

Five call sites (pinned by SHA) across two files:

- `.github/workflows/code.yml` — 4 sites (lines 60, 122, 152, 182)
- `.github/workflows/lint.yml` — 1 site (line 102)

`attach-binaries-to-release.yml` uses the branch-style `@cargo-hack`
tracking ref, which is a separate convention and is not affected by
this issue; left unchanged.

## Test plan

- CI on this PR is itself the test. If the `Code` and `Lint` workflows
  go green here, the bump works; then PR #3294 (and any other stuck PR)
  can be re-run or rebased onto this change.
- No source-code changes, no Rust touched — the diff is literally five
  `@SHA # pin@vX.Y.Z` line changes.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI: