### PR TITLE
ci: include walrus-deploy in release tarballs

### DIFF
--- a/binary-build-list.json
+++ b/binary-build-list.json
@@ -1,3 +1,3 @@
 {
-    "release_binaries": [ "walrus", "walrus-node", "walrus-upload-relay" ]
+    "release_binaries": [ "walrus", "walrus-node", "walrus-upload-relay", "walrus-deploy" ]
 }


### PR DESCRIPTION
## Summary

Add \`walrus-deploy\` to \`binary-build-list.json\` \`release_binaries\` so it gets bundled into the per-platform release tarballs that \`attach-binaries-to-release.yml\` publishes.

Today \`walrus-deploy\` is source-build-only — anyone setting up a local Walrus dev stack has to wait ~15-20 minutes on cargo just to get this one binary. With this change a local stack can pull pre-built binaries and start in ~1 minute.

## Why this works on every platform

| Platform | Mechanism | Status |
|---|---|---|
| linux x86_64 | Workflow pulls \`gs://mysten-walrus-binaries/walrus/<sha>/walrus-deploy\`, populated by mp3 from the \`walrus-service\` image | ✅ already extracted (\`Pulumi.{staging,production}.yaml\` \`mp3:binary_upload_config\`) |
| linux arm64 | Workflow pulls \`gs://mysten-walrus-binaries/walrus-arm64/<sha>/walrus-deploy\`, populated by mp3 from the \`walrus-service-arm64\` image | ✅ already extracted |
| macos x86_64 | \`cargo build --release\` on the runner; walrus-deploy's \`required-features = [\"deploy\"]\` is in the workspace default features (\`default = [\"client\", \"deploy\", \"node\"]\`) | ✅ binary already produced by cargo |
| macos arm64 | Same as above | ✅ |
| windows x86_64 | Same as above | ✅ in theory — see test plan |

## Backwards compatibility

No changes to the workflow itself, no changes to mp3, no changes to the existing release tarballs' contents — \`walrus-deploy\` is added alongside the existing \`walrus\`, \`walrus-node\`, \`walrus-upload-relay\` set, not replacing anything.

## Test plan

- [ ] Trigger \`attach-binaries-to-release.yml\` (workflow_dispatch) against an existing release tag and verify all 5 platform tarballs contain \`walrus-deploy\` (or \`walrus-deploy.exe\` for windows)
- [ ] Verify the linux x86_64 + arm64 paths fetch from the GCS prefix successfully
- [ ] Verify the macOS x86_64 + arm64 paths produce a runnable \`walrus-deploy\` from the cargo build
- [ ] Special attention to windows-x86_64: \`walrus-deploy\` may have linux-only dependencies (filesystem paths, sui-deploy fixtures). \`fail-fast: false\` is already set on the matrix, so if windows fails the other 4 platforms still publish; we can exclude windows for this binary as a follow-up if needed

## Reported by

Michael Hayes — surfaced in [#walrus-dev thread](https://mysten-labs.slack.com/archives/C079UUZQSM6/p1778019500764249), where Will Bradley confirmed the change is sui-operations-side compatible and requested buy-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)