### PR TITLE
fix: avoid msim consistency-check deadlock on shard-map lock

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -3054,6 +3054,9 @@ impl StorageNodeInner {
     }
 
     /// Returns true if the blob is stored at all shards that are in Active state.
+    // In simulation tests the consistency check uses `is_stored_at_active_shards_snapshot`
+    // instead, leaving this method without a caller under `cfg(msim)`.
+    #[cfg_attr(msim, allow(dead_code))]
     pub(crate) async fn is_stored_at_all_active_shards(
         &self,
         blob_id: &BlobId,
@@ -3070,6 +3073,57 @@ impl StorageNodeInner {
         }
 
         self.is_stored_at_specific_shards(blob_id, &shards).await
+    }
+
+    /// Snapshots the shard storages that are currently in `Active` state.
+    ///
+    /// The background consistency check captures this once, in async context, before entering its
+    /// `spawn_blocking` closure. Acquiring the shard-map read lock from *inside* that closure
+    /// (through `futures::executor::block_on`) deadlocks the single-threaded simulator against a
+    /// pending shard-removal writer, so we resolve the shards up front instead. See
+    /// `is_stored_at_active_shards_snapshot` for the synchronous existence check that consumes the
+    /// snapshot.
+    #[cfg(msim)]
+    pub(crate) async fn active_shard_storages_snapshot(&self) -> Vec<Arc<ShardStorage>> {
+        let mut active = Vec::new();
+        for shard_storage in self.storage.existing_shard_storages().await {
+            if matches!(shard_storage.status().await, Ok(ShardStatus::Active)) {
+                active.push(shard_storage);
+            }
+        }
+        active
+    }
+
+    /// Synchronous, snapshot-based counterpart of `is_stored_at_all_active_shards`.
+    ///
+    /// Used only by the background consistency check in simulation tests so that no shard-map lock
+    /// is acquired inside the `spawn_blocking` closure. The shards in `active_shard_storages` are
+    /// assumed to already be the active ones (see `active_shard_storages_snapshot`).
+    #[cfg(msim)]
+    pub(crate) fn is_stored_at_active_shards_snapshot(
+        &self,
+        blob_id: &BlobId,
+        active_shard_storages: &[Arc<ShardStorage>],
+    ) -> anyhow::Result<bool> {
+        // Mirror `is_stored_at_specific_shards`: run the cheap `may_have_sliver_pair` pre-check
+        // first (only when more than one shard), then the authoritative `is_sliver_pair_stored`.
+        if active_shard_storages.len() > 1 {
+            for shard_storage in active_shard_storages {
+                if !shard_storage.may_have_sliver_pair(blob_id)? {
+                    let shard = shard_storage.id();
+                    tracing::debug!(%blob_id, %shard, "blob not stored at shard");
+                    return Ok(false);
+                }
+            }
+        }
+        for shard_storage in active_shard_storages {
+            if !shard_storage.is_sliver_pair_stored(blob_id)? {
+                let shard = shard_storage.id();
+                tracing::debug!(%blob_id, %shard, "blob not stored at shard");
+                return Ok(false);
+            }
+        }
+        Ok(true)
     }
 
     pub(crate) fn storage(&self) -> &Storage {

--- a/crates/walrus-service/src/node/consistency_check.rs
+++ b/crates/walrus-service/src/node/consistency_check.rs
@@ -19,6 +19,8 @@ use typed_store::TypedStoreError;
 use walrus_core::{BlobId, Epoch};
 use walrus_utils::metrics::monitored_scope;
 
+#[cfg(msim)]
+use super::storage::ShardStorage;
 use super::{
     NodeStatus,
     StorageNodeInner,
@@ -112,6 +114,13 @@ pub(super) async fn schedule_background_consistency_check(
     let blob_sync_handler = blob_sync_handler.clone();
     let (tx, rx) = oneshot::channel();
 
+    // Snapshot the active shard storages once, here in async context, so that the existence check
+    // does not need to take the shard-map read lock from inside the `spawn_blocking` closure.
+    // Acquiring that lock there (through `futures::executor::block_on`) deadlocks the
+    // single-threaded simulator against a pending shard-removal writer.
+    #[cfg(msim)]
+    let active_shard_storages = node.active_shard_storages_snapshot().await;
+
     // Create a background thread which takes the ownership of the iterator and process it.
     tokio::task::spawn_blocking(move || {
         let _scope =
@@ -141,6 +150,8 @@ pub(super) async fn schedule_background_consistency_check(
             epoch,
             node_status,
             &blobs_not_yet_fully_synced,
+            #[cfg(msim)]
+            &active_shard_storages,
         );
 
         compose_certified_object_blob_list_digest(
@@ -215,6 +226,7 @@ fn compose_blob_list_digest_and_check_sliver_data_existence(
     node_status: NodeStatus,
     blobs_not_yet_fully_synced: &HashSet<BlobId>,
     scan_counter: &IntCounterVec,
+    #[cfg(msim)] active_shard_storages: &[Arc<ShardStorage>],
 ) -> Result<BlobConsistencyCheckResult, TypedStoreError> {
     // Create a new tokio runtime for the async task to check blob existence.
     #[cfg(not(msim))]
@@ -292,15 +304,21 @@ fn compose_blob_list_digest_and_check_sliver_data_existence(
                         );
                     }
 
-                    // Unfortunately, msim does not support tokio::Runtime::block_on, so we need to
-                    // use less ideal method to execute the async function that checks blob
-                    // data existence. Note that simtest is mostly for correctness verification, so
-                    // the performance is not a concern.
+                    // msim runs the whole consistency check inside a `spawn_blocking` closure that,
+                    // unlike production, executes on the single simulator task runner rather than a
+                    // real blocking thread. Driving an async existence check here with
+                    // `futures::executor::block_on` would park that runner while the future waits
+                    // for the shard-map read lock, deadlocking against a pending shard-removal
+                    // writer that needs the same runner to proceed. Instead we check the
+                    // pre-captured `active_shard_storages` snapshot synchronously, so no lock is
+                    // acquired and the runner is never parked. Note that simtest is mostly for
+                    // correctness verification, so performance is not a concern.
                     #[cfg(msim)]
                     {
                         handle_existence_check_result(
-                            futures::executor::block_on(
-                                node.is_stored_at_all_active_shards(&blob_info.0),
+                            node.is_stored_at_active_shards_snapshot(
+                                &blob_info.0,
+                                active_shard_storages,
                             ),
                             &mut total_fully_stored,
                             &mut existence_check_error,
@@ -358,6 +376,7 @@ fn certified_blob_consistency_check(
     epoch: Epoch,
     node_status: NodeStatus,
     blobs_not_yet_fully_synced: &HashSet<BlobId>,
+    #[cfg(msim)] active_shard_storages: &[Arc<ShardStorage>],
 ) {
     let _scope = monitored_scope::monitored_scope(
         "EpochChange::background_certified_blob_info_consistency_check",
@@ -371,6 +390,8 @@ fn certified_blob_consistency_check(
         node_status,
         blobs_not_yet_fully_synced,
         &node.metrics.blob_info_consistency_check_certified_scanned,
+        #[cfg(msim)]
+        active_shard_storages,
     ) {
         Ok(BlobConsistencyCheckResult {
             blob_list_digest,


### PR DESCRIPTION
## Description

Under `cfg(msim)`, `spawn_blocking` runs on the single simulator task runner. The consistency check used `futures::executor::block_on`, parking that runner while awaiting the shard-map `RwLock` read. 
Tokio read-write lock priority policy queues that read behind a pending shard-removal writer lock. However, pending shard-removal writer lock cannot proceed either as the msim task runner is parked. 

This PR snapshots the active shard storages once in async context before the `spawn_blocking` closure, then check each blob against the snapshot synchronously. No lock is taken inside the closure, so the runner is never parked. The changes are done in `cfg(msim)` helpers and production is not affected.

## Test plan
Compiles clean in both configurations. 

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
