### PR TITLE
fix: ubuntu-aarch64 release artifact shipped x86_64 walrus binaries

### DIFF
--- a/.github/workflows/attach-binaries-to-release.yml
+++ b/.github/workflows/attach-binaries-to-release.yml
@@ -89,6 +89,7 @@ jobs:
         run: |
           export arch=$(uname -m)
           export os_type="windows-${arch}"
+          echo "arch=${arch}" >> $GITHUB_ENV
           echo "os_type=${os_type}" >> $GITHUB_ENV
           echo "extention=$(echo ".exe")" >> $GITHUB_ENV
 
@@ -99,6 +100,9 @@ jobs:
           export arch=$(uname -m)
           export system_os=$(echo ${{ matrix.os }} | cut -d- -f1)
           export os_type="${system_os}-${arch}"
+          # arch must be persisted: the Linux GCS-prefix step below reads it to
+          # choose walrus-arm64/ vs walrus/. os_type alone is not enough.
+          echo "arch=${arch}" >> $GITHUB_ENV
           echo "os_type=${system_os}-${arch}" >> $GITHUB_ENV
 
       - name: Check if tar balls have been uploaded already
@@ -142,9 +146,13 @@ jobs:
           mkdir -p ${{ env.TMP_BUILD_DIR }} ./tmp
           [ ! -f ${{ env.BINARY_LIST_FILE }} ] && echo "${{ env.BINARY_LIST_FILE }} cannot be found" && exit 1
 
+          # Fail closed on an unexpected/empty arch rather than defaulting to the
+          # amd64 prefix — a silent fallthrough here shipped x86_64 binaries inside
+          # the ubuntu-aarch64 archive (testnet-v1.49.1).
           case "${arch}" in
             aarch64|arm64) gcs_prefix="gs://mysten-walrus-binaries/walrus-arm64/${walrus_sha}" ;;
-            *)             gcs_prefix="gs://mysten-walrus-binaries/walrus/${walrus_sha}" ;;
+            x86_64|amd64)  gcs_prefix="gs://mysten-walrus-binaries/walrus/${walrus_sha}" ;;
+            *) echo "::error::Unexpected or empty arch '${arch}' — refusing to guess the GCS prefix"; exit 1 ;;
           esac
 
           missing=()


### PR DESCRIPTION
## Problem

The `walrus-<net>-vX.Y.Z-ubuntu-aarch64.tgz` release artifact contains **x86_64** binaries, not aarch64. Reported for [`testnet-v1.49.1`](https://github.com/MystenLabs/walrus/releases/tag/testnet-v1.49.1).

Verified three ways:
- `file` on the shipped `ubuntu-aarch64.tgz` binaries → all `ELF … x86-64`.
- sha256 of the shipped aarch64 `walrus` (`a013b5eb…`) is **byte-identical to the amd64 GCS binary** `walrus/<sha>/walrus`; the correct arm64 binary (`cd9bce74…`, `ELF … ARM aarch64`) sat **unused** at `walrus-arm64/<sha>/`.
- The `ubuntu-arm64` job log shows it downloaded `gs://mysten-walrus-binaries/walrus/<sha>/…` (the amd64 prefix).

## Root cause

In **"Set os/arch variables"**, `arch` is only a shell `export` — just `os_type` is written to `$GITHUB_ENV`. The later **"Download prebuilt binaries from GCS (Linux)"** step keys its prefix on `${arch}`:

```bash
case "${arch}" in
  aarch64|arm64) gcs_prefix=".../walrus-arm64/${walrus_sha}" ;;
  *)             gcs_prefix=".../walrus/${walrus_sha}" ;;   # amd64
esac
```

`${arch}` is **empty** in that step (never persisted across steps), so the `case` falls through to the amd64 default. This affects **every** `ubuntu-aarch64` release built through this path. (macOS arm64 is unaffected — it builds natively via cargo; the per-`<sha>` arm64 binaries in GCS are correct, just weren't selected.)

## Fix

- Persist `arch` to `$GITHUB_ENV` in both os/arch steps so the GCS-prefix step actually sees it.
- Make the `case` **fail closed** on an unexpected/empty arch instead of silently defaulting to the amd64 prefix — so a regression like this errors loudly rather than shipping the wrong architecture.

## Test plan

- `actionlint` clean on the change (pre-existing warnings only: custom `ubuntu-ghcloud`/`ubuntu-arm64` runner labels and an unrelated SC2086 on the tag-validate step).
- Post-merge validation: re-run `attach-binaries-to-release.yml` via `workflow_dispatch` for a tag and confirm the `ubuntu-aarch64` job logs `…/walrus-arm64/<sha>/…` and `file` reports `ARM aarch64` for the packaged binaries.

## Remediation (separate from this fix)

The already-published `testnet-v1.49.1` (and prior) `ubuntu-aarch64` artifacts need re-attaching with the correct arm64 binaries — handled out of band once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)