### PR TITLE
ci(antithesis): migrate to per-container exclusion annotations

### DIFF
--- a/docker/walrus-antithesis/build-test-config-image/docker-compose.yaml
+++ b/docker/walrus-antithesis/build-test-config-image/docker-compose.yaml
@@ -16,6 +16,11 @@ services:
         ipv4_address: 10.0.0.20
     hostname: sui-localnet
     container_name: sui-localnet
+    annotations:
+      # Sui SDK emits Sometimes assertions that aren't relevant to Walrus testing,
+      # and Sui itself isn't the system under test here.
+      com.antithesis.exclude.faults: "all"
+      com.antithesis.exclude.assertion_type: "sometimes"
     image: ${SUI_IMAGE_NAME}
     platform: ${SUI_PLATFORM:-linux/amd64}
     environment:
@@ -143,6 +148,8 @@ services:
     platform: ${WALRUS_PLATFORM:-linux/amd64}
     hostname: walrus-stress-0
     container_name: walrus-stress-0
+    annotations:
+      com.antithesis.exclude.faults: "all"
     environment:
       - NODE_NAME=walrus-stress-0
       - NO_COLOR=1
@@ -165,6 +172,8 @@ services:
     platform: ${WALRUS_PLATFORM:-linux/amd64}
     hostname: walrus-staking-0
     container_name: walrus-staking-0
+    annotations:
+      com.antithesis.exclude.faults: "all"
     environment:
       - NODE_NAME=walrus-staking-0
       - NO_COLOR=1
@@ -189,6 +198,8 @@ services:
     platform: ${WALRUS_PLATFORM:-linux/amd64}
     hostname: walrus-observer
     container_name: walrus-observer
+    annotations:
+      com.antithesis.exclude.faults: "all"
     environment:
       - NO_COLOR=1
       - CHECK_INTERVAL=60


### PR DESCRIPTION
## Description

Antithesis added `com.antithesis.exclude.faults` and `com.antithesis.exclude.assertion_type` annotations as a per-container replacement for the previously hard-coded customization. 
The customization for sui-localnet (faults excluded, sometimes assertions disabled) was removed, so we need annotations to maintain parity. 

Also migrate walrus-stress-0, walrus-staking-0, and walrus-observer from the workflow `custom.exclude_from_faults` parameter to per-container annotations.

## Test plan

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
