### PR TITLE
fix(sui): drop dead errors check in certify_pooled_blobs

### DIFF
--- a/crates/walrus-sui/src/client/pooled_blob_ops.rs
+++ b/crates/walrus-sui/src/client/pooled_blob_ops.rs
@@ -243,14 +243,8 @@ impl SuiContractClientInner {
             .await?;
 
         let transaction = pt_builder.build_transaction_data(self.gas_budget).await?;
-        let res = self
-            .sign_and_send_transaction(transaction, "certify_pooled_blobs")
+        self.sign_and_send_transaction(transaction, "certify_pooled_blobs")
             .await?;
-
-        if !res.errors.is_empty() {
-            tracing::warn!(errors = ?res.errors, "failed to certify pooled blobs on Sui");
-            return Err(anyhow!("could not certify pooled blobs: {:?}", res.errors).into());
-        }
 
         Ok(())
     }


### PR DESCRIPTION
## Description

Semantic merge conflict between #3213 and #3262 on `main`:

- #3213 (`debffb27b`) added `crates/walrus-sui/src/client/pooled_blob_ops.rs`, which inspects `res.errors` on the return value of `sign_and_send_transaction`.
- #3262 (`68fef5609`) then split the transaction response into read/execute types and dropped the `errors` field from the execute path (it was "always empty on the execute path").

The branch was already dead code before the split — execution failures surface as `SuiClientError::TransactionExecutionError` via the `effects_status` check inside `sign_and_send_transaction` (`crates/walrus-sui/src/client.rs:1753`), so they already propagate through `?`. Now that the field is gone, the code no longer compiles. Drop the unreachable branch; the behavior is equivalent to what the other `*_blob_ops.rs` files already do.

## Test plan

CI Pipeline.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI: