### PR TITLE
docs: rename what-is-memwal to what-is-walrus-memory

### DIFF
--- a/docs/site/sidebarsWalrusMemory.js
+++ b/docs/site/sidebarsWalrusMemory.js
@@ -22,7 +22,7 @@ const sidebars = {
       collapsed: false,
       link: {
         type: "doc",
-        id: "getting-started/what-is-memwal",
+        id: "getting-started/what-is-walrus-memory",
       },
       items: [
         "getting-started/quick-start",

--- a/docs/site/src/scripts/transform-walrus-memory-docs.js
+++ b/docs/site/src/scripts/transform-walrus-memory-docs.js
@@ -24,7 +24,7 @@ const OUTPUT_DIR = path.resolve(SITE_ROOT, "../walrus-memory-content");
 
 // All known MemWal doc pages (from docs.json + orphans) for link rewriting
 const KNOWN_PAGES = [
-  "getting-started/what-is-memwal",
+  "getting-started/what-is-walrus-memory",
   "getting-started/quick-start",
   "getting-started/choose-your-path",
   "fundamentals/concepts/memory-space",
@@ -85,6 +85,11 @@ const KNOWN_PAGES = [
   "security/health-check-unsigned",
   "examples/example-apps",
 ];
+
+// --- File rename map (remote filename → local filename) ---
+const RENAME_MAP = {
+  "getting-started/what-is-memwal.md": "getting-started/what-is-walrus-memory.md",
+};
 
 // --- Mintlify component transforms ---
 
@@ -760,8 +765,11 @@ function main() {
     const content = fs.readFileSync(fullPath, "utf8");
     const transformed = transformFile(content);
 
+    // Apply file renames if configured
+    const outputRelPath = RENAME_MAP[relPath] || relPath;
+
     // Preserve directory structure
-    const outPath = path.join(OUTPUT_DIR, relPath);
+    const outPath = path.join(OUTPUT_DIR, outputRelPath);
     const outDir = path.dirname(outPath);
     if (!fs.existsSync(outDir)) {
       fs.mkdirSync(outDir, { recursive: true });

--- a/docs/site/src/theme/Navbar/Content/index.js
+++ b/docs/site/src/theme/Navbar/Content/index.js
@@ -287,7 +287,7 @@ export default function NavbarContent() {
               <>
                 <NavbarItems items={before} />
                 <AppsDropdown items={[
-                  { label: "Walrus Memory", href: "/walrus-memory/getting-started/what-is-memwal" },
+                  { label: "Walrus Memory", href: "/walrus-memory/getting-started/what-is-walrus-memory" },
                 ]} />
                 <NavbarItems items={after} />
               </>

--- a/docs/site/ws-resources.manual.json
+++ b/docs/site/ws-resources.manual.json
@@ -1066,6 +1066,10 @@
       "location": "/docs/sites",
       "status_code": 301
     },
+    "/walrus-memory/getting-started/what-is-memwal": {
+      "location": "/walrus-memory/getting-started/what-is-walrus-memory",
+      "status_code": 301
+    },
     "https://docs.walrus.site": {
       "location": "https://docs.wal.app",
       "status_code": 301


### PR DESCRIPTION
## Summary
- Renames the walrus-memory getting-started page slug from `what-is-memwal` to `what-is-walrus-memory` for clarity
- Adds a 301 redirect in `ws-resources.manual.json` so the old URL (`/walrus-memory/getting-started/what-is-memwal`) redirects to the new one
- Updates all references: sidebar, navbar link, and transform script (KNOWN_PAGES + RENAME_MAP so the remote-fetched file gets renamed during build)

## Test plan
- [ ] Run `pnpm build` in `docs/site/` and verify the build succeeds
- [ ] Confirm `/walrus-memory/getting-started/what-is-walrus-memory` loads correctly
- [ ] Confirm `/walrus-memory/getting-started/what-is-memwal` returns a 301 redirect
- [ ] Verify the sitemap contains the new URL and not the old one

🤖 Generated with [Claude Code](https://claude.com/claude-code)