### PR TITLE
feat: checkpoint node recovery progress to skip rescans on restart

### DIFF
--- a/crates/walrus-service/node_config_example.yaml
+++ b/crates/walrus-service/node_config_example.yaml
@@ -73,6 +73,7 @@ db_config:
     pin_l0_filter_and_index_blocks_in_block_cache: true
     hard_pending_compaction_bytes_limit: 0
   node_status: null
+  node_recovery_progress: null
   garbage_collector: null
   blob_info: null
   per_object_blob_info: null
@@ -238,6 +239,7 @@ checkpoint_config:
 admin_socket_path: null
 node_recovery_config:
   max_concurrent_blob_syncs_during_recovery: 1000
+  checkpoint_persist_interval: 1000
 blob_event_processor_config:
   num_workers: 10
 garbage_collection:

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -2967,7 +2967,7 @@ impl StorageNodeInner {
     }
 
     #[tracing::instrument(skip_all)]
-    async fn is_stored_at_specific_shards(
+    pub(crate) async fn is_stored_at_specific_shards(
         &self,
         blob_id: &BlobId,
         shards: &[ShardIndex],

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -1244,12 +1244,16 @@ pub struct NodeRecoveryConfig {
     /// Different from `BlobRecoveryConfig::max_concurrent_blob_syncs`, this is to control the
     /// number of blob recover tasks initiated by node recovery logic.
     pub max_concurrent_blob_syncs_during_recovery: usize,
+    /// Persist the recovery checkpoint after this many blob_ids of settled-progress have
+    /// advanced since the last persist. Bounds the worst-case rescan after a crash.
+    pub checkpoint_persist_interval: u64,
 }
 
 impl Default for NodeRecoveryConfig {
     fn default() -> Self {
         Self {
             max_concurrent_blob_syncs_during_recovery: 1000,
+            checkpoint_persist_interval: 1000,
         }
     }
 }

--- a/crates/walrus-service/src/node/node_recovery.rs
+++ b/crates/walrus-service/src/node/node_recovery.rs
@@ -1,31 +1,73 @@
 // Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    ops::Bound,
+    pin::Pin,
+    sync::Arc,
+    time::Duration,
+};
 
-use futures::stream::{FuturesUnordered, StreamExt};
+use futures::{StreamExt, future::BoxFuture, stream::FuturesUnordered};
+use serde::{Deserialize, Serialize};
 use sui_macros::fail_point_async;
-use tokio::sync::Mutex;
+use tokio::{sync::Mutex, time::Instant};
 use typed_store::TypedStoreError;
-use walrus_core::Epoch;
+use walrus_core::{BlobId, Epoch, ShardIndex};
 
 use super::{
     StorageNodeInner,
-    blob_sync::{BlobSyncHandler, SyncStatus},
+    blob_sync::{BlobSyncHandler, SyncOutcome, SyncStatus},
     config::NodeRecoveryConfig,
 };
 use crate::node::{NodeStatus, storage::blob_info::CertifiedBlobInfoApi};
+
+const RETRY_BACKOFF_INITIAL: Duration = Duration::from_secs(1);
+const RETRY_BACKOFF_MAX: Duration = Duration::from_secs(30);
+
+/// Persisted progress of an in-flight node recovery.
+///
+/// Snapshotted at recovery task start and updated as the scan settles blobs. On crash and
+/// restart, the next recovery task resumes from `last_settled_blob_id` if `owned_shards`
+/// matches the current owned-shards set (otherwise the checkpoint is discarded — see
+/// [`NodeRecoveryHandler::start_node_recovery`]).
+// Important: this struct is committed to database. Do not modify the existing fields. Only add
+// new fields at the end with `#[serde(default)]`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NodeRecoveryProgress {
+    /// The `certified_before_epoch` argument that the recovery task was started with.
+    pub epoch: Epoch,
+    /// The set of shards owned by the node at the moment the checkpoint was written.
+    pub owned_shards: BTreeSet<ShardIndex>,
+    /// All blobs with `blob_id <= last_settled_blob_id` have been observed in a scan as either
+    /// stored at all owned shards or no longer certified.
+    pub last_settled_blob_id: BlobId,
+}
 
 #[derive(Debug, Clone)]
 pub struct NodeRecoveryHandler {
     node: Arc<StorageNodeInner>,
     blob_sync_handler: Arc<BlobSyncHandler>,
 
-    // There can be at most one background shard removal task at a time.
+    // There can be at most one background recovery task at a time.
     task_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
 
-    // Configuration for node recovery.
     config: NodeRecoveryConfig,
+}
+
+/// Result of awaiting a single blob's sync watch channel.
+#[derive(Debug)]
+enum BlobSyncResult {
+    /// The blob is stored at all currently-owned shards (or was already, or an inconsistency
+    /// proof was filed).
+    Success(BlobId),
+    /// The blob's sync was cancelled — typically because the blob expired during the sync.
+    /// The recovery loop must re-check whether the blob is still certified or stored.
+    Cancelled(BlobId),
+    /// The sync was skipped because the node entered `RecoveryCatchUp` before the sync ran.
+    /// Recovery cannot make further progress and must bail out.
+    Skipped(BlobId),
 }
 
 impl NodeRecoveryHandler {
@@ -42,30 +84,59 @@ impl NodeRecoveryHandler {
         }
     }
 
-    /// Starts the node recovery process to recover blobs that are certified before the given epoch.
-    /// For blobs that are certified after `certified_before_epoch`, the event processing is in
-    /// charge of making sure the blob is stored at all shards.
+    /// Starts the node recovery process to recover blobs that are certified before the given
+    /// epoch. For blobs that are certified at or after `certified_before_epoch`, the event
+    /// processing path is in charge of making sure the blob is stored at all owned shards.
     ///
     /// Any existing recovery task will be canceled.
-    // TODO(WAL-864): Refactor this function to make it readable.
+    ///
+    /// # Checkpoint resume semantics
+    ///
+    /// Recovery persists a [`NodeRecoveryProgress`] checkpoint as the scan settles blobs, so
+    /// a crash mid-recovery does not force a rescan from the first blob.
+    ///
+    /// On entry, the persisted checkpoint is kept (and the scan resumes from
+    /// `last_settled_blob_id`) iff the node's currently-owned shard set equals
+    /// `checkpoint.owned_shards`. Otherwise the checkpoint is deleted and the scan restarts
+    /// from `Unbounded`. We deliberately do *not* gate the resume on the epoch matching.
+    ///
+    /// The invariant maintained for every settled blob_id is: "at scan time the blob was
+    /// either stored at all currently-owned shards, or not currently certified". This holds
+    /// across `certified_before_epoch` increases without rescanning because:
+    ///
+    /// 1. **New certifications during recovery** have `initial_certified_epoch >=
+    ///    certified_before_epoch_old` and are filtered out of the recovery iterator entirely;
+    ///    they're driven by the event-processing path
+    ///    (`BlobEventProcessor::process_blob_certified_event`), which calls `start_sync`
+    ///    independently. The `is_catching_up()` skip there does not fire during
+    ///    `RecoveryInProgress`, so this path is active throughout node recovery.
+    ///
+    /// 2. **Re-certifications of previously-uncertified blobs** also emit a `BlobCertified`
+    ///    event, handled the same way by event processing.
+    ///
+    /// 3. **Data on currently-owned shards is never wiped while owned**. Only shards listed
+    ///    in `shards_to_remove` (no longer owned) have their data deleted. Garbage collection
+    ///    only removes data for expired (uncertified) blobs, which still satisfies the
+    ///    invariant via the "not currently certified" clause.
+    ///
+    /// 4. **Shard ownership changes** break the invariant: a previously-acquired new shard is
+    ///    empty, and a removed-then-regained shard had its data wiped. The owned-shards
+    ///    equality check at task start catches this and discards the checkpoint.
     pub async fn start_node_recovery(
         &self,
         certified_before_epoch: Epoch,
     ) -> Result<(), TypedStoreError> {
         let mut locked_task_handle = self.task_handle.lock().await;
 
-        // Cancel any existing recovery task
         if let Some(old_task) = locked_task_handle.take() {
             tracing::info!("canceling existing node recovery task");
             old_task.abort();
-            // Wait for the old task to complete (it will return a JoinError due to cancellation)
             let _ = old_task.await;
         }
 
         let node = self.node.clone();
         let blob_sync_handler = self.blob_sync_handler.clone();
-        let max_concurrent_blob_syncs_during_recovery =
-            self.config.max_concurrent_blob_syncs_during_recovery;
+        let config = self.config.clone();
         let task_handle = tokio::spawn(async move {
             tracing::info!("waiting for latest event epoch to be set to restart node recovery");
             // When current_event_epoch() returns during node start up, if the node is lagging
@@ -82,207 +153,719 @@ impl NodeRecoveryHandler {
 
             fail_point_async!("start_node_recovery_entry");
 
-            loop {
-                // Node can enter recovery catch up mode while recovery is in progress. In this
-                // case, we should skip recovery. Once the node is caught up to the latest epoch,
-                // the recovery task will be restarted.
-                if node
-                    .storage
-                    .node_status()
-                    .expect("reading node status should not fail")
-                    .is_catching_up()
-                {
-                    tracing::info!(
-                        "node recovery encountered node is in catching up; skip recovery"
-                    );
-                    return;
-                }
-
-                // Keep track of ongoing blob syncs. Note that the memory usage of this list
-                // is capped by `max_concurrent_blob_syncs_during_recovery`.
-                let mut ongoing_syncs = FuturesUnordered::new();
-
-                // Keep track of whether there are more blobs to recover.
-                let mut has_more_blobs = false;
-                tracing::info!(
-                    "scanning blobs to recover certified blobs before epoch {}",
-                    certified_before_epoch
-                );
-                for (blob_id, blob_info) in node
-                    .storage
-                    .certified_blob_info_iter_before_epoch(certified_before_epoch)
-                    .filter_map(|blob_result| {
-                        blob_result
-                            .inspect_err(|error| {
-                                tracing::error!(?error, "failed to read certified blob")
-                            })
-                            .ok()
-                    })
-                {
-                    node.metrics
-                        .node_recovery_recover_blob_progress
-                        .set(i64::from(blob_id.first_two_bytes()));
-
-                    // Note that here we need to use the current epoch to check if the blob is
-                    // still certified. If the blob is retired, we don't need to recover it anymore.
-                    if !blob_info.is_certified(node.current_committee_epoch()) {
-                        // Skip blobs that are not certified in the given epoch. This
-                        // includes blobs that are invalid or expired.
-                        tracing::debug!(
-                            walrus.blob_id = %blob_id,
-                            walrus.blob_certified_before_epoch = certified_before_epoch,
-                            walrus.current_epoch = node.current_committee_epoch(),
-                            "skip non-certified blob"
-                        );
-                        continue;
-                    }
-
-                    // The node will only enter recovery mode if it has caught up to the latest
-                    // epoch. So we only need to check the latest epoch for the shard assignment.
-                    if let Ok(stored_at_all_shards) =
-                        node.is_stored_at_all_shards_at_latest_epoch(&blob_id).await
-                    {
-                        if stored_at_all_shards {
-                            tracing::debug!(
-                                walrus.blob_certified_before_epoch = certified_before_epoch,
-                                walrus.current_epoch = node.current_committee_epoch(),
-                                "blob is stored at all shards; skip recovery"
-                            );
-                            continue;
-                        }
-                    } else {
-                        tracing::warn!(
-                            walrus.blob_id = %blob_id,
-                            "failed to check if blob is stored at all shards; start blob sync"
-                        );
-                    }
-
-                    // There are more blobs to recover.
-                    has_more_blobs = true;
-
-                    // Limit the number of concurrent blob syncs to avoid overwhelming the system.
-                    // Note that checking the length of `ongoing_syncs` is sufficient since the loop
-                    // adds blob sync tasks sequentially.
-                    if ongoing_syncs.len() >= max_concurrent_blob_syncs_during_recovery {
-                        tracing::debug!(
-                            walrus.blob_id = %blob_id,
-                            number_of_tasks = %ongoing_syncs.len(),
-                            "max concurrent blob syncs reached; wait for one to complete"
-                        );
-                        while ongoing_syncs.len() >= max_concurrent_blob_syncs_during_recovery {
-                            ongoing_syncs.next().await;
-                        }
-
-                        // Since there is a wait, the blob might not be certified anymore. Check
-                        // again before starting the sync.
-                        if !blob_info.is_certified(node.current_committee_epoch()) {
-                            // Skip blobs that are not certified in the given epoch. This
-                            // includes blobs that are invalid or expired.
-                            tracing::debug!(
-                                walrus.blob_id = %blob_id,
-                                walrus.blob_certified_before_epoch = certified_before_epoch,
-                                walrus.current_epoch = node.current_committee_epoch(),
-                                "skip non-certified blob, post concurrency limit wait"
-                            );
-                            continue;
-                        }
-                    }
-
-                    tracing::debug!(
-                        walrus.blob_id = %blob_id,
-                        recoverying_epoch = certified_before_epoch,
-                        "start recovery sync for blob"
-                    );
-                    node.metrics.node_recovery_ongoing_blob_syncs.inc();
-                    let start_sync_result = blob_sync_handler
-                        .start_sync(
-                            blob_id,
-                            blob_info.initial_certified_epoch().expect(
-                                "certified blob should have an initial certified epoch set",
-                            ),
-                            None,
-                        )
-                        .await;
-                    sui_macros::fail_point!("fail_point_node_recovery_start_sync");
-                    match start_sync_result {
-                        Ok(mut receiver) => {
-                            let node_clone = node.clone();
-                            // Create a future that releases the permit when the sync completes
-                            let notify_with_permit = async move {
-                                // We don't care about the outcome here — this loop re-scans
-                                // and re-evaluates whether the blob still needs recovery.
-                                let _ = receiver
-                                    .wait_for(|status| matches!(status, SyncStatus::Done(_)))
-                                    .await;
-                                node_clone.metrics.node_recovery_ongoing_blob_syncs.dec();
-                            };
-                            ongoing_syncs.push(notify_with_permit);
-                        }
-                        Err(err) => {
-                            // The only place where start_sync can fail is when marking the
-                            // event complete, which is not applicable here since the there
-                            // is no event associated with the recovery task.
-                            panic!("failed to start recovery sync for blob {blob_id}: {err}",);
-                        }
-                    }
-                }
-
-                if !has_more_blobs {
-                    tracing::info!("no recovery blob found; stop recovery task");
-                    break;
-                }
-
-                // Wait for all ongoing syncs to complete
-                while (ongoing_syncs.next().await).is_some() {
-                    // Each sync completion automatically releases its permit
-                }
-
-                // TODO(WAL-669): right now, we have to do one more loop to check if all the blobs
-                // are recovered. This is not efficient because checking blob existence is
-                // expensive. It's better that blob sync handler can return the blob sync status
-                // and we can avoid the extra loop of all the blob syncs finished successfully.
-            }
-
-            let current_node_status = node
-                .storage
-                .node_status()
-                .expect("reading node status should not fail");
-            if current_node_status == NodeStatus::RecoveryInProgress(certified_before_epoch) {
-                tracing::info!("node recovery task finished; set node status to active");
-                match node.set_node_status(NodeStatus::Active) {
-                    Ok(()) => {
-                        node.contract_service
-                            .epoch_sync_done(certified_before_epoch, node.node_capability())
-                            .await
-                    }
-                    Err(error) => {
-                        tracing::error!(?error, "failed to set node status to active");
-                    }
-                }
-            } else {
-                tracing::warn!(
-                    node_status = %current_node_status,
-                    "node recovery task finished; but node status is not RecoveryInProgress; \
-                    skip setting node status to active"
-                );
-            }
+            RecoveryPass::new(node, blob_sync_handler, certified_before_epoch, config)
+                .run()
+                .await;
         });
         *locked_task_handle = Some(task_handle);
 
         Ok(())
     }
 
-    /// Restarts any in progress recovery.
+    /// Restarts any in-progress recovery.
     pub async fn restart_recovery(&self) -> anyhow::Result<()> {
         if let NodeStatus::RecoveryInProgress(recovering_epoch) = self.node.storage.node_status()? {
             tracing::info!(
                 "restarting node recovery to recover to the epoch {}",
                 recovering_epoch
             );
-
             self.start_node_recovery(recovering_epoch).await?;
         }
-
         Ok(())
+    }
+}
+
+/// Encapsulates the state of one recovery task run. A single pass over the certified-blob
+/// iterator (from the resume bound to the end), driving syncs concurrently and persisting
+/// checkpoints as blobs settle.
+struct RecoveryPass {
+    node: Arc<StorageNodeInner>,
+    blob_sync_handler: Arc<BlobSyncHandler>,
+    certified_before_epoch: Epoch,
+    /// Snapshot of shards owned at task start. Used consistently throughout the run for both
+    /// the "is stored at all shards" check and the checkpoint's `owned_shards` field. Any
+    /// epoch change that mutates this set re-invokes `start_node_recovery` (aborting this
+    /// task); the next task's owned-shards equality check will then discard the checkpoint.
+    owned_shards: BTreeSet<ShardIndex>,
+    owned_shards_vec: Vec<ShardIndex>,
+    config: NodeRecoveryConfig,
+
+    /// Blobs whose sync watch we are still awaiting.
+    in_flight_blob_ids: BTreeSet<BlobId>,
+    /// Blobs whose sync ended with Cancelled, awaiting the next retry attempt.
+    retry_pending: BTreeMap<BlobId, Instant>,
+    /// Backoff currently applied to each retry-pending blob (doubled on each consecutive
+    /// failure, capped at `RETRY_BACKOFF_MAX`).
+    retry_backoff: BTreeMap<BlobId, Duration>,
+
+    /// Highest blob_id known to be settled and safe to checkpoint past (assuming no smaller
+    /// blob is in flight or pending retry).
+    last_settled_blob_id: Option<BlobId>,
+    /// The most recent value persisted via `set_node_recovery_progress`, used to decide when
+    /// the next persist is due.
+    last_persisted_blob_id: Option<BlobId>,
+    /// Most recent blob_id yielded by the scan iterator.
+    scan_pos: Option<BlobId>,
+}
+
+impl RecoveryPass {
+    fn new(
+        node: Arc<StorageNodeInner>,
+        blob_sync_handler: Arc<BlobSyncHandler>,
+        certified_before_epoch: Epoch,
+        config: NodeRecoveryConfig,
+    ) -> Self {
+        let owned_shards_vec = node.owned_shards_at_latest_epoch();
+        let owned_shards = owned_shards_vec.iter().copied().collect();
+        Self {
+            node,
+            blob_sync_handler,
+            certified_before_epoch,
+            owned_shards,
+            owned_shards_vec,
+            config,
+            in_flight_blob_ids: BTreeSet::new(),
+            retry_pending: BTreeMap::new(),
+            retry_backoff: BTreeMap::new(),
+            last_settled_blob_id: None,
+            last_persisted_blob_id: None,
+            scan_pos: None,
+        }
+    }
+
+    async fn run(mut self) {
+        let resume_bound = self.load_or_reset_checkpoint();
+        self.last_persisted_blob_id = match resume_bound {
+            Bound::Excluded(id) => Some(id),
+            _ => None,
+        };
+        self.scan_pos = self.last_persisted_blob_id;
+
+        if self.is_catching_up() {
+            tracing::info!("node recovery encountered node is in catching up; skip recovery");
+            return;
+        }
+
+        tracing::info!(
+            "scanning blobs to recover certified blobs before epoch {}",
+            self.certified_before_epoch
+        );
+
+        // Hold the iterator's backing storage in a separate Arc clone so the iterator's
+        // borrow is on `node_for_iter.storage`, not on `self.node.storage` — that lets us
+        // mutably borrow `self` inside the loop body.
+        let node_for_iter = self.node.clone();
+        let iter = node_for_iter
+            .storage
+            .certified_blob_info_iter_before_epoch_from(self.certified_before_epoch, resume_bound);
+        let mut iter = iter.filter_map(|res| match res {
+            Ok(pair) => Some(pair),
+            Err(error) => {
+                tracing::error!(?error, "failed to read certified blob during scan");
+                None
+            }
+        });
+
+        let mut ongoing_syncs: FuturesUnordered<BoxFuture<'static, BlobSyncResult>> =
+            FuturesUnordered::new();
+        let mut scan_done = false;
+        let mut aborted = false;
+
+        while !aborted {
+            // Drain any ready completions before doing more work.
+            while let Some(result) = poll_ready(&mut ongoing_syncs) {
+                if self.handle_sync_result(result).await {
+                    aborted = true;
+                    break;
+                }
+            }
+            if aborted {
+                break;
+            }
+
+            // Issue retries whose backoff has elapsed.
+            self.poll_due_retries(&mut ongoing_syncs).await;
+
+            // Pull more blobs from the scan to fill the in-flight pool.
+            while !scan_done
+                && ongoing_syncs.len() < self.config.max_concurrent_blob_syncs_during_recovery
+            {
+                match iter.next() {
+                    Some((blob_id, blob_info)) => {
+                        self.scan_pos = Some(blob_id);
+                        self.node
+                            .metrics
+                            .node_recovery_recover_blob_progress
+                            .set(i64::from(blob_id.first_two_bytes()));
+
+                        let is_certified =
+                            blob_info.is_certified(self.node.current_committee_epoch());
+                        if !is_certified || self.is_stored_at_owned_shards(&blob_id).await {
+                            self.advance_settled(blob_id);
+                        } else {
+                            self.in_flight_blob_ids.insert(blob_id);
+                            self.node.metrics.node_recovery_ongoing_blob_syncs.inc();
+                            self.spawn_sync(
+                                blob_id,
+                                blob_info.initial_certified_epoch().expect(
+                                    "certified blob should have an initial certified epoch set",
+                                ),
+                                &mut ongoing_syncs,
+                            )
+                            .await;
+                        }
+                    }
+                    None => scan_done = true,
+                }
+            }
+
+            self.maybe_persist_checkpoint();
+
+            // Termination: scan exhausted, no in-flight syncs, no retries pending.
+            if scan_done && ongoing_syncs.is_empty() && self.retry_pending.is_empty() {
+                break;
+            }
+
+            // Wait for the next event: a sync completion or a retry becoming due.
+            let next_retry_deadline = self.retry_pending.values().min().copied();
+            tokio::select! {
+                Some(result) = ongoing_syncs.next(), if !ongoing_syncs.is_empty() => {
+                    if self.handle_sync_result(result).await {
+                        aborted = true;
+                    }
+                }
+                _ = sleep_until_opt(next_retry_deadline), if next_retry_deadline.is_some() => {}
+                // If neither arm is active (no ongoing syncs and no retries), the loop will
+                // exit via the termination check above on the next iteration — but we still
+                // need to make progress, so fall through with a yield.
+                else => {
+                    tokio::task::yield_now().await;
+                }
+            }
+
+            if self.is_catching_up() {
+                tracing::info!("node entered catching-up state mid-recovery; aborting");
+                aborted = true;
+            }
+        }
+
+        self.finalize(aborted).await;
+    }
+
+    /// Decides the resume bound based on the persisted checkpoint and current owned shards.
+    /// Discards the checkpoint if owned shards have changed.
+    fn load_or_reset_checkpoint(&self) -> Bound<BlobId> {
+        let progress = self
+            .node
+            .storage
+            .get_node_recovery_progress()
+            .unwrap_or_else(|error| {
+                tracing::error!(
+                    ?error,
+                    "failed to read node recovery checkpoint; starting from the beginning"
+                );
+                None
+            });
+        let decision = resume_decision(progress.as_ref(), &self.owned_shards);
+        match &decision {
+            ResumeDecision::Resume(blob_id) => {
+                tracing::info!(
+                    last_settled_blob_id = %blob_id,
+                    "resuming node recovery from persisted checkpoint"
+                );
+                sui_macros::fail_point!("fail_point_node_recovery_resumed_from_checkpoint");
+            }
+            ResumeDecision::Reset {
+                had_checkpoint: true,
+            } => {
+                tracing::info!(
+                    "discarding node recovery checkpoint: owned shards have changed since \
+                    it was written"
+                );
+                if let Err(error) = self.node.storage.clear_node_recovery_progress() {
+                    tracing::error!(?error, "failed to clear stale node recovery checkpoint");
+                }
+            }
+            ResumeDecision::Reset {
+                had_checkpoint: false,
+            } => {}
+        }
+        match decision {
+            ResumeDecision::Resume(blob_id) => Bound::Excluded(blob_id),
+            ResumeDecision::Reset { .. } => Bound::Unbounded,
+        }
+    }
+
+    fn is_catching_up(&self) -> bool {
+        self.node
+            .storage
+            .node_status()
+            .expect("reading node status should not fail")
+            .is_catching_up()
+    }
+
+    /// Returns the highest blob_id that is safe to checkpoint right now: bounded above by
+    /// the smallest in-flight or retry-pending blob.
+    fn eligible_checkpoint(&self) -> Option<BlobId> {
+        let smallest_unfinished = self
+            .in_flight_blob_ids
+            .iter()
+            .next()
+            .copied()
+            .into_iter()
+            .chain(self.retry_pending.keys().next().copied())
+            .min();
+        match smallest_unfinished {
+            Some(_) => self.last_settled_blob_id,
+            None => self.scan_pos.or(self.last_settled_blob_id),
+        }
+    }
+
+    /// Advances `last_settled_blob_id` to `blob_id` if doing so does not jump past any blob
+    /// still in flight or pending retry.
+    fn advance_settled(&mut self, blob_id: BlobId) {
+        let blocked = self
+            .in_flight_blob_ids
+            .iter()
+            .next()
+            .copied()
+            .into_iter()
+            .chain(self.retry_pending.keys().next().copied())
+            .min()
+            .is_some_and(|smallest| smallest < blob_id);
+        if blocked {
+            return;
+        }
+        match self.last_settled_blob_id {
+            None => self.last_settled_blob_id = Some(blob_id),
+            Some(current) if blob_id > current => self.last_settled_blob_id = Some(blob_id),
+            _ => {}
+        }
+    }
+
+    fn maybe_persist_checkpoint(&mut self) {
+        let Some(candidate) = self.eligible_checkpoint() else {
+            return;
+        };
+        let advance_blobs = match self.last_persisted_blob_id {
+            None => u64::MAX, // first persist is always allowed
+            Some(prev) if candidate > prev => blob_id_distance(prev, candidate),
+            _ => return,
+        };
+        if advance_blobs < self.config.checkpoint_persist_interval {
+            return;
+        }
+        let progress = NodeRecoveryProgress {
+            epoch: self.certified_before_epoch,
+            owned_shards: self.owned_shards.clone(),
+            last_settled_blob_id: candidate,
+        };
+        if let Err(error) = self.node.storage.set_node_recovery_progress(&progress) {
+            tracing::error!(?error, "failed to persist node recovery checkpoint");
+            return;
+        }
+        self.last_persisted_blob_id = Some(candidate);
+    }
+
+    async fn is_stored_at_owned_shards(&self, blob_id: &BlobId) -> bool {
+        match self
+            .node
+            .is_stored_at_specific_shards(blob_id, &self.owned_shards_vec)
+            .await
+        {
+            Ok(stored) => stored,
+            Err(error) => {
+                tracing::warn!(
+                    walrus.blob_id = %blob_id,
+                    ?error,
+                    "failed to check if blob is stored at owned shards; will start blob sync"
+                );
+                false
+            }
+        }
+    }
+
+    fn is_blob_still_certified(&self, blob_id: &BlobId) -> bool {
+        match self.node.storage.get_blob_info(blob_id) {
+            Ok(Some(info)) => info.is_certified(self.node.current_committee_epoch()),
+            _ => false,
+        }
+    }
+
+    async fn spawn_sync(
+        &self,
+        blob_id: BlobId,
+        certified_epoch: Epoch,
+        ongoing_syncs: &mut FuturesUnordered<BoxFuture<'static, BlobSyncResult>>,
+    ) {
+        tracing::debug!(walrus.blob_id = %blob_id, "start recovery sync for blob");
+        let start_sync_result = self
+            .blob_sync_handler
+            .start_sync(blob_id, certified_epoch, None)
+            .await;
+        sui_macros::fail_point!("fail_point_node_recovery_start_sync");
+        match start_sync_result {
+            Ok(mut receiver) => {
+                let fut: BoxFuture<'static, BlobSyncResult> = Box::pin(async move {
+                    let outcome = match receiver
+                        .wait_for(|status| matches!(status, SyncStatus::Done(_)))
+                        .await
+                    {
+                        Ok(guard) => match &*guard {
+                            SyncStatus::Done(outcome) => *outcome,
+                            SyncStatus::Pending => unreachable!(),
+                        },
+                        // All senders dropped without a final status — treat as cancellation
+                        // so the recovery loop re-evaluates the blob.
+                        Err(_) => SyncOutcome::Cancelled,
+                    };
+                    match outcome {
+                        SyncOutcome::Success => BlobSyncResult::Success(blob_id),
+                        SyncOutcome::Cancelled => BlobSyncResult::Cancelled(blob_id),
+                        SyncOutcome::Skipped => BlobSyncResult::Skipped(blob_id),
+                    }
+                });
+                ongoing_syncs.push(fut);
+            }
+            Err(err) => {
+                panic!("failed to start recovery sync for blob {blob_id}: {err}");
+            }
+        }
+    }
+
+    /// Returns true if the recovery task should abort.
+    async fn handle_sync_result(&mut self, result: BlobSyncResult) -> bool {
+        match result {
+            BlobSyncResult::Success(blob_id) => {
+                self.in_flight_blob_ids.remove(&blob_id);
+                self.retry_backoff.remove(&blob_id);
+                self.node.metrics.node_recovery_ongoing_blob_syncs.dec();
+                self.advance_settled(blob_id);
+                false
+            }
+            BlobSyncResult::Cancelled(blob_id) => {
+                self.in_flight_blob_ids.remove(&blob_id);
+                self.node.metrics.node_recovery_ongoing_blob_syncs.dec();
+                if !self.is_blob_still_certified(&blob_id)
+                    || self.is_stored_at_owned_shards(&blob_id).await
+                {
+                    self.retry_backoff.remove(&blob_id);
+                    self.advance_settled(blob_id);
+                } else {
+                    let backoff = next_retry_backoff(self.retry_backoff.get(&blob_id).copied());
+                    tracing::warn!(
+                        walrus.blob_id = %blob_id,
+                        backoff_secs = backoff.as_secs(),
+                        "blob sync was cancelled but blob still needs recovery; will retry"
+                    );
+                    self.retry_backoff.insert(blob_id, backoff);
+                    self.retry_pending.insert(blob_id, Instant::now() + backoff);
+                }
+                false
+            }
+            BlobSyncResult::Skipped(blob_id) => {
+                self.in_flight_blob_ids.remove(&blob_id);
+                self.node.metrics.node_recovery_ongoing_blob_syncs.dec();
+                tracing::info!(
+                    walrus.blob_id = %blob_id,
+                    "blob sync was skipped because node is in RecoveryCatchUp; \
+                    aborting node recovery"
+                );
+                true
+            }
+        }
+    }
+
+    /// Re-issues `start_sync` for any retry whose backoff deadline has elapsed.
+    async fn poll_due_retries(
+        &mut self,
+        ongoing_syncs: &mut FuturesUnordered<BoxFuture<'static, BlobSyncResult>>,
+    ) {
+        let now = Instant::now();
+        let due: Vec<BlobId> = self
+            .retry_pending
+            .iter()
+            .filter_map(|(&id, &deadline)| (deadline <= now).then_some(id))
+            .collect();
+        for blob_id in due {
+            self.retry_pending.remove(&blob_id);
+
+            if !self.is_blob_still_certified(&blob_id)
+                || self.is_stored_at_owned_shards(&blob_id).await
+            {
+                self.retry_backoff.remove(&blob_id);
+                self.advance_settled(blob_id);
+                continue;
+            }
+
+            let Ok(Some(info)) = self.node.storage.get_blob_info(&blob_id) else {
+                self.retry_backoff.remove(&blob_id);
+                continue;
+            };
+            let Some(certified_epoch) = info.initial_certified_epoch() else {
+                self.retry_backoff.remove(&blob_id);
+                continue;
+            };
+
+            self.in_flight_blob_ids.insert(blob_id);
+            self.node.metrics.node_recovery_ongoing_blob_syncs.inc();
+            self.spawn_sync(blob_id, certified_epoch, ongoing_syncs)
+                .await;
+        }
+    }
+
+    async fn finalize(&self, aborted: bool) {
+        // Persist whatever progress we have, even on abort.
+        if let Some(blob_id) = self.eligible_checkpoint() {
+            let progress = NodeRecoveryProgress {
+                epoch: self.certified_before_epoch,
+                owned_shards: self.owned_shards.clone(),
+                last_settled_blob_id: blob_id,
+            };
+            if let Err(error) = self.node.storage.set_node_recovery_progress(&progress) {
+                tracing::error!(?error, "failed to persist final node recovery checkpoint");
+            }
+        }
+
+        if aborted {
+            return;
+        }
+
+        let current_node_status = self
+            .node
+            .storage
+            .node_status()
+            .expect("reading node status should not fail");
+        if current_node_status == NodeStatus::RecoveryInProgress(self.certified_before_epoch) {
+            tracing::info!("node recovery task finished; set node status to active");
+            match self.node.set_node_status(NodeStatus::Active) {
+                Ok(()) => {
+                    if let Err(error) = self.node.storage.clear_node_recovery_progress() {
+                        tracing::error!(
+                            ?error,
+                            "failed to clear node recovery checkpoint after activation"
+                        );
+                    }
+                    self.node
+                        .contract_service
+                        .epoch_sync_done(self.certified_before_epoch, self.node.node_capability())
+                        .await
+                }
+                Err(error) => {
+                    tracing::error!(?error, "failed to set node status to active");
+                }
+            }
+        } else {
+            tracing::warn!(
+                node_status = %current_node_status,
+                "node recovery task finished; but node status is not RecoveryInProgress; \
+                skip setting node status to active"
+            );
+        }
+    }
+}
+
+/// Polls a `FuturesUnordered` without blocking; returns `Some` if a result is immediately
+/// available.
+fn poll_ready<F: std::future::Future + Unpin>(
+    stream: &mut FuturesUnordered<F>,
+) -> Option<F::Output> {
+    use std::task::{Context, Poll};
+
+    use futures::Stream;
+
+    let waker = futures::task::noop_waker();
+    let mut cx = Context::from_waker(&waker);
+    match Pin::new(stream).poll_next(&mut cx) {
+        Poll::Ready(Some(v)) => Some(v),
+        _ => None,
+    }
+}
+
+/// `tokio::time::sleep_until` for `Option<Instant>`, becoming a pending future for `None`.
+async fn sleep_until_opt(deadline: Option<Instant>) {
+    match deadline {
+        Some(deadline) => tokio::time::sleep_until(deadline).await,
+        None => std::future::pending::<()>().await,
+    }
+}
+
+/// Rough distance between two blob ids: numeric difference of their first 8 bytes. Used only
+/// to gate persistence frequency, so a coarse estimate is sufficient. The first byte is
+/// already exposed for metrics (`first_two_bytes`), so this is a natural extension.
+fn blob_id_distance(a: BlobId, b: BlobId) -> u64 {
+    let prefix_a = u64::from_be_bytes(a.0[..8].try_into().expect("32-byte BlobId"));
+    let prefix_b = u64::from_be_bytes(b.0[..8].try_into().expect("32-byte BlobId"));
+    prefix_b.saturating_sub(prefix_a)
+}
+
+/// Pure decision: should the current recovery task resume from a persisted checkpoint or
+/// discard it and start over? Extracted from [`RecoveryPass::load_or_reset_checkpoint`] so it
+/// can be unit-tested without spinning up a full node.
+#[derive(Debug, PartialEq, Eq)]
+enum ResumeDecision {
+    /// Resume the iterator with `Excluded(blob_id)` — every blob `<= blob_id` was settled in
+    /// a prior run.
+    Resume(BlobId),
+    /// Start the iterator from `Unbounded`. `had_checkpoint` indicates whether there was a
+    /// stale checkpoint that should be cleared from storage.
+    Reset { had_checkpoint: bool },
+}
+
+fn resume_decision(
+    progress: Option<&NodeRecoveryProgress>,
+    current_owned_shards: &BTreeSet<ShardIndex>,
+) -> ResumeDecision {
+    match progress {
+        Some(p) if &p.owned_shards == current_owned_shards => {
+            ResumeDecision::Resume(p.last_settled_blob_id)
+        }
+        Some(_) => ResumeDecision::Reset {
+            had_checkpoint: true,
+        },
+        None => ResumeDecision::Reset {
+            had_checkpoint: false,
+        },
+    }
+}
+
+/// Returns the next backoff for a blob whose sync just ended in Cancelled. Starts at
+/// `RETRY_BACKOFF_INITIAL` and doubles on each consecutive cancellation, capped at
+/// `RETRY_BACKOFF_MAX`. Extracted as a pure function for testability.
+fn next_retry_backoff(previous: Option<Duration>) -> Duration {
+    match previous {
+        None => RETRY_BACKOFF_INITIAL,
+        Some(prev) => (prev * 2).min(RETRY_BACKOFF_MAX),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeSet, time::Duration};
+
+    use walrus_core::{BlobId, ShardIndex};
+
+    use super::{
+        NodeRecoveryProgress,
+        RETRY_BACKOFF_INITIAL,
+        RETRY_BACKOFF_MAX,
+        ResumeDecision,
+        blob_id_distance,
+        next_retry_backoff,
+        resume_decision,
+    };
+
+    fn blob(byte: u8) -> BlobId {
+        BlobId([byte; 32])
+    }
+
+    fn shards(ids: &[u16]) -> BTreeSet<ShardIndex> {
+        ids.iter().copied().map(ShardIndex).collect()
+    }
+
+    #[test]
+    fn resume_decision_resumes_when_owned_shards_match() {
+        // Property: when the persisted owned_shards equals the current owned_shards, the
+        // checkpoint is kept (regardless of epoch — see start_node_recovery doc comment).
+        let progress = NodeRecoveryProgress {
+            epoch: 10,
+            owned_shards: shards(&[1, 3, 5]),
+            last_settled_blob_id: blob(42),
+        };
+        assert_eq!(
+            resume_decision(Some(&progress), &shards(&[1, 3, 5])),
+            ResumeDecision::Resume(blob(42)),
+            "same shards at same epoch should resume"
+        );
+
+        let progress_diff_epoch = NodeRecoveryProgress {
+            epoch: 99,
+            ..progress.clone()
+        };
+        assert_eq!(
+            resume_decision(Some(&progress_diff_epoch), &shards(&[1, 3, 5])),
+            ResumeDecision::Resume(blob(42)),
+            "same shards across different epochs should still resume"
+        );
+    }
+
+    #[test]
+    fn resume_decision_resets_when_owned_shards_change() {
+        // Property: any difference in the owned-shards set invalidates the checkpoint —
+        // gained shards are empty, and removed-then-regained shards may have been wiped.
+        let progress = NodeRecoveryProgress {
+            epoch: 10,
+            owned_shards: shards(&[1, 3, 5]),
+            last_settled_blob_id: blob(42),
+        };
+        for current in [
+            shards(&[1, 3, 5, 7]), // gained a shard
+            shards(&[1, 3]),       // lost a shard
+            shards(&[2, 4, 6]),    // entirely different
+            shards(&[]),           // empty
+        ] {
+            assert_eq!(
+                resume_decision(Some(&progress), &current),
+                ResumeDecision::Reset {
+                    had_checkpoint: true
+                },
+                "changed shards {:?} should reset",
+                current,
+            );
+        }
+    }
+
+    #[test]
+    fn resume_decision_resets_when_no_checkpoint() {
+        assert_eq!(
+            resume_decision(None, &shards(&[1, 2, 3])),
+            ResumeDecision::Reset {
+                had_checkpoint: false
+            },
+        );
+    }
+
+    #[test]
+    fn blob_id_distance_is_zero_when_destination_is_not_greater() {
+        // saturating_sub returns zero for equal or decreasing prefixes, which gates persists
+        // (we never persist a checkpoint going backwards).
+        assert_eq!(blob_id_distance(blob(5), blob(5)), 0);
+        assert_eq!(blob_id_distance(blob(10), blob(5)), 0);
+    }
+
+    #[test]
+    fn blob_id_distance_grows_with_prefix_difference() {
+        // Property: a larger prefix gap means a larger reported distance — used to decide
+        // when enough advancement has accumulated for the next persist.
+        assert!(blob_id_distance(blob(1), blob(2)) > 0);
+        assert!(blob_id_distance(blob(1), blob(100)) > blob_id_distance(blob(1), blob(2)));
+    }
+
+    #[test]
+    fn retry_backoff_doubles_each_cancellation_up_to_cap() {
+        // Property: each consecutive Cancelled outcome for the same blob doubles the
+        // backoff, capped at RETRY_BACKOFF_MAX. The first retry waits the initial backoff.
+        assert_eq!(next_retry_backoff(None), RETRY_BACKOFF_INITIAL);
+        let mut current = RETRY_BACKOFF_INITIAL;
+        for _ in 0..20 {
+            let next = next_retry_backoff(Some(current));
+            assert!(next >= current, "backoff should not decrease");
+            assert!(next <= RETRY_BACKOFF_MAX, "backoff should not exceed cap");
+            current = next;
+        }
+        assert_eq!(
+            current, RETRY_BACKOFF_MAX,
+            "backoff should saturate at the cap after enough retries"
+        );
+        // Once at the cap, subsequent retries stay at the cap (not over).
+        assert_eq!(
+            next_retry_backoff(Some(RETRY_BACKOFF_MAX)),
+            RETRY_BACKOFF_MAX
+        );
+        // And we don't lose track if a caller supplies an already-capped value.
+        assert_eq!(
+            next_retry_backoff(Some(Duration::from_secs(60))),
+            RETRY_BACKOFF_MAX
+        );
     }
 }

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -49,6 +49,7 @@ use self::{
         garbage_collector_last_started_epoch_key,
         garbage_collector_table_cf_name,
         metadata_cf_name,
+        node_recovery_progress_cf_name,
         node_status_cf_name,
         pending_recover_slivers_column_family_name,
         primary_slivers_column_family_name,
@@ -62,6 +63,7 @@ use self::{
 use super::{
     errors::{ShardNotAssigned, SyncShardServiceError},
     metrics::{NodeMetricSet, STATUS_FAILURE, STATUS_SUCCESS},
+    node_recovery::NodeRecoveryProgress,
 };
 use crate::utils::{self, BatchProcessingResult};
 
@@ -183,6 +185,7 @@ impl Display for NodeStatus {
 pub struct Storage {
     database: Arc<RocksDB>,
     node_status: DBMap<(), NodeStatus>,
+    node_recovery_progress: DBMap<(), NodeRecoveryProgress>,
     metadata: DBMap<BlobId, BlobMetadata>,
     blob_info: BlobInfoTable,
     event_cursor: EventCursorTable,
@@ -279,6 +282,8 @@ impl Storage {
 
         let node_status_cf_name = node_status_cf_name();
         let node_status_options = db_table_opts_factory.node_status();
+        let node_recovery_progress_cf_name = node_recovery_progress_cf_name();
+        let node_recovery_progress_options = db_table_opts_factory.node_recovery_progress();
         let metadata_options = db_table_opts_factory.metadata();
         let metadata_cf_name = metadata_cf_name();
         let blob_info_column_families = BlobInfoTable::options(&db_table_opts_factory);
@@ -292,6 +297,10 @@ impl Storage {
             .map(|(name, opts)| (name.as_str(), std::mem::take(opts)))
             .chain([
                 (node_status_cf_name, node_status_options),
+                (
+                    node_recovery_progress_cf_name,
+                    node_recovery_progress_options,
+                ),
                 (metadata_cf_name, metadata_options),
                 (event_cursor_cf_name, event_cursor_options),
                 (
@@ -327,6 +336,13 @@ impl Storage {
         if node_status.get(&())?.is_none() {
             node_status.insert(&(), &NodeStatus::Standby)?;
         }
+
+        let node_recovery_progress = DBMap::reopen(
+            &database,
+            Some(node_recovery_progress_cf_name),
+            &ReadWriteOptions::default(),
+            false,
+        )?;
 
         let garbage_collector_table = DBMap::reopen(
             &database,
@@ -384,6 +400,7 @@ impl Storage {
         let storage = Self {
             database,
             node_status,
+            node_recovery_progress,
             metadata,
             blob_info,
             event_cursor,
@@ -413,6 +430,26 @@ impl Storage {
 
     pub(super) fn set_node_status(&self, status: NodeStatus) -> Result<(), TypedStoreError> {
         self.node_status.insert(&(), &status)
+    }
+
+    /// Returns the persisted node recovery progress, if any.
+    pub(crate) fn get_node_recovery_progress(
+        &self,
+    ) -> Result<Option<NodeRecoveryProgress>, TypedStoreError> {
+        self.node_recovery_progress.get(&())
+    }
+
+    /// Persists the given node recovery progress.
+    pub(crate) fn set_node_recovery_progress(
+        &self,
+        progress: &NodeRecoveryProgress,
+    ) -> Result<(), TypedStoreError> {
+        self.node_recovery_progress.insert(&(), progress)
+    }
+
+    /// Clears any persisted node recovery progress.
+    pub(crate) fn clear_node_recovery_progress(&self) -> Result<(), TypedStoreError> {
+        self.node_recovery_progress.remove(&())
     }
 
     /// Returns the last epochs for which garbage collection was started and completed.
@@ -1278,6 +1315,17 @@ impl Storage {
     ) -> BlobInfoIterator<'_> {
         self.blob_info
             .certified_blob_info_iter_before_epoch(epoch, std::ops::Bound::Unbounded)
+    }
+
+    /// Returns an iterator over the certified blob info before the specified epoch, starting
+    /// at the given bound.
+    pub(crate) fn certified_blob_info_iter_before_epoch_from(
+        &self,
+        epoch: Epoch,
+        starting_blob_id_bound: std::ops::Bound<BlobId>,
+    ) -> BlobInfoIterator<'_> {
+        self.blob_info
+            .certified_blob_info_iter_before_epoch(epoch, starting_blob_id_bound)
     }
 
     /// Returns an iterator over the certified per-object blob info before the specified epoch.
@@ -2399,6 +2447,36 @@ pub(crate) mod tests {
             all_certified_blob_object_ids(&storage, 4)?,
             vec![object_ids[1], object_ids[2]]
         );
+
+        Ok(())
+    }
+
+    // Verifies the storage round-trip for NodeRecoveryProgress: not present initially,
+    // readable after set, gone after clear. Also verifies that a non-trivial owned_shards
+    // set survives serialization unchanged.
+    #[tokio::test]
+    async fn node_recovery_progress_round_trip() -> TestResult {
+        let storage = empty_storage().await;
+        let inner = &storage.inner;
+
+        assert!(inner.get_node_recovery_progress()?.is_none());
+
+        let progress = NodeRecoveryProgress {
+            epoch: 42,
+            owned_shards: [ShardIndex(1), ShardIndex(2), ShardIndex(7)]
+                .into_iter()
+                .collect(),
+            last_settled_blob_id: BlobId([7; 32]),
+        };
+        inner.set_node_recovery_progress(&progress)?;
+
+        let loaded = inner
+            .get_node_recovery_progress()?
+            .expect("should have loaded progress");
+        assert_eq!(loaded, progress);
+
+        inner.clear_node_recovery_progress()?;
+        assert!(inner.get_node_recovery_progress()?.is_none());
 
         Ok(())
     }

--- a/crates/walrus-service/src/node/storage/constants.rs
+++ b/crates/walrus-service/src/node/storage/constants.rs
@@ -9,6 +9,7 @@ const PER_OBJECT_BLOB_INFO_COLUMN_FAMILY_NAME: &str = "per_object_blob_info";
 const PER_OBJECT_POOLED_BLOB_INFO_COLUMN_FAMILY_NAME: &str = "per_object_pooled_blob_info";
 const STORAGE_POOL_INFO_COLUMN_FAMILY_NAME: &str = "storage_pool_info";
 const NODE_STATUS_COLUMN_FAMILY_NAME: &str = "node_status";
+const NODE_RECOVERY_PROGRESS_COLUMN_FAMILY_NAME: &str = "node_recovery_progress";
 const METADATA_COLUMN_FAMILY_NAME: &str = "metadata";
 const EVENT_INDEX_COLUMN_FAMILY_NAME: &str = "latest_handled_event_index";
 const EVENT_CURSOR_COLUMN_FAMILY_NAME: &str = "event_cursor";
@@ -53,6 +54,11 @@ pub fn storage_pool_info_cf_name() -> &'static str {
 /// Returns the name of the node status column family.
 pub fn node_status_cf_name() -> &'static str {
     NODE_STATUS_COLUMN_FAMILY_NAME
+}
+
+/// Returns the name of the node recovery progress column family.
+pub fn node_recovery_progress_cf_name() -> &'static str {
+    NODE_RECOVERY_PROGRESS_COLUMN_FAMILY_NAME
 }
 
 /// Returns the name of the metadata column family.
@@ -143,6 +149,7 @@ mod tests {
         assert_eq!(aggregate_blob_info_cf_name(), "aggregate_blob_info");
         assert_eq!(per_object_blob_info_cf_name(), "per_object_blob_info");
         assert_eq!(node_status_cf_name(), "node_status");
+        assert_eq!(node_recovery_progress_cf_name(), "node_recovery_progress");
         assert_eq!(event_index_cf_name(), "latest_handled_event_index");
 
         let shard = ShardIndex(900);

--- a/crates/walrus-service/src/node/storage/database_config.rs
+++ b/crates/walrus-service/src/node/storage/database_config.rs
@@ -336,6 +336,8 @@ pub struct DatabaseConfig {
     //
     /// Node status database options.
     pub(super) node_status: Option<DatabaseTableOptions>,
+    /// Node recovery progress database options.
+    pub(super) node_recovery_progress: Option<DatabaseTableOptions>,
     /// Garbage collector database options.
     pub(super) garbage_collector: Option<DatabaseTableOptions>,
     /// Blob info database options.
@@ -426,6 +428,11 @@ impl DatabaseConfig {
     /// Returns the node status database option.
     pub fn node_status(&self) -> DatabaseTableOptions {
         Self::inherit_from_or_use_template(&self.node_status, self.standard())
+    }
+
+    /// Returns the node recovery progress database option.
+    pub fn node_recovery_progress(&self) -> DatabaseTableOptions {
+        Self::inherit_from_or_use_template(&self.node_recovery_progress, self.standard())
     }
 
     /// Returns the garbage collector database option.
@@ -543,6 +550,7 @@ impl Default for DatabaseConfig {
             blob_info_template: DatabaseTableOptions::blob_info_template(),
             metadata: DatabaseTableOptions::metadata(),
             node_status: None,
+            node_recovery_progress: None,
             garbage_collector: None,
             blob_info: None,
             per_object_blob_info: None,
@@ -734,6 +742,11 @@ impl DatabaseTableOptionsFactory {
     /// Returns the node status database option with shared cache.
     pub fn node_status(&self) -> Options {
         self.to_options(&self.config.node_status(), false)
+    }
+
+    /// Returns the node recovery progress database option with shared cache.
+    pub fn node_recovery_progress(&self) -> Options {
+        self.to_options(&self.config.node_recovery_progress(), false)
     }
 
     /// Returns the garbage collector database option with shared cache.

--- a/crates/walrus-simtest/tests/simtest_failure.rs
+++ b/crates/walrus-simtest/tests/simtest_failure.rs
@@ -216,6 +216,11 @@ mod tests {
                 max_concurrent_blob_syncs_during_recovery;
         }
 
+        // Persist the recovery checkpoint after every settled blob so the second recovery run
+        // (after the in-recovery crash below) has a non-empty checkpoint to resume from
+        // regardless of how few blobs the workload generated.
+        node_recovery_config.checkpoint_persist_interval = 1;
+
         let (_sui_cluster, walrus_cluster, client, _, _) = test_cluster::E2eTestSetupBuilder::new()
             .with_epoch_duration(Duration::from_secs(30))
             .with_test_nodes_config(
@@ -278,22 +283,42 @@ mod tests {
             .await
             .expect("stake with node pool should not fail");
 
-        // Probabilistically trigger a node crash during node recovery.
-        let crash_during_recovery = rand::thread_rng().gen_bool(0.1);
-        if crash_during_recovery {
-            let fail_triggered = Arc::new(AtomicBool::new(false));
+        // Trigger a second node crash during node recovery, forcing the recovery to restart.
+        // The restarted recovery should resume from the checkpoint persisted by the first
+        // recovery run rather than rescanning from blob_id 0 — verified by the
+        // `recovery_resume_count` observer below.
+        {
+            let recovery_crash_triggered = Arc::new(AtomicBool::new(false));
             let target_fail_node_id = walrus_cluster.nodes[0]
                 .node_id
                 .expect("node id should be set");
-            let fail_triggered_clone = fail_triggered.clone();
-
             sui_macros::register_fail_point("fail_point_node_recovery_start_sync", move || {
                 crash_target_node(
                     target_fail_node_id,
-                    fail_triggered_clone.clone(),
+                    recovery_crash_triggered.clone(),
                     Duration::from_secs(5),
                 );
             });
+        }
+
+        // Count every time the node's recovery task resumes from a persisted checkpoint.
+        // Must be > 0 by the end of the test since we deliberately crash node 0 during its
+        // first recovery run above.
+        let recovery_resume_count = Arc::new(AtomicUsize::new(0));
+        {
+            let target_fail_node_id = walrus_cluster.nodes[0]
+                .node_id
+                .expect("node id should be set");
+            let recovery_resume_count_clone = recovery_resume_count.clone();
+            sui_macros::register_fail_point(
+                "fail_point_node_recovery_resumed_from_checkpoint",
+                move || {
+                    if sui_simulator::current_simnode_id() != target_fail_node_id {
+                        return;
+                    }
+                    recovery_resume_count_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                },
+            );
         }
 
         tokio::time::sleep(Duration::from_secs(150)).await;
@@ -332,6 +357,16 @@ mod tests {
         }
 
         assert_eq!(node_health_info[0].node_status, "Active");
+
+        // The in-recovery crash above forced a second recovery run on the restarted node.
+        // That second run must have resumed from the persisted checkpoint at least once,
+        // proving recovery progress is preserved across restarts instead of rescanning from
+        // blob_id 0.
+        assert!(
+            recovery_resume_count.load(std::sync::atomic::Ordering::SeqCst) > 0,
+            "node recovery should have resumed from a persisted checkpoint at least once \
+            after the in-recovery crash, but the resume observer never fired"
+        );
 
         workload_handle.abort();
 


### PR DESCRIPTION
## Description

Previously start_node_recovery rescanned the certified-blob iterator from the first blob_id on every invocation and on every outer-loop pass, so a crash mid-recovery lost all progress and a successful first pass still re-read every blob to verify storage.

Persist a NodeRecoveryProgress {epoch, owned_shards, last_settled_blob_id} checkpoint in a new RocksDB column family. On resume, keep the checkpoint iff the current owned-shards set equals the persisted one — otherwise the "stored at all shards" assertion may no longer hold (new shards are empty and removed-then-regained shards have been wiped).

Refactor blob_sync_handler.start_sync to return watch::Receiver<SyncStatus> instead of Arc<Notify>, propagating SyncOutcome::{Success, Cancelled, Skipped} to callers. This is multi-consumer safe by construction and incidentally fixes a latent notify_one bug where a second waiter on the same blob would block forever. With real outcomes available, the recovery loop no longer needs the outer "re-scan to verify" pass (TODO(WAL-669)).

Cancelled outcomes that leave a blob still certified and unstored are queued for retry with exponential backoff (1s -> 30s cap). The settled cursor never advances past any in-flight or retry-pending blob_id.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [x] Storage node: storage node full recovery has checkpoint now.
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
