### PR TITLE
chore: default WALRUS_GRPC_MIGRATION_LEVEL to 100

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -199,19 +199,19 @@ jobs:
           gcp_credentials_json: ${{ secrets.GCP_WALRUS_RELEASE_BUCKET_SVCUSER_CREDENTIALS }}
 
       - run: ./scripts/simtest/install.sh
-      - name: Run tests (seed=1)
-        run: MSIM_TEST_SEED=1 cargo simtest simtest --profile simtest
-      - name: Run tests (seed=2, grpc-client-enabled)
-        run: MSIM_TEST_SEED=2 WALRUS_GRPC_MIGRATION_LEVEL=100 cargo simtest simtest --profile simtest
-      - name: Run tests (seed=3)
+      - name: Run tests (seed=1, legacy json-rpc)
+        run: MSIM_TEST_SEED=1 WALRUS_GRPC_MIGRATION_LEVEL=0 cargo simtest simtest --profile simtest
+      - name: Run tests (seed=2)
+        run: MSIM_TEST_SEED=2 cargo simtest simtest --profile simtest
+      - name: Run tests (seed=3, legacy json-rpc)
         if: env.SIMTEST_REDUCED != 'true'
-        run: MSIM_TEST_SEED=3 cargo simtest simtest --profile simtest
-      - name: Run tests (seed=4, grpc-client-enabled)
+        run: MSIM_TEST_SEED=3 WALRUS_GRPC_MIGRATION_LEVEL=0 cargo simtest simtest --profile simtest
+      - name: Run tests (seed=4)
         if: env.SIMTEST_REDUCED != 'true'
-        run: MSIM_TEST_SEED=4 WALRUS_GRPC_MIGRATION_LEVEL=100 cargo simtest simtest --profile simtest
-      - name: Run tests (seed=5, grpc-client-enabled)
+        run: MSIM_TEST_SEED=4 cargo simtest simtest --profile simtest
+      - name: Run tests (seed=5)
         if: env.SIMTEST_REDUCED != 'true'
-        run: MSIM_TEST_SEED=5 WALRUS_GRPC_MIGRATION_LEVEL=100 cargo simtest simtest --profile simtest
+        run: MSIM_TEST_SEED=5 cargo simtest simtest --profile simtest
 
   simtests-build:
     name: Build all simtests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ MSIM_TEST_SEED=1 cargo simtest simtest <test_name> --profile simtest
 ./scripts/run-all-simtests.sh
 ```
 
-Key env vars: `MSIM_TEST_SEED` (default: 1), `WALRUS_GRPC_MIGRATION_LEVEL` (0 or 100).
+Key env vars: `MSIM_TEST_SEED` (default: 1), `WALRUS_GRPC_MIGRATION_LEVEL` (default: 100; set to 0 for legacy JSON-RPC).
 
 ### Move Contracts
 

--- a/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
@@ -218,7 +218,7 @@ pub struct GasBudgetAndPrice {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd)]
 pub struct GrpcMigrationLevel(u32);
 
-const GRPC_MIGRATION_LEVEL_LEGACY_U32: u32 = 0;
+const GRPC_MIGRATION_LEVEL_DEFAULT_U32: u32 = 100;
 const GRPC_MIGRATION_LEVEL_GET_OBJECT: GrpcMigrationLevel = GrpcMigrationLevel(1);
 const GRPC_MIGRATION_LEVEL_BATCH_OBJECTS: GrpcMigrationLevel = GrpcMigrationLevel(2);
 const GRPC_MIGRATION_LEVEL_SELECT_COINS: GrpcMigrationLevel = GrpcMigrationLevel(3);
@@ -235,7 +235,7 @@ impl Default for GrpcMigrationLevel {
             std::env::var("WALRUS_GRPC_MIGRATION_LEVEL")
                 .ok()
                 .and_then(|v| v.parse().ok())
-                .unwrap_or(GRPC_MIGRATION_LEVEL_LEGACY_U32)
+                .unwrap_or(GRPC_MIGRATION_LEVEL_DEFAULT_U32)
         });
         Self(*VALUE)
     }


### PR DESCRIPTION
> Stacked on #3405 — merge that first.

## Summary

- Switch the `WALRUS_GRPC_MIGRATION_LEVEL` default from `0` (legacy JSON-RPC) to `100` (fully migrated) so every binary that builds a `RetriableSuiClient` without setting the env var runs gRPC. Renamed the source-of-truth constant `GRPC_MIGRATION_LEVEL_LEGACY_U32` → `GRPC_MIGRATION_LEVEL_DEFAULT_U32` in `crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs`.
- Updated `CLAUDE.md` env var note to document `100` as the default.
- Adjusted the simtests workflow to preserve the existing legacy/gRPC seed mix: dropped the now-redundant `WALRUS_GRPC_MIGRATION_LEVEL=100` on seeds 2/4/5, pinned seeds 1/3 to `WALRUS_GRPC_MIGRATION_LEVEL=0`.
- Left the `grpc_migration_level: [0, 100]` test matrix alone — open question whether to narrow it (e.g., move `0` to a nightly job) since the legacy path is still wired.

## Test plan

- [x] `cargo clippy --workspace --all-features --tests -- -D warnings` clean
- [x] `cargo nextest run` — 1099 tests passed, 110 skipped
- [ ] CI simtest seeds 1 (legacy), 2 (default gRPC), 3 (legacy), 4 (default gRPC), 5 (default gRPC)
- [ ] CI matrix at `WALRUS_GRPC_MIGRATION_LEVEL={0, 100}` for the rust-tests job