### PR TITLE
perf: offload remaining blocking RocksDB reads to spawn_blocking

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -309,7 +309,7 @@ pub trait ServiceState {
     fn metadata_status(
         &self,
         blob_id: &BlobId,
-    ) -> Result<StoredOnNodeStatus, RetrieveMetadataError>;
+    ) -> impl Future<Output = Result<StoredOnNodeStatus, RetrieveMetadataError>> + Send;
 
     /// Retrieves a primary or secondary sliver for a blob for a shard held by this storage node.
     fn retrieve_sliver(
@@ -376,7 +376,10 @@ pub trait ServiceState {
     > + Send;
 
     /// Retrieves the blob status for the given `blob_id`.
-    fn blob_status(&self, blob_id: &BlobId) -> Result<BlobStatus, BlobStatusError>;
+    fn blob_status(
+        &self,
+        blob_id: &BlobId,
+    ) -> impl Future<Output = Result<BlobStatus, BlobStatusError>> + Send;
 
     /// Returns the number of shards the node is currently operating with.
     fn n_shards(&self) -> NonZeroU16;
@@ -3283,11 +3286,15 @@ impl StorageNodeInner {
         blob_id: &BlobId,
         verified: Arc<VerifiedBlobMetadataWithId>,
     ) -> Result<bool, StoreMetadataError> {
-        if self
-            .storage
-            .has_metadata(blob_id)
-            .context("could not check metadata existence")?
-        {
+        let has_metadata = {
+            let storage = self.storage.clone();
+            let blob_id = *blob_id;
+            tokio::task::spawn_blocking(move || storage.has_metadata(&blob_id))
+                .map(unwrap_or_resume_unwind)
+                .await
+                .context("could not check metadata existence")?
+        };
+        if has_metadata {
             return Ok(false);
         }
 
@@ -3330,7 +3337,7 @@ impl StorageNodeInner {
         }
 
         let pending = self.pending_metadata_cache.get(blob_id).await;
-        let is_registered = self.is_blob_registered(blob_id)?;
+        let is_registered = self.is_blob_registered(blob_id).await?;
 
         match (pending, is_registered, allow_pending) {
             (Some(metadata), _, _) => Ok((metadata, false)),
@@ -3343,11 +3350,15 @@ impl StorageNodeInner {
         &self,
         blob_id: &BlobId,
     ) -> Result<(), StoreMetadataError> {
-        if self
-            .storage
-            .has_metadata(blob_id)
-            .context("could not check metadata existence")?
-        {
+        let has_metadata = {
+            let storage = self.storage.clone();
+            let blob_id = *blob_id;
+            tokio::task::spawn_blocking(move || storage.has_metadata(&blob_id))
+                .map(unwrap_or_resume_unwind)
+                .await
+                .context("could not check metadata existence")?
+        };
+        if has_metadata {
             return Ok(());
         }
 
@@ -3483,12 +3494,15 @@ impl StorageNodeInner {
         Ok(())
     }
 
-    fn is_blob_registered(&self, blob_id: &BlobId) -> Result<bool, anyhow::Error> {
-        Ok(self
-            .storage
-            .get_blob_info(blob_id)
-            .context("could not retrieve blob info")?
-            .is_some_and(|blob_info| blob_info.is_registered(self.current_committee_epoch())))
+    async fn is_blob_registered(&self, blob_id: &BlobId) -> Result<bool, anyhow::Error> {
+        let storage = self.storage.clone();
+        let blob_id = *blob_id;
+        let blob_info = tokio::task::spawn_blocking(move || storage.get_blob_info(&blob_id))
+            .map(unwrap_or_resume_unwind)
+            .await
+            .context("could not retrieve blob info")?;
+        let epoch = self.current_committee_epoch();
+        Ok(blob_info.is_some_and(|blob_info| blob_info.is_registered(epoch)))
     }
 
     fn notify_registration(&self, blob_id: &BlobId) {
@@ -3500,13 +3514,13 @@ impl StorageNodeInner {
         // blob scoped, so it can return `true` due to registration of a different object that
         // references the same `BlobId`.
         if timeout.is_zero() {
-            return self.is_blob_registered(blob_id).unwrap_or(false);
+            return self.is_blob_registered(blob_id).await.unwrap_or(false);
         }
 
         let notify = self.registration_notifier.acquire(blob_id);
         let notified = notify.notified();
 
-        if self.is_blob_registered(blob_id).unwrap_or(false) {
+        if self.is_blob_registered(blob_id).await.unwrap_or(false) {
             return true;
         }
 
@@ -3526,7 +3540,7 @@ impl StorageNodeInner {
         }
 
         match tokio::time::timeout(timeout, notified).await {
-            Ok(()) => self.is_blob_registered(blob_id).unwrap_or(false),
+            Ok(()) => self.is_blob_registered(blob_id).await.unwrap_or(false),
             Err(_) => false,
         }
     }
@@ -3568,7 +3582,7 @@ impl StorageNodeInner {
     }
 
     /// Common validation for blob operations
-    fn validate_blob_access<E>(
+    async fn validate_blob_access<E>(
         &self,
         blob_id: &BlobId,
         forbidden_error: E,
@@ -3578,7 +3592,7 @@ impl StorageNodeInner {
         E: From<anyhow::Error>,
     {
         ensure!(!self.is_blocked(blob_id), forbidden_error);
-        ensure!(self.is_blob_registered(blob_id)?, unavailable_error,);
+        ensure!(self.is_blob_registered(blob_id).await?, unavailable_error,);
         Ok(())
     }
 
@@ -3842,7 +3856,7 @@ impl StorageNodeInner {
         blob_id: BlobId,
         defer_duration: std::time::Duration,
     ) -> Result<(), SetRecoveryDeferralError> {
-        let is_registered = self.is_blob_registered(&blob_id).map_err(|error| {
+        let is_registered = self.is_blob_registered(&blob_id).await.map_err(|error| {
             tracing::warn!(
                 walrus.blob_id = %blob_id,
                 ?error,
@@ -4055,7 +4069,7 @@ impl ServiceState for StorageNode {
     fn metadata_status(
         &self,
         blob_id: &BlobId,
-    ) -> Result<StoredOnNodeStatus, RetrieveMetadataError> {
+    ) -> impl Future<Output = Result<StoredOnNodeStatus, RetrieveMetadataError>> + Send {
         self.inner.metadata_status(blob_id)
     }
 
@@ -4129,7 +4143,10 @@ impl ServiceState for StorageNode {
             .retrieve_multiple_decoding_symbols(blob_id, target_slivers, target_type)
     }
 
-    fn blob_status(&self, blob_id: &BlobId) -> Result<BlobStatus, BlobStatusError> {
+    fn blob_status(
+        &self,
+        blob_id: &BlobId,
+    ) -> impl Future<Output = Result<BlobStatus, BlobStatusError>> + Send {
         self.inner.blob_status(blob_id)
     }
 
@@ -4187,16 +4204,18 @@ impl ServiceState for StorageNodeInner {
             blob_id,
             RetrieveMetadataError::Forbidden,
             RetrieveMetadataError::Unavailable,
-        )?;
+        )
+        .await?;
 
         let storage = self.storage.clone();
         let blob_id = *blob_id;
-        tokio::task::spawn_blocking(move || storage.get_metadata(&blob_id))
+        let metadata = tokio::task::spawn_blocking(move || storage.get_metadata(&blob_id))
             .map(unwrap_or_resume_unwind)
             .await
             .context("database error when retrieving metadata")?
-            .ok_or(RetrieveMetadataError::Unavailable)
-            .inspect(|_| self.metrics.metadata_retrieved_total.inc())
+            .ok_or(RetrieveMetadataError::Unavailable)?;
+        self.metrics.metadata_retrieved_total.inc();
+        Ok(metadata)
     }
 
     /// Stores metadata for a blob.
@@ -4210,10 +4229,13 @@ impl ServiceState for StorageNodeInner {
     ) -> Result<bool, StoreMetadataError> {
         let blob_id = *metadata.blob_id();
 
-        let blob_info = self
-            .storage
-            .get_blob_info(&blob_id)
-            .context("could not retrieve blob info")?;
+        let blob_info = {
+            let storage = self.storage.clone();
+            tokio::task::spawn_blocking(move || storage.get_blob_info(&blob_id))
+                .map(unwrap_or_resume_unwind)
+                .await
+                .context("could not retrieve blob info")?
+        };
 
         if let Some(event) = blob_info
             .as_ref()
@@ -4222,11 +4244,14 @@ impl ServiceState for StorageNodeInner {
             return Err(StoreMetadataError::InvalidBlob(event));
         }
 
-        if self
-            .storage
-            .has_metadata(&blob_id)
-            .context("could not check metadata existence")?
-        {
+        let has_metadata = {
+            let storage = self.storage.clone();
+            tokio::task::spawn_blocking(move || storage.has_metadata(&blob_id))
+                .map(unwrap_or_resume_unwind)
+                .await
+                .context("could not check metadata existence")?
+        };
+        if has_metadata {
             return Ok(false);
         }
 
@@ -4275,7 +4300,7 @@ impl ServiceState for StorageNodeInner {
             return Ok(false);
         }
 
-        if self.is_blob_registered(&blob_id)? {
+        if self.is_blob_registered(&blob_id).await? {
             // Read the blob info again because registration can race between the initial blob_info
             // check and adding to the cache. Flush immediately in that case so the pending metadata
             // doesn’t linger indefinitely.
@@ -4290,11 +4315,16 @@ impl ServiceState for StorageNodeInner {
         Ok(true)
     }
 
-    fn metadata_status(
+    async fn metadata_status(
         &self,
         blob_id: &BlobId,
     ) -> Result<StoredOnNodeStatus, RetrieveMetadataError> {
-        match self.storage.has_metadata(blob_id) {
+        let storage = self.storage.clone();
+        let blob_id = *blob_id;
+        match tokio::task::spawn_blocking(move || storage.has_metadata(&blob_id))
+            .map(unwrap_or_resume_unwind)
+            .await
+        {
             Ok(true) => Ok(StoredOnNodeStatus::Stored),
             Ok(false) => Ok(StoredOnNodeStatus::Nonexistent),
             Err(err) => Err(RetrieveMetadataError::Internal(err.into())),
@@ -4313,7 +4343,8 @@ impl ServiceState for StorageNodeInner {
             blob_id,
             RetrieveSliverError::Forbidden,
             RetrieveSliverError::Unavailable,
-        )?;
+        )
+        .await?;
 
         self.retrieve_sliver_unchecked(blob_id, sliver_pair_index, sliver_type)
             .await
@@ -4384,7 +4415,7 @@ impl ServiceState for StorageNodeInner {
                     inserted,
                     "store_sliver: buffered sliver in pending cache"
                 );
-                if self.is_blob_registered(&blob_id)? {
+                if self.is_blob_registered(&blob_id).await? {
                     // Registration may arrive between the initial registration check and the point
                     // where we enqueue the sliver. If it does, flush everything immediately so the
                     // data doesn’t stay buffered without another trigger.
@@ -4413,7 +4444,7 @@ impl ServiceState for StorageNodeInner {
         blob_persistence_type: &BlobPersistenceType,
     ) -> Result<StorageConfirmation, ComputeStorageConfirmationError> {
         ensure!(
-            self.is_blob_registered(blob_id)?,
+            self.is_blob_registered(blob_id).await?,
             ComputeStorageConfirmationError::NotCurrentlyRegistered,
         );
 
@@ -4482,11 +4513,14 @@ impl ServiceState for StorageNodeInner {
         self.wait_for_registration_inner(blob_id, timeout)
     }
 
-    fn blob_status(&self, blob_id: &BlobId) -> Result<BlobStatus, BlobStatusError> {
-        Ok(self
-            .storage
-            .get_blob_info(blob_id)
-            .context("could not retrieve blob info")?
+    async fn blob_status(&self, blob_id: &BlobId) -> Result<BlobStatus, BlobStatusError> {
+        let storage = self.storage.clone();
+        let blob_id = *blob_id;
+        let blob_info = tokio::task::spawn_blocking(move || storage.get_blob_info(&blob_id))
+            .map(unwrap_or_resume_unwind)
+            .await
+            .context("could not retrieve blob info")?;
+        Ok(blob_info
             .map(|blob_info| blob_info.to_blob_status(self.current_committee_epoch()))
             .unwrap_or_default())
     }
@@ -4519,6 +4553,7 @@ impl ServiceState for StorageNodeInner {
             RetrieveSliverError::Forbidden,
             RetrieveSliverError::Unavailable,
         )
+        .await
         .map_err(RetrieveSymbolError::RetrieveSliver)?;
 
         let encoding_type = self
@@ -4592,6 +4627,7 @@ impl ServiceState for StorageNodeInner {
             RetrieveSliverError::Forbidden,
             RetrieveSliverError::Unavailable,
         )
+        .await
         .map_err(RetrieveSymbolError::RetrieveSliver)?;
 
         if target_sliver_indexes.is_empty() {
@@ -4670,20 +4706,27 @@ impl ServiceState for StorageNodeInner {
         let latest_checkpoint_sequence_number =
             self.event_manager.latest_checkpoint_sequence_number();
 
+        let (node_status, event_progress) = {
+            let storage = self.storage.clone();
+            tokio::task::spawn_blocking(move || {
+                let node_status = storage
+                    .node_status()
+                    .expect("fetching node status should not fail");
+                let event_progress = storage
+                    .get_event_cursor_progress()
+                    .expect("get cursor progress should not fail");
+                (node_status, event_progress)
+            })
+            .await
+            .expect("spawn_blocking task panicked")
+        };
+
         ServiceHealthInfo {
             uptime: self.start_time.elapsed(),
             epoch: self.current_committee_epoch(),
             public_key: self.public_key().clone(),
-            node_status: self
-                .storage
-                .node_status()
-                .expect("fetching node status should not fail")
-                .to_string(),
-            event_progress: self
-                .storage
-                .get_event_cursor_progress()
-                .expect("get cursor progress should not fail")
-                .into(),
+            node_status: node_status.to_string(),
+            event_progress: event_progress.into(),
             shard_detail,
             shard_summary,
             latest_checkpoint_sequence_number,
@@ -5376,7 +5419,7 @@ mod tests {
             status_event,
             is_certified,
             ..
-        } = node.as_ref().blob_status(&BLOB_ID)?
+        } = node.as_ref().blob_status(&BLOB_ID).await?
         else {
             panic!("got nonexistent blob status")
         };
@@ -5597,7 +5640,8 @@ mod tests {
         let metadata_status = storage_node
             .as_ref()
             .inner
-            .metadata_status(metadata.blob_id())?;
+            .metadata_status(metadata.blob_id())
+            .await?;
         assert_eq!(metadata_status, StoredOnNodeStatus::Stored);
         Ok(())
     }
@@ -5612,7 +5656,7 @@ mod tests {
             .await?;
 
         assert!(matches!(
-            node.as_ref().blob_status(&BLOB_ID),
+            node.as_ref().blob_status(&BLOB_ID).await,
             Ok(BlobStatus::Nonexistent)
         ));
 
@@ -8686,6 +8730,7 @@ mod tests {
                     .storage_node
                     .inner
                     .blob_status(&OTHER_BLOB_ID)
+                    .await
                     .expect("getting blob status should succeed"),
                 BlobStatus::Nonexistent
             );
@@ -9899,7 +9944,8 @@ mod tests {
             cluster.nodes[0]
                 .storage_node
                 .inner
-                .is_blob_registered(blob_details.blob_id())?
+                .is_blob_registered(blob_details.blob_id())
+                .await?
         );
 
         Ok(())

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -4706,27 +4706,20 @@ impl ServiceState for StorageNodeInner {
         let latest_checkpoint_sequence_number =
             self.event_manager.latest_checkpoint_sequence_number();
 
-        let (node_status, event_progress) = {
-            let storage = self.storage.clone();
-            tokio::task::spawn_blocking(move || {
-                let node_status = storage
-                    .node_status()
-                    .expect("fetching node status should not fail");
-                let event_progress = storage
-                    .get_event_cursor_progress()
-                    .expect("get cursor progress should not fail");
-                (node_status, event_progress)
-            })
-            .await
-            .expect("spawn_blocking task panicked")
-        };
-
         ServiceHealthInfo {
             uptime: self.start_time.elapsed(),
             epoch: self.current_committee_epoch(),
             public_key: self.public_key().clone(),
-            node_status: node_status.to_string(),
-            event_progress: event_progress.into(),
+            node_status: self
+                .storage
+                .node_status()
+                .expect("fetching node status should not fail")
+                .to_string(),
+            event_progress: self
+                .storage
+                .get_event_cursor_progress()
+                .expect("get cursor progress should not fail")
+                .into(),
             shard_detail,
             shard_summary,
             latest_checkpoint_sequence_number,

--- a/crates/walrus-service/src/node/blob_event_processor.rs
+++ b/crates/walrus-service/src/node/blob_event_processor.rs
@@ -3,6 +3,7 @@
 
 use std::{num::NonZeroUsize, sync::Arc};
 
+use futures::FutureExt as _;
 use sui_macros::fail_point_async;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use walrus_core::{BlobId, Epoch};
@@ -12,6 +13,7 @@ use walrus_utils::metrics::monitored_scope;
 use self::pending_events::{PendingEventCounter, PendingEventGuard};
 use super::{StorageNodeInner, blob_sync::BlobSyncHandler, metrics, system_events::EventHandle};
 use crate::{
+    common::utils::unwrap_or_resume_unwind,
     event::events::CheckpointEventPosition,
     node::{
         storage::blob_info::{BlobInfoApi, CertifiedBlobInfoApi},
@@ -204,8 +206,15 @@ impl BackgroundEventProcessor {
             }
         );
 
+        let is_certified = {
+            let node = self.node.clone();
+            let blob_id = blob_id;
+            tokio::task::spawn_blocking(move || node.is_blob_certified(&blob_id))
+                .map(unwrap_or_resume_unwind)
+                .await?
+        };
         if skip_blob_sync_in_test
-            || !self.node.is_blob_certified(&blob_id)?
+            || !is_certified
             || self.node.storage.node_status()?.is_catching_up()
             || (current_event_epoch.is_some()
                 && self
@@ -265,7 +274,13 @@ impl BackgroundEventProcessor {
         let current_committee_epoch = self.node.current_committee_epoch();
         tracing::Span::current().record("walrus.epoch", current_committee_epoch);
 
-        if let Some(blob_info) = self.node.storage.get_blob_info(&blob_id)? {
+        let blob_info = {
+            let storage = self.node.storage.clone();
+            tokio::task::spawn_blocking(move || storage.get_blob_info(&blob_id))
+                .map(unwrap_or_resume_unwind)
+                .await?
+        };
+        if let Some(blob_info) = blob_info {
             if !blob_info.is_certified(current_committee_epoch) {
                 self.node
                     .blob_retirement_notifier

--- a/crates/walrus-service/src/node/server.rs
+++ b/crates/walrus-service/src/node/server.rs
@@ -644,7 +644,7 @@ mod tests {
             Ok(true)
         }
 
-        fn metadata_status(
+        async fn metadata_status(
             &self,
             blob_id: &BlobId,
         ) -> Result<walrus_storage_node_client::api::StoredOnNodeStatus, RetrieveMetadataError>
@@ -758,7 +758,7 @@ mod tests {
 
         /// Returns a "certified" blob status for blob ID starting with zero, `Nonexistent` when
         /// starting with 1, and otherwise an error.
-        fn blob_status(&self, blob_id: &BlobId) -> Result<BlobStatus, BlobStatusError> {
+        async fn blob_status(&self, blob_id: &BlobId) -> Result<BlobStatus, BlobStatusError> {
             if blob_id.0[0] == 0 {
                 Ok(BlobStatus::Permanent {
                     end_epoch: 3,

--- a/crates/walrus-service/src/node/server/routes.rs
+++ b/crates/walrus-service/src/node/server/routes.rs
@@ -171,7 +171,9 @@ pub async fn get_metadata_status<S: SyncServiceState>(
     State(state): State<RestApiState<S>>,
     Path(BlobIdString(blob_id)): Path<BlobIdString>,
 ) -> Result<ApiSuccess<StoredOnNodeStatus>, RetrieveMetadataError> {
-    Ok(ApiSuccess::ok(state.service.metadata_status(&blob_id)?))
+    Ok(ApiSuccess::ok(
+        state.service.metadata_status(&blob_id).await?,
+    ))
 }
 
 /// Store blob metadata.
@@ -744,7 +746,7 @@ pub async fn get_blob_status<S: SyncServiceState>(
     State(state): State<RestApiState<S>>,
     Path(BlobIdString(blob_id)): Path<BlobIdString>,
 ) -> Result<ApiSuccess<BlobStatus>, BlobStatusError> {
-    Ok(ApiSuccess::ok(state.service.blob_status(&blob_id)?))
+    Ok(ApiSuccess::ok(state.service.blob_status(&blob_id).await?))
 }
 
 #[derive(Debug, Clone, serde::Deserialize, utoipa::IntoParams)]

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -1225,7 +1225,7 @@ impl Storage {
             while fetched_blobs.len() < sliver_count {
                 let remaining_count = sliver_count - fetched_blobs.len();
 
-                // Set starting point: initial request start or after last fetched blob.
+                // Set starting point - either the initial request start or after last fetched blob
                 let starting_blob_id_bound =
                     last_fetched_blob_id.map_or(Included(starting_blob_id), Excluded);
 
@@ -1237,10 +1237,11 @@ impl Storage {
                     .collect::<Result<Vec<_>, TypedStoreError>>()?;
 
                 if blobs_to_fetch.is_empty() {
+                    // No more blobs to fetch.
                     break;
                 }
 
-                // Update last fetched ID for next iteration.
+                // Update last fetched ID for next iteration
                 last_fetched_blob_id = blobs_to_fetch.last().cloned();
 
                 let mut slivers = shard.fetch_slivers(sliver_type, &blobs_to_fetch)?;

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -1225,7 +1225,7 @@ impl Storage {
             while fetched_blobs.len() < sliver_count {
                 let remaining_count = sliver_count - fetched_blobs.len();
 
-                // Set starting point - either the initial request start or after last fetched blob
+                // Set starting point: initial request start or after last fetched blob.
                 let starting_blob_id_bound =
                     last_fetched_blob_id.map_or(Included(starting_blob_id), Excluded);
 
@@ -1237,11 +1237,10 @@ impl Storage {
                     .collect::<Result<Vec<_>, TypedStoreError>>()?;
 
                 if blobs_to_fetch.is_empty() {
-                    // No more blobs to fetch.
                     break;
                 }
 
-                // Update last fetched ID for next iteration
+                // Update last fetched ID for next iteration.
                 last_fetched_blob_id = blobs_to_fetch.last().cloned();
 
                 let mut slivers = shard.fetch_slivers(sliver_type, &blobs_to_fetch)?;


### PR DESCRIPTION
## Description
Close WAL-1140
Follow-up to #3271. Re-applies the three call clusters (`has_metadata`, `get_blob_info`, `node_status`). Routes these RocksDB reads off the tokio runtime so a slow read can no longer stall unrelated async work.

### What's included
- `has_metadata`, `get_blob_info`, `node_status`,  `get_event_cursor_progress` on the per-event and per-request hot paths

### What's intentionally not included
- `node_status` on the per-event hot path. It's a single-row CF, the entry is always cache-hot, and wrapping it adds a yield + thread-hop on every event.
- Cold paths: epoch change, shard sync, node recovery, startup, GC bookkeeping. These run a handful of times per epoch (or once at startup).

## Test plan
Existing tests pass.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
