### PR TITLE
chore(grpc): gRPC migration level 8 - owned objects

### DIFF
--- a/crates/walrus-sui/src/client/dual_client.rs
+++ b/crates/walrus-sui/src/client/dual_client.rs
@@ -65,6 +65,9 @@ use crate::{
         EventEnvelope,
         ExecuteTransactionResponse,
         ObjectChangeEntry,
+        OwnedObjectEntry,
+        OwnedObjectsCursor,
+        OwnedObjectsPage,
         SuiCommitteeInfo,
         TransactionEffectsStatus,
         TransactionResponse,
@@ -445,6 +448,58 @@ impl DualClient {
         Ok(type_origins)
     }
 
+    /// List owned objects via the gRPC `ListOwnedObjects` RPC.
+    ///
+    /// Returns a single page in protocol-agnostic form. Callers paginate by feeding
+    /// `next_cursor` (when `has_next_page` is true) back in as `page_token`. The cursor is
+    /// opaque to the client; the server may rotate its representation.
+    pub async fn list_owned_objects_grpc(
+        &self,
+        owner: SuiAddress,
+        type_filter: Option<&str>,
+        page_token: Option<Bytes>,
+    ) -> Result<OwnedObjectsPage, SuiClientError> {
+        tracing::debug!(
+            ?owner,
+            ?type_filter,
+            ?page_token,
+            "DualClient::list_owned_objects_grpc called"
+        );
+        let mut grpc_client = self.grpc_client.clone();
+        let response = list_owned_objects(
+            owner,
+            type_filter,
+            page_token,
+            &mut grpc_client,
+            MAX_OWNED_OBJECTS_BATCH_SIZE,
+        )
+        .await
+        .with_context(|| {
+            format!(
+                "error listing owned objects for owner [owner={:?}, object_type={:?}]",
+                owner, type_filter
+            )
+        })?;
+
+        let response = response.into_inner();
+        let mut data = Vec::with_capacity(response.objects.len());
+        for object in response.objects {
+            data.push(convert_grpc_object_to_owned_object_entry(object).with_context(|| {
+                format!(
+                    "error converting object to OwnedObjectEntry [owner={:?}, object_type={:?}]",
+                    owner, type_filter
+                )
+            })?);
+        }
+        let next_cursor = response.next_page_token.map(OwnedObjectsCursor::from_grpc);
+        let has_next_page = next_cursor.is_some();
+        Ok(OwnedObjectsPage {
+            data,
+            next_cursor,
+            has_next_page,
+        })
+    }
+
     pub(crate) async fn fetch_batch_of_objects<U: AssociatedContractStruct>(
         &self,
         owner: SuiAddress,
@@ -468,7 +523,7 @@ impl DualClient {
         // instead of using this incremental approach across servers.
         let response = list_owned_objects(
             owner,
-            object_type,
+            Some(object_type),
             page_token,
             &mut grpc_client,
             MAX_OWNED_OBJECTS_BATCH_SIZE,
@@ -851,7 +906,7 @@ async fn execute_transaction_and_convert(
 
 async fn list_owned_objects(
     owner: SuiAddress,
-    object_type: &str,
+    object_type: Option<&str>,
     next_page_token: Option<Bytes>,
     grpc_client: &mut GrpcClient,
     batch_size: u32,
@@ -867,8 +922,10 @@ async fn list_owned_objects(
             Object::path_builder().balance(),
             Object::path_builder().previous_transaction(),
         ]))
-        .with_page_size(batch_size)
-        .with_object_type(object_type);
+        .with_page_size(batch_size);
+    if let Some(object_type) = object_type {
+        request = request.with_object_type(object_type);
+    }
     if let Some(next_page_token) = next_page_token {
         request = request.with_page_token(next_page_token);
     }
@@ -883,7 +940,7 @@ async fn list_owned_coin_objects(
 ) -> Result<tonic::Response<ListOwnedObjectsResponse>, tonic::Status> {
     list_owned_objects(
         owner,
-        object_type,
+        Some(object_type),
         next_page_token,
         grpc_client,
         MAX_SELECT_COINS_BATCH_SIZE,
@@ -920,6 +977,37 @@ fn convert_grpc_object_to_object_with_ref<U: AssociatedContractStruct>(
                 .context("parsing digest")?,
         ),
     ))
+}
+
+fn convert_grpc_object_to_owned_object_entry(
+    object: Object,
+) -> Result<OwnedObjectEntry, anyhow::Error> {
+    let object_type = object
+        .object_type
+        .context("no object_type in object")?
+        .parse::<StructTag>()
+        .context("parsing move object_type")?;
+    let bcs_bytes = object
+        .contents
+        .context("no contents in object")?
+        .value
+        .context("no value in contents")?
+        .to_vec();
+    Ok(OwnedObjectEntry {
+        object_id: object
+            .object_id
+            .context("no object_id in object")?
+            .parse()
+            .context("parsing object_id")?,
+        version: object.version.context("no version in object")?.into(),
+        digest: object
+            .digest
+            .context("no digest in object")?
+            .parse()
+            .context("parsing digest")?,
+        object_type,
+        bcs_bytes,
+    })
 }
 
 fn convert_grpc_object_to_coin(object: Object) -> Result<Coin, anyhow::Error> {

--- a/crates/walrus-sui/src/client/read_client.rs
+++ b/crates/walrus-sui/src/client/read_client.rs
@@ -16,17 +16,7 @@ use std::{
 use anyhow::{Context, Result, anyhow, bail};
 use chrono::{DateTime, Utc};
 use futures::FutureExt as _;
-use sui_sdk::{
-    apis::EventApi,
-    rpc_types::{
-        EventFilter,
-        SuiObjectData,
-        SuiObjectDataFilter,
-        SuiObjectDataOptions,
-        SuiObjectResponseQuery,
-    },
-    types::base_types::ObjectID,
-};
+use sui_sdk::{apis::EventApi, rpc_types::EventFilter, types::base_types::ObjectID};
 use sui_types::{
     Identifier,
     TypeTag,
@@ -80,7 +70,7 @@ use crate::{
             WalrusSubsidiesInner,
         },
     },
-    utils::{get_sui_object_from_bcs, handle_pagination},
+    utils::get_sui_object_from_bcs,
 };
 
 const EVENT_MODULE: &str = "events";
@@ -777,65 +767,58 @@ impl SuiReadClient {
             contract_struct = %U::CONTRACT_STRUCT,
         );
 
-        let results = self
-            .get_owned_object_data(owner, type_args, U::CONTRACT_STRUCT)
-            .instrument(span.clone())
-            .await?;
+        let struct_tag = U::CONTRACT_STRUCT
+            .to_move_struct_tag_with_type_map(&self.type_origin_map(), type_args)?;
 
-        Ok(results.filter_map(move |object_data| {
+        let entries = async {
+            let mut entries = Vec::new();
+            let mut cursor = None;
+            loop {
+                let page = self
+                    .sui_client
+                    .get_owned_objects(owner, Some(struct_tag.clone()), cursor)
+                    .await?;
+                entries.extend(page.data);
+                if !page.has_next_page {
+                    break;
+                }
+                let Some(next_cursor) = page.next_cursor else {
+                    break;
+                };
+                cursor = Some(next_cursor);
+            }
+            SuiClientResult::Ok(entries)
+        }
+        .instrument(span.clone())
+        .await?;
+
+        Ok(entries.into_iter().filter_map(move |entry| {
             let _entered = span.enter();
-            object_data.map_or_else(
-                |error| {
+            // The server-side filter already constrains the type, but keep the assertion as a
+            // defense-in-depth check, matching the JSON-RPC `try_from_object_data` path.
+            if entry.object_type.name.as_str() != U::CONTRACT_STRUCT.name
+                || entry.object_type.module.as_str() != U::CONTRACT_STRUCT.module
+            {
+                tracing::warn!(
+                    contract_struct = %U::CONTRACT_STRUCT,
+                    actual = %entry.object_type,
+                    object_id = %entry.object_id,
+                    "owned object did not match expected struct tag",
+                );
+                return None;
+            }
+            match bcs::from_bytes::<U>(&entry.bcs_bytes) {
+                Result::Ok(value) => Some(value),
+                Result::Err(error) => {
                     tracing::warn!(
                         ?error,
                         contract_struct = %U::CONTRACT_STRUCT,
-                        "failed to convert to local type",
+                        object_id = %entry.object_id,
+                        "failed to deserialize owned object",
                     );
                     None
-                },
-                |object_data| match U::try_from_object_data(&object_data) {
-                    Result::Ok(value) => Some(value),
-                    Result::Err(error) => {
-                        tracing::warn!(
-                            ?error,
-                            contract_struct = %U::CONTRACT_STRUCT,
-                            "failed to convert to local type",
-                        );
-                        None
-                    }
-                },
-            )
-        }))
-    }
-
-    /// Get all the [`SuiObjectData`] objects of the specified type for the specified owner.
-    async fn get_owned_object_data<'a>(
-        &'a self,
-        owner: SuiAddress,
-        type_args: &'a [TypeTag],
-        object_type: contracts::StructTag<'a>,
-    ) -> Result<impl Iterator<Item = Result<SuiObjectData>> + 'a> {
-        let struct_tag =
-            object_type.to_move_struct_tag_with_type_map(&self.type_origin_map(), type_args)?;
-        Ok(handle_pagination(move |cursor| {
-            self.sui_client.get_owned_objects(
-                owner,
-                Some(SuiObjectResponseQuery {
-                    filter: Some(SuiObjectDataFilter::StructType(struct_tag.clone())),
-                    options: Some(SuiObjectDataOptions::new().with_bcs().with_type()),
-                }),
-                cursor,
-                None,
-            )
-        })
-        .await?
-        .map(|resp| {
-            resp.data.ok_or_else(|| {
-                anyhow!(
-                    "response does not contain object data [err={:?}]",
-                    resp.error
-                )
-            })
+                }
+            }
         }))
     }
 

--- a/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
@@ -36,6 +36,7 @@ use sui_sdk::{
         SuiMoveNormalizedStructType,
         SuiMoveNormalizedType,
         SuiObjectData,
+        SuiObjectDataFilter,
         SuiObjectDataOptions,
         SuiObjectResponse,
         SuiObjectResponseQuery,
@@ -88,6 +89,9 @@ use crate::{
         EventEnvelope,
         ExecuteTransactionResponse,
         ObjectChangeEntry,
+        OwnedObjectEntry,
+        OwnedObjectsCursor,
+        OwnedObjectsPage,
         SuiCommitteeInfo,
         TransactionEffectsStatus,
         TransactionResponse,
@@ -222,6 +226,7 @@ const GRPC_MIGRATION_LEVEL_GET_BALANCE: GrpcMigrationLevel = GrpcMigrationLevel(
 const GRPC_MIGRATION_LEVEL_TRANSACTION_READS: GrpcMigrationLevel = GrpcMigrationLevel(5);
 const GRPC_MIGRATION_LEVEL_SERVICE_INFO: GrpcMigrationLevel = GrpcMigrationLevel(6);
 const GRPC_MIGRATION_LEVEL_TRANSACTION_WRITES: GrpcMigrationLevel = GrpcMigrationLevel(7);
+const GRPC_MIGRATION_LEVEL_OWNED_OBJECTS: GrpcMigrationLevel = GrpcMigrationLevel(8);
 
 impl Default for GrpcMigrationLevel {
     fn default() -> Self {
@@ -889,37 +894,59 @@ impl RetriableSuiClient {
             .await
     }
 
-    /// Return a paginated response with the objects owned by the given address.
+    /// Return a paginated response with the objects owned by the given address, optionally
+    /// filtered to a single Move type.
     ///
-    /// Calls [`sui_sdk::apis::ReadApi::get_owned_objects`] internally.
+    /// At `WALRUS_GRPC_MIGRATION_LEVEL >= 8` this routes through the gRPC `ListOwnedObjects`
+    /// RPC; otherwise it falls back to the JSON-RPC `getOwnedObjects` endpoint. The returned
+    /// [`OwnedObjectsCursor`] is opaque and tied to whichever backend produced it.
     #[tracing::instrument(level = Level::DEBUG, skip_all)]
     pub async fn get_owned_objects(
         &self,
         address: SuiAddress,
-        query: Option<SuiObjectResponseQuery>,
-        cursor: Option<ObjectID>,
-        limit: Option<usize>,
-    ) -> SuiClientResult<ObjectsPage> {
-        async fn make_request(
-            client: Arc<DualClient>,
-            address: SuiAddress,
-            query: Option<SuiObjectResponseQuery>,
-            cursor: Option<ObjectID>,
-            limit: Option<usize>,
-        ) -> SuiClientResult<ObjectsPage> {
-            Ok(client
-                .sui_client()
-                .read_api()
-                .get_owned_objects(address, query, cursor, limit)
-                .await?)
+        type_filter: Option<StructTag>,
+        cursor: Option<OwnedObjectsCursor>,
+    ) -> SuiClientResult<OwnedObjectsPage> {
+        if self.grpc_migration_level >= GRPC_MIGRATION_LEVEL_OWNED_OBJECTS {
+            self.get_owned_objects_grpc(address, type_filter, cursor)
+                .await
+        } else {
+            self.get_owned_objects_json_rpc(address, type_filter, cursor)
+                .await
         }
+    }
+
+    async fn get_owned_objects_grpc(
+        &self,
+        address: SuiAddress,
+        type_filter: Option<StructTag>,
+        cursor: Option<OwnedObjectsCursor>,
+    ) -> SuiClientResult<OwnedObjectsPage> {
+        debug_assert!(self.grpc_migration_level >= GRPC_MIGRATION_LEVEL_OWNED_OBJECTS);
+        let page_token = cursor
+            .map(OwnedObjectsCursor::into_grpc)
+            .transpose()
+            .map_err(SuiClientError::Internal)?;
+        let type_filter_str = type_filter.as_ref().map(StructTag::to_string);
+
         let request = |client: Arc<DualClient>, method: &'static str| {
-            let query = query.clone();
+            let type_filter_str = type_filter_str.clone();
+            let page_token = page_token.clone();
             retry_rpc_errors(
                 self.get_strategy(),
                 move || {
-                    let query = query.clone();
-                    make_request(client.clone(), address, query, cursor, limit)
+                    let type_filter_str = type_filter_str.clone();
+                    let page_token = page_token.clone();
+                    let client = client.clone();
+                    async move {
+                        client
+                            .list_owned_objects_grpc(
+                                address,
+                                type_filter_str.as_deref(),
+                                page_token,
+                            )
+                            .await
+                    }
                 },
                 self.metrics.clone(),
                 method,
@@ -929,6 +956,63 @@ impl RetriableSuiClient {
         self.failover_sui_client
             .with_failover(request, None, "get_owned_objects")
             .await
+    }
+
+    async fn get_owned_objects_json_rpc(
+        &self,
+        address: SuiAddress,
+        type_filter: Option<StructTag>,
+        cursor: Option<OwnedObjectsCursor>,
+    ) -> SuiClientResult<OwnedObjectsPage> {
+        debug_assert!(self.grpc_migration_level < GRPC_MIGRATION_LEVEL_OWNED_OBJECTS);
+        let json_cursor = cursor
+            .map(OwnedObjectsCursor::into_json_rpc)
+            .transpose()
+            .map_err(SuiClientError::Internal)?;
+        let query = SuiObjectResponseQuery {
+            filter: type_filter.map(SuiObjectDataFilter::StructType),
+            options: Some(SuiObjectDataOptions::new().with_bcs().with_type()),
+        };
+
+        async fn make_request(
+            client: Arc<DualClient>,
+            address: SuiAddress,
+            query: SuiObjectResponseQuery,
+            cursor: Option<ObjectID>,
+        ) -> SuiClientResult<ObjectsPage> {
+            Ok(client
+                .sui_client()
+                .read_api()
+                .get_owned_objects(address, Some(query), cursor, None)
+                .await?)
+        }
+        let request = |client: Arc<DualClient>, method: &'static str| {
+            let query = query.clone();
+            retry_rpc_errors(
+                self.get_strategy(),
+                move || {
+                    let query = query.clone();
+                    make_request(client.clone(), address, query, json_cursor)
+                },
+                self.metrics.clone(),
+                method,
+            )
+        };
+
+        let raw_page = self
+            .failover_sui_client
+            .with_failover(request, None, "get_owned_objects")
+            .await?;
+
+        let mut data = Vec::with_capacity(raw_page.data.len());
+        for response in raw_page.data {
+            data.push(OwnedObjectEntry::try_from(response).map_err(SuiClientError::Internal)?);
+        }
+        Ok(OwnedObjectsPage {
+            data,
+            next_cursor: raw_page.next_cursor.map(OwnedObjectsCursor::from_json_rpc),
+            has_next_page: raw_page.has_next_page,
+        })
     }
 
     /// Returns a [`sui_types::object::Object`] based on the provided [`ObjectID`].

--- a/crates/walrus-sui/src/types.rs
+++ b/crates/walrus-sui/src/types.rs
@@ -56,6 +56,9 @@ pub use transaction::{
     TransactionResponseOptions,
 };
 
+pub mod owned_objects;
+pub use owned_objects::{OwnedObjectEntry, OwnedObjectsCursor, OwnedObjectsPage};
+
 pub mod move_structs;
 pub use move_structs::{
     Blob,

--- a/crates/walrus-sui/src/types/owned_objects.rs
+++ b/crates/walrus-sui/src/types/owned_objects.rs
@@ -1,0 +1,111 @@
+// Copyright (c) Walrus Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Protocol-agnostic types for paginated owned-object listing.
+//!
+//! These mirror the JSON-RPC `ObjectsPage` envelope but live in `walrus-sui` so callers do not
+//! depend on `sui_sdk::rpc_types`. Both the JSON-RPC fallback and the gRPC `ListOwnedObjects`
+//! path produce the same shape.
+
+use anyhow::Context as _;
+use bytes::Bytes;
+use move_core_types::language_storage::StructTag;
+use sui_sdk::rpc_types::{SuiData as _, SuiObjectResponse};
+use sui_types::base_types::{ObjectDigest, ObjectID, SequenceNumber};
+
+use crate::contracts::MoveConversionError;
+
+/// A single owned object as returned by either RPC backend.
+#[derive(Debug, Clone)]
+pub struct OwnedObjectEntry {
+    /// The on-chain object id.
+    pub object_id: ObjectID,
+    /// Object version.
+    pub version: SequenceNumber,
+    /// Object digest.
+    pub digest: ObjectDigest,
+    /// Move struct tag of the object.
+    pub object_type: StructTag,
+    /// BCS bytes of the Move object contents (the `bcs_bytes` of the underlying Move object).
+    pub bcs_bytes: Vec<u8>,
+}
+
+/// Opaque page cursor returned by the previous page; pass it back into the next call.
+#[derive(Debug, Clone)]
+pub struct OwnedObjectsCursor(OwnedObjectsCursorInner);
+
+#[derive(Debug, Clone)]
+enum OwnedObjectsCursorInner {
+    JsonRpc(ObjectID),
+    Grpc(Bytes),
+}
+
+impl OwnedObjectsCursor {
+    /// Wraps a JSON-RPC `ObjectID` cursor.
+    pub fn from_json_rpc(cursor: ObjectID) -> Self {
+        Self(OwnedObjectsCursorInner::JsonRpc(cursor))
+    }
+
+    /// Wraps an opaque gRPC page-token.
+    pub fn from_grpc(token: Bytes) -> Self {
+        Self(OwnedObjectsCursorInner::Grpc(token))
+    }
+
+    /// Extracts the JSON-RPC cursor variant. Errors if the cursor is from the gRPC backend.
+    pub fn into_json_rpc(self) -> anyhow::Result<ObjectID> {
+        match self.0 {
+            OwnedObjectsCursorInner::JsonRpc(id) => Ok(id),
+            OwnedObjectsCursorInner::Grpc(_) => Err(anyhow::anyhow!(
+                "expected JSON-RPC owned-objects cursor, got gRPC variant"
+            )),
+        }
+    }
+
+    /// Extracts the gRPC cursor variant. Errors if the cursor is from the JSON-RPC backend.
+    pub fn into_grpc(self) -> anyhow::Result<Bytes> {
+        match self.0 {
+            OwnedObjectsCursorInner::Grpc(bytes) => Ok(bytes),
+            OwnedObjectsCursorInner::JsonRpc(_) => Err(anyhow::anyhow!(
+                "expected gRPC owned-objects cursor, got JSON-RPC variant"
+            )),
+        }
+    }
+}
+
+/// A page of owned objects. Drop-in replacement for `sui_sdk::rpc_types::ObjectsPage` that does
+/// not leak `sui_sdk` types.
+#[derive(Debug, Clone, Default)]
+pub struct OwnedObjectsPage {
+    /// Owned objects in this page.
+    pub data: Vec<OwnedObjectEntry>,
+    /// Cursor for the next page, if any.
+    pub next_cursor: Option<OwnedObjectsCursor>,
+    /// Whether the underlying RPC says there is at least one more page.
+    pub has_next_page: bool,
+}
+
+impl TryFrom<SuiObjectResponse> for OwnedObjectEntry {
+    type Error = anyhow::Error;
+
+    fn try_from(response: SuiObjectResponse) -> Result<Self, Self::Error> {
+        let data = response.data.with_context(|| {
+            format!(
+                "response does not contain object data [err={:?}]",
+                response.error
+            )
+        })?;
+        let raw = data
+            .bcs
+            .as_ref()
+            .ok_or(MoveConversionError::NoBcs)?
+            .try_as_move()
+            .ok_or(MoveConversionError::NotMoveObject)?;
+        Ok(OwnedObjectEntry {
+            object_id: data.object_id,
+            version: data.version,
+            digest: data.digest,
+            object_type: raw.type_.clone(),
+            bcs_bytes: raw.bcs_bytes.clone(),
+        })
+    }
+}

--- a/crates/walrus-sui/src/utils.rs
+++ b/crates/walrus-sui/src/utils.rs
@@ -3,14 +3,7 @@
 
 //! Helper functions for the crate.
 
-use std::{
-    collections::HashSet,
-    future::Future,
-    num::NonZeroU16,
-    path::Path,
-    str::FromStr,
-    time::Duration,
-};
+use std::{collections::HashSet, num::NonZeroU16, path::Path, str::FromStr, time::Duration};
 
 use anyhow::{Context as _, Result, anyhow};
 use move_core_types::language_storage::StructTag;
@@ -24,7 +17,7 @@ use sui_keys::keystore::{
     Keystore,
 };
 use sui_sdk::{
-    rpc_types::{Page, SuiObjectResponse},
+    rpc_types::SuiObjectResponse,
     sui_client_config::{SuiClientConfig, SuiEnv},
     types::base_types::ObjectID,
 };
@@ -209,39 +202,6 @@ where
             U::CONTRACT_STRUCT
         )
     })?)
-}
-
-pub(crate) async fn handle_pagination<F, T, C, Fut, ErrorT>(
-    closure: F,
-) -> Result<impl Iterator<Item = T>, ErrorT>
-where
-    F: FnMut(Option<C>) -> Fut,
-    T: 'static,
-    Fut: Future<Output = Result<Page<T, C>, ErrorT>>,
-    ErrorT: std::error::Error,
-{
-    handle_pagination_with_cursor(closure, None).await
-}
-
-pub(crate) async fn handle_pagination_with_cursor<F, T, C, Fut, ErrorT>(
-    mut closure: F,
-    mut cursor: Option<C>,
-) -> Result<impl Iterator<Item = T>, ErrorT>
-where
-    F: FnMut(Option<C>) -> Fut,
-    T: 'static,
-    Fut: Future<Output = Result<Page<T, C>, ErrorT>>,
-    ErrorT: std::error::Error,
-{
-    let mut cont = true;
-    let mut iterators = vec![];
-    while cont {
-        let page = closure(cursor).await?;
-        cont = page.has_next_page;
-        cursor = page.next_cursor;
-        iterators.push(page.data.into_iter());
-    }
-    Ok(iterators.into_iter().flatten())
 }
 
 // Wallet setup


### PR DESCRIPTION
## Description

Migrates `get_owned_objects` to gRPC at migration level 8.

- Adds protocol-agnostic `OwnedObjectsPage` / `OwnedObjectEntry` / `OwnedObjectsCursor` in `walrus-sui` so the API no longer leaks `sui_sdk::rpc_types`.
- `DualClient::list_owned_objects_grpc` reuses the existing `list_owned_objects` helper (proven at level 3 for coin selection).
- `RetriableSuiClient::get_owned_objects` now branches on `GRPC_MIGRATION_LEVEL_OWNED_OBJECTS`; the JSON-RPC fallback maps each `SuiObjectResponse` through a `TryFrom` impl that lives next to the new types.
- `SuiReadClient::get_owned_objects<U>` deserializes from `OwnedObjectEntry.bcs_bytes` and absorbs the now-unused `get_owned_object_data`.
- Drops dead `handle_pagination` helpers and trims unused `sui_sdk` imports out of `read_client.rs` and `utils.rs`.

## Test plan

- \`chk\` (cargo fmt + clippy --all-features --tests + workspace test build).
- \`cargo nextest run -p walrus-sui\` (35/35 pass) and \`cargo test --doc -p walrus-sui\`.
- The CI \`WALRUS_GRPC_MIGRATION_LEVEL=[0, 100]\` matrix exercises both the JSON-RPC fallback and the new gRPC path.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI: