### PR TITLE
test: assert sync_shard rejects missing auth header

### DIFF
--- a/crates/walrus-service/src/node/server.rs
+++ b/crates/walrus-service/src/node/server.rs
@@ -552,6 +552,7 @@ mod tests {
         InconsistencyProof,
         PublicKey,
         RecoverySymbol,
+        ShardIndex,
         Sliver,
         SliverIndex,
         SliverPairIndex,
@@ -577,6 +578,7 @@ mod tests {
             SignedMessage,
             StorageConfirmation,
             SyncShardMsg,
+            SyncShardRequest,
             SyncShardResponse,
         },
         metadata::{UnverifiedBlobMetadataWithId, VerifiedBlobMetadataWithId},
@@ -1181,6 +1183,40 @@ mod tests {
             .expect_err("confirmation request should fail");
 
         assert_eq!(err.http_status_code(), Some(code));
+    }
+
+    #[tokio::test]
+    async fn sync_shard_missing_authorization_header() {
+        let (config, _handle) = start_rest_api_with_test_config().await;
+
+        let url = format!(
+            "https://{}{}",
+            config.as_ref().rest_api_address,
+            routes::SYNC_SHARD_ENDPOINT
+        );
+
+        let key_pair = ProtocolKeyPair::generate();
+        let sync_shard_msg = SyncShardMsg::new(
+            1,
+            SyncShardRequest::new(
+                ShardIndex(0),
+                SliverType::Primary,
+                walrus_core::test_utils::random_blob_id(),
+                10,
+                1,
+            ),
+        );
+        let signed_request = key_pair.sign_message(&sync_shard_msg);
+
+        let client = storage_node_client(config.as_ref()).into_inner();
+        let response = client
+            .post(url)
+            .body(bcs::to_bytes(&signed_request).expect("signed request serializes"))
+            .send()
+            .await
+            .expect("request should be sent without error");
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Approach
Added a unit test in `crates/walrus-service/src/node/server.rs` that brings up the storage node REST API with the same helper used by surrounding tests, then issues a raw `POST` to `SYNC_SHARD_ENDPOINT` without an `Authorization` header. The body is a valid BCS-encoded `SignedSyncShardRequest` so the assertion is unambiguously about the missing header rather than a malformed payload. The `Authorization` axum extractor runs before the body extractor, so the request must produce a `401 UNAUTHORIZED`.

## Changes
- New test `sync_shard_missing_authorization_header` in `crates/walrus-service/src/node/server.rs`
- Imports `ShardIndex` and `SyncShardRequest` into the `tests` module to construct the signed request

## What I did NOT do
- No production code changes — purely a test
- No new dependencies

## Verification
- [x] cargo fmt -- --config group_imports=StdExternalCrate,imports_granularity=Crate,imports_layout=HorizontalVertical
- [x] cargo clippy --all-features --tests on `-p walrus-service --lib --tests` (passed with `-D warnings`)
- [ ] cargo nextest run — could not link the test binary locally due to disk exhaustion in the sandbox (`ld terminated with signal 7`); the rustc compile step succeeded, only the link step failed. Test will exercise in CI.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SDTKRYFMhVo4gh6MUVEEEr)_