### PR TITLE
ci: dispatch prebuild-walrus-images (renamed from ensure-walrus-binaries)

### DIFF
--- a/.github/workflows/trigger-artifacts-builds.yml
+++ b/.github/workflows/trigger-artifacts-builds.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # mp3 pre-warm — fires on every release-branch push.
-      - name: Dispatch ensure-walrus-binaries in MystenLabs/sui-operations
+      - name: Dispatch prebuild-walrus-images in MystenLabs/sui-operations
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # pin@v4.0.1
         with:
           repository: MystenLabs/sui-operations
           token: ${{ secrets.SUI_OPS_DISPATCH_TOKEN }}
-          event-type: ensure-walrus-binaries
+          event-type: prebuild-walrus-images
           client-payload: >
             {
               "walrus_commit": "${{ github.sha }}",


### PR DESCRIPTION
## Summary

- Switches the cross-repo `repository_dispatch` event-type from `ensure-walrus-binaries` to `prebuild-walrus-images`, matching the rename in [sui-operations#7752](https://github.com/MystenLabs/sui-operations/pull/7752).
- The sui-operations listener accepts both names during the rollout, so merge order between the two PRs doesn't matter.

## Test plan

- [ ] After both this PR and [sui-operations#7752](https://github.com/MystenLabs/sui-operations/pull/7752) land, push a commit to a release-tracking branch and observe a `Prebuild Walrus images` run in sui-operations triggered by the new event-type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)