### PR TITLE
ci: also dispatch ensure-walrus-binaries on release-branch pushes

### DIFF
--- a/.github/workflows/trigger-artifacts-builds.yml
+++ b/.github/workflows/trigger-artifacts-builds.yml
@@ -5,9 +5,11 @@ on:
   workflow_dispatch:
   push:
     branches:
+      - main
       - devnet
       - testnet
       - mainnet
+      - "releases/walrus-*-release"
 
 concurrency: ${{ github.workflow }}-${{ github.ref_name }}
 
@@ -15,10 +17,37 @@ jobs:
   trigger-artifact-builds:
     runs-on: ubuntu-latest
     steps:
+      # Legacy multi-OS artifact pipeline: cargo builds on ubuntu/macos/windows
+      # runners, DockerHub tagging, release tarballs. Scoped to branch-named
+      # release flows because walrus-build-artifacts.yml keys everything by
+      # branch name. Will shrink (and eventually drop ubuntu) once Phase 4d of
+      # the pipeline unification retires its ubuntu matrix in favor of mp3
+      # extraction.
       - name: Dispatch Walrus Artifact Builds in MystenLabs/sui-operations
+        if: contains(fromJSON('["devnet", "testnet", "mainnet"]'), github.ref_name)
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # pin@v4.0.1
         with:
           repository: MystenLabs/sui-operations
           token: ${{ secrets.SUI_OPS_DISPATCH_TOKEN }}
           event-type: walrus-build-artifacts
           client-payload: '{"branch": "${{ github.ref_name }}"}'
+
+      # mp3 pre-warm: builds the walrus-service Docker image once per SHA and
+      # its extraction sidecar drops walrus/walrus-node/walrus-deploy into
+      #   gs://mysten-walrus-binaries/walrus/<sha>/
+      # so ansible deploys and sui-operations' walrus-deploy / walrus-deploy-ptn
+      # workflows hit a warm cache instead of serially rebuilding at deploy time.
+      #
+      # Fires on every push to release-tracking branches (main + release cuts),
+      # matching the sui-side pattern of MystenLabs/sui/pre-build-images.yml →
+      # MystenLabs/sui-operations/prebuild-sui-images.yml.
+      - name: Dispatch ensure-walrus-binaries in MystenLabs/sui-operations
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # pin@v4.0.1
+        with:
+          repository: MystenLabs/sui-operations
+          token: ${{ secrets.SUI_OPS_DISPATCH_TOKEN }}
+          event-type: ensure-walrus-binaries
+          client-payload: >
+            {
+              "walrus_commit": "${{ github.sha }}"
+            }


### PR DESCRIPTION
## Summary

Extends this existing trigger so it also fires [\`ensure-walrus-binaries.yml\`](https://github.com/MystenLabs/sui-operations/blob/main/.github/workflows/ensure-walrus-binaries.yml) in \`MystenLabs/sui-operations\`, matching the sui-side pattern where [\`pre-build-images.yml\`](https://github.com/MystenLabs/sui/blob/main/.github/workflows/pre-build-images.yml) pre-warms GCS for downstream ansible deploys.

## Changes

- **Trigger branch list broadened**: adds \`main\` and \`releases/walrus-*-release\` to the existing \`devnet\` / \`testnet\` / \`mainnet\`.
- **Legacy \`walrus-build-artifacts\` dispatch gated** to \`devnet\` / \`testnet\` / \`mainnet\` only — that workflow keys everything by branch name and has nothing to do on \`main\` or individual release branches. No behavior change on those three.
- **New \`ensure-walrus-binaries\` dispatch step** fires on every trigger branch, payload \`{"walrus_commit": "${{ github.sha }}"}\`. mp3 builds \`walrus-service\` once per SHA and its extraction sidecar drops \`walrus\` / \`walrus-node\` / \`walrus-deploy\` into \`gs://mysten-walrus-binaries/walrus/<sha>/\`.

Both dispatches use the existing \`SUI_OPS_DISPATCH_TOKEN\`. No new secrets.

## Result
- **\`main\` / \`releases/walrus-*-release\` push** → only mp3 pre-warm fires (fast, no duplicate work).
- **\`devnet\` / \`testnet\` / \`mainnet\` push** → both paths fire. mp3 cache-hits on repeat extraction calls, so the overlap is a no-op.

Once Phase 4d of the pipeline unification retires ubuntu from \`walrus-build-artifacts.yml\`, the first dispatch can be removed and this file simplifies to just the mp3 pre-warm.

## Test plan
- [x] actionlint clean.
- [ ] Merge → next push to \`main\` should fire only the second dispatch. Verify in sui-operations Actions that \`Ensure Walrus binaries in GCS\` runs with the new SHA.
- [ ] Next push to \`devnet\` / \`testnet\` / \`mainnet\` should fire both. Verify both top-level workflows appear in sui-operations Actions.
- [ ] Confirm \`gs://mysten-walrus-binaries/walrus/<sha>/\` populated end-to-end (\`walrus\`, \`walrus-node\`, \`walrus-deploy\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)