### PR TITLE
fix: remove duplicate walrus-memory pages from llms.txt

### DIFF
--- a/docs/site/src/scripts/copy-markdown-files.js
+++ b/docs/site/src/scripts/copy-markdown-files.js
@@ -300,10 +300,6 @@ const walrusMemoryOutputDir = path.join(outputDir, 'walrus-memory');
 if (fs.existsSync(walrusMemoryDir)) {
   console.log('\n📝 Exporting Walrus Memory docs...');
   fs.mkdirSync(walrusMemoryOutputDir, { recursive: true });
-  copyMarkdownFiles(walrusMemoryDir, walrusMemoryDir);
-  // Move exported files from their default output location to the walrus-memory subdirectory
-  // copyMarkdownFiles writes to outputDir based on baseDir, so we need to re-export with correct paths
-  // Actually, let's do a direct recursive copy with cleaning
   function copyWalrusMemoryFiles(dir, baseDir) {
     const files = fs.readdirSync(dir);
     files.forEach(file => {


### PR DESCRIPTION
## Summary

Fix duplicate Walrus Memory entries in `llms.txt` and the markdown export.

## Problem

Walrus Memory pages appeared twice in `static/markdown/` and `llms.txt`:
- `docs/getting-started/what-is-memwal` (wrong, no prefix)
- `docs/walrus-memory/getting-started/what-is-memwal` (correct)

## Cause

`copy-markdown-files.js` called `copyMarkdownFiles()` on the walrus-memory-content directory, which wrote files to `static/markdown/` without the `walrus-memory/` prefix. The separate `copyWalrusMemoryFiles()` function then correctly wrote them again under `static/markdown/walrus-memory/`.

## Fix

Remove the redundant `copyMarkdownFiles()` call. Only `copyWalrusMemoryFiles()` runs, writing files exclusively to `static/markdown/walrus-memory/`.

## Test plan

- [x] `llms.txt` contains only `docs/walrus-memory/*` URLs for Walrus Memory pages
- [x] No memwal files exist outside `static/markdown/walrus-memory/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)