### PR TITLE
feat(simtest): support TEST_FILTER env var in simtest-run.sh

### DIFF
--- a/scripts/simtest/simtest-run.sh
+++ b/scripts/simtest/simtest-run.sh
@@ -52,9 +52,15 @@ WATCHDOG_TIMEOUT_MS=30000
 # By default run 1 iteration for each test, if not specified.
 : ${TEST_NUM:=1}
 
+# By default run all walrus simtests (filtered by the `walrus-simtest` binary name), if not
+# specified. Set TEST_FILTER to a specific test name to run only that test, e.g.
+# TEST_FILTER=test_repeated_node_crash.
+: ${TEST_FILTER:=simtest}
+
 echo ""
 echo "================================================"
 echo "Running e2e simtests with $TEST_NUM iterations"
+echo "Test filter: $TEST_FILTER"
 echo "================================================"
 date
 
@@ -66,7 +72,7 @@ TMPDIR="$WALRUS_TMP_DIR" \
 MSIM_TEST_SEED="$SEED" \
 MSIM_TEST_NUM=${TEST_NUM} \
 MSIM_WATCHDOG_TIMEOUT_MS="$WATCHDOG_TIMEOUT_MS" \
-scripts/simtest/cargo-simtest simtest simtest \
+scripts/simtest/cargo-simtest simtest "$TEST_FILTER" \
   --color never \
   --test-threads "$NUM_CPUS" \
   --profile simtestnightly 2>&1 | tee "$LOG_FILE"


### PR DESCRIPTION
## Summary

Adds an optional `TEST_FILTER` env var to `scripts/simtest/simtest-run.sh`.

- Defaults to `simtest`, which matches the `walrus-simtest` binary name and therefore runs **all** walrus simtests — preserving current behavior exactly.
- Setting it to a specific test name runs only that test, e.g. `TEST_FILTER=test_repeated_node_crash`.

The filter is threaded into the existing `cargo-simtest simtest <filter>` invocation (replacing the previously hardcoded `simtest` argument). `cargo-simtest` already handles an arbitrary filter as its first positional, so no change is needed there.

## Motivation

Enables targeted nightly workflows that exercise a single simtest with a high iteration count (e.g. running `test_repeated_node_crash` 200 times). A companion sui-operations workflow (`walrus-repeated-node-crash-simtest-nightly.yaml`) will set `TEST_FILTER` + `TEST_NUM` to drive this.

## Test plan

- Default behavior unchanged: with `TEST_FILTER` unset, the script runs `cargo-simtest simtest simtest ...` exactly as before.
- With `TEST_FILTER=test_repeated_node_crash`, the script runs `cargo-simtest simtest test_repeated_node_crash ...`, which `nextest` resolves to the single test in `crates/walrus-simtest/tests/simtest_failure.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)