### PR TITLE
feat(walrus_subsidies): add migrate function for V2 upgrade

### DIFF
--- a/contracts/walrus_subsidies/sources/walrus_subsidies.move
+++ b/contracts/walrus_subsidies/sources/walrus_subsidies.move
@@ -16,6 +16,8 @@ use walrus_subsidies::walrus_subsidies_inner::{Self, WalrusSubsidiesInnerV1};
 const EUnauthorizedAdminCap: u64 = 0;
 /// The package version is not compatible with the WalrusSubsidies object.
 const EWrongVersion: u64 = 1;
+/// Migration cannot run because the object is already at or above the current version.
+const EInvalidMigration: u64 = 2;
 
 // === Versioning ===
 
@@ -165,6 +167,23 @@ public fun process_subsidies(
 ) {
     check_version(self);
     self.inner_mut().process_subsidies(staking, system, clock);
+}
+
+// === Migration ===
+
+/// Migrate the `WalrusSubsidies` object to the current package version.
+///
+/// Must be called once per package upgrade. Bumps the on-chain version and
+/// updates the stored `package_id` so that clients route to the new package.
+///
+/// Permissionless: callable by anyone after a package upgrade. Safe because
+/// `package_id_for_current_version()` resolves to the upgraded package via the
+/// `V{N}` marker type's defining package, which only the `UpgradeCap` holder
+/// can have published.
+public fun migrate(self: &mut WalrusSubsidies) {
+    assert!(self.version < VERSION, EInvalidMigration);
+    self.version = VERSION;
+    self.package_id = package_id_for_current_version();
 }
 
 // === Internal Functions ===

--- a/contracts/walrus_subsidies/tests/walrus_subsidies_tests.move
+++ b/contracts/walrus_subsidies/tests/walrus_subsidies_tests.move
@@ -360,3 +360,31 @@ fun test_variable_subsidy_rates_across_epochs() {
     nodes.destroy!(|node| node.destroy());
     runner.destroy();
 }
+
+#[test, expected_failure(abort_code = walrus_subsidies::EInvalidMigration)]
+fun test_migrate_aborts_when_already_at_current_version() {
+    let admin = @0xA11CE;
+    let mut runner = e2e_runner::prepare(admin).build();
+
+    let admin_cap;
+    runner.tx!(admin, |staking, system, ctx| {
+        admin_cap =
+            walrus_subsidies::new(
+                system,
+                staking,
+                DEFAULT_SYSTEM_SUBSIDY_RATE,
+                DEFAULT_BASE_SUBSIDY,
+                DEFAULT_PER_SHARD_SUBSIDY,
+                ctx,
+            );
+    });
+    runner.scenario().next_tx(admin);
+
+    let mut subsidies = runner.scenario().take_shared<WalrusSubsidies>();
+    // Freshly-created object is already at the current VERSION; migrate must abort.
+    subsidies.migrate();
+
+    test_scenario::return_shared(subsidies);
+    destroy(admin_cap);
+    runner.destroy();
+}


### PR DESCRIPTION
## Description

Adds a permissionless `migrate` function that bumps the on-chain `WalrusSubsidies.version` field and updates `package_id` to the upgraded package. Without this, a package upgrade to VERSION=2 would brick the contract because every public function calls `check_version`, which asserts `self.version == VERSION`.

The function is safe to be permissionless because
`package_id_for_current_version()` resolves to whatever package legitimately declares the `V2` marker type, and only the `UpgradeCap` holder can publish that package.

Rollout per network: publish the package upgrade, then call `migrate` exactly once to flip the object to the new version.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
