### PR TITLE
refactor: inline publish_tx_kind to drop last ungated sui_sdk call

### DIFF
--- a/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
@@ -1478,20 +1478,6 @@ impl RetriableSuiClient {
             .await
     }
 
-    /// Returns a reference to the current internal [`DualClient`]. Avoid using this function.
-    ///
-    // TODO: WAL-778 find callsites to this method, and replace them with implementations that make
-    // use of failover, since this call is a cheat to bypass the failover mechanism.
-    #[deprecated(
-        note = "please implement a full treatment in RetriableSuiClient for your use case"
-    )]
-    pub async fn get_current_client(&self) -> Arc<DualClient> {
-        self.failover_sui_client
-            .get_current_client()
-            .await
-            .expect("client must have been created")
-    }
-
     /// Returns the Sui Object of type `U` with the provided [`ObjectID`].
     #[tracing::instrument(
         level = Level::DEBUG, skip_all, fields(object_type = %U::CONTRACT_STRUCT)

--- a/crates/walrus-sui/src/system_setup.rs
+++ b/crates/walrus-sui/src/system_setup.rs
@@ -278,10 +278,6 @@ pub(crate) async fn publish_package(
         compile_package(package_path, build_config, Some(chain_id.clone()), wallet).await?;
 
     let compiled_modules = compiled_package.get_package_bytes(false);
-
-    // Publish the package: build the publish TransactionKind locally. Equivalent to
-    // sui_sdk's TransactionBuilder::publish_tx_kind, which is a pure PTB construction
-    // with no RPC.
     let transaction_kind = {
         let mut pt_builder = ProgrammableTransactionBuilder::new();
         let upgrade_cap = pt_builder.publish_upgradeable(

--- a/crates/walrus-sui/src/system_setup.rs
+++ b/crates/walrus-sui/src/system_setup.rs
@@ -279,24 +279,22 @@ pub(crate) async fn publish_package(
 
     let compiled_modules = compiled_package.get_package_bytes(false);
 
-    // Publish the package
-    // TODO: WAL-778 support `publish_tx_kind` with failover mechanics.
-    #[allow(deprecated)]
-    let transaction_kind = retry_client
-        .get_current_client()
-        .await
-        .sui_client()
-        .transaction_builder()
-        .publish_tx_kind(
-            sender,
+    // Publish the package: build the publish TransactionKind locally. Equivalent to
+    // sui_sdk's TransactionBuilder::publish_tx_kind, which is a pure PTB construction
+    // with no RPC.
+    let transaction_kind = {
+        let mut pt_builder = ProgrammableTransactionBuilder::new();
+        let upgrade_cap = pt_builder.publish_upgradeable(
             compiled_modules,
             compiled_package
                 .dependency_ids
                 .published
                 .into_values()
                 .collect(),
-        )
-        .await?;
+        );
+        pt_builder.transfer_arg(sender, upgrade_cap);
+        TransactionKind::programmable(pt_builder.finish())
+    };
 
     let GasBudgetAndPrice {
         gas_budget,


### PR DESCRIPTION
## Summary
- Replaces the deprecated `sui_sdk` `transaction_builder().publish_tx_kind(...)` call in `crates/walrus-sui/src/system_setup.rs::publish_package` with a local `ProgrammableTransactionBuilder` construction (`publish_upgradeable` + `transfer_arg` + `TransactionKind::programmable`). `publish_tx_kind` is a pure-local PTB builder in the SDK — no RPC, no failover semantics apply — so this is a literal inlining of its four-line body.
- Deletes the now-zero-caller `RetriableSuiClient::get_current_client()` along with its `#[deprecated]` attribute and WAL-778 TODO. The method is unconditional dead code after the inlining above (not gated by `grpc_migration_level`).
- Eliminates the last ungated `sui_sdk::SuiClient` JSON-RPC call site in `walrus-sui` (WAL-778). Every other JSON-RPC call now lives behind a `grpc_migration_level` gate.

## Test plan

CI Pipeline.