### PR TITLE
fix: harden sync_shard authorization and bound sliver_count

### DIFF
--- a/crates/walrus-service/node_config_example.yaml
+++ b/crates/walrus-service/node_config_example.yaml
@@ -155,6 +155,7 @@ tls:
   certificate_path: null
 shard_sync_config:
   sliver_count_per_sync_request: 1000
+  max_sliver_count_per_sync_request: 100000
   shard_sync_retry_min_backoff_secs: 60
   shard_sync_retry_max_backoff_secs: 600
   max_concurrent_blob_recovery_during_shard_recovery: 100

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -676,6 +676,8 @@ pub struct StorageNodeInner {
     consistency_check_config: StorageNodeConsistencyCheckConfig,
     checkpoint_manager: Option<Arc<DbCheckpointManager>>,
     garbage_collection_config: GarbageCollectionConfig,
+    // Server-side cap on the `sliver_count` a sync-shard request may ask for; `None` disables it.
+    max_sliver_count_per_sync_request: Option<usize>,
     recovery_deferrals: RecoveryDeferrals,
     recovery_deferral_notify: Arc<Notify>,
     recovery_deferral_cleanup_token: CancellationToken,
@@ -876,6 +878,9 @@ impl StorageNode {
             consistency_check_config: config.consistency_check.clone(),
             checkpoint_manager,
             garbage_collection_config: config.garbage_collection,
+            max_sliver_count_per_sync_request: config
+                .shard_sync_config
+                .max_sliver_count_per_sync_request,
             recovery_deferrals: std::sync::Arc::new(RwLock::new(Default::default())),
             recovery_deferral_notify: Arc::new(Notify::new()),
             recovery_deferral_cleanup_token: CancellationToken::new(),
@@ -4852,7 +4857,11 @@ impl ServiceState for StorageNodeInner {
         }
 
         self.storage
-            .handle_sync_shard_request(request, current_committee.epoch)
+            .handle_sync_shard_request(
+                request,
+                current_committee.epoch,
+                self.max_sliver_count_per_sync_request,
+            )
             .await
     }
 }
@@ -4943,10 +4952,9 @@ mod tests {
     };
 
     use chrono::Utc;
-    use config::ShardSyncConfig;
+    use config::{DEFAULT_MAX_SLIVER_COUNT_PER_SYNC_REQUEST, ShardSyncConfig};
     use contract_service::MockSystemContractService;
     use storage::{
-        MAX_SLIVER_COUNT_PER_SYNC_REQUEST,
         ShardStatus,
         tests::{BLOB_ID, OTHER_SHARD_INDEX, SHARD_INDEX, WhichSlivers, populated_storage},
     };
@@ -7654,7 +7662,7 @@ mod tests {
             matches!(
                 result,
                 Err(SyncShardServiceError::RequestedSliverCountExceedsLimit { limit, .. })
-                    if limit == MAX_SLIVER_COUNT_PER_SYNC_REQUEST
+                    if limit == DEFAULT_MAX_SLIVER_COUNT_PER_SYNC_REQUEST
             ),
             "expected RequestedSliverCountExceedsLimit, got {result:?}"
         );

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -4815,12 +4815,21 @@ impl ServiceState for StorageNodeInner {
 
         tracing::debug!(?request, "sync shard request received");
 
+        // Snapshot the current committee once so the epoch and shard-ownership checks below observe
+        // a single consistent state; a committee advance between two separate reads could otherwise
+        // produce a spurious rejection.
+        let current_committee = self
+            .committee_service
+            .active_committees()
+            .current_committee()
+            .clone();
+
         // If the epoch of the requester should not be older than the current epoch of the node.
         // In a normal scenario, a storage node will never fetch shards from a future epoch.
-        if request.epoch() != self.current_committee_epoch() {
+        if request.epoch() != current_committee.epoch {
             return Err(InvalidEpochError {
                 request_epoch: request.epoch(),
-                server_epoch: self.current_committee_epoch(),
+                server_epoch: current_committee.epoch,
             }
             .into());
         }
@@ -4830,10 +4839,7 @@ impl ServiceState for StorageNodeInner {
         // committee is the current one (during an epoch change the gaining committee is `current`,
         // the losing committee `previous`). This narrows authorization from any committee member to
         // the node actually gaining the shard.
-        if !self
-            .committee_service
-            .active_committees()
-            .current_committee()
+        if !current_committee
             .shards_for_node_public_key(&public_key)
             .contains(&request.shard_index())
         {
@@ -4846,7 +4852,7 @@ impl ServiceState for StorageNodeInner {
         }
 
         self.storage
-            .handle_sync_shard_request(request, self.current_committee_epoch())
+            .handle_sync_shard_request(request, current_committee.epoch)
             .await
     }
 }

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -4825,12 +4825,11 @@ impl ServiceState for StorageNodeInner {
             .into());
         }
 
-        // Verify that the requester is the node gaining this shard: `request.shard_index()` must be
-        // assigned to its public key in the committee for `request.epoch()`. The epoch check above
-        // ties the request to the current epoch, so that committee is the current one (during an
-        // epoch change the gaining committee is `current`, the losing committee `previous`).
-        // Without this, any committee member could drive a bulk sliver transfer for a shard it does
-        // not own.
+        // Require the requester to be assigned `request.shard_index()` in the committee for
+        // `request.epoch()`. The epoch check above ties the request to the current epoch, so that
+        // committee is the current one (during an epoch change the gaining committee is `current`,
+        // the losing committee `previous`). This narrows authorization from any committee member to
+        // the node actually gaining the shard.
         if !self
             .committee_service
             .active_committees()
@@ -7613,8 +7612,8 @@ mod tests {
         Ok(())
     }
 
-    // An oversized `sliver_count` is rejected before allocation, preventing a capacity-overflow
-    // panic (`u64::MAX`) or an allocation abort.
+    // A `sliver_count` above the server-side limit is rejected before the response vector is
+    // allocated.
     #[tokio::test]
     async fn sync_shard_node_api_rejects_oversized_sliver_count() -> TestResult {
         let (cluster, _, _) =
@@ -7622,7 +7621,7 @@ mod tests {
                 .await?;
 
         // node 0 owns shard 0, so the request passes authorization and reaches the sliver-count
-        // bound. Without the bound, `Vec::with_capacity(u64::MAX as usize)` would panic.
+        // bound; `u64::MAX` is far above the limit and is rejected.
         let request =
             SyncShardRequest::new(ShardIndex(0), SliverType::Primary, BLOB_ID, u64::MAX, 2);
         let signed_request = cluster.nodes[0]

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -4825,6 +4825,27 @@ impl ServiceState for StorageNodeInner {
             .into());
         }
 
+        // Verify that the requester is the node gaining this shard: `request.shard_index()` must be
+        // assigned to its public key in the committee for `request.epoch()`. The epoch check above
+        // ties the request to the current epoch, so that committee is the current one (during an
+        // epoch change the gaining committee is `current`, the losing committee `previous`).
+        // Without this, any committee member could drive a bulk sliver transfer for a shard it does
+        // not own.
+        if !self
+            .committee_service
+            .active_committees()
+            .current_committee()
+            .shards_for_node_public_key(&public_key)
+            .contains(&request.shard_index())
+        {
+            tracing::warn!(
+                walrus.shard_index = %request.shard_index(),
+                walrus.node = %public_key,
+                "rejecting sync shard request: requester does not own the shard"
+            );
+            return Err(SyncShardServiceError::Unauthorized);
+        }
+
         self.storage
             .handle_sync_shard_request(request, self.current_committee_epoch())
             .await
@@ -4911,6 +4932,7 @@ fn map_flush_error_to_confirmation(error: PendingCacheError) -> ComputeStorageCo
 #[cfg(test)]
 mod tests {
     use std::{
+        collections::HashSet,
         sync::{Arc, OnceLock},
         time::Duration,
     };
@@ -4919,6 +4941,7 @@ mod tests {
     use config::ShardSyncConfig;
     use contract_service::MockSystemContractService;
     use storage::{
+        MAX_SLIVER_COUNT_PER_SYNC_REQUEST,
         ShardStatus,
         tests::{BLOB_ID, OTHER_SHARD_INDEX, SHARD_INDEX, WhichSlivers, populated_storage},
     };
@@ -4948,10 +4971,12 @@ mod tests {
             BlobCertified,
             BlobDeleted,
             BlobRegistered,
+            Committee,
             InvalidBlobId,
             PooledBlobCertified,
             PooledBlobDeleted,
             PooledBlobRegistered,
+            StorageNode,
             StorageNodeCap,
             StoragePoolEvent,
             move_structs::EpochState,
@@ -6091,6 +6116,100 @@ mod tests {
             cluster.wait_for_nodes_to_reach_epoch(epoch).await;
         }
 
+        Ok(())
+    }
+
+    /// Reassigns `shards` to `cluster.nodes[destination_idx]` in the current committee so that the
+    /// destination is the node gaining them, as a real epoch change would arrange.
+    ///
+    /// Shard-sync tests fake a migration by creating storage on the destination directly, without a
+    /// committee that reflects the gain. `sync_shard` now rejects requesters that do not own the
+    /// shard, so the destination must own it in the current committee. The previous committee (used
+    /// to look up the sync source) and the epoch are left unchanged, keeping source selection and
+    /// recovery as in production.
+    ///
+    /// `keep_destination_shards` controls how the sync source is handled. For a direct transfer the
+    /// source holds the data and must stay reachable (for example for metadata recovery), so the
+    /// destination hands it its own previous shards (a swap). For recovery the source holds no data
+    /// and the destination must keep its existing shards to reconstruct from, so the source is
+    /// dropped once empty (`Committee` forbids empty members).
+    async fn reassign_shards_to_destination_in_current_committee(
+        cluster: &TestCluster,
+        shards: &[ShardIndex],
+        destination_idx: usize,
+        keep_destination_shards: bool,
+    ) -> TestResult {
+        let handle = cluster
+            .lookup_service_handle
+            .as_ref()
+            .expect("shard-sync test clusters use a stub lookup service");
+        let destination_key = cluster.nodes[destination_idx].public_key().clone();
+        let shard_set: HashSet<ShardIndex> = shards.iter().copied().collect();
+
+        let updated = {
+            let committees = handle
+                .committees
+                .lock()
+                .expect("lookup mutex is not poisoned");
+            let current = committees.current_committee();
+            let mut members: Vec<StorageNode> = current.members().to_vec();
+            let destination_pos = members
+                .iter()
+                .position(|member| member.public_key == destination_key)
+                .expect("destination is a committee member");
+            let destination_original = members[destination_pos].shard_ids.clone();
+
+            // The destination owns the synced shards, plus its existing shards when recovering.
+            let mut destination_shards = if keep_destination_shards {
+                destination_original.clone()
+            } else {
+                Vec::new()
+            };
+            for shard in shards {
+                if !destination_shards.contains(shard) {
+                    destination_shards.push(*shard);
+                }
+            }
+            members[destination_pos].shard_ids = destination_shards;
+
+            for (index, member) in members.iter_mut().enumerate() {
+                if index != destination_pos
+                    && member
+                        .shard_ids
+                        .iter()
+                        .any(|shard| shard_set.contains(shard))
+                {
+                    member.shard_ids.retain(|shard| !shard_set.contains(shard));
+                    if !keep_destination_shards {
+                        // Hand the source the destination's old shards so it stays non-empty.
+                        member
+                            .shard_ids
+                            .extend(destination_original.iter().copied());
+                    }
+                }
+            }
+            members.retain(|member| !member.shard_ids.is_empty());
+            let new_current = Committee::new(members, current.epoch, current.n_shards())
+                .expect("reassigned committee covers every shard exactly once");
+            ActiveCommittees::new_with_next(
+                Arc::new(new_current),
+                committees.previous_committee().cloned(),
+                committees.next_committee().cloned(),
+                committees.is_change_in_progress(),
+            )
+        };
+        *handle
+            .committees
+            .lock()
+            .expect("lookup mutex is not poisoned") = updated;
+
+        for node in &cluster.nodes {
+            node.storage_node
+                .inner
+                .committee_service
+                .begin_committee_change_to_latest_committee()
+                .await?;
+        }
         Ok(())
     }
 
@@ -7453,6 +7572,91 @@ mod tests {
         Ok(())
     }
 
+    // A committee member requesting a shard it is not assigned in the current committee is rejected
+    // before any sliver transfer.
+    #[tokio::test]
+    async fn sync_shard_node_api_rejects_unowned_shard() -> TestResult {
+        // node 0 holds shards 0 and 1; node 1 holds shards 2 and 3.
+        let (cluster, _, _) =
+            cluster_with_initial_epoch_and_certified_blobs(&[&[0, 1], &[2, 3]], &[BLOB], 2, None)
+                .await?;
+
+        // node 1, a committee member, requests shard 0, which it does not own. The request is
+        // signed by and verified against node 1's key, so it passes signature verification but must
+        // fail the shard-ownership check.
+        let request = SyncShardRequest::new(ShardIndex(0), SliverType::Primary, BLOB_ID, 10, 2);
+        let signed_request = cluster.nodes[1]
+            .as_ref()
+            .inner
+            .protocol_key_pair
+            .sign_message(&SyncShardMsg::new(2, request));
+
+        let result = cluster.nodes[0]
+            .storage_node
+            .sync_shard(
+                cluster.nodes[1]
+                    .as_ref()
+                    .inner
+                    .protocol_key_pair
+                    .0
+                    .public()
+                    .clone(),
+                signed_request,
+            )
+            .await;
+
+        assert!(
+            matches!(result, Err(SyncShardServiceError::Unauthorized)),
+            "expected Unauthorized, got {result:?}"
+        );
+
+        Ok(())
+    }
+
+    // An oversized `sliver_count` is rejected before allocation, preventing a capacity-overflow
+    // panic (`u64::MAX`) or an allocation abort.
+    #[tokio::test]
+    async fn sync_shard_node_api_rejects_oversized_sliver_count() -> TestResult {
+        let (cluster, _, _) =
+            cluster_with_initial_epoch_and_certified_blobs(&[&[0, 1], &[2, 3]], &[BLOB], 2, None)
+                .await?;
+
+        // node 0 owns shard 0, so the request passes authorization and reaches the sliver-count
+        // bound. Without the bound, `Vec::with_capacity(u64::MAX as usize)` would panic.
+        let request =
+            SyncShardRequest::new(ShardIndex(0), SliverType::Primary, BLOB_ID, u64::MAX, 2);
+        let signed_request = cluster.nodes[0]
+            .as_ref()
+            .inner
+            .protocol_key_pair
+            .sign_message(&SyncShardMsg::new(2, request));
+
+        let result = cluster.nodes[0]
+            .storage_node
+            .sync_shard(
+                cluster.nodes[0]
+                    .as_ref()
+                    .inner
+                    .protocol_key_pair
+                    .0
+                    .public()
+                    .clone(),
+                signed_request,
+            )
+            .await;
+
+        assert!(
+            matches!(
+                result,
+                Err(SyncShardServiceError::RequestedSliverCountExceedsLimit { limit, .. })
+                    if limit == MAX_SLIVER_COUNT_PER_SYNC_REQUEST
+            ),
+            "expected RequestedSliverCountExceedsLimit, got {result:?}"
+        );
+
+        Ok(())
+    }
+
     #[tokio::test]
     async fn can_read_locked_shard() -> TestResult {
         let (cluster, events, blob) =
@@ -7633,6 +7837,12 @@ mod tests {
                 .update_status_in_test(ShardStatus::None)
                 .await?;
         }
+
+        // node 1 is the destination that gains `assignment[0]` by direct transfer from node 0;
+        // reflect that in the committee so the source accepts its sync requests.
+        let synced_shards: Vec<_> = assignment[0].iter().map(|i| ShardIndex(*i)).collect();
+        reassign_shards_to_destination_in_current_committee(&cluster, &synced_shards, 1, false)
+            .await?;
 
         Ok((
             cluster,
@@ -7855,6 +8065,11 @@ mod tests {
                 blob_index_to_end_epoch,
                 blob_index_to_deletable,
             )
+            .await?;
+
+        // node 1 is the destination that recovers shard 0; reflect that in the committee so the
+        // source accepts its sync requests. It keeps its own shards to reconstruct from.
+        reassign_shards_to_destination_in_current_committee(&cluster, &[ShardIndex(0)], 1, true)
             .await?;
 
         Ok((cluster, blob_details, event_senders))

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -7796,6 +7796,7 @@ mod tests {
     async fn setup_cluster_for_shard_sync_tests(
         assignment: Option<&[&[u16]]>,
         shard_sync_config: Option<ShardSyncConfig>,
+        keep_destination_shards: bool,
     ) -> TestResult<(TestCluster, Vec<EncodedBlob>, Storage, Arc<ShardStorageSet>)> {
         let assignment = assignment.unwrap_or(&[&[0], &[1, 2, 3]]);
         let blobs: Vec<[u8; 32]> = (1..24).map(|i| [i; 32]).collect();
@@ -7837,11 +7838,17 @@ mod tests {
                 .await?;
         }
 
-        // node 1 is the destination that gains `assignment[0]` by direct transfer from node 0;
-        // reflect that in the committee so the source accepts its sync requests.
+        // node 1 is the destination that gains `assignment[0]`; reflect that in the committee so
+        // the source accepts its sync requests. Recovery-exercising tests pass
+        // `keep_destination_shards` so node 1 retains the shards it reconstructs from.
         let synced_shards: Vec<_> = assignment[0].iter().map(|i| ShardIndex(*i)).collect();
-        reassign_shards_to_destination_in_current_committee(&cluster, &synced_shards, 1, false)
-            .await?;
+        reassign_shards_to_destination_in_current_committee(
+            &cluster,
+            &synced_shards,
+            1,
+            keep_destination_shards,
+        )
+        .await?;
 
         Ok((
             cluster,
@@ -7980,7 +7987,8 @@ mod tests {
             ..Default::default()
         };
         let (cluster, blob_details, storage_dst, shard_storage_set) =
-            setup_cluster_for_shard_sync_tests(Some(assignment), Some(shard_sync_config)).await?;
+            setup_cluster_for_shard_sync_tests(Some(assignment), Some(shard_sync_config), false)
+                .await?;
 
         let expected_shard_count = assignment[0].len();
 
@@ -8306,7 +8314,7 @@ mod tests {
             sliver_type: SliverType,
         ) -> TestResult {
             let (cluster, blob_details, storage_dst, shard_storage_set) =
-                setup_cluster_for_shard_sync_tests(None, None).await?;
+                setup_cluster_for_shard_sync_tests(None, None, true).await?;
 
             assert_eq!(shard_storage_set.shard_storage.len(), 1);
             let shard_storage_dst = shard_storage_set.shard_storage[0].clone();
@@ -8387,7 +8395,7 @@ mod tests {
             sliver_type: SliverType,
         ) -> TestResult {
             let (cluster, blob_details, storage_dst, shard_storage_set) =
-                setup_cluster_for_shard_sync_tests(None, None).await?;
+                setup_cluster_for_shard_sync_tests(None, None, true).await?;
 
             assert_eq!(shard_storage_set.shard_storage.len(), 1);
             let shard_storage_dst = shard_storage_set.shard_storage[0].clone();
@@ -8501,7 +8509,7 @@ mod tests {
                 ..Default::default()
             };
             let (cluster, blob_details, storage_dst, shard_storage_set) =
-                setup_cluster_for_shard_sync_tests(None, Some(shard_sync_config)).await?;
+                setup_cluster_for_shard_sync_tests(None, Some(shard_sync_config), true).await?;
 
             assert_eq!(shard_storage_set.shard_storage.len(), 1);
             let shard_storage_dst = shard_storage_set.shard_storage[0].clone();
@@ -8568,7 +8576,7 @@ mod tests {
         }
         async fn sync_shard_src_abnormal_return(fail_point: &'static str) -> TestResult {
             let (cluster, _blob_details, storage_dst, shard_storage_set) =
-                setup_cluster_for_shard_sync_tests(None, None).await?;
+                setup_cluster_for_shard_sync_tests(None, None, true).await?;
 
             assert_eq!(shard_storage_set.shard_storage.len(), 1);
             let shard_storage_dst = shard_storage_set.shard_storage[0].clone();
@@ -8693,6 +8701,15 @@ mod tests {
             shard_storage_dst
                 .update_status_in_test(ShardStatus::None)
                 .await?;
+
+            // node 1 gains shard 0; reflect that in the committee so node 0 accepts its requests.
+            reassign_shards_to_destination_in_current_committee(
+                &cluster,
+                &[ShardIndex(0)],
+                1,
+                true,
+            )
+            .await?;
 
             // Starts the shard syncing process in the new shard, which should only use happy path
             // shard sync to sync non-expired certified blobs.
@@ -8846,7 +8863,7 @@ mod tests {
             fail_before_start_fetching: bool,
         ) -> TestResult {
             let (cluster, blob_details, storage_dst, shard_storage_set) =
-                setup_cluster_for_shard_sync_tests(None, None).await?;
+                setup_cluster_for_shard_sync_tests(None, None, false).await?;
 
             assert_eq!(shard_storage_set.shard_storage.len(), 1);
             let shard_storage_dst = shard_storage_set.shard_storage[0].clone();

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -1160,6 +1160,9 @@ impl Default for CommitteeServiceConfig {
     }
 }
 
+/// Default hard upper bound on the `sliver_count` a single sync-shard request may ask for.
+pub const DEFAULT_MAX_SLIVER_COUNT_PER_SYNC_REQUEST: usize = 100_000;
+
 /// Configuration for Walrus storage node shard synchronization.
 #[serde_as]
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
@@ -1167,6 +1170,12 @@ impl Default for CommitteeServiceConfig {
 pub struct ShardSyncConfig {
     /// The number of slivers to fetch in a single sync shard request.
     pub sliver_count_per_sync_request: u64,
+    /// Hard server-side upper bound on the `sliver_count` a single sync-shard request may ask for.
+    ///
+    /// Requests above it are rejected before the response vector is allocated, keeping the
+    /// allocation bounded. Defaults to [`DEFAULT_MAX_SLIVER_COUNT_PER_SYNC_REQUEST`] when unset;
+    /// set explicitly to `null` to disable the limit.
+    pub max_sliver_count_per_sync_request: Option<usize>,
     /// The minimum backoff time for shard sync retries.
     #[serde_as(as = "DurationSeconds<u64>")]
     #[serde(rename = "shard_sync_retry_min_backoff_secs")]
@@ -1203,6 +1212,7 @@ impl Default for ShardSyncConfig {
     fn default() -> Self {
         Self {
             sliver_count_per_sync_request: 1000,
+            max_sliver_count_per_sync_request: Some(DEFAULT_MAX_SLIVER_COUNT_PER_SYNC_REQUEST),
             shard_sync_retry_min_backoff: Duration::from_mins(1),
             shard_sync_retry_max_backoff: Duration::from_mins(10),
             max_concurrent_blob_recovery_during_shard_recovery: 100,
@@ -2162,6 +2172,28 @@ mod tests {
         "};
 
         let _: StorageNodeConfig = serde_yaml::from_str(yaml)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn shard_sync_max_sliver_count_serde() -> TestResult {
+        // Unset falls back to the default limit.
+        let unset: ShardSyncConfig = serde_yaml::from_str("{}")?;
+        assert_eq!(
+            unset.max_sliver_count_per_sync_request,
+            Some(DEFAULT_MAX_SLIVER_COUNT_PER_SYNC_REQUEST)
+        );
+
+        // Explicit null disables the limit.
+        let disabled: ShardSyncConfig =
+            serde_yaml::from_str("max_sliver_count_per_sync_request: null")?;
+        assert_eq!(disabled.max_sliver_count_per_sync_request, None);
+
+        // An explicit value is honored.
+        let custom: ShardSyncConfig =
+            serde_yaml::from_str("max_sliver_count_per_sync_request: 42")?;
+        assert_eq!(custom.max_sliver_count_per_sync_request, Some(42));
 
         Ok(())
     }

--- a/crates/walrus-service/src/node/errors.rs
+++ b/crates/walrus-service/src/node/errors.rs
@@ -404,6 +404,13 @@ pub enum SyncShardServiceError {
     #[rest_api_error(reason = "REQUEST_UNAUTHORIZED", status = ApiStatusCode::PermissionDenied)]
     Unauthorized,
 
+    /// The requested number of slivers exceeds the server-side limit.
+    #[error("the requested sliver count {requested} exceeds the limit of {limit}")]
+    #[rest_api_error(
+        reason = "SLIVER_COUNT_EXCEEDS_LIMIT", status = ApiStatusCode::InvalidArgument
+    )]
+    RequestedSliverCountExceedsLimit { requested: usize, limit: usize },
+
     /// The client cannot initiate a sync as it is not a storage node in the current committee.
     #[error("verification of the request to start the sync failed: {0}")]
     #[rest_api_error(

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -83,9 +83,9 @@ pub(crate) use shard::{PrimarySliverData, SecondarySliverData, ShardStatus, Shar
 
 /// Hard server-side upper bound on the `sliver_count` a single sync-shard request may ask for.
 ///
-/// `sliver_count` is attacker-controlled (part of the signed request but otherwise unbounded), so
-/// requests above this limit are rejected before any allocation to prevent a capacity-overflow
-/// panic or an out-of-memory abort. The default requester batch size is
+/// `sliver_count` is taken from the request and is otherwise only bounded on the requester side, so
+/// requests above this limit are rejected before the response vector is allocated, keeping the
+/// allocation bounded. The default requester batch size is
 /// [`ShardSyncConfig::sliver_count_per_sync_request`] (1000); this leaves ample headroom for
 /// operators that tune it upward.
 ///
@@ -1237,9 +1237,8 @@ impl Storage {
             }
         }
 
-        // Reject oversized requests before allocating: `Vec::with_capacity(sliver_count)` below
-        // would otherwise panic on overflow (`u64::MAX`) or abort the process via
-        // `handle_alloc_error` (a large non-overflowing value).
+        // Bound `sliver_count` before it sizes the `Vec::with_capacity` allocation below; it comes
+        // from the request and is otherwise only limited on the requester side.
         let sliver_count = request.sliver_count();
         if sliver_count > MAX_SLIVER_COUNT_PER_SYNC_REQUEST {
             return Err(SyncShardServiceError::RequestedSliverCountExceedsLimit {

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -81,17 +81,6 @@ mod shard;
 
 pub(crate) use shard::{PrimarySliverData, SecondarySliverData, ShardStatus, ShardStorage};
 
-/// Hard server-side upper bound on the `sliver_count` a single sync-shard request may ask for.
-///
-/// `sliver_count` is taken from the request and is otherwise only bounded on the requester side, so
-/// requests above this limit are rejected before the response vector is allocated, keeping the
-/// allocation bounded. The default requester batch size is
-/// [`ShardSyncConfig::sliver_count_per_sync_request`] (1000); this leaves ample headroom for
-/// operators that tune it upward.
-///
-/// [`ShardSyncConfig::sliver_count_per_sync_request`]: super::config::ShardSyncConfig
-pub(crate) const MAX_SLIVER_COUNT_PER_SYNC_REQUEST: usize = 100_000;
-
 /// The status of the node.
 ///
 /// ```text
@@ -1224,6 +1213,7 @@ impl Storage {
         &self,
         request: &SyncShardRequest,
         current_epoch: Epoch,
+        max_sliver_count: Option<usize>,
     ) -> Result<SyncShardResponse, SyncShardServiceError> {
         #[cfg(msim)]
         {
@@ -1238,12 +1228,15 @@ impl Storage {
         }
 
         // Bound `sliver_count` before it sizes the `Vec::with_capacity` allocation below; it comes
-        // from the request and is otherwise only limited on the requester side.
+        // from the request and is otherwise only limited on the requester side. `None` disables the
+        // bound, which an operator can configure if it interferes with shard sync.
         let sliver_count = request.sliver_count();
-        if sliver_count > MAX_SLIVER_COUNT_PER_SYNC_REQUEST {
+        if let Some(limit) = max_sliver_count
+            && sliver_count > limit
+        {
             return Err(SyncShardServiceError::RequestedSliverCountExceedsLimit {
                 requested: sliver_count,
-                limit: MAX_SLIVER_COUNT_PER_SYNC_REQUEST,
+                limit,
             });
         }
 
@@ -2178,7 +2171,7 @@ pub(crate) mod tests {
         );
         let SyncShardResponse::V1(slivers) = storage
             .as_ref()
-            .handle_sync_shard_request(&request, 2)
+            .handle_sync_shard_request(&request, 2, None)
             .await?;
 
         // Verify response matches expected
@@ -2206,7 +2199,7 @@ pub(crate) mod tests {
             SyncShardRequest::new(ShardIndex(123), SliverType::Primary, BlobId([1; 32]), 1, 1);
         let response = storage
             .as_ref()
-            .handle_sync_shard_request(&request, 0)
+            .handle_sync_shard_request(&request, 0, None)
             .await
             .unwrap_err();
 

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -81,6 +81,17 @@ mod shard;
 
 pub(crate) use shard::{PrimarySliverData, SecondarySliverData, ShardStatus, ShardStorage};
 
+/// Hard server-side upper bound on the `sliver_count` a single sync-shard request may ask for.
+///
+/// `sliver_count` is attacker-controlled (part of the signed request but otherwise unbounded), so
+/// requests above this limit are rejected before any allocation to prevent a capacity-overflow
+/// panic or an out-of-memory abort. The default requester batch size is
+/// [`ShardSyncConfig::sliver_count_per_sync_request`] (1000); this leaves ample headroom for
+/// operators that tune it upward.
+///
+/// [`ShardSyncConfig::sliver_count_per_sync_request`]: super::config::ShardSyncConfig
+pub(crate) const MAX_SLIVER_COUNT_PER_SYNC_REQUEST: usize = 100_000;
+
 /// The status of the node.
 ///
 /// ```text
@@ -1226,11 +1237,21 @@ impl Storage {
             }
         }
 
+        // Reject oversized requests before allocating: `Vec::with_capacity(sliver_count)` below
+        // would otherwise panic on overflow (`u64::MAX`) or abort the process via
+        // `handle_alloc_error` (a large non-overflowing value).
+        let sliver_count = request.sliver_count();
+        if sliver_count > MAX_SLIVER_COUNT_PER_SYNC_REQUEST {
+            return Err(SyncShardServiceError::RequestedSliverCountExceedsLimit {
+                requested: sliver_count,
+                limit: MAX_SLIVER_COUNT_PER_SYNC_REQUEST,
+            });
+        }
+
         let Some(shard) = self.shard_storage(request.shard_index()).await else {
             return Err(ShardNotAssigned(request.shard_index(), current_epoch).into());
         };
 
-        let sliver_count = request.sliver_count();
         let starting_blob_id = request.starting_blob_id();
         let sliver_type = request.sliver_type();
         let blob_info = self.blob_info.clone();


### PR DESCRIPTION
## Summary
- `sync_shard` now requires the requester to be assigned the requested shard in the current committee, rather than accepting any committee member.
- The per-request `sliver_count` is bounded before the response vector is allocated. The bound is configurable via `ShardSyncConfig::max_sliver_count_per_sync_request` (unset keeps the default of 100000; `null` disables it).
- Shard-sync tests reassign the synced shards to the destination in the committee so the source accepts the request, matching a real epoch change.

---
*Authored with Claude Code*
