### PR TITLE
ci: pass cache_family to prebuild-walrus-images dispatch

### DIFF
--- a/.github/workflows/trigger-artifacts-builds.yml
+++ b/.github/workflows/trigger-artifacts-builds.yml
@@ -27,6 +27,7 @@ jobs:
           client-payload: >
             {
               "walrus_commit": "${{ github.sha }}",
+              "cache_family": "${{ github.ref_name }}",
               "build_arm64": "true"
             }
 


### PR DESCRIPTION
## Summary

- Adds \`cache_family: github.ref_name\` to the \`repository_dispatch\` payload sent to MystenLabs/sui-operations on every Walrus push.
- Walrus-side analogue of [MystenLabs/sui#26584](https://github.com/MystenLabs/sui/pull/26584) (already merged).
- Pairs with [MystenLabs/sui-operations#7886](https://github.com/MystenLabs/sui-operations/pull/7886) and [MystenLabs/mp3#134](https://github.com/MystenLabs/mp3/pull/134).
- One line. Zero behaviour change until #7886 is deployed; the receiver already reads \`client_payload.cache_family\` and the mp3 rewriter falls back to \`repo_ref\` when the field is absent.

## Why

mp3's \`/cargo-target\` cache id was previously derived from \`repo_ref\`. When \`repo_ref\` is a SHA (which it is on every push), the bucket id changes per commit and warm incremental walrus builds restart from a cold cache.

After all three PRs land the bucket key is the originating branch.

## Branch → bucket mapping

| github.ref_name | mp3 bucket key |
|---|---|
| \`main\` | \`main\` |
| \`releases/walrus-v1.47.0-release\` | \`release-releases-walrus-v1-47-0-release\` (slugged) |
| \`testnet\` | \`other-testnet\` |
| \`mainnet\` | \`other-mainnet\` |
| \`devnet\` | \`other-devnet\` |

## Test plan

- [ ] Merge order: sui-ops#7886 first → this PR. (Reverse order is safe — \`cache_family\` is silently ignored if the receiver hasn't been deployed yet.)
- [ ] After merge, watch a \`prebuild-walrus-images\` run triggered by a push to main and confirm the build request payload includes \`cache_family=\"main\"\` and the cargo-target cache id is keyed off \`main\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)