### PR TITLE
chore: bump Rust toolchain to v1.96

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ registration, certification, and economics.
 ### Prerequisites
 
 System packages: `libssl-dev pkg-config zlib1g-dev libpq-dev build-essential cmake`
-Rust toolchain: 1.93 (specified in `rust-toolchain.toml`)
+Rust toolchain: 1.96 (specified in `rust-toolchain.toml`)
 
 ### Building
 

--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -99,7 +99,7 @@ use walrus_sui::{
     test_utils::{self, fund_addresses, wallet_for_testing},
     types::{
         Blob,
-        move_errors::{MoveExecutionError, RawMoveError},
+        move_errors::MoveExecutionError,
         move_structs::{BlobAttribute, BlobWithAttribute, Credits, SharedBlob},
     },
 };
@@ -2584,14 +2584,10 @@ async fn test_blob_attribute_fields_operations() -> TestResult {
         .await;
     assert!(matches!(
         result.unwrap_err().downcast::<SuiClientError>().unwrap().as_ref(),
-        SuiClientError::TransactionExecutionError(
-            MoveExecutionError::OtherMoveModule(RawMoveError {
-                function,
-                module,
-                error_code,
-                ..
-            })
-        ) if function.as_str() == "get_idx" && module.as_str() == "vec_map" && *error_code == 1
+        SuiClientError::TransactionExecutionError(MoveExecutionError::OtherMoveModule(raw))
+            if raw.function.as_str() == "get_idx"
+                && raw.module.as_str() == "vec_map"
+                && raw.error_code == 1
     ));
 
     Ok(())

--- a/crates/walrus-sdk/src/node_client.rs
+++ b/crates/walrus-sdk/src/node_client.rs
@@ -855,7 +855,7 @@ impl<T: ReadClient> WalrusNodeClient<T> {
                     for sliver in recovered_slivers.iter() {
                         sliver_selector.remove_sliver(&sliver.index);
                     }
-                    all_slivers.extend(recovered_slivers.into_iter());
+                    all_slivers.extend(recovered_slivers);
                 }
                 Ok(Err(error)) => {
                     tracing::debug!(?error, "error recovering slivers");

--- a/crates/walrus-service/src/client/cli/runner.rs
+++ b/crates/walrus-service/src/client/cli/runner.rs
@@ -1914,10 +1914,7 @@ impl ClientCommandRunner {
                 .zip(iter::repeat(amounts[0]))
                 .collect::<Vec<_>>()
         } else {
-            node_ids
-                .into_iter()
-                .zip(amounts.into_iter())
-                .collect::<Vec<_>>()
+            node_ids.into_iter().zip(amounts).collect::<Vec<_>>()
         };
         let client = get_contract_client(self.config?, self.wallet?, self.gas_budget).await?;
         let staked_wal = client.stake_with_node_pools(&node_ids_with_amounts).await?;

--- a/crates/walrus-service/src/client/daemon/cache.rs
+++ b/crates/walrus-service/src/client/daemon/cache.rs
@@ -417,9 +417,7 @@ mod tests {
         expected_responses: Vec<CacheResponse>,
     ) {
         let responses = run_cache(requests).await;
-        for (response, expected_response) in
-            responses.into_iter().zip(expected_responses.into_iter())
-        {
+        for (response, expected_response) in responses.into_iter().zip(expected_responses) {
             assert_eq!(response.expect("response is ok"), expected_response);
         }
     }

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -6170,7 +6170,7 @@ mod tests {
         let all_other_node_events = Sender::new(48);
         let event_providers = vec![node_0_events.clone(); 1]
             .into_iter()
-            .chain(vec![all_other_node_events.clone(); assignment.len() - 1].into_iter())
+            .chain(vec![all_other_node_events.clone(); assignment.len() - 1])
             .collect::<Vec<_>>();
 
         let cluster = {

--- a/crates/walrus-service/src/node/wal_price_monitor.rs
+++ b/crates/walrus-service/src/node/wal_price_monitor.rs
@@ -404,7 +404,7 @@ impl WalPriceMonitor {
 
                 // Collect successful price fetches
                 let mut prices = Vec::new();
-                for (fetcher, result) in fetchers.iter().zip(results.into_iter()) {
+                for (fetcher, result) in fetchers.iter().zip(results) {
                     match result {
                         Ok(price) => {
                             tracing::debug!(

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -2860,7 +2860,7 @@ pub mod test_cluster {
             let sui_rpc_urls: Vec<String> = {
                 let cluster = sui_cluster.lock().await;
                 once(cluster.rpc_url().to_string())
-                    .chain(cluster.additional_rpc_urls().into_iter())
+                    .chain(cluster.additional_rpc_urls())
                     .collect()
             };
 

--- a/crates/walrus-storage-node-client/src/tls.rs
+++ b/crates/walrus-storage-node-client/src/tls.rs
@@ -252,7 +252,7 @@ impl ServerCertVerifier for TlsCertificateVerifier {
         );
 
         match result {
-            Ok(verified) if !self.has_pinned_public_key_or_unset(end_entity) => {
+            Ok(_verified) if !self.has_pinned_public_key_or_unset(end_entity) => {
                 Err(rustls::Error::General(
                     "the server's certificate does not match the pinned public key".to_owned(),
                 ))

--- a/crates/walrus-sui/build.rs
+++ b/crates/walrus-sui/build.rs
@@ -175,8 +175,10 @@ pub enum MoveExecutionError {
     }
     code.push_str(
         r#"    /// Error in other move modules.
+    // Boxed to keep this variant from dominating the size of `MoveExecutionError`; the typed
+    // variants already box `RawMoveError`.
     #[error("Unknown move error occurred: {0}")]
-    OtherMoveModule(RawMoveError),
+    OtherMoveModule(Box<RawMoveError>),
     /// A non-parsable move error.
     #[error("unparsable move error occurred: {0}")]
     NotParsable(String),
@@ -204,10 +206,12 @@ fn generate_move_error_from_impl(module_error_defs: &[ModuleErrorDefs]) -> Strin
     }
 
     // Add the fallback case.
-    code.push_str("            _ => Ok(Self::OtherMoveModule(error)),\n");
+    code.push_str("            _ => Ok(Self::OtherMoveModule(Box::new(error))),\n");
 
     code.push_str("        }\n");
-    code.push_str("        .unwrap_or_else(|e: ConversionError| Self::OtherMoveModule(e.0))\n");
+    code.push_str(
+        "        .unwrap_or_else(|e: ConversionError| Self::OtherMoveModule(Box::new(e.0)))\n",
+    );
     code.push_str("    }\n");
     code.push_str("}\n\n");
 

--- a/crates/walrus-sui/src/client.rs
+++ b/crates/walrus-sui/src/client.rs
@@ -126,8 +126,9 @@ pub enum SuiClientError {
     #[error(transparent)]
     Internal(#[from] anyhow::Error),
     /// Error resulting from a Sui-SDK call.
+    // Wrapped in a `Box` to avoid the large memory overhead of this error variant.
     #[error(transparent)]
-    SuiSdkError(#[from] sui_sdk::error::Error),
+    SuiSdkError(#[from] Box<sui_sdk::error::Error>),
     /// Other errors resulting from Sui crates.
     // Wrapped in a `Box` to avoid the large memory overhead of this error variant.
     #[error(transparent)]
@@ -222,6 +223,12 @@ pub enum SuiClientError {
 impl From<sui_types::error::SuiError> for SuiClientError {
     fn from(error: sui_types::error::SuiError) -> Self {
         Self::SuiError(Box::new(error))
+    }
+}
+
+impl From<sui_sdk::error::Error> for SuiClientError {
+    fn from(error: sui_sdk::error::Error) -> Self {
+        Self::SuiSdkError(Box::new(error))
     }
 }
 

--- a/crates/walrus-sui/src/client/owned_blob_ops.rs
+++ b/crates/walrus-sui/src/client/owned_blob_ops.rs
@@ -912,10 +912,7 @@ impl SuiContractClientInner {
 
         let mut pt_builder = self.transaction_builder();
 
-        for (blob_params, object_arg) in certify_and_extend_parameters
-            .iter()
-            .zip(object_args.into_iter())
-        {
+        for (blob_params, object_arg) in certify_and_extend_parameters.iter().zip(object_args) {
             let blob = blob_params.blob;
 
             if let Some(certificate) = blob_params.certificate.as_ref() {
@@ -970,7 +967,7 @@ impl SuiContractClientInner {
 
         let results = certify_and_extend_parameters
             .iter()
-            .zip(post_store_action_results.into_iter())
+            .zip(post_store_action_results)
             .map(|(blob_params, r)| CertifyAndExtendBlobResult {
                 blob_object_id: blob_params.blob.id,
                 post_store_action_result: r,

--- a/crates/walrus-sui/src/client/read_client.rs
+++ b/crates/walrus-sui/src/client/read_client.rs
@@ -683,12 +683,12 @@ impl SuiReadClient {
             )
             .await
             .map_err(|err| match err {
-                SuiClientError::SuiSdkError(sui_sdk::error::Error::InsufficientFund {
-                    address: _,
-                    amount,
-                }) => match coin_type {
-                    CoinType::Wal => SuiClientError::NoCompatibleWalCoins,
-                    CoinType::Sui => SuiClientError::NoCompatibleGasCoins(Some(amount)),
+                SuiClientError::SuiSdkError(boxed) => match *boxed {
+                    sui_sdk::error::Error::InsufficientFund { amount, .. } => match coin_type {
+                        CoinType::Wal => SuiClientError::NoCompatibleWalCoins,
+                        CoinType::Sui => SuiClientError::NoCompatibleGasCoins(Some(amount)),
+                    },
+                    other => SuiClientError::SuiSdkError(Box::new(other)),
                 },
                 err => err,
             })

--- a/crates/walrus-sui/src/client/retry_client/failover.rs
+++ b/crates/walrus-sui/src/client/retry_client/failover.rs
@@ -56,9 +56,7 @@ pub trait MakeRetriableError {
 
 impl MakeRetriableError for SuiClientError {
     fn make_retriable_error() -> Self {
-        SuiClientError::SuiSdkError(sui_sdk::error::Error::RpcError(
-            jsonrpsee::core::ClientError::RequestTimeout,
-        ))
+        sui_sdk::error::Error::RpcError(jsonrpsee::core::ClientError::RequestTimeout).into()
     }
 }
 

--- a/docker/walrus-antithesis/build-walrus-image-for-antithesis/Dockerfile
+++ b/docker/walrus-antithesis/build-walrus-image-for-antithesis/Dockerfile
@@ -8,7 +8,7 @@
 
 # Stage 1: Base Build Environment + Builder
 # -------------------------------------
-FROM rust:1.93-bookworm AS builder
+FROM rust:1.96-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends cmake clang \

--- a/docker/walrus-orchestrator/Dockerfile
+++ b/docker/walrus-orchestrator/Dockerfile
@@ -3,7 +3,7 @@
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
 
-FROM rust:1.93-bookworm AS builder
+FROM rust:1.96-bookworm AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends cmake clang \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/walrus-proxy/Dockerfile
+++ b/docker/walrus-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.93-bookworm AS builder
+FROM rust:1.96-bookworm AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends cmake clang \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/walrus-service/Dockerfile
+++ b/docker/walrus-service/Dockerfile
@@ -3,7 +3,7 @@
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
 
-FROM rust:1.93-bookworm AS builder
+FROM rust:1.96-bookworm AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends cmake clang \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/walrus-service/Dockerfile.walrus-backup
+++ b/docker/walrus-service/Dockerfile.walrus-backup
@@ -3,7 +3,7 @@
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
 
-FROM rust:1.93-bookworm AS builder
+FROM rust:1.96-bookworm AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends cmake clang \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/walrus-stress/Dockerfile
+++ b/docker/walrus-stress/Dockerfile
@@ -3,7 +3,7 @@
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
 
-FROM rust:1.93-bookworm AS builder
+FROM rust:1.96-bookworm AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends cmake clang \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/walrus-upload-relay/Dockerfile
+++ b/docker/walrus-upload-relay/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.93-bookworm AS builder
+FROM rust:1.96-bookworm AS builder
 RUN apt-get update && apt-get install -y --no-install-recommends cmake clang \
     && rm -rf /var/lib/apt/lists/*
 ARG PROFILE=release

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.93"
+channel = "1.96"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Description

Bumps the Rust toolchain to the latest stable release 1.96 in the `rust-toolchain.toml` and all Dockerfiles.

Minor code changes were necessary to address new Clippy warnings. The biggest was to box some error variants in `walrus-sui` to limit the overall error sizes.

## Test plan

CI.