### PR TITLE
chore: install psql in walrus-backup image

### DIFF
--- a/docker/walrus-service/Dockerfile.walrus-backup
+++ b/docker/walrus-service/Dockerfile.walrus-backup
@@ -25,7 +25,7 @@ RUN cargo build \
 # Production Image for walrus backup CLI
 FROM debian:bookworm-slim AS walrus-backup
 
-RUN apt-get update && apt-get install -y ca-certificates curl libpq-dev
+RUN apt-get update && apt-get install -y ca-certificates curl libpq-dev postgresql-client
 ARG PROFILE=release
 ARG RUST_LOG=info,walrus_service::common::event_blob_downloader=warn
 ENV RUST_LOG=$RUST_LOG


### PR DESCRIPTION
## Summary
- Add `postgresql-client` to the walrus-backup production image so `psql` is available inside the container for ad-hoc database inspection.

## Test plan
- [ ] Build the `walrus-backup` image and confirm `psql --version` works in the resulting container.