### PR TITLE
ci: gate build_arm64 to network branch pushes

### DIFF
--- a/.github/workflows/trigger-artifacts-builds.yml
+++ b/.github/workflows/trigger-artifacts-builds.yml
@@ -28,7 +28,7 @@ jobs:
             {
               "walrus_commit": "${{ github.sha }}",
               "cache_family": "${{ github.ref_name }}",
-              "build_arm64": "true"
+              "build_arm64": "${{ github.ref_name == 'devnet' || github.ref_name == 'testnet' || github.ref_name == 'mainnet' }}"
             }
 
       # Branch-tag aliases + macos/windows tarballs. Release branches only.


### PR DESCRIPTION
## Summary

Change `.github/workflows/trigger-artifacts-builds.yml` so the `build_arm64` flag passed to `prebuild-walrus-images` is only `true` on pushes to `devnet`, `testnet`, or `mainnet`. Main and release-branch commits drop to amd64-only.

## Why

Today, every push that lands in main or in any `releases/walrus-*-release` branch dispatches the mp3 prebuild with `build_arm64: "true"` hardcoded, which fans out into:

- `walrus-service-arm64` image build (full cargo compile for three binaries)
- `walrus-upload-relay-arm64` image build
- arm64 binaries extracted to `gs://mysten-walrus-binaries/walrus-arm64/<sha>/` and `gs://mysten-walrus-binaries/signed-arm64/<sha>/`

From earlier mp3 prod sampling, **arm64 builds were ~28% of the last 100 walrus builds in a 7-day window**. None of those arm64 artifacts are actually consumed outside of release events — they're produced "in case" and then never used until a `devnet|testnet|mainnet` branch update or a GitHub release fires.

That's significant cumulative compute (each arm64 build = ~20m cold) and also added pressure on the `buildkitd-ss` pool (which my earlier mp3 audit found to be at `max=24` with 6 pending pods during peak hours, partly because arm64 builds bypass the stateful_pool allowlist and always run cold).

## The pattern matches sui

[`MystenLabs/sui/.github/workflows/pre-build-images.yml` line 31](https://github.com/MystenLabs/sui/blob/main/.github/workflows/pre-build-images.yml#L31) does exactly this:

```yaml
"build_arm64": "${{ github.ref_name == 'devnet' || github.ref_name == 'testnet' || github.ref_name == 'mainnet' }}",
```

Effect: sui only fires arm64 image+binary work on the three network branches, which is why my earlier 100-build sui sample showed 0% arm64 builds — they only happen on the rare network-branch tick. Walrus should behave the same.

## Files changed

- `.github/workflows/trigger-artifacts-builds.yml` — one-line change to the `build_arm64` value in the `client-payload` block.

## Not affected (intentionally)

- **`.github/workflows/attach-binaries-to-release.yml`** — still builds arm64 release artifacts (`ubuntu-arm64`, `macos-arm64`) on every release tag. This is the "GitHub release created" path the request specifically asked to preserve.
- **`.github/workflows/sccache-warmup.yml`** — separate scheduled warmup that still includes `ubuntu-arm64`. Out of scope; can be revisited if the arm64 sccache cache is no longer worth warming after this change reduces arm64 build frequency.
- **`prebuild-walrus-images.yml`** (in sui-operations) — already gates its arm64 matrix include on the `build_arm64` input, so this PR's payload change is the only edit needed; no sui-operations PR.
- **`walrus-staging-continuous.yaml`** (in sui-operations) — already passes `build_arm64: "false"` for release-branch CI, so already correct.

## Test plan

After merge, on the next main commit:

- [ ] `prebuild-walrus-images` dispatch should fire as usual.
- [ ] mp3 should NOT enqueue any arm64 walrus image builds for that SHA (verify by grepping image-builder logs for `build .*walrus.*linux/arm64`).
- [ ] A subsequent push to `devnet`, `testnet`, or `mainnet` should restore arm64 image builds.
- [ ] A GitHub release tag should still produce arm64 release binaries via `attach-binaries-to-release.yml`.

## Expected impact

- ~14 fewer cold arm64 walrus image builds per week (each ~20m of buildkit-ss compute).
- Reduced pressure on the `buildkitd-ss` pool during cron-driven main-branch CI runs.
- arm64 release binaries / images for `devnet|testnet|mainnet` and GitHub releases are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)