### PR TITLE
perf: run GC phase 1 before execute_epoch_change

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -1894,6 +1894,14 @@ impl StorageNode {
             c.sync_node_params().await?;
         }
 
+        // Run GC phase 1 (blob info cleanup) before the rest of the epoch-change work.
+        // Phase 1 only iterates global blob-info CFs against `event.epoch`; it does not depend
+        // on the upcoming committee or shard transitions. Running it first means a phase-1
+        // error stops processing before any committee/shard state changes, and shard removal
+        // (spawned by `execute_epoch_change` as part of the finisher task) cannot contend with
+        // phase 1's disk traffic on the same RocksDB instance.
+        self.start_garbage_collection_task(event.epoch).await?;
+
         // Capture the event index before the handle is moved into `execute_epoch_change` so
         // we can later detect whether this event is being reprocessed.
         let event_index = event_handle.index();
@@ -1903,7 +1911,9 @@ impl StorageNode {
         let shard_map_lock = self.inner.storage.lock_shards().await;
 
         // Now the general tasks around epoch change are done. Next, entering epoch change logic
-        // to bring the node state to the next epoch.
+        // to bring the node state to the next epoch. `execute_epoch_change` ends by spawning
+        // the finisher task (shard removal + `epoch_sync_done` + `mark_as_complete`), so the
+        // finisher is guaranteed to fire only after phase 1 succeeded.
         self.execute_epoch_change(event_handle, event, shard_map_lock)
             .await?;
 
@@ -1917,8 +1927,6 @@ impl StorageNode {
         // for the epoch that just ended.
         self.epoch_change_driver
             .schedule_post_epoch_change_subsidies();
-
-        self.start_garbage_collection_task(event.epoch).await?;
 
         // Schedule the storage node consistency check after garbage collection has settled the
         // aggregate blob info table. The iterator's `is_certified` filter relies on counters

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -3517,21 +3517,22 @@ impl StorageNodeInner {
         }
     }
 
-    /// Note: if the parent future is dropped, the `spawn_blocking` task runs to completion
-    /// and holds the `StorageShardLock` until shard creation finishes.
+    /// Keeps the shard-map write guard on the async task while offloading RocksDB shard creation
+    /// to `spawn_blocking`. Moving the guard into the blocking thread can strand waiters in
+    /// simulation when it is dropped there.
     async fn create_storage_for_shards_in_background(
         self: &Arc<Self>,
         new_shards: Vec<ShardIndex>,
-        shard_map_lock: StorageShardLock,
+        mut shard_map_lock: StorageShardLock,
     ) -> Result<(), anyhow::Error> {
-        let this = self.clone();
-        tokio::task::spawn_blocking(move || {
-            this.storage
-                .create_storage_for_shards_locked(shard_map_lock, &new_shards)
-        })
-        .in_current_span()
-        .map(unwrap_or_resume_unwind)
-        .await?;
+        let missing = shard_map_lock.missing_shards(&new_shards);
+        let storage = self.storage.clone();
+        let shard_storages =
+            tokio::task::spawn_blocking(move || storage.create_storage_for_shards(&missing))
+                .in_current_span()
+                .map(unwrap_or_resume_unwind)
+                .await?;
+        shard_map_lock.insert_shards(shard_storages);
         Ok(())
     }
 
@@ -7611,7 +7612,7 @@ mod tests {
         let shard_indices: Vec<_> = assignment[0].iter().map(|i| ShardIndex(*i)).collect();
         node_inner
             .storage
-            .create_storage_for_shards(&shard_indices)
+            .create_storage_for_shards_for_testing(&shard_indices)
             .await?;
         let mut shard_storage = vec![];
         for shard_index in shard_indices {
@@ -7910,7 +7911,7 @@ mod tests {
         };
         node_inner
             .storage
-            .create_storage_for_shards(&[ShardIndex(0)])
+            .create_storage_for_shards_for_testing(&[ShardIndex(0)])
             .await?;
         let shard_storage_dst = node_inner
             .storage
@@ -7989,7 +7990,7 @@ mod tests {
         };
         node_inner
             .storage
-            .create_storage_for_shards(&[ShardIndex(0)])
+            .create_storage_for_shards_for_testing(&[ShardIndex(0)])
             .await?;
         let shard_storage_dst = node_inner
             .storage
@@ -8468,7 +8469,7 @@ mod tests {
             };
             node_inner
                 .storage
-                .create_storage_for_shards(&[ShardIndex(0)])
+                .create_storage_for_shards_for_testing(&[ShardIndex(0)])
                 .await?;
             let shard_storage_dst = node_inner
                 .storage
@@ -8553,7 +8554,7 @@ mod tests {
             };
             node_inner
                 .storage
-                .create_storage_for_shards(&[ShardIndex(0)])
+                .create_storage_for_shards_for_testing(&[ShardIndex(0)])
                 .await?;
             let shard_storage_dst = node_inner
                 .storage
@@ -8962,7 +8963,7 @@ mod tests {
             };
             node_inner
                 .storage
-                .create_storage_for_shards(&[ShardIndex(0)])
+                .create_storage_for_shards_for_testing(&[ShardIndex(0)])
                 .await?;
             let shard_storage_dst = node_inner
                 .storage
@@ -9031,7 +9032,7 @@ mod tests {
             };
             node_inner
                 .storage
-                .create_storage_for_shards(&[ShardIndex(0)])
+                .create_storage_for_shards_for_testing(&[ShardIndex(0)])
                 .await?;
             node_inner.storage.clear_metadata_in_test()?;
             node_inner.set_node_status(NodeStatus::RecoverMetadata)?;

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -3,7 +3,7 @@
 
 use core::fmt::{self, Display};
 use std::{
-    collections::{HashMap, hash_map::Entry},
+    collections::HashMap,
     fmt::Debug,
     ops::Bound::{self, Excluded, Included},
     path::Path,
@@ -205,6 +205,24 @@ impl StorageShardLock {
     /// Returns the shards that are currently present in the storage.
     pub fn existing_shards(&self) -> &[ShardIndex] {
         &self.existing_shards
+    }
+
+    /// Returns the subset of `new_shards` that are not already present in the locked map.
+    pub(crate) fn missing_shards(&self, new_shards: &[ShardIndex]) -> Vec<ShardIndex> {
+        new_shards
+            .iter()
+            .copied()
+            .filter(|i| !self.shards_guard.contains_key(i))
+            .collect()
+    }
+
+    /// Inserts shard storages into the locked map, skipping any indices already present.
+    pub(crate) fn insert_shards(&mut self, shard_storages: Vec<(ShardIndex, Arc<ShardStorage>)>) {
+        for (shard_index, shard_storage) in shard_storages {
+            self.shards_guard
+                .entry(shard_index)
+                .or_insert(shard_storage);
+        }
     }
 }
 
@@ -469,19 +487,22 @@ impl Storage {
 
     /// Creates the storage for the specified shards, if it does not exist yet.
     #[cfg(any(test, feature = "test-utils"))]
-    pub(crate) async fn create_storage_for_shards(
+    pub(crate) async fn create_storage_for_shards_for_testing(
         &self,
         new_shards: &[ShardIndex],
     ) -> Result<(), TypedStoreError> {
-        let shard_map_lock = self.lock_shards().await;
-        self.create_storage_for_shards_locked(shard_map_lock, new_shards)
+        let mut locked_map = self.lock_shards().await;
+        let missing = locked_map.missing_shards(new_shards);
+        locked_map.insert_shards(self.create_storage_for_shards(&missing)?);
+        Ok(())
     }
 
-    pub(crate) fn create_storage_for_shards_locked(
+    /// Creates shard storages for the given indices without touching the shards map. Safe to
+    /// call from `spawn_blocking` while the caller retains the shard-map write guard.
+    pub(crate) fn create_storage_for_shards(
         &self,
-        mut locked_map: StorageShardLock,
         new_shards: &[ShardIndex],
-    ) -> Result<(), TypedStoreError> {
+    ) -> Result<Vec<(ShardIndex, Arc<ShardStorage>)>, TypedStoreError> {
         let start = Instant::now();
         let labels = Labels {
             collection_name: "shards",
@@ -491,34 +512,29 @@ impl Storage {
         };
         tracing::info!(count = new_shards.len(), "creating storage for shards");
 
+        let mut shard_storages = Vec::with_capacity(new_shards.len());
         for &shard_index in new_shards {
-            match locked_map.shards_guard.entry(shard_index) {
-                Entry::Vacant(entry) => {
-                    let shard_storage = ShardStorage::create_or_reopen(
-                        shard_index,
-                        &self.database,
-                        &self.db_table_opts_factory,
-                        Some(ShardStatus::None),
-                        &self.metrics_registry,
-                    )
-                    .inspect_err(|error| {
-                        self.metrics
-                            .observe_operation_duration(labels.with_error(error), start.elapsed());
-                    })?;
-
-                    tracing::info!(
-                        walrus.shard_index = %shard_index,
-                        "successfully created storage for shard"
-                    );
-                    entry.insert(Arc::new(shard_storage));
-                }
-                Entry::Occupied(_) => (),
-            }
+            let shard_storage = ShardStorage::create_or_reopen(
+                shard_index,
+                &self.database,
+                &self.db_table_opts_factory,
+                Some(ShardStatus::None),
+                &self.metrics_registry,
+            )
+            .inspect_err(|error| {
+                self.metrics
+                    .observe_operation_duration(labels.with_error(error), start.elapsed());
+            })?;
+            tracing::info!(
+                walrus.shard_index = %shard_index,
+                "successfully created storage for shard"
+            );
+            shard_storages.push((shard_index, Arc::new(shard_storage)));
         }
 
         self.metrics
             .observe_operation_duration(labels.with_response(Ok(&())), start.elapsed());
-        Ok(())
+        Ok(shard_storages)
     }
 
     #[tracing::instrument(skip_all)]
@@ -1452,7 +1468,7 @@ pub(crate) mod tests {
             // TODO: call create storage once with the list of storages.
             storage
                 .as_mut()
-                .create_storage_for_shards(&[*shard])
+                .create_storage_for_shards_for_testing(&[*shard])
                 .await?;
             let shard_storage = storage
                 .as_ref()
@@ -2061,7 +2077,10 @@ pub(crate) mod tests {
 
         // Initialize storage with two shards
         let shards = [ShardIndex(3), ShardIndex(5)];
-        storage.as_mut().create_storage_for_shards(&shards).await?;
+        storage
+            .as_mut()
+            .create_storage_for_shards_for_testing(&shards)
+            .await?;
 
         // Populate shards with slivers
         for shard in shards {

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -3383,7 +3383,7 @@ pub async fn empty_storage_with_shards(shards: &[ShardIndex]) -> WithTempDir<Sto
     .expect("storage creation must succeed");
 
     storage
-        .create_storage_for_shards(shards)
+        .create_storage_for_shards_for_testing(shards)
         .await
         .expect("should be able to create storage for shards");
 


### PR DESCRIPTION
## Description

 - Run GC phase 1 (blob-info cleanup) inline before `execute_epoch_change` so it doesn't contend with shard removal for HDD I/O during epoch transitions.

- While testing this reorder, Mysten simulator exposed a deadlock-prone pattern: a simulated task can block the single Mysten simulator task runner while waiting for shard-map access that depends on another simulated task making progress. The specific failure involved the background consistency check task waiting behind the shard-removal task.

- This PR also avoids moving `StorageShardLock` into `spawn_blocking`. That was not the direct root cause of the observed deadlock, but it is the same class of unsafe simulator pattern: shard-map access should not be tied to blocking work that still depends on the Mysten simulator task runner.
 
## Test plan
 - Existing tests pass

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
