### PR TITLE
chore: improve backup GC query performance

### DIFF
--- a/crates/walrus-service/src/backup/garbage_collector.rs
+++ b/crates/walrus-service/src/backup/garbage_collector.rs
@@ -89,10 +89,9 @@ async fn collect_garbage(
     //
     // The expiry predicate is written as `end_epoch <= current_epoch - offset` rather
     // than `end_epoch + offset <= current_epoch` so the planner can range-bound the
-    // scan against the indexed `end_epoch` column. EXPLAIN ANALYZE on a production
-    // dataset confirmed this rewrite is meaningfully faster than the additive form,
-    // because the planner's predicate-prover handles `column <= constant` but doesn't
-    // rewrite arithmetic on the indexed side.
+    // scan against the indexed `end_epoch` column. The planner's predicate-prover
+    // handles `column <= constant` but doesn't rewrite arithmetic on the indexed side,
+    // so the additive form forces a full index iteration with a per-row filter.
     let garbage_query = format!(
         "
             WITH expired_blob_ids AS (

--- a/crates/walrus-service/src/backup/garbage_collector.rs
+++ b/crates/walrus-service/src/backup/garbage_collector.rs
@@ -70,7 +70,7 @@ async fn collect_garbage(
         .expect("failed to connect to postgres for collect_garbage");
 
     // GC eligibility for a blob is a single per-row predicate:
-    //   regular source dead — `end_epoch IS NULL OR end_epoch + offset <= current_epoch`
+    //   regular source dead — `end_epoch IS NULL OR end_epoch <= current_epoch - offset`
     //   AND no live pool refs — `pool_ref_count = 0`
     //
     // The `blob_state_gc_eligible` partial index materializes exactly this row set
@@ -86,6 +86,13 @@ async fn collect_garbage(
     // subsequent object-storage delete succeeds, the blob's state moves to 'deleted'
     // and `initiate_gc_after` becomes irrelevant. If the delete fails, the deferral
     // throttles retries so a persistent storage outage doesn't hot-loop.
+    //
+    // The expiry predicate is written as `end_epoch <= current_epoch - offset` rather
+    // than `end_epoch + offset <= current_epoch` so the planner can range-bound the
+    // scan against the indexed `end_epoch` column. EXPLAIN ANALYZE on a production
+    // dataset confirmed this rewrite is meaningfully faster than the additive form,
+    // because the planner's predicate-prover handles `column <= constant` but doesn't
+    // rewrite arithmetic on the indexed side.
     let garbage_query = format!(
         "
             WITH expired_blob_ids AS (
@@ -95,8 +102,10 @@ async fn collect_garbage(
                     AND pool_ref_count = 0
                     AND (
                         end_epoch IS NULL
-                        OR end_epoch + {offset}
-                            <= COALESCE((SELECT MAX(epoch) FROM epoch_change_start_event), 0)
+                        OR end_epoch <= COALESCE(
+                                (SELECT MAX(epoch) FROM epoch_change_start_event),
+                                0
+                            ) - {offset}
                     )
                     AND (initiate_gc_after IS NULL OR initiate_gc_after < NOW())
                 ORDER BY end_epoch NULLS FIRST
@@ -221,7 +230,7 @@ async fn collect_garbage(
 /// Drains a bounded batch of `pooled_blob_ref` rows belonging to expired pools.
 ///
 /// Each batch atomically:
-///   1. picks an expired pool (`end_epoch + offset <= current_epoch`),
+///   1. picks an expired pool (`end_epoch <= current_epoch - offset`),
 ///   2. deletes up to `POOL_EXPIRY_BATCH_SIZE` of its refs,
 ///   3. decrements `pool_ref_count` on the affected blobs by exactly the number of
 ///      refs deleted, and
@@ -285,8 +294,10 @@ pub(crate) async fn drain_expired_pool_refs_step(
         "
             WITH selected_pool AS (
                 SELECT storage_pool_id FROM storage_pool_state
-                WHERE end_epoch + {offset}
-                    <= COALESCE((SELECT MAX(epoch) FROM epoch_change_start_event), 0)
+                WHERE end_epoch <= COALESCE(
+                        (SELECT MAX(epoch) FROM epoch_change_start_event),
+                        0
+                    ) - {offset}
                 ORDER BY end_epoch
                 LIMIT 1
             ),
@@ -337,8 +348,10 @@ pub(crate) async fn cleanup_drained_pools(
     let affected = diesel::sql_query(format!(
         "
             DELETE FROM storage_pool_state sps
-            WHERE sps.end_epoch + {offset}
-                    <= COALESCE((SELECT MAX(epoch) FROM epoch_change_start_event), 0)
+            WHERE sps.end_epoch <= COALESCE(
+                    (SELECT MAX(epoch) FROM epoch_change_start_event),
+                    0
+                ) - {offset}
                 AND NOT EXISTS (
                     SELECT 1 FROM pooled_blob_ref pbr
                     WHERE pbr.storage_pool_id = sps.storage_pool_id

--- a/crates/walrus-service/src/backup/service.rs
+++ b/crates/walrus-service/src/backup/service.rs
@@ -343,7 +343,7 @@ pub(crate) async fn dispatch_contract_event(
         // pooled_blob_ref (one row per (pool, blob_id) pair — guaranteed unique by the
         // on-chain contract) and a denormalized live-ref count in blob_state.pool_ref_count.
         // The GC's eligibility predicate is then a single per-row check:
-        //   (end_epoch IS NULL OR end_epoch + offset <= current_epoch) AND pool_ref_count = 0
+        //   (end_epoch IS NULL OR end_epoch <= current_epoch - offset) AND pool_ref_count = 0
         // No JOIN, no classifier, no daily re-check.
         //
         // The two writes (pool ref insert, counter increment) live in a single statement
@@ -716,8 +716,10 @@ fn start_db_metrics_loop(metrics_runtime: &MetricsAndLoggingRuntime, config: &Ba
                 state = 'archived'
                 AND bs.pool_ref_count = 0
                 AND (bs.end_epoch IS NULL
-                    OR bs.end_epoch + {offset}
-                        <= COALESCE((SELECT MAX(epoch) FROM epoch_change_start_event), 0))
+                    OR bs.end_epoch <= COALESCE(
+                            (SELECT MAX(epoch) FROM epoch_change_start_event),
+                            0
+                        ) - {offset})
             UNION
             SELECT
                 'total_bytes_archived' AS name,


### PR DESCRIPTION
## Description

  Rewrite four backup GC SQL predicates from `end_epoch + offset <= current_epoch`
  to `end_epoch <= current_epoch - offset` so Postgres can range-bound the index
  scan instead of iterating the full partial index with a per-row filter.

  Postgres' planner doesn't push arithmetic on the indexed side into an index
  range scan. With the additive form, the planner uses the partial index but
  applies the predicate as a filter — meaning every entry in the index gets
  read, the arithmetic gets evaluated, and rows that don't satisfy the
  inequality are discarded. With the subtractive form, the planner produces an
  `Index Cond:` and stops scanning once `end_epoch` exceeds the bound.

  ## Verification

  EXPLAIN ANALYZE on the production database confirmed:

  - **Form A (additive, before)**: `Filter: ((end_epoch + N) <= ...)`,
    with a high `Rows Removed by Filter` count.
  - **Form B (subtractive, after)**: `Index Cond: (end_epoch <= ...)`,
    early termination at the bound.

  Form B is meaningfully faster on the production-scale dataset.


## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
