### PR TITLE
chore: move consistency check after per object GC is finished

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -1867,27 +1867,9 @@ impl StorageNode {
             c.sync_node_params().await?;
         }
 
-        // Start storage node consistency check if
-        // - consistency check is enabled
-        // - node is not reprocessing events (blob info table should not be affected by future
-        //   events)
-        let node_is_reprocessing_events =
-            self.inner.storage.get_latest_handled_event_index()? >= event_handle.index();
-        if self.inner.consistency_check_config.enable_consistency_check
-            && !node_is_reprocessing_events
-            && let Err(err) = consistency_check::schedule_background_consistency_check(
-                self.inner.clone(),
-                self.blob_sync_handler.clone(),
-                event.epoch,
-            )
-            .await
-        {
-            tracing::warn!(
-                ?err,
-                walrus.epoch = event.epoch,
-                "failed to schedule background blob info consistency check"
-            );
-        }
+        // Capture the event index before the handle is moved into `execute_epoch_change` so
+        // we can later detect whether this event is being reprocessed.
+        let event_index = event_handle.index();
 
         // During epoch change, we need to lock the read access to shard map until all the new
         // shards are created.
@@ -1910,6 +1892,34 @@ impl StorageNode {
             .schedule_post_epoch_change_subsidies();
 
         self.start_garbage_collection_task(event.epoch).await?;
+
+        // Schedule the storage node consistency check after garbage collection has settled the
+        // aggregate blob info table. The iterator's `is_certified` filter relies on counters
+        // that GC decrements for newly-expired deletable and pooled blobs, so the digest
+        // depends on whether GC has run. Taking the snapshot after GC keeps the digest
+        // deterministic across nodes and across replay of `EpochChangeStart` after a crash.
+        //
+        // Skipped when:
+        // - consistency check is disabled
+        // - node is reprocessing events (blob info table should not be affected by future
+        //   events)
+        let node_is_reprocessing_events =
+            self.inner.storage.get_latest_handled_event_index()? >= event_index;
+        if self.inner.consistency_check_config.enable_consistency_check
+            && !node_is_reprocessing_events
+            && let Err(err) = consistency_check::schedule_background_consistency_check(
+                self.inner.clone(),
+                self.blob_sync_handler.clone(),
+                event.epoch,
+            )
+            .await
+        {
+            tracing::warn!(
+                ?err,
+                walrus.epoch = event.epoch,
+                "failed to schedule background blob info consistency check"
+            );
+        }
 
         Ok(())
     }

--- a/crates/walrus-service/src/node/consistency_check.rs
+++ b/crates/walrus-service/src/node/consistency_check.rs
@@ -96,6 +96,12 @@ struct BlobConsistencyCheckResult {
 /// Schedule a background task to compute the hash of the list of certified blobs at the
 /// beginning of the epoch, and conduct blob sliver data existence check. This is used to detect
 /// inconsistencies in the blob info table between the nodes.
+///
+/// This must be called after garbage collection's blob-info cleanup has completed for `epoch`.
+/// The aggregate-blob-info iterator's `is_certified` filter relies on counters that GC
+/// decrements for newly-expired deletable and pooled blobs (see `BlobInfoV2::is_certified`),
+/// so the digest depends on whether GC has run. Taking the snapshot post-GC keeps the digest
+/// deterministic across nodes and across replay of `EpochChangeStart` after a crash.
 pub(super) async fn schedule_background_consistency_check(
     node: Arc<StorageNodeInner>,
     blob_sync_handler: Arc<BlobSyncHandler>,


### PR DESCRIPTION
## Description

Fixes a non-deterministic blob-info consistency-check digest at epoch transitions.

  `BlobInfoV2::is_certified` returns `true` for a deletable/pooled blob whose
  objects have all expired until GC decrements its certified counters. So the
  digest depends on whether GC has run for the epoch.

  `process_epoch_change_start_event` scheduled the consistency check before
  `start_garbage_collection_task`, exposing the divergence on `EpochChangeStart`
  replay: the first run snapshots pre-GC, GC mutates the counters, and a crash
  before `mark_as_complete` (gated on the spawned `epoch_sync_done`) leaves the
  event cursor unadvanced — so the replayed handler re-snapshots post-GC and
  produces a different digest from the rest of the cluster.

  Move the consistency-check call to after `start_garbage_collection_task`.
  The snapshot is now taken from a settled table; replay re-runs GC as a no-op
  and produces the same digest as the first run. GC's position is unchanged.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
