### PR TITLE
ci(version-bump): use app token for git push so CI fires on bot PRs

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -116,8 +116,7 @@ jobs:
       - name: Deliver via PR
         if: inputs.delivery == 'pr'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          AUTOMERGE_TOKEN: ${{ steps.automerge_token.outputs.token }}
+          GH_TOKEN: ${{ steps.automerge_token.outputs.token }}
           GITHUB_ACTOR: ${{ github.actor }}
           NEW_VERSION: ${{ steps.bump.outputs.new_version }}
           REF_NAME: ${{ github.ref_name }}
@@ -129,7 +128,11 @@ jobs:
           git add Cargo.toml Cargo.lock
           BODY="chore: bump walrus version to v${NEW_VERSION}"
           git commit -m "$BODY"
-          git push -u origin "$BRANCH"
+          # Push using the app token URL so the push is attributed to the GitHub App,
+          # not github-actions[bot]. Pushes with GITHUB_TOKEN don't trigger CI workflows.
+          git push -u \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "$BRANCH"
 
           gh pr create \
             --base "$REF_NAME" \
@@ -138,9 +141,7 @@ jobs:
             --reviewer "wbbradley,halfprice,liquid-helium,ebmifa" \
             --body "Walrus v${NEW_VERSION} Version Bump"
 
-          # Use dedicated token for auto-merge so the resulting push triggers downstream workflows
-          MERGE_TOKEN="${AUTOMERGE_TOKEN:-$GH_TOKEN}"
-          GH_TOKEN="$MERGE_TOKEN" gh pr merge --auto --squash --delete-branch "$BRANCH"
+          gh pr merge --auto --squash --delete-branch "$BRANCH"
 
       - name: Deliver direct push
         if: inputs.delivery == 'direct'


### PR DESCRIPTION
## Summary

Port the pattern from [`MystenLabs/sui`'s `version-bump.yml`](https://github.com/MystenLabs/sui/blob/main/.github/workflows/version-bump.yml) so the version-bump bot PR triggers the full CI fan-out instead of just `semgrep-cloud-platform/scan`.

## Root cause

The current workflow pushes the version-bump branch with `secrets.GITHUB_TOKEN`, which makes the push (and the resulting PR opened by `gh pr create`) attributed to `github-actions[bot]`. GitHub deliberately suppresses workflow triggers when one `GITHUB_TOKEN`-authenticated workflow opens a PR — that's the documented [workflow-loop guard](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow). Concretely, the version-bump PRs (e.g. #3415 today) open with only `semgrep-cloud-platform/scan` running — the entire rust / lint / simtest / docker fan-out is skipped, and the PR appears "green" before any of the real checks have started.

Today's #3415 only ran 1 check on open; after pushing an empty commit by hand from a user identity, all 27 checks ran. That's the smoking gun for the bot-attribution path.

## Fix

We already mint a GitHub App token via `actions/create-github-app-token` for the `gh pr merge --auto` step (using `WALRUS_AUTOMERGE_APP_ID` + `WALRUS_AUTOMERGE_PRIVATE_KEY`). Use that same App token for the **git push** as well — pushes attributed to the App identity DO fire downstream PR workflows. This mirrors the sui pattern exactly:

\`\`\`bash
git push -u \
  "https://x-access-token:\${GH_TOKEN}@github.com/\${GITHUB_REPOSITORY}.git" \
  "\$BRANCH"
\`\`\`

Since `GH_TOKEN` is now the App token throughout the step, the dedicated `AUTOMERGE_TOKEN` env var and the `MERGE_TOKEN` fallback in the merge step are no longer needed — just `gh pr merge --auto`.

## Prerequisite ⚠️

The `walrus-automerge` GitHub App must have **`contents:write`** in its installation permissions (in addition to whatever PR perms it already holds for `gh pr merge`). If it currently only has `pull_requests:write`, the push will 403 and the App's installation permissions need to be widened before this lands — otherwise the next version-bump run will fail at the push step.

Please confirm the App perms before merging. If contents:write is missing, the fix is to update the App configuration in https://github.com/organizations/MystenLabs/settings/apps/walrus-automerge → Permissions → Repository permissions → Contents: Read and write.

## Test plan

- [ ] Confirm `walrus-automerge` App has `contents:write` in its installation permissions
- [ ] After merge, the next `gh workflow run version-bump.yml` triggers should produce PRs with the full ~27-check fan-out from the start (no empty-commit nudge needed)
- [ ] Auto-merge still works end-to-end

## Related

- Today's victim: #3415 — opened with 1 check, took an empty commit nudge to fire CI
- sui reference: https://github.com/MystenLabs/sui/blob/main/.github/workflows/version-bump.yml#L98-L129

🤖 Generated with [Claude Code](https://claude.com/claude-code)