### PR TITLE
docs: update storage costs with fixed USD pricing

### DIFF
--- a/docs/content/system-overview/storage-costs.mdx
+++ b/docs/content/system-overview/storage-costs.mdx
@@ -32,7 +32,7 @@ Data is encoded using erasure coding with approximately 4.5x redundancy across i
 
 #### Portability
 
-Data is not tied to a single provider and can be accessed across environments without migration overhead. Moving data across centralized cloud storage can be costly (egress fees) and operationally complex.
+Data is not tied to a single provider and can be accessed across environments efficiently without migration overhead. Moving data across centralized cloud storage can be costly (egress fees) and operationally complex.
 
 #### Verifiability
 

--- a/docs/content/system-overview/storage-costs.mdx
+++ b/docs/content/system-overview/storage-costs.mdx
@@ -1,14 +1,20 @@
 ---
 title: Storage Costs
-description: "Comprehensive guide to Walrus storage costs including WAL tokens, SUI gas fees, and cost optimization strategies."
-keywords: ["walrus", "storage costs", "wal token", "sui gas", "cost optimization", "storage resources", "upload costs", "tokenomics"]
+description: "Comprehensive guide to Walrus storage costs including fixed USD-denominated pricing, WAL tokens, SUI gas fees, and cost optimization strategies."
+keywords: ["walrus", "storage costs", "wal token", "sui gas", "cost optimization", "storage resources", "upload costs", "tokenomics", "pricing"]
 ---
 
-Storing blobs on Walrus Mainnet incurs 2 separate costs:
+When choosing a platform to store and verify data, you should consider reliability, uptime, availability, programmability, and price predictability. Walrus offers a fixed, USD-denominated storage cost of **$0.023/GB/month**, allowing you to budget and scale with confidence.
 
-- **WAL** for the storage operation. You pay per storage unit per epoch. In other words, the cost scales with blob size and epoch. Run `walrus info` to see current pricing, including the price per encoded storage unit and the additional write fee. See [WAL tokenomics](https://www.walrus.xyz/wal-token) and the [Walrus delegated proof of stake system](/walrus.pdf) for more details.
+Use the [Walrus Cost Calculator](https://costcalculator.wal.app/) to estimate total storage costs interactively.
 
-- **SUI** for executing transactions on Sui Mainnet. Each operation that interacts with the Sui blockchain (registering a blob, posting a certificate, extending storage) incurs a gas fee in SUI. See [SUI tokenomics](https://docs.sui.io/concepts/tokenomics) and [SUI gas fee calculation](https://docs.sui.io/concepts/tokenomics/gas-in-sui) for more details.
+## How pricing works
+
+Storage on Walrus is paid in WAL but priced at a fixed rate of **$0.023/GB/month**. The amount of WAL required adjusts automatically as the WAL token price changes.
+
+Behind the scenes, Walrus storage nodes track WAL prices from multiple sources and periodically update their onchain price vote to keep costs aligned with USD.
+
+You also pay **SUI** for executing transactions on Sui Mainnet. Each operation that interacts with the Sui blockchain (registering a blob, posting a certificate, extending storage) incurs a gas fee in SUI. See [SUI tokenomics](https://docs.sui.io/concepts/tokenomics) and [SUI gas fee calculation](https://docs.sui.io/concepts/tokenomics/gas-in-sui) for more details.
 
 :::tip
 
@@ -16,17 +22,25 @@ Walrus uses erasure coding with approximately 5x expansion. The storage cost sho
 
 :::
 
-:::caution
+## What you get for $0.023/GB/month
 
-There are plans to stabilize costs to USD so that storage fees are not subject to WAL fluctuations.
+At $0.023 per GB per month, Walrus is in line with centralized storage providers but includes additional capabilities and lower configuration requirements.
 
-:::
+#### Built-in redundancy
 
-## Cost calculator
+Data is encoded using erasure coding with approximately 4.5x redundancy across independent storage nodes. Achieving similar redundancy in a centralized provider typically requires storing additional copies in multiple regions.
 
-Use the [Walrus Cost Calculator](https://costcalculator.wal.app/) to estimate total storage costs interactively.
+#### Portability
 
-Walrus storage costs are a combination of WAL and SUI fees incurred from storage resources, upload costs, Sui transaction fees, and Sui object storage resources.
+Data is not tied to a single provider and can be accessed across environments without migration overhead. Moving data across centralized cloud storage can be costly (egress fees) and operationally complex.
+
+#### Verifiability
+
+Data is content-addressed and cryptographically verifiable, so you can prove it has not been altered. Cloud storage providers rely on internal checksums to maintain integrity but do not provide independent verification.
+
+#### Programmable access control
+
+Access is enforced through onchain policies, enabling fine-grained, dynamic permissioning reusable across systems. Cloud storage providers manage access through centralized policies outside application logic, often requiring additional infrastructure for dynamic behavior.
 
 #### Storage resources
 


### PR DESCRIPTION
## Summary
- Revise storage costs page to reflect the new fixed USD-denominated pricing model ($0.023/GB/month paid in WAL)
- Add "How pricing works" section explaining automatic WAL price adjustment through onchain price votes
- Add "What you get" section highlighting advantages over centralized providers: built-in redundancy, portability, verifiability, and programmable access control
- Remove outdated caution admonition about planned USD cost stabilization (now shipped)

## Test plan
- [ ] Verify docs build successfully (`cd docs/site && pnpm build`)
- [ ] Review page renders correctly with `pnpm start`
- [ ] Confirm all internal and external links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)