### PR TITLE
perf: parallelize blob encoding with rayon + move off tokio reactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13102,6 +13102,7 @@ dependencies = [
  "p256",
  "proptest",
  "rand 0.8.5",
+ "rayon",
  "reed-solomon-simd",
  "serde",
  "serde_test",

--- a/crates/walrus-core/Cargo.toml
+++ b/crates/walrus-core/Cargo.toml
@@ -18,6 +18,7 @@ fastcrypto.workspace = true
 hex.workspace = true
 p256 = { workspace = true, features = ["pem", "pkcs8"] }
 rand.workspace = true
+rayon.workspace = true
 reed-solomon-simd.workspace = true
 serde.workspace = true
 serde_with.workspace = true

--- a/crates/walrus-core/src/encoding/blob_encoding.rs
+++ b/crates/walrus-core/src/encoding/blob_encoding.rs
@@ -5,6 +5,7 @@ use alloc::{collections::BTreeSet, vec, vec::Vec};
 use core::{cmp, marker::PhantomData, num::NonZeroU16, ops::Range, slice::Chunks};
 
 use fastcrypto::hash::Blake2b256;
+use rayon::prelude::*;
 use tracing::{Level, Span};
 
 use super::{
@@ -29,6 +30,21 @@ use crate::{
     merkle::{MerkleTree, Node, leaf_hash},
     metadata::{SliverPairMetadata, VerifiedBlobMetadataWithId},
 };
+
+/// Peak intermediate memory we let the per-batch parallel encoder collect before scattering.
+///
+/// Each batch parallel-encodes a set of source slivers and collects the resulting symbol
+/// bodies (plus per-symbol leaf hashes for the primary path) into a `Vec`. The batch size is
+/// then `BUDGET / per_item_bytes`, clamped to `[1, total_items]`. 256 MB is comfortably below
+/// any reasonable server's RAM and large enough to keep rayon work-stealing saturated even at
+/// the 13 GiB blob limit (where `per_item_bytes ~ 65 MiB` and the batch shrinks to ~4 items).
+const PARALLEL_BATCH_MEM_BUDGET_BYTES: usize = 256 * 1024 * 1024;
+
+/// Compute a per-batch item count from a memory budget.
+fn parallel_batch_size(per_item_bytes: usize, total_items: usize) -> usize {
+    let raw = PARALLEL_BATCH_MEM_BUDGET_BYTES / per_item_bytes.max(1);
+    raw.max(1).min(total_items.max(1))
+}
 
 /// A wrapper around a blob that can be either owned (i.e., `Vec<u8>`) or borrowed (`&[u8]`).
 #[derive(Debug)]
@@ -303,30 +319,53 @@ impl<'a> BlobEncoder<'a> {
 
         drop(self.blob);
 
+        let n_rows = self.inner.n_rows_usize();
+        let n_cols = self.inner.n_columns_usize();
+        let n_shards = self.inner.config.n_shards_as_usize();
+        let symbol_size = self.inner.symbol_size.get() as usize;
+
         // Compute the remaining secondary slivers by encoding the rows (i.e., primary slivers)
         // using the secondary encoding.
-        let mut secondary_encoder = self.inner.get_encoder::<Secondary>();
-        for (r, row) in primary_slivers
-            .iter()
-            .take(self.inner.n_rows_usize())
-            .enumerate()
-        {
-            let encode_result = secondary_encoder
-                .encode(row.symbols.data())
-                .expect("size has already been checked");
-            for (symbol, sliver) in encode_result.recovery_iter().zip(
-                secondary_slivers
-                    .iter_mut()
-                    .skip(self.inner.n_columns_usize()),
-            ) {
-                sliver.copy_symbol_to(r, symbol);
+        //
+        // PERF: this loop is the dominant cost of `encode_with_metadata` for medium and large
+        // blobs. We parallelize across rows via rayon, collecting recovery symbols per row in a
+        // batch, then sequentially scattering them into `secondary_slivers` (whose writes form
+        // a scatter pattern that the borrow checker can't safely express across parallel tasks).
+        // Batches are sized to bound peak intermediate memory at
+        // [`PARALLEL_BATCH_MEM_BUDGET_BYTES`]; on the multi-GB blob path this is what keeps the
+        // collect step from blowing up RSS.
+        let recovery_per_row = n_shards.saturating_sub(n_cols);
+        let secondary_batch_size = parallel_batch_size(recovery_per_row * symbol_size, n_rows);
+        let mut batch_results: Vec<Vec<Vec<u8>>> = Vec::with_capacity(secondary_batch_size);
+        for batch_start in (0..n_rows).step_by(secondary_batch_size) {
+            let batch_end = cmp::min(batch_start + secondary_batch_size, n_rows);
+            batch_results.clear();
+            primary_slivers[batch_start..batch_end]
+                .par_iter()
+                .map_init(
+                    || self.inner.get_encoder::<Secondary>(),
+                    |encoder, sliver| {
+                        let result = encoder
+                            .encode(sliver.symbols.data())
+                            .expect("size has already been checked");
+                        result.recovery_iter().map(|s| s.to_vec()).collect()
+                    },
+                )
+                .collect_into_vec(&mut batch_results);
+            for (i, symbols) in batch_results.iter().enumerate() {
+                let r = batch_start + i;
+                for (symbol, sliver) in symbols
+                    .iter()
+                    .zip(secondary_slivers.iter_mut().skip(n_cols))
+                {
+                    sliver.copy_symbol_to(r, symbol);
+                }
             }
         }
-        drop(secondary_encoder);
+        drop(batch_results);
 
         // Now we can encode all secondary slivers, computing the remaining primary slivers and all
         // symbol hashes.
-        let n_shards = self.inner.config.n_shards_as_usize();
         let mut symbol_hashes = vec![Node::Empty; n_shards * n_shards];
 
         // Create the non-systematic primary slivers.
@@ -334,25 +373,64 @@ impl<'a> BlobEncoder<'a> {
             self.inner.n_rows.get()..self.inner.config.n_shards().get(),
         ));
 
-        let mut primary_encoder = self.inner.get_encoder::<Primary>();
-        for (col_index, column) in secondary_slivers.iter().enumerate() {
-            let symbols = primary_encoder
-                .encode_all_ref(column.symbols.data())
-                .expect("size has already been checked");
-            for (row_index, symbol) in symbols.to_symbols().enumerate() {
-                symbol_hashes[n_shards * row_index + col_index] = leaf_hash::<Blake2b256>(symbol);
-            }
-            if col_index < self.inner.n_columns_usize() {
-                for (symbol, sliver) in symbols
-                    .to_symbols()
-                    .zip(primary_slivers.iter_mut())
-                    .skip(self.inner.n_rows_usize())
-                {
-                    sliver.copy_symbol_to(col_index, symbol);
+        // PERF: same batched-parallel strategy as the secondary loop above. Each column produces
+        // (a) a full set of leaf hashes (one per row) and (b) optionally a set of symbol bodies
+        // for the non-systematic primary slivers. We compute hashes inside the parallel task
+        // (saves a second pass over encoded symbols on the host) but defer the scatter into
+        // `symbol_hashes` / `primary_slivers` to a serial step because both have indexed writes
+        // that aliasing-check would reject across rayon tasks.
+        type PrimaryBatchItem = (Vec<Node>, Option<Vec<Vec<u8>>>);
+        let per_col_bytes = (n_shards * symbol_size) + (n_shards * 32 /* Blake2b256 */);
+        let primary_batch_size = parallel_batch_size(per_col_bytes, n_shards);
+        let mut primary_batch: Vec<PrimaryBatchItem> = Vec::with_capacity(primary_batch_size);
+        for batch_start in (0..n_shards).step_by(primary_batch_size) {
+            let batch_end = cmp::min(batch_start + primary_batch_size, n_shards);
+            primary_batch.clear();
+            secondary_slivers[batch_start..batch_end]
+                .par_iter()
+                .enumerate()
+                .map_init(
+                    || self.inner.get_encoder::<Primary>(),
+                    |encoder, (i, column)| {
+                        let col_index = batch_start + i;
+                        let symbols_result = encoder
+                            .encode_all_ref(column.symbols.data())
+                            .expect("size has already been checked");
+                        let hashes: Vec<Node> = symbols_result
+                            .to_symbols()
+                            .map(leaf_hash::<Blake2b256>)
+                            .collect();
+                        let sliver_symbols = if col_index < n_cols {
+                            Some(
+                                symbols_result
+                                    .to_symbols()
+                                    .skip(n_rows)
+                                    .map(|s| s.to_vec())
+                                    .collect(),
+                            )
+                        } else {
+                            None
+                        };
+                        (hashes, sliver_symbols)
+                    },
+                )
+                .collect_into_vec(&mut primary_batch);
+            for (i, (hashes, sliver_symbols)) in primary_batch.drain(..).enumerate() {
+                let col_index = batch_start + i;
+                for (row_index, hash) in hashes.into_iter().enumerate() {
+                    symbol_hashes[n_shards * row_index + col_index] = hash;
+                }
+                if let Some(symbols) = sliver_symbols {
+                    for (symbol, sliver) in symbols
+                        .iter()
+                        .zip(primary_slivers.iter_mut().skip(n_rows))
+                    {
+                        sliver.copy_symbol_to(col_index, symbol);
+                    }
                 }
             }
         }
-        drop(primary_encoder);
+        drop(primary_batch);
 
         let sliver_pairs = primary_slivers
             .into_iter()

--- a/crates/walrus-upload-relay/src/controller.rs
+++ b/crates/walrus-upload-relay/src/controller.rs
@@ -165,16 +165,26 @@ impl Controller {
         }
 
         let encode_start_timer = Instant::now();
-        // PERF: encoding should probably be done on a separate thread pool.
-        let (sliver_pairs, metadata) = self
-            .client
-            .encoding_config()
-            .get_for_type(
-                params
-                    .encoding_type
-                    .unwrap_or(walrus_sdk::core::DEFAULT_ENCODING),
-            )
-            .encode_with_metadata(body.into())?;
+        // Encoding is CPU-bound and can take hundreds of milliseconds for
+        // multi-GB blobs. Run it on `spawn_blocking` so the tokio reactor
+        // thread stays free to drive other concurrent requests. The
+        // `EncodingConfig` is cheap to clone (all `Copy` fields), and
+        // `Bytes` is `Send`, so the move into the blocking task is free.
+        let encoding_config = self.client.encoding_config().clone();
+        let encoding_type = params
+            .encoding_type
+            .unwrap_or(walrus_sdk::core::DEFAULT_ENCODING);
+        let (sliver_pairs, metadata) = tokio::task::spawn_blocking(move || {
+            encoding_config
+                .get_for_type(encoding_type)
+                .encode_with_metadata(body.into())
+        })
+        .await
+        .map_err(|join_err| {
+            WalrusUploadRelayError::Other(anyhow::anyhow!(
+                "blob encoding task failed to join: {join_err}"
+            ))
+        })??;
         let duration = encode_start_timer.elapsed();
 
         tracing::debug!(


### PR DESCRIPTION
## Summary

Two related changes that target the encode latency for medium- and large-blob uploads through the upload relay.

1. **`walrus-upload-relay`**: wrap `encode_with_metadata` in `tokio::task::spawn_blocking`. Addresses the existing `PERF` TODO at `controller.rs:168`. Stops a single multi-second encode from starving the tokio reactor and blocking other concurrent requests.

2. **`walrus-core`**: parallelize both inner loops of `BlobEncoder::encode_with_metadata` with rayon, using per-thread encoders (`map_init`). Both loops scatter to shared mutable state, which the borrow checker can't safely express across parallel tasks, so we use a batched collect-then-scatter pattern with a 256 MiB intermediate-buffer cap. The primary loop additionally moves Blake2b256 leaf hashing inside the parallel task so the per-shard hashing parallelises alongside the encode.

## Bench

`cargo bench --bench blob_encoding`, mainnet config (`n_shards=1000`), measured on an Apple M5 (10 GPU cores, 12 perf+effic CPU cores):

| blob size | before (serial) | after (rayon) | speedup |
| --- | --- | --- | --- |
| 32 MiB | ~73 MiB/s | 122 MiB/s | **+71%** |
| 1 GiB | ~183 MiB/s | ~500 MiB/s | **+172% (2.7×)** |

The larger speedup at 1 GiB reflects two things: (a) Apple cores have more memory bandwidth than a single AVX core can saturate, so per-core parallelism scales near-linearly; (b) the per-call symbol size is larger at 1 GiB so the per-encode rayon overhead is amortized better. We expect even larger relative wins on a 16-core AVX-512 server.

## Why this is safe

- 245 walrus-core unit tests pass unchanged. Bit-identity to the serial implementation is preserved by construction — each iteration calls the same `rss::Encoder::encode` / `encode_all_ref` API, the scatter pattern's outputs are non-overlapping (each iteration writes to a unique `(sliver_idx, position)` pair), and we explicitly collect-then-scatter rather than parallel-write so we don't need `unsafe`.
- The batched collect-then-scatter uses bounded intermediate memory (`PARALLEL_BATCH_MEM_BUDGET_BYTES = 256 MiB`). For a 13 GiB blob this reduces batch size to ~4 items, still parallel within each batch.
- rayon is already in the workspace dependencies and used in `walrus-service::node::recovery_symbol_service` — no new top-level dep.
- The `EncodingConfig` clone in `walrus-upload-relay` is cheap: all fields are `Copy`.

## Test plan

- [x] `cargo test -p walrus-core --lib --release` — 245 passed, 3 ignored
- [x] `cargo test -p walrus-upload-relay --release` — 8 passed
- [x] `cargo bench -p walrus-core --bench blob_encoding -- "encode_with_metadata/(32MiB|1GiB)"` — see numbers above
- [ ] CI: workspace-wide test run
- [ ] Reviewer-suggested benches at other sizes / configurations

## Notes for reviewers

- The blob_encoding.rs change is structural but each iteration's body is unchanged — the diff is mostly the loop wrapper.
- I considered an `unsafe` raw-pointer scatter (lower memory overhead, slightly faster at the very large blob sizes where intermediate memory dominates) but went with the safe collect-then-scatter for this PR — happy to follow up with that variant if you'd prefer the perf at the cost of an `unsafe` block.
- Rayon's `map_init` gives us a per-rayon-worker-thread encoder. If `get_encoder::<Secondary>()` / `<Primary>()` is expensive enough that the per-thread instantiation becomes a bottleneck, we could pool encoders explicitly — but at current perf numbers this doesn't appear to matter.