### PR TITLE
ci: docker/walrus-service: support optional RUSTFLAGS_APPEND build arg

### DIFF
--- a/docker/walrus-service/Dockerfile
+++ b/docker/walrus-service/Dockerfile
@@ -8,6 +8,11 @@ FROM rust:1.93-bookworm AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION
+# Optional extra rustc flags. Empty default preserves native-CPU builds.
+# Callers (e.g. mp3 image-builder) can pass "-C target-cpu=generic" to
+# produce a portable x86_64 binary for older Ubuntu hosts.
+ARG RUSTFLAGS_APPEND=""
+ENV RUSTFLAGS=$RUSTFLAGS_APPEND
 WORKDIR "$WORKDIR/walrus"
 RUN apt-get update && apt-get install -y cmake clang
 


### PR DESCRIPTION
## Summary

- Adds an optional `RUSTFLAGS_APPEND` build arg to the `builder` stage of `docker/walrus-service/Dockerfile`.
- Empty default keeps today's native-CPU build unchanged.
- Callers can pass `RUSTFLAGS_APPEND=-C target-cpu=generic` to produce a portable x86_64 binary for older Ubuntu hosts.

## Motivation

Part of the ongoing effort to unify the walrus ubuntu binary pipeline on top of mp3 image extraction. Today the `-generic` variant for older Ubuntu is still produced by the GHA `walrus-build-artifacts.yml` matrix using direct cargo. To retire that matrix we need mp3 to produce the `-generic` artifact too. A follow-up sui-operations PR will add a `walrus-service-generic` rule in `pulumi/apps/mp3` that uses this build arg, emit a second amd64 matrix entry in `prepare_walrus_matrix.py`, and extend `ensure-walrus-binaries.yml` with the corresponding flat-file + tarball outputs.

## Test plan

- [x] Diff is a pure addition with an empty default — no caller today passes `RUSTFLAGS_APPEND`, so all existing K8s image builds remain native-CPU.
- [ ] After merge, the sui-operations follow-up will exercise the `-C target-cpu=generic` path end-to-end via a real mp3 build + flat-file publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)