### PR TITLE
chore: enrich recovery symbol verification failure logs

### DIFF
--- a/crates/walrus-storage-node-client/src/client.rs
+++ b/crates/walrus-storage-node-client/src/client.rs
@@ -649,19 +649,32 @@ impl StorageNodeClient {
             "the server returned recovery symbols"
         );
 
+        // Capture identifiers out of `metadata`/`Arc` so they can be logged from inside the
+        // `spawn_blocking` closure, where the parent tracing span context is lost.
+        let blob_id = *metadata.blob_id();
+
         tokio::task::spawn_blocking(move || {
             let mut final_error =
                 NodeError::other(ListAndVerifyRecoverySymbolsError::EmptyResponse);
 
             symbols.retain(|symbol| {
+                let symbol_id = symbol.id();
+                let proof_axis = symbol.proof_axis();
                 let _guard = tracing::info_span!(
                     "list_and_verify_recovery_symbols__retain",
-                    walrus.symbol.id = %symbol.id()
+                    walrus.symbol.id = %symbol_id
                 )
                 .entered();
 
                 if !filter.accepts(symbol) {
-                    tracing::warn!("server returned a symbol with an unrequested proof axis");
+                    tracing::warn!(
+                        walrus.blob_id = %blob_id,
+                        walrus.symbol.id = %symbol_id,
+                        walrus.symbol.proof_axis = ?proof_axis,
+                        walrus.target_index = %target_index,
+                        walrus.target_type = ?target_type,
+                        "server returned a symbol with an unrequested proof axis"
+                    );
                     return false;
                 }
 
@@ -671,7 +684,15 @@ impl StorageNodeClient {
                     target_index,
                     target_type,
                 ) {
-                    tracing::warn!(?error, "recovery symbol verification failed");
+                    tracing::warn!(
+                        ?error,
+                        walrus.blob_id = %blob_id,
+                        walrus.symbol.id = %symbol_id,
+                        walrus.symbol.proof_axis = ?proof_axis,
+                        walrus.target_index = %target_index,
+                        walrus.target_type = ?target_type,
+                        "recovery symbol verification failed"
+                    );
                     final_error = NodeError::other(error);
                     return false;
                 }


### PR DESCRIPTION
## Summary

- Add `walrus.blob_id`, `walrus.symbol.id`, `walrus.symbol.proof_axis`, `walrus.target_index`, and `walrus.target_type` directly to the WARN events emitted in `list_and_verify_recovery_symbols`.
- The blob id is captured before the `spawn_blocking` call because the parent tracing span context is dropped at the task boundary, which is why these failure logs currently only carry the inner symbol id and the Merkle error.

## Motivation

When a recovery symbol fails verification (for example `InvalidProof(RootMismatch)`), the current log line tells us the symbol's `(primary, secondary)` indices and the error variant, but **not** the blob it belongs to, the recovery target, or which axis the proof was constructed from. That makes it hard to attribute a failure to a specific blob / peer when triaging recovery noise from a node in `RecoveryInProgress`. With these fields the WARN line is self-sufficient for debugging.

## Test plan

- [x] `cargo check -p walrus-storage-node-client`
- [x] `cargo clippy -p walrus-storage-node-client --all-features --tests -- -D warnings`
- [x] Full pre-commit hook (cargo-fmt, cargo-test, clippy-with-tests, cargo-doc) passed locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)