### PR TITLE
docs: add pricing calculator guidance

### DIFF
--- a/docs/content/getting-started/index.mdx
+++ b/docs/content/getting-started/index.mdx
@@ -83,7 +83,7 @@ To confirm the Walrus configuration also uses Testnet, run the following command
 $ walrus info
 ```
 
-Make sure that the output of this command includes `Epoch duration: 1day` to indicate connection to Testnet.
+Make sure that the output of this command includes `Epoch duration: 1day` to indicate connection to Testnet. The same output also includes current storage pricing information. For interactive cost estimates, use the [Walrus Cost Calculator](https://costcalculator.wal.app/).
 
 For detailed information about the `walrus` CLI, use `walrus --help`. Append `--help` to any `walrus` subcommand to get details about that specific command.
 
@@ -129,7 +129,7 @@ The argument `ed25519` specifies the key pair scheme to be of type ed25519.
 
 ##step Fund Sui account with tokens
 
-Before you can upload a file to Walrus and store it as a blob, you need SUI tokens to pay transaction fees and WAL tokens to pay for storage on the network. Walrus Testnet uses Testnet WAL tokens that have no value. You can exchange them at a 1:1 rate for Testnet SUI tokens.
+Before you can upload a file to Walrus and store it as a blob, you need SUI tokens to pay transaction fees and WAL tokens to pay for storage on the network. Walrus Testnet uses Testnet WAL tokens that have no value. You can exchange them at a 1:1 rate for Testnet SUI tokens. For more information about storage costs, see [Storage Costs](/docs/system-overview/storage-costs).
 
 Navigate to the SUI Testnet faucet: https://faucet.sui.io/
 

--- a/docs/content/system-overview/storage-costs.mdx
+++ b/docs/content/system-overview/storage-costs.mdx
@@ -6,7 +6,11 @@ keywords: ["walrus", "storage costs", "wal token", "sui gas", "cost optimization
 
 When choosing a platform to store and verify data, you should consider reliability, uptime, availability, programmability, and price predictability. Walrus offers a fixed, USD-denominated storage cost of **$0.023/GB/month**, allowing you to budget and scale with confidence.
 
-Use the [Walrus Cost Calculator](https://costcalculator.wal.app/) to estimate total storage costs interactively.
+## Estimate storage costs
+
+Use the [Walrus Cost Calculator](https://costcalculator.wal.app/) to estimate storage costs before you upload. The calculator is the recommended place to model storage size, duration, encoding overhead, WAL storage costs, and SUI transaction costs together.
+
+For command-line estimates, run `walrus info` to view current storage prices and upload fees. You can also run `walrus store --dry-run ...` to see the encoded size used in WAL cost calculations without submitting transactions.
 
 ## How pricing works
 
@@ -18,7 +22,7 @@ You also pay **SUI** for executing transactions on Sui Mainnet. Each operation t
 
 :::tip
 
-Walrus uses erasure coding with approximately 5x expansion. The storage cost shown by `walrus info` accounts for this. You do not need to calculate the expansion yourself.
+Walrus uses erasure coding with approximately 5x expansion. The cost calculator and `walrus info` account for this. You do not need to calculate the expansion yourself.
 
 :::
 
@@ -98,11 +102,11 @@ Burning a blob's corresponding object on Sui does not delete the blob data on Wa
 
 #### Estimating costs without submitting transactions
 
-These commands help estimate costs without submitting transactions:
+Use the [Walrus Cost Calculator](https://costcalculator.wal.app/) for interactive planning. These commands help estimate costs locally without submitting transactions:
 
-- `walrus info` — displays current costs for buying storage resources and uploads.
+- `walrus info` displays current costs for buying storage resources and uploads.
 
-- `walrus store --dry-run ...` — outputs the encoded size used in WAL cost calculations without submitting any transactions.
+- `walrus store --dry-run ...` outputs the encoded size used in WAL cost calculations without submitting any transactions.
 
 ## Storage resource lifecycle
 

--- a/docs/content/system-overview/storage-costs.mdx
+++ b/docs/content/system-overview/storage-costs.mdx
@@ -8,7 +8,17 @@ When choosing a platform to store and verify data, you should consider reliabili
 
 ## Estimate storage costs
 
-Use the [Walrus Cost Calculator](https://costcalculator.wal.app/) to estimate storage costs before you upload. The calculator is the recommended place to model storage size, duration, encoding overhead, WAL storage costs, and SUI transaction costs together.
+Use the embedded Walrus Cost Calculator to estimate storage costs before you upload. The calculator models storage size, duration, encoding overhead, WAL storage costs, and SUI transaction costs together.
+
+<iframe
+  src="https://costcalculator.wal.app/"
+  title="Walrus Cost Calculator"
+  width="100%"
+  height="720"
+  style={{ border: 0, borderRadius: '8px' }}
+/>
+
+If the calculator does not load, open the [Walrus Cost Calculator](https://costcalculator.wal.app/) in a new tab.
 
 For command-line estimates, run `walrus info` to view current storage prices and upload fees. You can also run `walrus store --dry-run ...` to see the encoded size used in WAL cost calculations without submitting transactions.
 


### PR DESCRIPTION
## Description

Updates Storage Costs guidance for BEDU-249 using the pricing direction confirmed in BEDU-250.

Changes include:

- Adds an “Estimate storage costs” section near the top of Storage Costs.
- Links the Walrus Cost Calculator as the recommended interactive estimator.
- Mentions `walrus info` for current CLI pricing information.
- Mentions `walrus store --dry-run ...` for encoded-size estimates before submitting transactions.
- Adds a Getting Started cross-link to Storage Costs.

Closes [BEDU-249](https://linear.app/mysten-labs/issue/BEDU-249/p13-embed-the-walrus-pricing-calculator-into-the-docs).

## Test plan

- Ran `git diff --check`.
- Ran `pnpm build` from `docs/site`.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the relevant heading)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI: