### PR TITLE
ci: trigger ensure-walrus-binaries in sui-operations on release-branch pushes

### DIFF
--- a/.github/workflows/ensure-binaries.yml
+++ b/.github/workflows/ensure-binaries.yml
@@ -1,0 +1,45 @@
+name: Trigger ensure-walrus-binaries for walrus commits
+
+# Walrus-side analog of MystenLabs/sui/.github/workflows/pre-build-images.yml.
+#
+# On every push to release-tracking branches (main, devnet, testnet, mainnet,
+# releases/walrus-*-release), repository_dispatch into MystenLabs/sui-operations
+# so its `ensure-walrus-binaries.yml` pre-populates GCS with the three binary
+# artifacts (walrus, walrus-node, walrus-deploy) for this commit SHA:
+#   gs://mysten-walrus-binaries/walrus/<sha>/{walrus,walrus-node,walrus-deploy}
+#
+# mp3 builds the walrus-service Docker image once per SHA and its extraction
+# sidecar drops the binaries into GCS. Subsequent consumers — walrus-deploy.yaml
+# and walrus-deploy-ptn.yaml in sui-operations, plus ansible roles — hit a
+# warm cache instead of re-building.
+#
+# Coexists with `trigger-artifacts-builds.yml`, which serves the legacy
+# `walrus-build-artifacts.yml` (macOS + Windows cargo builds, DockerHub tagging,
+# release tarballs). That path stays until Phase 4d retires its ubuntu matrix.
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - devnet
+      - testnet
+      - mainnet
+      - "releases/walrus-*-release"
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  ensure-walrus-binaries:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch ensure-walrus-binaries in MystenLabs/sui-operations
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # pin@v4.0.1
+        with:
+          repository: MystenLabs/sui-operations
+          token: ${{ secrets.SUI_OPS_DISPATCH_TOKEN }}
+          event-type: ensure-walrus-binaries
+          client-payload: >
+            {
+              "walrus_commit": "${{ github.sha }}"
+            }


### PR DESCRIPTION
## Summary

Walrus-side analog of [\`MystenLabs/sui/pre-build-images.yml\`](https://github.com/MystenLabs/sui/blob/main/.github/workflows/pre-build-images.yml). Fires on every push to release-tracking branches and \`repository_dispatch\`es into \`MystenLabs/sui-operations\` so its [\`ensure-walrus-binaries.yml\`](https://github.com/MystenLabs/sui-operations/blob/main/.github/workflows/ensure-walrus-binaries.yml) pre-populates GCS with the three consumable binaries for this SHA:

\`\`\`
gs://mysten-walrus-binaries/walrus/<sha>/walrus
gs://mysten-walrus-binaries/walrus/<sha>/walrus-node
gs://mysten-walrus-binaries/walrus/<sha>/walrus-deploy
\`\`\`

mp3 builds the \`walrus-service\` Docker image once per SHA, its extraction sidecar drops the binaries into GCS. Ansible deploys and the \`walrus-deploy\` / \`walrus-deploy-ptn\` workflows in sui-operations then hit a warm cache instead of triggering the build serially at deploy time.

## Trigger branches
- \`main\`
- \`devnet\`, \`testnet\`, \`mainnet\`
- \`releases/walrus-*-release\`

Matches the sui-side branch list. \`workflow_dispatch\` enabled for manual re-runs.

## Coexists with \`trigger-artifacts-builds.yml\`
That workflow still drives the legacy macOS/Windows cargo builds + DockerHub tagging + release tarballs via \`walrus-build-artifacts.yml\` in sui-operations. Stays until Phase 4d of the pipeline unification retires ubuntu from that matrix.

## Auth
Uses \`SUI_OPS_DISPATCH_TOKEN\`, consistent with the existing cross-repo dispatch workflows in this repo (\`trigger-artifacts-builds.yml\`, \`create-release-announce.yml\`, \`gen-sui-upgrade-version-pr.yml\`).

## Test plan
- [x] actionlint clean.
- [ ] Merge → next push to \`main\` should fire the dispatch. Verify in sui-operations Actions that \`Ensure Walrus binaries in GCS\` runs with the new SHA.
- [ ] Confirm \`gs://mysten-walrus-binaries/walrus/<sha>/\` gets populated end-to-end (\`walrus\`, \`walrus-node\`, \`walrus-deploy\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)