### PR TITLE
docs(walrus): add known gotcha callouts

### DIFF
--- a/docs/content/data-security.mdx
+++ b/docs/content/data-security.mdx
@@ -40,6 +40,18 @@ Seal integrates seamlessly with Walrus and is recommended for any use cases invo
 - Time-locked or token-gated data
 - Data shared between trusted parties or roles
 
+:::tip Seal transactions need an explicit sender
+
+When building a programmable transaction block (PTB) for Seal policy checks, set the transaction sender before passing the PTB to Seal. The sender must match the address that is requesting decryption access.
+
+```ts
+tx.setSender(address);
+```
+
+If the sender is missing or does not match, decryption can fail with `Transaction was not signed by the correct sender`.
+
+:::
+
 To get started, refer to [Seal SDK](https://www.npmjs.com/package/@mysten/seal).
 
 ## Nautilus: Secure and verifiable off-chain computation

--- a/docs/content/http-api/storing-blobs.mdx
+++ b/docs/content/http-api/storing-blobs.mdx
@@ -4,6 +4,12 @@ description: Store blobs on Walrus using HTTP PUT requests through a publisher, 
 keywords: [ walrus, HTTP, API, publisher, store, blob, PUT, deletable, permanent, quilt ]
 ---
 
+:::caution No public Mainnet publisher
+
+Walrus has no public unauthenticated publisher on Mainnet, and there will not be one — a publisher pays WAL for every blob it stores. On Mainnet, run your own authenticated publisher (or use the [Upload Relay](/docs/operator-guide/upload-relay) or TypeScript SDK directly). The public publisher endpoints below are for Testnet, where WAL has no value.
+
+:::
+
 You can store data using HTTP PUT requests. The following examples use `curl` to store blobs through a publisher:
 
 ```sh

--- a/docs/content/http-api/storing-blobs.mdx
+++ b/docs/content/http-api/storing-blobs.mdx
@@ -6,7 +6,7 @@ keywords: [ walrus, HTTP, API, publisher, store, blob, PUT, deletable, permanent
 
 :::caution No public Mainnet publisher
 
-Walrus has no public unauthenticated publisher on Mainnet, and there will not be one — a publisher pays WAL for every blob it stores. On Mainnet, run your own authenticated publisher (or use the [Upload Relay](/docs/operator-guide/upload-relay) or TypeScript SDK directly). The public publisher endpoints below are for Testnet, where WAL has no value.
+Walrus has no public unauthenticated publisher on Mainnet. There are no plans to create one. On Mainnet, run your own authenticated publisher (or use the [Upload Relay](/docs/operator-guide/upload-relay) or [TypeScript SDK](/docs/typescript-sdk/sdks) directly). The public publisher endpoints below are for Testnet, where WAL has no monetary value.
 
 :::
 

--- a/docs/content/troubleshooting/network-errors.mdx
+++ b/docs/content/troubleshooting/network-errors.mdx
@@ -455,3 +455,16 @@ Error: Failed to allocate encoding buffer
 **Cause:** The blob is too large for available memory. The encoding needs at least 4.5x the blob size if the blob is to be stored. If the blob is only encoded to compute the metadata or blob ID, it's only ~1.5x.
 
 **Solution:** Run the CLI on a machine with sufficient RAM. Split large blobs into smaller chunks in your application before uploading. If you are using a publisher, use one with more available memory.
+
+#### `insufficient balance` despite holding WAL
+
+**Error:**
+
+```text
+Error: insufficient balance
+Error: no WAL coins found for storage payment
+```
+
+**Cause:** Your WAL may be from a different package than the Walrus client expects. Some third-party Testnet faucets distribute WAL from a non-canonical package, and the client rejects it with an `insufficient balance` error even though a balance appears in your wallet.
+
+**Solution:** Acquire WAL through the official path documented in [Getting Started](/docs/getting-started), not third-party faucets. On Testnet, use the WAL exchange (`walrus get-wal`); on Mainnet, swap SUI for WAL through a supported exchange. WAL from an unsupported package cannot be used for storage payments.


### PR DESCRIPTION
## Description

Adds three known gotcha callouts for common Walrus builder issues:

- Mainnet has no unauthenticated public publisher
- WAL coin-type mismatch can cause `insufficient balance` errors
- Seal PTBs need an explicit `tx.setSender(address)` before policy checks

These address the remaining in-doc gotcha cards for BEDU-255:
- BEDU-258
- BEDU-266
- BEDU-267

BEDU-265 was already addressed by the merged BEDU-254 eventual-consistency page.

## Test plan

- Previewed locally in the docs site
- Verified the new callouts render on:
  - `/docs/http-api/storing-blobs`
  - `/docs/troubleshooting/network-errors`
  - `/docs/data-security`