### PR TITLE
refactor: move checkpoint_wait_timeout off RetriableSuiClient onto write path

### DIFF
--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -91,7 +91,6 @@ use walrus_sui::{
         ReadClient,
         SuiClientError,
         SuiContractClient,
-        dual_client::DEFAULT_CHECKPOINT_WAIT_TIMEOUT,
         retry_client::{RetriableSuiClient, retriable_sui_client::LazySuiClientBuilder},
     },
     coin::Coin,
@@ -2775,9 +2774,7 @@ pub async fn test_select_coins_max_objects() -> TestResult {
     let retry_client = RetriableSuiClient::new(
         rpc_urls
             .iter()
-            .map(|rpc_url| {
-                LazySuiClientBuilder::new(rpc_url, None, DEFAULT_CHECKPOINT_WAIT_TIMEOUT)
-            })
+            .map(|rpc_url| LazySuiClientBuilder::new(rpc_url, None))
             .collect(),
         ExponentialBackoffConfig::default(),
     )?;
@@ -3043,11 +3040,7 @@ async fn test_store_with_upload_relay_with_tip() {
             .rpc_url()
             .to_string();
         RetriableSuiClient::new(
-            vec![LazySuiClientBuilder::new(
-                &rpc_url,
-                None,
-                DEFAULT_CHECKPOINT_WAIT_TIMEOUT,
-            )],
+            vec![LazySuiClientBuilder::new(&rpc_url, None)],
             ExponentialBackoffConfig::default(),
         )
         .expect("create retry client")

--- a/crates/walrus-proxy/src/providers/walrus/query.rs
+++ b/crates/walrus-proxy/src/providers/walrus/query.rs
@@ -106,7 +106,6 @@ pub async fn get_walrus_nodes(
         &[rpc_address],
         &contract_config,
         backoff_config,
-        walrus_sui::client::dual_client::DEFAULT_CHECKPOINT_WAIT_TIMEOUT,
     )
     .await
     .map_err(|e| {

--- a/crates/walrus-service/bin/node.rs
+++ b/crates/walrus-service/bin/node.rs
@@ -622,7 +622,6 @@ mod commands {
             ReadClient as _,
             SuiReadClient,
             contract_config::ContractConfig,
-            dual_client::DEFAULT_CHECKPOINT_WAIT_TIMEOUT,
             retry_client::{RetriableSuiClient, retriable_sui_client::LazySuiClientBuilder},
         },
         config::{WalletConfig, load_wallet_context_from_path},
@@ -1107,11 +1106,7 @@ mod commands {
         };
 
         let retriable_sui_client = RetriableSuiClient::new(
-            vec![LazySuiClientBuilder::new(
-                sui_rpc_url,
-                None,
-                DEFAULT_CHECKPOINT_WAIT_TIMEOUT,
-            )],
+            vec![LazySuiClientBuilder::new(sui_rpc_url, None)],
             ExponentialBackoffConfig::default(),
         )?;
         let contract_config = ContractConfig::new(system_object_id, staking_object_id);

--- a/crates/walrus-service/src/backup/service.rs
+++ b/crates/walrus-service/src/backup/service.rs
@@ -595,7 +595,6 @@ async fn backup_fetcher(
             ),
             backup_config.sui.backoff_config.clone(),
             None,
-            walrus_sui::client::dual_client::DEFAULT_CHECKPOINT_WAIT_TIMEOUT,
         )
         .context("[backup_fetcher] cannot create RetriableSuiClient")?,
         &backup_config.sui.contract_config,

--- a/crates/walrus-service/src/client/cli.rs
+++ b/crates/walrus-service/src/client/cli.rs
@@ -153,7 +153,6 @@ pub async fn get_sui_read_client_from_rpc_node_or_wallet(
         &rpc_urls,
         backoff_config,
         config.communication_config.sui_client_request_timeout,
-        config.checkpoint_wait_timeout(),
     )
     .context(format!(
         "cannot connect to Sui RPC nodes at {}",

--- a/crates/walrus-service/src/client/cli/backfill.rs
+++ b/crates/walrus-service/src/client/cli/backfill.rs
@@ -257,7 +257,6 @@ async fn get_backfill_client(config: ClientConfig) -> Result<WalrusNodeClient<Su
         &config.rpc_urls,
         config.backoff_config().clone(),
         None,
-        config.checkpoint_wait_timeout(),
     )?;
     let sui_read_client = config.new_read_client(retriable_sui_client).await?;
     let refresh_handle = config

--- a/crates/walrus-service/src/client/multiplexer.rs
+++ b/crates/walrus-service/src/client/multiplexer.rs
@@ -503,7 +503,6 @@ impl<'a> SubClientLoader<'a> {
             rpc_urls,
             self.config.backoff_config().clone(),
             self.config.communication_config.sui_client_request_timeout,
-            self.config.checkpoint_wait_timeout(),
         )?;
 
         if should_refill(&sui_client, address, Coin::SUI, min_balance).await {

--- a/crates/walrus-service/src/common/config.rs
+++ b/crates/walrus-service/src/common/config.rs
@@ -74,7 +74,6 @@ impl SuiConfig {
             &combined_rpc_urls,
             &self.contract_config,
             self.backoff_config.clone(),
-            self.checkpoint_wait_timeout(),
         )
         .await
     }
@@ -88,6 +87,7 @@ impl SuiConfig {
         Ok(SuiContractClient::new_with_read_client(
             wallet,
             self.gas_budget,
+            self.checkpoint_wait_timeout(),
             read_client,
         )?)
     }
@@ -180,13 +180,10 @@ impl SuiReaderConfig {
     /// Creates a new [`SuiReadClient`] based on the configuration.
     pub async fn new_read_client(&self) -> Result<SuiReadClient, SuiClientError> {
         let combined_rpc_urls = combine_rpc_urls(&self.rpc, &self.additional_rpc_endpoints);
-        // The checkpoint-wait timeout only applies to transaction execution, which read clients
-        // never perform; pass the default to satisfy the constructor.
         SuiReadClient::new_for_rpc_urls(
             &combined_rpc_urls,
             &self.contract_config,
             self.backoff_config.clone(),
-            walrus_sui::client::dual_client::DEFAULT_CHECKPOINT_WAIT_TIMEOUT,
         )
         .await
     }

--- a/crates/walrus-service/src/common/utils.rs
+++ b/crates/walrus-service/src/common/utils.rs
@@ -493,12 +493,7 @@ pub async fn generate_sui_wallet(
     );
     let wallet = walrus_sui::utils::create_wallet(path, sui_network.env(), None, None).await?;
     let rpc_urls = &[wallet.get_rpc_url()];
-    let client = RetriableSuiClient::new_for_rpc_urls(
-        rpc_urls,
-        Default::default(),
-        None,
-        walrus_sui::client::dual_client::DEFAULT_CHECKPOINT_WAIT_TIMEOUT,
-    )?;
+    let client = RetriableSuiClient::new_for_rpc_urls(rpc_urls, Default::default(), None)?;
 
     let wallet_address = wallet.active_address();
     tracing::info!("generated a new Sui wallet; address: {wallet_address}");

--- a/crates/walrus-service/src/event/event_processor/client.rs
+++ b/crates/walrus-service/src/event/event_processor/client.rs
@@ -8,7 +8,6 @@ use std::{sync::Arc, time::Duration};
 use anyhow::Result;
 use walrus_sui::client::{
     SuiClientMetricSet,
-    dual_client::DEFAULT_CHECKPOINT_WAIT_TIMEOUT,
     retry_client::{
         RetriableRpcClient,
         RetriableSuiClient,
@@ -83,13 +82,7 @@ impl ClientManager {
         let sui_client = RetriableSuiClient::new(
             rest_urls
                 .iter()
-                .map(|rpc_url| {
-                    LazySuiClientBuilder::new(
-                        rpc_url,
-                        Some(request_timeout),
-                        DEFAULT_CHECKPOINT_WAIT_TIMEOUT,
-                    )
-                })
+                .map(|rpc_url| LazySuiClientBuilder::new(rpc_url, Some(request_timeout)))
                 .collect(),
             ExponentialBackoffConfig::default(),
         )?;

--- a/crates/walrus-service/src/testbed.rs
+++ b/crates/walrus-service/src/testbed.rs
@@ -378,11 +378,7 @@ pub async fn deploy_walrus_contract(
 
         // Get coins from faucet for the wallet.
         let sui_client = RetriableSuiClient::new(
-            vec![LazySuiClientBuilder::new(
-                rpc_url,
-                None,
-                DEFAULT_CHECKPOINT_WAIT_TIMEOUT,
-            )],
+            vec![LazySuiClientBuilder::new(rpc_url, None)],
             Default::default(),
         )?;
         request_sui_from_faucet(admin_wallet.active_address(), &sui_network, &sui_client).await?;

--- a/crates/walrus-stress/src/generator.rs
+++ b/crates/walrus-stress/src/generator.rs
@@ -75,7 +75,6 @@ impl LoadGenerator {
             client_config
                 .communication_config
                 .sui_client_request_timeout,
-            client_config.checkpoint_wait_timeout(),
         )?;
 
         let sui_read_client = client_config.new_read_client(sui_client.clone()).await?;

--- a/crates/walrus-stress/src/generator/write_client.rs
+++ b/crates/walrus-stress/src/generator/write_client.rs
@@ -266,7 +266,6 @@ async fn new_client(
                 LazySuiClientBuilder::new(
                     rpc_url,
                     config.communication_config.sui_client_request_timeout,
-                    config.checkpoint_wait_timeout(),
                 )
             })
             .collect(),
@@ -274,7 +273,12 @@ async fn new_client(
     )?;
     let sui_read_client = config.new_read_client(sui_client).await?;
     let sui_contract_client = wallet.and_then(|wallet| {
-        SuiContractClient::new_with_read_client(wallet, gas_budget, Arc::new(sui_read_client))
+        SuiContractClient::new_with_read_client(
+            wallet,
+            gas_budget,
+            config.checkpoint_wait_timeout(),
+            Arc::new(sui_read_client),
+        )
     })?;
 
     let client = sui_contract_client.and_then(|contract_client| {

--- a/crates/walrus-sui/src/client.rs
+++ b/crates/walrus-sui/src/client.rs
@@ -541,17 +541,12 @@ impl SuiContractClient {
         tracing::debug!("creating a new `SuiContractClient`");
         let read_client = Arc::new(
             SuiReadClient::new(
-                RetriableSuiClient::new_for_rpc_urls(
-                    rpc_urls,
-                    backoff_config.clone(),
-                    None,
-                    checkpoint_wait_timeout,
-                )?,
+                RetriableSuiClient::new_for_rpc_urls(rpc_urls, backoff_config.clone(), None)?,
                 contract_config,
             )
             .await?,
         );
-        Self::new_with_read_client(wallet, gas_budget, read_client)
+        Self::new_with_read_client(wallet, gas_budget, checkpoint_wait_timeout, read_client)
     }
 
     /// Constructor for [`SuiContractClient`] with metrics.
@@ -566,24 +561,20 @@ impl SuiContractClient {
     ) -> SuiClientResult<Self> {
         let read_client = Arc::new(
             SuiReadClient::new(
-                RetriableSuiClient::new_for_rpc_urls(
-                    rpc_urls,
-                    backoff_config.clone(),
-                    None,
-                    checkpoint_wait_timeout,
-                )?
-                .with_metrics(Some(metrics)),
+                RetriableSuiClient::new_for_rpc_urls(rpc_urls, backoff_config.clone(), None)?
+                    .with_metrics(Some(metrics)),
                 contract_config,
             )
             .await?,
         );
-        Self::new_with_read_client(wallet, gas_budget, read_client)
+        Self::new_with_read_client(wallet, gas_budget, checkpoint_wait_timeout, read_client)
     }
 
     /// Constructor for [`SuiContractClient`] with an existing [`SuiReadClient`].
     pub fn new_with_read_client(
         wallet: Wallet,
         gas_budget: Option<u64>,
+        checkpoint_wait_timeout: Duration,
         read_client: Arc<SuiReadClient>,
     ) -> SuiClientResult<Self> {
         let wallet_address = wallet.active_address();
@@ -592,6 +583,7 @@ impl SuiContractClient {
                 wallet,
                 read_client.clone(),
                 gas_budget,
+                checkpoint_wait_timeout,
             )?),
             read_client,
             wallet_address,
@@ -1190,6 +1182,8 @@ struct SuiContractClientInner {
     /// The gas budget used by the client. If not set, the client will use a dry run to estimate
     /// the required gas budget.
     gas_budget: Option<u64>,
+    /// Timeout for waiting for checkpoint inclusion after gRPC transaction execution.
+    checkpoint_wait_timeout: Duration,
 }
 
 impl SuiContractClientInner {
@@ -1198,11 +1192,13 @@ impl SuiContractClientInner {
         wallet: Wallet,
         read_client: Arc<SuiReadClient>,
         gas_budget: Option<u64>,
+        checkpoint_wait_timeout: Duration,
     ) -> SuiClientResult<Self> {
         Ok(Self {
             wallet,
             read_client,
             gas_budget,
+            checkpoint_wait_timeout,
         })
     }
 
@@ -1746,7 +1742,7 @@ impl SuiContractClientInner {
         // Execute the transaction and wait for response
         let response = self
             .retriable_sui_client()
-            .execute_transaction(signed_transaction, method)
+            .execute_transaction(signed_transaction, method, self.checkpoint_wait_timeout)
             .await?;
 
         // Check transaction execution status from effects

--- a/crates/walrus-sui/src/client/dual_client.rs
+++ b/crates/walrus-sui/src/client/dual_client.rs
@@ -94,8 +94,6 @@ pub struct DualClient {
     /// The Sui SDK client for JSON RPC calls. This will eventually be removed.
     sui_client: Option<SuiClient>,
     grpc_client: GrpcClient,
-    /// Timeout for waiting for checkpoint inclusion after gRPC transaction execution.
-    checkpoint_wait_timeout: Duration,
 }
 
 impl std::fmt::Debug for DualClient {
@@ -142,7 +140,6 @@ impl DualClient {
     pub async fn new(
         rpc_url: impl AsRef<str>,
         request_timeout: Option<Duration>,
-        checkpoint_wait_timeout: Duration,
     ) -> Result<Self, SuiClientError> {
         let mut client_builder = SuiClientBuilder::default();
         if let Some(request_timeout) = request_timeout {
@@ -154,7 +151,6 @@ impl DualClient {
         Ok(Self {
             sui_client,
             grpc_client,
-            checkpoint_wait_timeout,
         })
     }
 
@@ -712,6 +708,7 @@ impl DualClient {
     pub fn execute_transaction_grpc(
         &self,
         transaction: &Transaction,
+        checkpoint_wait_timeout: Duration,
     ) -> Result<BoxedExecuteTxFuture<'_>, SuiClientError> {
         let tx_data_bytes = bcs::to_bytes(transaction.transaction_data())
             .context("failed to BCS-serialize TransactionData")?;
@@ -757,7 +754,6 @@ impl DualClient {
                     .object_type(),
             ]));
 
-        let checkpoint_wait_timeout = self.checkpoint_wait_timeout;
         Ok(Box::pin(execute_transaction_and_convert(
             grpc_client,
             request,

--- a/crates/walrus-sui/src/client/read_client.rs
+++ b/crates/walrus-sui/src/client/read_client.rs
@@ -448,14 +448,8 @@ impl SuiReadClient {
         rpc_addresses: &[S],
         contract_config: &ContractConfig,
         backoff_config: ExponentialBackoffConfig,
-        checkpoint_wait_timeout: Duration,
     ) -> SuiClientResult<Self> {
-        let client = RetriableSuiClient::new_for_rpc_urls(
-            rpc_addresses,
-            backoff_config,
-            None,
-            checkpoint_wait_timeout,
-        )?;
+        let client = RetriableSuiClient::new_for_rpc_urls(rpc_addresses, backoff_config, None)?;
         Self::new(client, contract_config).await
     }
 

--- a/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
@@ -130,22 +130,14 @@ pub struct LazySuiClientBuilder {
     rpc_url: String,
     /// Override the default timeout for any requests.
     request_timeout: Option<Duration>,
-    /// Timeout for waiting for checkpoint inclusion after gRPC transaction execution.
-    checkpoint_wait_timeout: Duration,
 }
 
 impl LazySuiClientBuilder {
-    /// Creates a new [`LazySuiClientBuilder`] from a URL, an optional `request_timeout`, and a
-    /// `checkpoint_wait_timeout`.
-    pub fn new(
-        rpc_url: impl AsRef<str>,
-        request_timeout: Option<Duration>,
-        checkpoint_wait_timeout: Duration,
-    ) -> Self {
+    /// Creates a new [`LazySuiClientBuilder`] from a URL and an optional `request_timeout`.
+    pub fn new(rpc_url: impl AsRef<str>, request_timeout: Option<Duration>) -> Self {
         Self {
             rpc_url: rpc_url.as_ref().to_string(),
             request_timeout,
-            checkpoint_wait_timeout,
         }
     }
 }
@@ -185,14 +177,7 @@ impl LazyClientBuilder<DualClient> for LazySuiClientBuilder {
                 Some(RPC_MAX_TRIES),
             )
             .get_strategy(StdRng::from_entropy().next_u64()),
-            || async {
-                DualClient::new(
-                    self.rpc_url.as_str(),
-                    self.request_timeout,
-                    self.checkpoint_wait_timeout,
-                )
-                .await
-            },
+            || async { DualClient::new(self.rpc_url.as_str(), self.request_timeout).await },
             None,
             "build_sui_client",
         )
@@ -354,13 +339,10 @@ impl RetriableSuiClient {
         rpc_addresses: &[S],
         backoff_config: ExponentialBackoffConfig,
         request_timeout: Option<Duration>,
-        checkpoint_wait_timeout: Duration,
     ) -> SuiClientResult<Self> {
         let failover_clients = rpc_addresses
             .iter()
-            .map(|rpc_url| {
-                LazySuiClientBuilder::new(rpc_url, request_timeout, checkpoint_wait_timeout)
-            })
+            .map(|rpc_url| LazySuiClientBuilder::new(rpc_url, request_timeout))
             .collect::<Vec<_>>();
         Ok(Self::new(failover_clients, backoff_config)?)
     }
@@ -1989,12 +1971,16 @@ impl RetriableSuiClient {
 
     /// Executes a transaction.
     ///
+    /// `checkpoint_wait_timeout` is consumed only by the gRPC path; the JSON-RPC fallback
+    /// ignores it.
+    ///
     /// Uses `Box::pin` to cap the future size on the stack, since the response types are large
     /// and cause stack overflows in deep async call chains.
     pub fn execute_transaction(
         &self,
         transaction: Transaction,
         method: &'static str,
+        checkpoint_wait_timeout: Duration,
     ) -> std::pin::Pin<
         Box<
             dyn std::future::Future<Output = SuiClientResult<ExecuteTransactionResponse>>
@@ -2004,7 +1990,7 @@ impl RetriableSuiClient {
     > {
         Box::pin(async move {
             if self.grpc_migration_level >= GRPC_MIGRATION_LEVEL_TRANSACTION_WRITES {
-                self.execute_transaction_with_grpc(transaction, method)
+                self.execute_transaction_with_grpc(transaction, method, checkpoint_wait_timeout)
                     .await
             } else {
                 self.execute_transaction_with_json_rpc(transaction, method)
@@ -2072,6 +2058,7 @@ impl RetriableSuiClient {
         &self,
         transaction: Transaction,
         method: &'static str,
+        checkpoint_wait_timeout: Duration,
     ) -> SuiClientResult<ExecuteTransactionResponse> {
         let span = tracing::debug_span!("execute_transaction", method);
         async {
@@ -2089,7 +2076,9 @@ impl RetriableSuiClient {
                                     &transaction,
                                 )?;
                             }
-                            client.execute_transaction_grpc(&transaction)?.await
+                            client
+                                .execute_transaction_grpc(&transaction, checkpoint_wait_timeout)?
+                                .await
                         }
                     },
                     self.metrics.clone(),

--- a/crates/walrus-sui/src/system_setup.rs
+++ b/crates/walrus-sui/src/system_setup.rs
@@ -40,16 +40,9 @@ use walrus_core::{EpochCount, ensure};
 #[cfg(any(test, feature = "test-utils"))]
 use crate::test_utils::system_setup;
 use crate::{
-    client::{
-        dual_client::DEFAULT_CHECKPOINT_WAIT_TIMEOUT,
-        retry_client::{
-            RetriableSuiClient,
-            retriable_sui_client::{
-                GasBudgetAndPrice,
-                LazySuiClientBuilder,
-                MAX_GAS_PAYMENT_OBJECTS,
-            },
-        },
+    client::retry_client::{
+        RetriableSuiClient,
+        retriable_sui_client::{GasBudgetAndPrice, LazySuiClientBuilder, MAX_GAS_PAYMENT_OBJECTS},
     },
     coin::Coin,
     contracts,
@@ -258,11 +251,7 @@ pub(crate) async fn publish_package(
 ) -> Result<ExecutedTransaction> {
     let sender = wallet.active_address();
     let retry_client = RetriableSuiClient::new(
-        vec![LazySuiClientBuilder::new(
-            wallet.get_rpc_url(),
-            None,
-            DEFAULT_CHECKPOINT_WAIT_TIMEOUT,
-        )],
+        vec![LazySuiClientBuilder::new(wallet.get_rpc_url(), None)],
         Default::default(),
     )?;
 
@@ -654,11 +643,7 @@ pub async fn create_system_and_staking_objects(
     let address = wallet.active_address();
 
     let retry_client = RetriableSuiClient::new(
-        vec![LazySuiClientBuilder::new(
-            wallet.get_rpc_url(),
-            None,
-            DEFAULT_CHECKPOINT_WAIT_TIMEOUT,
-        )],
+        vec![LazySuiClientBuilder::new(wallet.get_rpc_url(), None)],
         Default::default(),
     )?;
 

--- a/crates/walrus-sui/src/utils.rs
+++ b/crates/walrus-sui/src/utils.rs
@@ -476,12 +476,7 @@ pub async fn get_sui_from_wallet_or_faucet(
     let min_balance = sui_amount + 2 * one_sui;
     let sender = wallet.active_address();
     let rpc_urls = &[wallet.get_rpc_url()];
-    let client = RetriableSuiClient::new_for_rpc_urls(
-        rpc_urls,
-        Default::default(),
-        None,
-        crate::client::dual_client::DEFAULT_CHECKPOINT_WAIT_TIMEOUT,
-    )?;
+    let client = RetriableSuiClient::new_for_rpc_urls(rpc_urls, Default::default(), None)?;
     let balance = client.get_total_balance(sender, Coin::SUI).await?;
     if balance >= min_balance {
         let mut ptb = ProgrammableTransactionBuilder::new();

--- a/crates/walrus-upload-relay/src/controller.rs
+++ b/crates/walrus-upload-relay/src/controller.rs
@@ -582,7 +582,6 @@ pub async fn get_client_with_config(
         &client_config.rpc_urls,
         client_config.backoff_config().clone(),
         None,
-        client_config.checkpoint_wait_timeout(),
     )?
     .with_metrics(Some(Arc::new(SuiClientMetricSet::new(registry))));
 


### PR DESCRIPTION
## Description

`checkpoint_wait_timeout` was stored on `RetriableSuiClient`/`DualClient` and threaded through `SuiReadClient::new_for_rpc_urls`, but it is only consulted by `DualClient::execute_transaction_grpc`. Every read-only constructor was forced to carry a write-path parameter it never read.

This PR relocates the timeout to the write path:

- Removes the field/parameter from `DualClient`, `LazySuiClientBuilder`, `RetriableSuiClient::new_for_rpc_urls`, and `SuiReadClient::new_for_rpc_urls`.
- Stores it on `SuiContractClientInner`; `sign_and_send_transaction` passes it as a method argument through `RetriableSuiClient::execute_transaction` → `DualClient::execute_transaction_grpc`. The JSON-RPC fallback ignores it.
- Adds a `checkpoint_wait_timeout` argument to `SuiContractClient::new_with_read_client`; `new`/`new_with_metrics` keep theirs and forward through.
- Read-only call sites drop the now-redundant `DEFAULT_CHECKPOINT_WAIT_TIMEOUT` boilerplate; write-path call sites in `walrus-stress` and `walrus-service` common config thread the configured value into the contract client.

`DEFAULT_CHECKPOINT_WAIT_TIMEOUT` (30s) and the `SuiConfig`/`ClientConfig` accessors are unchanged. No behavior change.

## Test plan

CI Pipeline.