### PR TITLE
chore(walrus-service): add metrics for db checkpoint creation

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -826,14 +826,17 @@ impl StorageNode {
             config.pending_metadata_cache.cache_ttl,
             metrics.clone(),
         );
-        let checkpoint_manager =
-            match DbCheckpointManager::new(storage.get_db(), config.checkpoint_config.clone()) {
-                Ok(manager) => Some(Arc::new(manager)),
-                Err(error) => {
-                    tracing::warn!(?error, "failed to initialize checkpoint manager");
-                    None
-                }
-            };
+        let checkpoint_manager = match DbCheckpointManager::new(
+            storage.get_db(),
+            config.checkpoint_config.clone(),
+            Some(metrics.clone()),
+        ) {
+            Ok(manager) => Some(Arc::new(manager)),
+            Err(error) => {
+                tracing::warn!(?error, "failed to initialize checkpoint manager");
+                None
+            }
+        };
         let system_parameters = contract_service.fixed_system_parameters();
         let (latest_event_epoch_sender, latest_event_epoch_watcher) = watch::channel(None);
         let inner = Arc::new(StorageNodeInner {

--- a/crates/walrus-service/src/node/db_checkpoint.rs
+++ b/crates/walrus-service/src/node/db_checkpoint.rs
@@ -58,7 +58,10 @@ use tokio::{task::JoinHandle, time};
 use tokio_util::sync::CancellationToken;
 use typed_store::rocks::RocksDB;
 
-use crate::node::errors::DbCheckpointError;
+use crate::node::{
+    errors::DbCheckpointError,
+    metrics::{NodeMetricSet, STATUS_FAILURE, STATUS_SUCCESS},
+};
 
 /// Configuration for RocksDB db_checkpoint management.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -282,9 +285,14 @@ impl DbCheckpointManager {
     const DEFAULT_TASK_TIMEOUT: StdDuration = time::Duration::from_hours(1);
 
     /// Create a new db_checkpoint manager for RocksDB.
-    //
-    // TODO(WAL-845): Add metrics for db_checkpoint creation and restore.
-    pub fn new(db: Arc<RocksDB>, config: DbCheckpointConfig) -> Result<Self, DbCheckpointError> {
+    ///
+    /// When `metrics` is provided, db_checkpoint creation attempts are tracked via the
+    /// `db_checkpoint_create_*` metrics on [`NodeMetricSet`].
+    pub(crate) fn new(
+        db: Arc<RocksDB>,
+        config: DbCheckpointConfig,
+        metrics: Option<Arc<NodeMetricSet>>,
+    ) -> Result<Self, DbCheckpointError> {
         tracing::info!(?config, "DbCheckpointManager starting...");
         if let Some(db_checkpoint_dir) = config.db_checkpoint_dir.as_ref() {
             create_dir_all(db_checkpoint_dir).map_err(|e| DbCheckpointError::Other(e.into()))?;
@@ -298,7 +306,14 @@ impl DbCheckpointManager {
         let (command_tx, command_rx) = tokio::sync::mpsc::channel(10);
 
         let execution_loop: JoinHandle<Result<(), DbCheckpointError>> = tokio::spawn(async move {
-            Self::execution_loop(db_clone, config_clone, cancel_token_clone, command_rx).await?;
+            Self::execution_loop(
+                db_clone,
+                config_clone,
+                cancel_token_clone,
+                command_rx,
+                metrics,
+            )
+            .await?;
             Ok(())
         });
 
@@ -404,6 +419,7 @@ impl DbCheckpointManager {
         config: DbCheckpointConfig,
         cancel_token: CancellationToken,
         mut command_rx: tokio::sync::mpsc::Receiver<DbCheckpointRequest>,
+        metrics: Option<Arc<NodeMetricSet>>,
     ) -> Result<(), DbCheckpointError> {
         let mut current_task: Option<Arc<DelayedTask>> = None;
 
@@ -430,26 +446,34 @@ impl DbCheckpointManager {
                             } else {
                                 let db_clone = db.clone();
                                 let config_clone = config.clone();
+                                let metrics_clone = metrics.clone();
                                 current_task = Some(Arc::new(DelayedTask::new(
                                     time::Instant::now() + delay.unwrap_or_default(),
                                     Self::DEFAULT_TASK_TIMEOUT,
                                     move || {
+                                        let start = std::time::Instant::now();
                                         let result = Self::create_backup_impl(
                                             &db_clone, &db_checkpoint_dir, config_clone.sync,
                                             Some(config_clone.max_background_operations)
                                         );
-                                        match &result {
+                                        let elapsed = start.elapsed().as_secs_f64();
+                                        let status = match &result {
                                             Ok(_) => {
                                                 Self::purge_old_db_checkpoints(
                                                     &db_checkpoint_dir, config.max_db_checkpoints
                                                 );
+                                                STATUS_SUCCESS
                                             },
                                             Err(error) => {
                                                 tracing::error!(
                                                     ?error,
                                                     "failed to create DB checkpoint"
                                                 );
+                                                STATUS_FAILURE
                                             }
+                                        };
+                                        if let Some(metrics) = metrics_clone.as_ref() {
+                                            Self::record_create_metrics(metrics, status, elapsed);
                                         }
                                         result
                                     },
@@ -477,6 +501,20 @@ impl DbCheckpointManager {
         }
 
         Ok(())
+    }
+
+    /// Records db_checkpoint creation metrics. Called from the blocking thread inside the
+    /// create-backup task so timing reflects the actual checkpoint operation.
+    fn record_create_metrics(metrics: &NodeMetricSet, status: &str, elapsed_seconds: f64) {
+        walrus_utils::with_label!(metrics.db_checkpoint_create_total, status).inc();
+        walrus_utils::with_label!(metrics.db_checkpoint_create_duration_seconds, status)
+            .observe(elapsed_seconds);
+        if status == STATUS_SUCCESS {
+            let now_secs = Utc::now().timestamp();
+            metrics
+                .db_checkpoint_last_successful_timestamp_seconds
+                .set(now_secs);
+        }
     }
 
     async fn schedule_loop(
@@ -838,6 +876,7 @@ mod tests {
                     db_checkpoint_dir: Some(db_checkpoint_dir.path().to_path_buf()),
                     ..Default::default()
                 },
+                None,
             )?;
 
             db_checkpoint_manager
@@ -890,6 +929,77 @@ mod tests {
                 );
             }
         }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn db_checkpoint_create_records_success_metrics() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let db_dir = tempdir()?;
+        let db_checkpoint_dir = tempdir()?;
+        let metrics = Arc::new(NodeMetricSet::new(
+            &walrus_utils::metrics::Registry::default(),
+        ));
+
+        let mut db_opts = Options::default();
+        db_opts.create_missing_column_families(true);
+        db_opts.create_if_missing(true);
+        let db = rocks::open_cf_opts(
+            db_dir.path(),
+            Some(db_opts),
+            MetricConf::default(),
+            &[("default", cf_options_with_blobs())],
+        )?;
+        let db_map = DBMap::<Vec<u8>, Vec<u8>>::reopen(
+            &db,
+            Some("default"),
+            &ReadWriteOptions::default(),
+            false,
+        )?;
+        for (key, value) in generate_test_data(10, MIN_BLOB_SIZE.into()) {
+            db_map.insert(&key, &value)?;
+        }
+
+        let db_checkpoint_manager = DbCheckpointManager::new(
+            db,
+            DbCheckpointConfig {
+                db_checkpoint_dir: Some(db_checkpoint_dir.path().to_path_buf()),
+                ..Default::default()
+            },
+            Some(metrics.clone()),
+        )?;
+
+        db_checkpoint_manager
+            .schedule_and_wait_for_db_checkpoint_creation(Some(db_checkpoint_dir.path()), None)
+            .await?;
+
+        assert_eq!(
+            walrus_utils::with_label!(metrics.db_checkpoint_create_total, STATUS_SUCCESS).get(),
+            1,
+            "success counter should be incremented exactly once"
+        );
+        assert_eq!(
+            walrus_utils::with_label!(metrics.db_checkpoint_create_total, STATUS_FAILURE).get(),
+            0,
+            "failure counter should not be incremented on success"
+        );
+        assert_eq!(
+            walrus_utils::with_label!(
+                metrics.db_checkpoint_create_duration_seconds,
+                STATUS_SUCCESS
+            )
+            .get_sample_count(),
+            1,
+            "duration histogram should observe exactly one success sample"
+        );
+        assert!(
+            metrics
+                .db_checkpoint_last_successful_timestamp_seconds
+                .get()
+                > 0,
+            "last-successful timestamp should be set to a positive unix timestamp"
+        );
 
         Ok(())
     }

--- a/crates/walrus-service/src/node/metrics.rs
+++ b/crates/walrus-service/src/node/metrics.rs
@@ -276,6 +276,18 @@ walrus_utils::metrics::define_metric_set! {
 
         #[help = "Total number of failed WAL price fetch requests"]
         wal_price_fetch_failure_total: IntCounterVec["price_source"],
+
+        #[help = "Total number of db checkpoint creation attempts per outcome"]
+        db_checkpoint_create_total: IntCounterVec["status"],
+
+        #[help = "Duration of db checkpoint creation in seconds"]
+        db_checkpoint_create_duration_seconds: HistogramVec {
+            labels: ["status"],
+            buckets: db_checkpoint_duration_buckets(),
+        },
+
+        #[help = "Unix timestamp (in seconds) of the most recent successful db checkpoint"]
+        db_checkpoint_last_successful_timestamp_seconds: IntGauge[],
     }
 }
 
@@ -346,6 +358,12 @@ impl NodeMetricSet {
 /// histograms created by Prometheus.
 fn default_buckets_for_slow_operations() -> Vec<f64> {
     prometheus::exponential_buckets(0.03125, 2.0, 14).expect("count, start, and factor are valid")
+}
+
+/// Returns 13 buckets from 1 second to 4096 seconds (~68 minutes), suitable for db checkpoint
+/// creation times which can range from seconds (small DBs) to nearly an hour.
+fn db_checkpoint_duration_buckets() -> Vec<f64> {
+    prometheus::exponential_buckets(1.0, 2.0, 13).expect("count, start, and factor are valid")
 }
 
 fn with_zero_bucket(mut buckets: Vec<f64>) -> Vec<f64> {


### PR DESCRIPTION
## TODO addressed
> TODO(WAL-845): Add metrics for db_checkpoint creation and restore.

(Marker lived in `crates/walrus-service/src/node/db_checkpoint.rs` directly above `DbCheckpointManager::new`.)

## Approach
Add three new metrics to `NodeMetricSet` and plumb an `Option<Arc<NodeMetricSet>>` through `DbCheckpointManager::new` so the periodic creation path can record them. The metric update lives inside the blocking task that runs `create_backup_impl`, so the duration histogram reflects the actual checkpoint operation and the success counter is recorded before the response is sent back to the requester. The `Option` lets callers without a registry (the existing test and the CLI restore subcommand) opt out cleanly without conditional compilation.

The metrics are:
- `walrus_db_checkpoint_create_total{status}` — counter of attempts by `success`/`failure`.
- `walrus_db_checkpoint_create_duration_seconds{status}` — histogram with buckets from 1s to ~68m (`exponential_buckets(1.0, 2.0, 13)`), sized for the wide range of checkpoint times in production.
- `walrus_db_checkpoint_last_successful_timestamp_seconds` — unix timestamp of the most recent successful creation; useful for staleness alerts.

## Changes
- `crates/walrus-service/src/node/metrics.rs`: add the three metric fields to `NodeMetricSet` and a `db_checkpoint_duration_buckets()` helper.
- `crates/walrus-service/src/node/db_checkpoint.rs`: add `metrics` parameter to `DbCheckpointManager::new` (now `pub(crate)` since `NodeMetricSet` is `pub(crate)`), thread it into the execution loop, time the create operation and call a new `record_create_metrics` helper. Add a focused unit test `db_checkpoint_create_records_success_metrics` that runs a real checkpoint and asserts the success counter, the failure counter, the histogram sample count, and the last-successful timestamp gauge. Remove the now-obsolete TODO comment.
- `crates/walrus-service/src/node.rs`: pass `Some(metrics.clone())` to `DbCheckpointManager::new` at the storage-node construction site.

## What I did NOT do
- Did not add Prometheus metrics for restore. The only caller of `DbCheckpointManager::restore_from_backup` outside tests is the one-shot `walrus-node restore` CLI subcommand, which has no metrics registry and no Prometheus scraper attached. The existing `tracing::info!` lines in that path already cover observability for that flow.
- Did not change the `pub` surface of `DbCheckpointManager` beyond demoting `new` to `pub(crate)` — required because `NodeMetricSet` is `pub(crate)` and a `pub fn` taking it would trip `private_interfaces`. `new` is only called from inside `walrus-service`, so this is a no-op for downstream users.
- Did not add a config knob for the duration buckets — they are reasonable defaults and can be promoted later.

## Verification
- [x] `cargo fmt -- --config group_imports=StdExternalCrate,imports_granularity=Crate,imports_layout=HorizontalVertical`
- [x] `cargo build -p walrus-service` (clean)
- [x] `cargo clippy -p walrus-service --all-features --tests --lib --bins -- -D warnings` (clean; pre-existing `garbage_collector_last_completed_epoch` dead-code warning in `storage.rs` is unrelated and not -D-warned)
- [ ] `cargo nextest run -p walrus-service` / `cargo test -p walrus-service --lib node::db_checkpoint::` — could not run locally: nextest is not installed in this environment and `cargo test` exhausted disk space while rebuilding `librocksdb-sys` test artifacts (`No space left on device`). The library and tests compiled cleanly under clippy `--tests`, and the new test is a small additive case that CI will execute.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ECuHZvdX3kCgVpHQNqLCzu)_