### PR TITLE
fix: preserve response URL through http client middleware

### DIFF
--- a/crates/walrus-storage-node-client/src/client/middleware.rs
+++ b/crates/walrus-storage-node-client/src/client/middleware.rs
@@ -20,6 +20,7 @@ use reqwest::{
     Method,
     Request,
     Response,
+    ResponseBuilderExt as _,
     StatusCode,
     header::{HeaderMap, HeaderName, HeaderValue},
 };
@@ -475,9 +476,23 @@ where
             .into_response_monitor(output.as_ref());
 
         let output = output.map(|response| -> Response {
+            // `From<reqwest::Response> for http::Response` drops the URL, and the inverse
+            // conversion only repopulates it from a `ResponseUrl` extension (otherwise reqwest
+            // substitutes a placeholder that surfaces in error logs). Capture the URL and
+            // re-attach the extension via the public `ResponseBuilderExt::url` helper.
+            let url = response.url().clone();
             let response: http::Response<_> = response.into();
-            let response = response.map(|body| reqwest::Body::wrap(VisitBody::new(body, monitor)));
-            response.into()
+            let (mut parts, body) = response.into_parts();
+            let body = reqwest::Body::wrap(VisitBody::new(body, monitor));
+            let url_extensions = http::Response::builder()
+                .url(url)
+                .body(())
+                .expect("response builder with only an extension is infallible")
+                .into_parts()
+                .0
+                .extensions;
+            parts.extensions.extend(url_extensions);
+            http::Response::from_parts(parts, body).into()
         });
 
         Poll::Ready(output)


### PR DESCRIPTION
## Summary

- When running with `RUST_LOG=debug`, errors from `walrus-storage-node-client` logged the placeholder URL `http://no.url.provided.local/` instead of the real node URL, making the logs useless for debugging.
- The HTTP client middleware (introduced in #1774) wraps response bodies for monitoring by round-tripping `reqwest::Response → http::Response → reqwest::Response`. reqwest's `From<Response> for http::Response` drops the URL, and the inverse conversion only repopulates it from a private `ResponseUrl` extension — falling back to `http://no.url.provided.local/` otherwise. That placeholder then shows up in `reqwest::Error`'s `Display` impl, which is what `#[tracing::instrument(err = ...)]` records.
- Fix: capture `response.url().clone()` before the conversion, and re-attach it as a `ResponseUrl` extension via the public `ResponseBuilderExt::url` helper before converting back, so the URL survives the round trip.

Before:

```
2026-04-23T17:32:54.557467Z DEBUG run{command="read-quilt"}:node{index=20 committee_epoch=29 pk_prefix="ietmTd4Y..."}:get_and_verify_metadata{walrus.blob_id=EywgYccuuBhWXJsbkCH5VzpKT2ovc5DoNycMGqqg7BE}: walrus_storage_node_client::client: error=HTTP status client error (404 Not Found) for url (http://no.url.provided.local/): the requested metadata is unavailable (NOT_FOUND, 404 Not Found)
```

After:

```
2026-04-23T18:02:32.574791Z DEBUG run{command="read-quilt"}:node{index=55 committee_epoch=29 pk_prefix="oM6LQok5..."}:get_and_verify_metadata{walrus.blob_id=EywgYccuuBhWXJsbkCH5VzpKT2ovc5DoNycMGqqg7BE}: walrus_storage_node_client::client: error=HTTP status client error (404 Not Found) for url (https://walrus-mainnet.redundex.com:9185/v1/blobs/EywgYccuuBhWXJsbkCH5VzpKT2ovc5DoNycMGqqg7BE/metadata): the requested metadata is unavailable (NOT_FOUND, 404 Not Found)
```

## Test plan

Pre-commit hooks + CI. Manually verified on mainnet that `RUST_LOG=debug walrus read-quilt ...` now logs the real node URL in the error output.

---

*Authored with Claude Code*
