### PR TITLE
chore: cleanup existing subsidy multisig operation workflow

### DIFF
--- a/.github/workflows/create-tx-for-multisig-subsidy.yml
+++ b/.github/workflows/create-tx-for-multisig-subsidy.yml
@@ -1,17 +1,17 @@
-name: Build TX for Multisig Operation
+name: Build TX for Multisig Subsidy Operation
 
 on:
   workflow_dispatch:
     inputs:
       transaction_type:
-        description: "select transaction type to create"
+        description: "select subsidy transaction type to create"
         type: choice
         options:
           - upgrade-walrus-subsidies
           - set-walrus-subsidy-rates
           - add-wal-to-subsidies
       gas_object_id:
-        description: "object id to get gas from for multisig transaction"
+        description: "object id to get gas from for the multisig subsidy transaction"
         required: false
         type: string
       commit:
@@ -42,7 +42,7 @@ on:
 
 jobs:
   create-tx:
-    name: Create TX for multisig
+    name: Create TX for multisig subsidy
     runs-on: ubuntu-latest
 
     steps:
@@ -67,10 +67,10 @@ jobs:
         run: |
           sui client switch --env mainnet
 
-      - name: Create unsigned transaction for multisig
+      - name: Create unsigned transaction for multisig subsidy
         run: |
           mkdir -p artifacts
-          ./scripts/create_multisig_tx.sh \
+          ./scripts/create_multisig_subsidy_tx.sh \
             -t '${{ inputs.transaction_type }}' \
             -g '${{ inputs.gas_object_id }}' \
             -b '${{ inputs.base_subsidy_frost }}' \

--- a/scripts/create_multisig_subsidy_tx.sh
+++ b/scripts/create_multisig_subsidy_tx.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 # Copyright (c) Walrus Foundation
 # SPDX-License-Identifier: Apache-2.0
-# This script allows creating unsigned transactions for operations that need to be signed
-# by a Walrus multisig address.
+# This script creates unsigned transactions for Walrus subsidies operations
+# (`upgrade-walrus-subsidies`, `set-walrus-subsidy-rates`, `add-wal-to-subsidies`)
+# that need to be signed by the Walrus subsidies multisig addresses.
 # Intended to be used using the github workflow defined in
-# `../.github/workflows/create-tx-for-multisig.yml`
+# `../.github/workflows/create-tx-for-multisig-subsidy.yml`
 
 GAS_OBJECT_ID=""
 TX_TYPE=""


### PR DESCRIPTION
## Description

Rename the pre-existing multisig operation in the scope of subsidy operation (since now we have governance related
multisig operation now).

Given the difference between the two types of operations, create a multisig workflow for each of them seems cleaner.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
