### PR TITLE
chore: change consistency check buckets

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"d367b398-3727-4527-a143-9a875d60c5db","pid":62030,"procStart":"Wed May  6 17:38:37 2026","acquiredAt":1778089423028}

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -238,11 +238,10 @@ pub use config_synchronizer::{ConfigLoader, ConfigSynchronizer, StorageNodeConfi
 pub use garbage_collector::GarbageCollectionConfig;
 
 // The number of events are dominated by the checkpoints, as we don't expect all checkpoints
-// contain Walrus events. 2K events per recording is roughly 1 recording per 9 minutes, which
-// gives a 3-hour Antithesis test ~20 recordings to cross-check across nodes. Label cardinality
-// is bounded by NUM_DIGEST_BUCKETS below.
+// contain Walrus events. 20K events per recording is roughly 1 recording per 1.5 hours.
+// Label cardinality is bounded by NUM_DIGEST_BUCKETS below.
 #[cfg(not(msim))]
-const NUM_EVENTS_PER_DIGEST_RECORDING: u64 = 2_000;
+const NUM_EVENTS_PER_DIGEST_RECORDING: u64 = 20_000;
 
 // In simtest, we record event source for events to make event index consistency checking more
 // accurate.
@@ -252,14 +251,9 @@ const NUM_EVENTS_PER_DIGEST_RECORDING: u64 = 1;
 // Number of distinct buckets for the `periodic_event_source_for_deterministic_events`
 // metric. The bucket label is `(event_index / NUM_EVENTS_PER_DIGEST_RECORDING) %
 // NUM_DIGEST_BUCKETS`, so buckets are reused every
-// `NUM_DIGEST_BUCKETS * NUM_EVENTS_PER_DIGEST_RECORDING` events.
-//
-// With 1000 buckets and the non-msim recording interval of 2_000 events, reuse only
-// happens after 2_000_000 events (tens of hours of cluster runtime), which keeps the
-// cross-node observer from seeing two different recordings collide in the same bucket
-// and flagging it as a spurious divergence. Analogous to `EPOCH_BUCKET_COUNT` in
-// consistency_check.rs.
-const NUM_DIGEST_BUCKETS: u64 = 1_000;
+// `NUM_DIGEST_BUCKETS * NUM_EVENTS_PER_DIGEST_RECORDING` events. Analogous to
+// `EPOCH_BUCKET_COUNT` in consistency_check.rs.
+const NUM_DIGEST_BUCKETS: u64 = 10;
 const CHECKPOINT_EVENT_POSITION_SCALE: u64 = 100;
 
 /// Indicates how the node should treat uploads.
@@ -2499,7 +2493,7 @@ impl StorageNode {
     ) -> Result<(), TypedStoreError> {
         // Only record every Nth event.
         // `NUM_EVENTS_PER_DIGEST_RECORDING` is chosen so a node produces a recording roughly
-        // every ~9 minutes, giving a 3-hour Antithesis test ~20 recordings to cross-check.
+        // every 1.5 hours.
 
         if !event_index.is_multiple_of(NUM_EVENTS_PER_DIGEST_RECORDING) {
             return Ok(());

--- a/crates/walrus-service/src/node/consistency_check.rs
+++ b/crates/walrus-service/src/node/consistency_check.rs
@@ -164,12 +164,7 @@ pub(super) async fn schedule_background_consistency_check(
 /// Metrics like `walrus_blob_info_consistency_check{epoch="N"}` use `epoch % EPOCH_BUCKET_COUNT`
 /// as the label so that Prometheus label cardinality stays bounded. A bucket is reused (and its
 /// old value overwritten) every `EPOCH_BUCKET_COUNT` epochs.
-///
-/// The cross-node observer in Antithesis tests compares these labels across nodes. If a node
-/// misses an epoch update, a stale value in a reused bucket looks like a data divergence. Setting
-/// the count high enough (1000) ensures buckets are never reused within any realistic test
-/// duration, while the memory cost remains negligible.
-const EPOCH_BUCKET_COUNT: u32 = 1_000;
+const EPOCH_BUCKET_COUNT: u32 = 10;
 
 fn get_epoch_bucket(epoch: Epoch) -> String {
     (epoch % EPOCH_BUCKET_COUNT).to_string()


### PR DESCRIPTION
## Description

The previous setting increase metrics cardinality by 100x, which is too expensive to track in prod.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
