### PR TITLE
test(walrus-service): assert shard_sync_progress is cleared at sync end

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -7813,12 +7813,11 @@ mod tests {
         // Checks that the shard is completely migrated.
         check_all_blobs_are_synced(&blob_details, &storage_dst, &shard_storage_dst, &[])?;
 
-        // Checks that the shard sync progress is reset.
+        // Checks that the shard sync progress entry is removed at the end of the sync.
         assert!(
             shard_storage_dst
-                .get_last_synced_blob_id()
-                .expect("getting last synced blob id should succeed")
-                .is_none()
+                .is_shard_sync_progress_empty()
+                .expect("reading shard sync progress should succeed")
         );
         Ok(())
     }
@@ -7931,12 +7930,11 @@ mod tests {
             &[],
         )?;
 
-        // Checks that the shard sync progress is reset.
+        // Checks that the shard sync progress entry is removed at the end of the sync.
         assert!(
             shard_storage_dst
-                .get_last_synced_blob_id()
-                .expect("getting last synced blob id should succeed")
-                .is_none()
+                .is_shard_sync_progress_empty()
+                .expect("reading shard sync progress should succeed")
         );
 
         Ok(())
@@ -8010,12 +8008,11 @@ mod tests {
             &[],
         )?;
 
-        // Checks that the shard sync progress is reset.
+        // Checks that the shard sync progress entry is removed at the end of the sync.
         assert!(
             shard_storage_dst
-                .get_last_synced_blob_id()
-                .expect("getting last synced blob id should succeed")
-                .is_none()
+                .is_shard_sync_progress_empty()
+                .expect("reading shard sync progress should succeed")
         );
 
         Ok(())
@@ -8138,12 +8135,11 @@ mod tests {
             // Checks that the shard is completely migrated.
             check_all_blobs_are_synced(&blob_details, &storage_dst, &shard_storage_dst, &[])?;
 
-            // Checks that the shard sync progress is reset.
+            // Checks that the shard sync progress entry is removed at the end of the sync.
             assert!(
                 shard_storage_dst
-                    .get_last_synced_blob_id()
-                    .expect("getting last synced blob id should succeed")
-                    .is_none()
+                    .is_shard_sync_progress_empty()
+                    .expect("reading shard sync progress should succeed")
             );
 
             Ok(())
@@ -8313,12 +8309,11 @@ mod tests {
             // Checks that the shard is completely migrated.
             check_all_blobs_are_synced(&blob_details, &storage_dst, &shard_storage_dst, &[])?;
 
-            // Checks that the shard sync progress is reset.
+            // Checks that the shard sync progress entry is removed at the end of the sync.
             assert!(
                 shard_storage_dst
-                    .get_last_synced_blob_id()
-                    .expect("getting last synced blob id should succeed")
-                    .is_none()
+                    .is_shard_sync_progress_empty()
+                    .expect("reading shard sync progress should succeed")
             );
 
             if must_use_recovery {
@@ -8362,12 +8357,11 @@ mod tests {
             wait_until_no_sync_tasks(&cluster.nodes[1].storage_node.shard_sync_handler).await?;
             check_all_blobs_are_synced(&_blob_details, &storage_dst, &shard_storage_dst, &[])?;
 
-            // Checks that the shard sync progress is reset.
+            // Checks that the shard sync progress entry is removed at the end of the sync.
             assert!(
                 shard_storage_dst
-                    .get_last_synced_blob_id()
-                    .expect("getting last synced blob id should succeed")
-                    .is_none()
+                    .is_shard_sync_progress_empty()
+                    .expect("reading shard sync progress should succeed")
             );
 
             Ok(())
@@ -8485,12 +8479,11 @@ mod tests {
             // All blobs should be recovered in the new dst node.
             check_all_blobs_are_synced(&details, &node_inner.storage, &shard_storage_dst, &[])?;
 
-            // Checks that the shard sync progress is reset.
+            // Checks that the shard sync progress entry is removed at the end of the sync.
             assert!(
                 shard_storage_dst
-                    .get_last_synced_blob_id()
-                    .expect("getting last synced blob id should succeed")
-                    .is_none()
+                    .is_shard_sync_progress_empty()
+                    .expect("reading shard sync progress should succeed")
             );
 
             // Checks that shard sync recovery is not triggered.
@@ -8601,12 +8594,11 @@ mod tests {
                 &[],
             )?;
 
-            // Checks that the shard sync progress is reset.
+            // Checks that the shard sync progress entry is removed at the end of the sync.
             assert!(
                 shard_storage_dst
-                    .get_last_synced_blob_id()
-                    .expect("getting last synced blob id should succeed")
-                    .is_none()
+                    .is_shard_sync_progress_empty()
+                    .expect("reading shard sync progress should succeed")
             );
 
             Ok(())
@@ -8685,12 +8677,11 @@ mod tests {
             // Checks that the shard is completely migrated.
             check_all_blobs_are_synced(&blob_details, &storage_dst, &shard_storage_dst, &[])?;
 
-            // Checks that the shard sync progress is reset.
+            // Checks that the shard sync progress entry is removed at the end of the sync.
             assert!(
                 shard_storage_dst
-                    .get_last_synced_blob_id()
-                    .expect("getting last synced blob id should succeed")
-                    .is_none()
+                    .is_shard_sync_progress_empty()
+                    .expect("reading shard sync progress should succeed")
             );
 
             Ok(())
@@ -8980,12 +8971,11 @@ mod tests {
                 &non_synced_blob_index,
             )?;
 
-            // Checks that the shard sync progress is reset.
+            // Checks that the shard sync progress entry is removed at the end of the sync.
             assert!(
                 shard_storage_dst
-                    .get_last_synced_blob_id()
-                    .expect("getting last synced blob id should succeed")
-                    .is_none()
+                    .is_shard_sync_progress_empty()
+                    .expect("reading shard sync progress should succeed")
             );
 
             clear_fail_point("shard_recovery_skip_initial_blob_certification_check");

--- a/crates/walrus-service/src/node/storage/shard.rs
+++ b/crates/walrus-service/src/node/storage/shard.rs
@@ -219,13 +219,6 @@ impl ShardSyncProgress {
             sliver_type,
         })
     }
-
-    #[cfg(test)]
-    fn last_synced_blob_id(&self) -> Option<BlobId> {
-        match self {
-            ShardSyncProgress::V1(p) => Some(p.last_synced_blob_id),
-        }
-    }
 }
 
 // Represents the last synced status of the shard after restart.
@@ -1764,11 +1757,10 @@ impl ShardStorage {
             .collect()
     }
 
+    /// Returns `true` when no `ShardSyncProgress` entry is recorded for this shard.
     #[cfg(test)]
-    pub(crate) fn get_last_synced_blob_id(&self) -> Result<Option<BlobId>, TypedStoreError> {
-        self.shard_sync_progress
-            .get(&())
-            .map(|progress| progress.and_then(|p| p.last_synced_blob_id()))
+    pub(crate) fn is_shard_sync_progress_empty(&self) -> Result<bool, TypedStoreError> {
+        Ok(self.shard_sync_progress.get(&())?.is_none())
     }
 }
 
@@ -2025,6 +2017,29 @@ mod tests {
         }
 
         assert_eq!(shard.is_sliver_pair_stored(&BLOB_ID)?, is_pair_stored);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn record_start_shard_sync_clears_existing_progress() -> TestResult {
+        let storage = empty_storage().await;
+        let shard = storage
+            .as_ref()
+            .shard_storage(SHARD_INDEX)
+            .await
+            .expect("shard should exist");
+
+        // Seed a residual progress entry, as if a previous sync was interrupted partway through.
+        shard
+            .shard_sync_progress
+            .insert(&(), &ShardSyncProgress::new(BLOB_ID, SliverType::Primary))?;
+        assert!(!shard.is_shard_sync_progress_empty()?);
+
+        shard.record_start_shard_sync().await?;
+
+        assert!(shard.is_shard_sync_progress_empty()?);
+        assert_eq!(shard.status().await?, ShardStatus::ActiveSync);
 
         Ok(())
     }


### PR DESCRIPTION
## TODO addressed
> Test shard_sync_progress is cleared at the end

## Approach
The shard sync code clears its on-disk `shard_sync_progress` column-family entry both at the start of a new sync (`record_start_shard_sync`) and at the end of a successful sync (inside `start_sync_shard_before_epoch_impl`). The existing e2e tests in `node.rs` asserted clearing via `get_last_synced_blob_id().is_none()`, which only reads the inner field rather than checking whether the CF entry actually exists. Add a more explicit `is_shard_sync_progress_empty` test helper on `ShardStorage` that reads the column-family entry directly, and add a focused unit test that seeds a residual entry and verifies `record_start_shard_sync` wipes it. Replace the indirect assertions across the 10 existing sync-completion tests so a regression that leaves a stale CF entry behind would now fail the assertion unambiguously, regardless of any future change to the `ShardSyncProgress` schema.

## Changes
- `crates/walrus-service/src/node/storage/shard.rs`: add `ShardStorage::is_shard_sync_progress_empty` (cfg(test)) and a `record_start_shard_sync_clears_existing_progress` unit test that seeds a `ShardSyncProgress` entry and asserts it is gone after `record_start_shard_sync`. Drop the now-unused `get_last_synced_blob_id` helper and the `ShardSyncProgress::last_synced_blob_id` accessor it was the only caller of.
- `crates/walrus-service/src/node.rs`: replace 10 `get_last_synced_blob_id().is_none()` assertions in `sync_shard_complete_transfer`, `sync_shard_shard_recovery`, `sync_shard_partial_recovery`, and the failure-injection simtests with the new helper, and update the comment to "...is removed at the end of the sync".

## What I did NOT do
- Did not add a unit test that exercises the end-of-sync clearing path directly; that path is inside `start_sync_shard_before_epoch_impl` and needs a real `StorageNodeInner` + cluster, which the existing e2e tests in `node.rs` already cover (now with the stronger assertion).
- Did not refactor the simtest `sync_shard_start_from_progress` family, which intentionally asserts a specific in-progress blob id — that semantics is different from "entry is cleared".

## Verification
- [x] cargo fmt -- --config group_imports=StdExternalCrate,imports_granularity=Crate,imports_layout=HorizontalVertical
- [x] cargo clippy -p walrus-service --all-features --tests --lib -- -D warnings (clean)
- [ ] cargo nextest run -p walrus-service — nextest is not installed in this environment; the new unit test was started under `cargo test -p walrus-service --lib` but did not complete within the session window. The change is a small additive test plus a mechanical assertion swap, and the test compiles cleanly under `cargo clippy --tests`. CI will execute it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CVUaqGbouiccJmnSbbev57)_