### PR TITLE
chore(antithesis): increase the number of consistency-check buckets via env vars

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -238,22 +238,46 @@ pub use config_synchronizer::{ConfigLoader, ConfigSynchronizer, StorageNodeConfi
 pub use garbage_collector::GarbageCollectionConfig;
 
 // The number of events are dominated by the checkpoints, as we don't expect all checkpoints
-// contain Walrus events. 20K events per recording is roughly 1 recording per 1.5 hours.
-// Label cardinality is bounded by NUM_DIGEST_BUCKETS below.
+// contain Walrus events. 20K events per recording is roughly 1 recording per 1.5 hours in
+// production. Antithesis runs override this via `WALRUS_NUM_EVENTS_PER_DIGEST_RECORDING` to get
+// recordings every few minutes for cross-node consistency checking. Label cardinality is bounded
+// by `NUM_DIGEST_BUCKETS` below.
 #[cfg(not(msim))]
-const NUM_EVENTS_PER_DIGEST_RECORDING: u64 = 20_000;
+fn num_events_per_digest_recording() -> u64 {
+    static VALUE: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
+    *VALUE.get_or_init(|| {
+        std::env::var("WALRUS_NUM_EVENTS_PER_DIGEST_RECORDING")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .filter(|&v| v > 0)
+            .unwrap_or(20_000)
+    })
+}
 
 // In simtest, we record event source for events to make event index consistency checking more
 // accurate.
 #[cfg(msim)]
-const NUM_EVENTS_PER_DIGEST_RECORDING: u64 = 1;
+fn num_events_per_digest_recording() -> u64 {
+    1
+}
 
 // Number of distinct buckets for the `periodic_event_source_for_deterministic_events`
-// metric. The bucket label is `(event_index / NUM_EVENTS_PER_DIGEST_RECORDING) %
-// NUM_DIGEST_BUCKETS`, so buckets are reused every
-// `NUM_DIGEST_BUCKETS * NUM_EVENTS_PER_DIGEST_RECORDING` events. Analogous to
-// `EPOCH_BUCKET_COUNT` in consistency_check.rs.
-const NUM_DIGEST_BUCKETS: u64 = 10;
+// metric. The bucket label is `(event_index / num_events_per_digest_recording()) %
+// num_digest_buckets()`, so buckets are reused every
+// `num_digest_buckets() * num_events_per_digest_recording()` events. Antithesis runs override
+// this via `WALRUS_NUM_DIGEST_BUCKETS` to prevent the cross-node observer from seeing bucket
+// reuse as spurious divergence. Analogous to `EPOCH_BUCKET_COUNT` in consistency_check.rs.
+fn num_digest_buckets() -> u64 {
+    static VALUE: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
+    *VALUE.get_or_init(|| {
+        std::env::var("WALRUS_NUM_DIGEST_BUCKETS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .filter(|&v| v > 0)
+            .unwrap_or(10)
+    })
+}
+
 const CHECKPOINT_EVENT_POSITION_SCALE: u64 = 100;
 
 /// Indicates how the node should treat uploads.
@@ -2508,10 +2532,11 @@ impl StorageNode {
         event_source: &CheckpointEventPosition,
     ) -> Result<(), TypedStoreError> {
         // Only record every Nth event.
-        // `NUM_EVENTS_PER_DIGEST_RECORDING` is chosen so a node produces a recording roughly
-        // every 1.5 hours.
+        // `num_events_per_digest_recording()` is chosen so a node produces a recording roughly
+        // every 1.5 hours in production; Antithesis runs override it via env var for
+        // ~minute-scale cadence.
 
-        if !event_index.is_multiple_of(NUM_EVENTS_PER_DIGEST_RECORDING) {
+        if !event_index.is_multiple_of(num_events_per_digest_recording()) {
             return Ok(());
         }
 
@@ -2524,8 +2549,9 @@ impl StorageNode {
             return Ok(());
         }
 
-        let bucket = (event_index / NUM_EVENTS_PER_DIGEST_RECORDING) % NUM_DIGEST_BUCKETS;
-        debug_assert!(bucket < NUM_DIGEST_BUCKETS);
+        let num_digest_buckets = num_digest_buckets();
+        let bucket = (event_index / num_events_per_digest_recording()) % num_digest_buckets;
+        debug_assert!(bucket < num_digest_buckets);
 
         // The event source is the combination of checkpoint sequence number and counter.
         // We scale the checkpoint sequence number by `CHECKPOINT_EVENT_POSITION_SCALE` to add

--- a/crates/walrus-service/src/node/consistency_check.rs
+++ b/crates/walrus-service/src/node/consistency_check.rs
@@ -167,13 +167,25 @@ pub(super) async fn schedule_background_consistency_check(
 
 /// Number of distinct epoch buckets used for consistency-check Prometheus labels.
 ///
-/// Metrics like `walrus_blob_info_consistency_check{epoch="N"}` use `epoch % EPOCH_BUCKET_COUNT`
+/// Metrics like `walrus_blob_info_consistency_check{epoch="N"}` use `epoch % epoch_bucket_count()`
 /// as the label so that Prometheus label cardinality stays bounded. A bucket is reused (and its
-/// old value overwritten) every `EPOCH_BUCKET_COUNT` epochs.
-const EPOCH_BUCKET_COUNT: u32 = 10;
+/// old value overwritten) every `epoch_bucket_count()` epochs.
+///
+/// Antithesis runs override this via `WALRUS_EPOCH_BUCKET_COUNT` to prevent the cross-node
+/// observer from seeing bucket reuse as a spurious cross-node divergence on long test runs.
+fn epoch_bucket_count() -> u32 {
+    static VALUE: std::sync::OnceLock<u32> = std::sync::OnceLock::new();
+    *VALUE.get_or_init(|| {
+        std::env::var("WALRUS_EPOCH_BUCKET_COUNT")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .filter(|&v| v > 0)
+            .unwrap_or(10)
+    })
+}
 
 fn get_epoch_bucket(epoch: Epoch) -> String {
-    (epoch % EPOCH_BUCKET_COUNT).to_string()
+    (epoch % epoch_bucket_count()).to_string()
 }
 
 fn handle_existence_check_result(

--- a/docker/walrus-antithesis/build-test-config-image/docker-compose.yaml
+++ b/docker/walrus-antithesis/build-test-config-image/docker-compose.yaml
@@ -92,9 +92,15 @@ services:
     platform: ${WALRUS_PLATFORM:-linux/amd64}
     hostname: dryrun-node-0
     container_name: dryrun-node-0
+    # The three WALRUS_* env vars below widen consistency-check bucket counts to avoid
+    # bucket-reuse false positives during long Antithesis runs. Production keeps the lower
+    # defaults baked into the binary. See node.rs and node/consistency_check.rs.
     environment:
       - NODE_NAME=dryrun-node-0
       - NO_COLOR=1
+      - WALRUS_NUM_EVENTS_PER_DIGEST_RECORDING=2000
+      - WALRUS_NUM_DIGEST_BUCKETS=1000
+      - WALRUS_EPOCH_BUCKET_COUNT=1000
     volumes:
       - sui-bin:/root/sui_bin
       - walrus-deploy-outputs:/opt/walrus/outputs
@@ -113,6 +119,9 @@ services:
     environment:
       - NODE_NAME=dryrun-node-1
       - NO_COLOR=1
+      - WALRUS_NUM_EVENTS_PER_DIGEST_RECORDING=2000
+      - WALRUS_NUM_DIGEST_BUCKETS=1000
+      - WALRUS_EPOCH_BUCKET_COUNT=1000
 
   walrus-node-2:
     <<: *walrus-node
@@ -124,6 +133,9 @@ services:
     environment:
       - NODE_NAME=dryrun-node-2
       - NO_COLOR=1
+      - WALRUS_NUM_EVENTS_PER_DIGEST_RECORDING=2000
+      - WALRUS_NUM_DIGEST_BUCKETS=1000
+      - WALRUS_EPOCH_BUCKET_COUNT=1000
 
   walrus-node-3:
     <<: *walrus-node
@@ -135,6 +147,9 @@ services:
     environment:
       - NODE_NAME=dryrun-node-3
       - NO_COLOR=1
+      - WALRUS_NUM_EVENTS_PER_DIGEST_RECORDING=2000
+      - WALRUS_NUM_DIGEST_BUCKETS=1000
+      - WALRUS_EPOCH_BUCKET_COUNT=1000
 
   # Stress client for testing
   walrus-stress-0:


### PR DESCRIPTION
## Description

Make `NUM_EVENTS_PER_DIGEST_RECORDING`, `NUM_DIGEST_BUCKETS`, and `EPOCH_BUCKET_COUNT` overridable at startup via env vars:
      * `WALRUS_NUM_EVENTS_PER_DIGEST_RECORDING` (default 20_000)
      * `WALRUS_NUM_DIGEST_BUCKETS` (default 10)
      * `WALRUS_EPOCH_BUCKET_COUNT` (default 10)

Production keeps the small defaults, so Prometheus/Mimir cardinality stays where #3350 set it. The Antithesis docker-compose sets the wider values (2000, 1000, 1000) used by PR #3055 to prevent the cross-node observer from flagging bucket-reuse as spurious divergence on long runs.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
