### PR TITLE
ci: fetch prebuilt walrus binaries from GCS in attach-binaries-to-release.yml on Linux

### DIFF
--- a/.github/workflows/attach-binaries-to-release.yml
+++ b/.github/workflows/attach-binaries-to-release.yml
@@ -161,7 +161,8 @@ jobs:
           done
 
           if [ ${#missing[@]} -ne 0 ]; then
-            echo "::error::Missing prebuilt binaries at ${gcs_prefix}/ — these must be produced by sui-operations/prebuild-walrus-images.yml + mp3:binary_upload_config before tagging: ${missing[*]}"
+            echo "::error::Missing prebuilt binaries at ${gcs_prefix}/: ${missing[*]}"
+            echo "::error::These must be produced by sui-operations/prebuild-walrus-images.yml + mp3:binary_upload_config before tagging."
             exit 1
           fi
 

--- a/.github/workflows/attach-binaries-to-release.yml
+++ b/.github/workflows/attach-binaries-to-release.yml
@@ -123,6 +123,50 @@ jobs:
           gcloud storage cp gs://mysten-walrus-binaries/${{ env.gcp_existing_archive }} ./tmp/walrus-${{ env.walrus_tag }}-${os_type}.tgz
           tar -xf ./tmp/walrus-${{ env.walrus_tag }}-${os_type}.tgz -C ${{ env.TMP_BUILD_DIR }}
 
+      - name: Resolve walrus_sha for prebuilt binary lookup (Linux)
+        if: ${{ startsWith(matrix.os, 'ubuntu') && env.gcp_existing_archive == '' }}
+        shell: bash
+        run: |
+          echo "walrus_sha=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+
+      - name: Download prebuilt binaries from GCS (Linux)
+        if: ${{ startsWith(matrix.os, 'ubuntu') && env.gcp_existing_archive == '' }}
+        shell: bash
+        run: |
+          # Pulls binaries that mp3 (sui-operations/prebuild-walrus-images.yml) extracted
+          # from prebuilt walrus images. amd64 lands at gs://mysten-walrus-binaries/walrus/<sha>/<basename>,
+          # arm64 at gs://mysten-walrus-binaries/walrus-arm64/<sha>/<basename> — see mp3's
+          # binary_upload_config in sui-operations/pulumi/apps/mp3 (walrus-service[-arm64] and
+          # walrus-upload-relay[-arm64] rules). Fails loudly if any binary in
+          # binary-build-list.json release_binaries is missing.
+          mkdir -p ${{ env.TMP_BUILD_DIR }} ./tmp
+          [ ! -f ${{ env.BINARY_LIST_FILE }} ] && echo "${{ env.BINARY_LIST_FILE }} cannot be found" && exit 1
+
+          case "${arch}" in
+            aarch64|arm64) gcs_prefix="gs://mysten-walrus-binaries/walrus-arm64/${walrus_sha}" ;;
+            *)             gcs_prefix="gs://mysten-walrus-binaries/walrus/${walrus_sha}" ;;
+          esac
+
+          missing=()
+          for binary in $(jq -r '.release_binaries[]' ${{ env.BINARY_LIST_FILE }}); do
+            binary=$(echo "${binary}" | tr -d $'\r')
+            src="${gcs_prefix}/${binary}"
+            dest="${{ env.TMP_BUILD_DIR }}/${binary}"
+            echo "Downloading ${src}"
+            if ! gcloud storage cp "${src}" "${dest}"; then
+              missing+=("${binary}")
+              continue
+            fi
+            chmod +x "${dest}"
+          done
+
+          if [ ${#missing[@]} -ne 0 ]; then
+            echo "::error::Missing prebuilt binaries at ${gcs_prefix}/ — these must be produced by sui-operations/prebuild-walrus-images.yml + mp3:binary_upload_config before tagging: ${missing[*]}"
+            exit 1
+          fi
+
+          tar -cvzf ./tmp/walrus-${{ env.walrus_tag }}-${{ env.os_type }}.tgz -C ${{ env.TMP_BUILD_DIR }} .
+
       - name: Install nexttest (Windows)
         if: ${{ startsWith(matrix.os, 'windows') && env.gcp_existing_archive == '' }}
         uses: taiki-e/install-action@cargo-hack # pin@cargo-hack
@@ -154,12 +198,6 @@ jobs:
         run: |
           brew install postgresql
 
-      - name: Install postgres (Ubuntu arm64)
-        if: ${{ matrix.os == 'ubuntu-arm64' && env.gcp_existing_archive == '' }}
-        shell: bash
-        run: |
-          sudo apt update && sudo apt install libpq-dev
-
       - name: Remove unused apps (MacOS arm64)
         if: ${{ matrix.os == 'macos-latest-xlarge' && env.gcp_existing_archive == '' }}
         continue-on-error: true
@@ -174,17 +212,17 @@ jobs:
           df -h /
 
       - name: Setup sccache
-        if: ${{ env.gcp_existing_archive == '' }}
+        if: ${{ !startsWith(matrix.os, 'ubuntu') && env.gcp_existing_archive == '' }}
         uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # pin@v0.0.9
 
       - name: Cargo build for ${{ matrix.os }} platform
-        if: ${{ env.gcp_existing_archive == '' }}
+        if: ${{ !startsWith(matrix.os, 'ubuntu') && env.gcp_existing_archive == '' }}
         shell: bash
         run: |
           [ -f ~/.cargo/env ] && source ~/.cargo/env ; cargo build --release
 
       - name: Rename and archive binaries for ${{ matrix.os }}
-        if: ${{ env.gcp_existing_archive == '' }}
+        if: ${{ !startsWith(matrix.os, 'ubuntu') && env.gcp_existing_archive == '' }}
         shell: bash
         run: |
           mkdir -p ${{ env.TMP_BUILD_DIR }}


### PR DESCRIPTION
## Summary

- Replaces the on-runner `cargo build` for `ubuntu-ghcloud` and `ubuntu-arm64` in `attach-binaries-to-release.yml` with `gcloud storage cp` from the GCS prefixes mp3 already populates ahead of release tagging.
- amd64 → `gs://mysten-walrus-binaries/walrus/<sha>/<binary>`.
- arm64 → `gs://mysten-walrus-binaries/walrus-arm64/<sha>/<binary>`.
- Windows and macOS still build from source — mp3 only produces Linux binaries.
- Fails loudly with a `::error::` annotation if any binary in `binary-build-list.json` `release_binaries` (`walrus`, `walrus-node`, `walrus-upload-relay`) is missing from GCS, so the gap surfaces before a tag ships.

## Why this is safe to land standalone

Mirror of [MystenLabs/sui#26411](https://github.com/MystenLabs/sui/pull/26411) — same idea, different cloud. Unlike the sui change, all three walrus `release_binaries` are already extracted by mp3's `binary_upload_config` for **both** amd64 and arm64 (via `MystenLabs/walrus:walrus-service`, `walrus-service-arm64`, `walrus-upload-relay`, `walrus-upload-relay-arm64` in `sui-operations/pulumi/apps/mp3`). No companion sui-operations PR needed.

The auth path is unchanged: the workflow already runs `google-github-actions/auth` with `GCP_WALRUS_RELEASE_BUCKET_SVCUSER_CREDENTIALS`, which has read access to `gs://mysten-walrus-binaries`.

## Test plan
- [ ] Trigger this workflow via `workflow_dispatch` against a non-production tag (e.g., a recent main commit that has flowed through `prebuild-walrus-images.yml`)
- [ ] Confirm Linux jobs no longer cargo-build, that the per-binary `gcloud storage cp` succeeds, and the resulting `.tgz` is uploaded + attached to the release
- [ ] Verify Windows/macOS still cargo-build cleanly
- [ ] Confirm the existing `gcp_existing_archive` shortcut still works (re-run for an already-released version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)