### PR TITLE
docs: add walrus-memory landing page

### DIFF
--- a/docs/site/sidebarsWalrusMemory.js
+++ b/docs/site/sidebarsWalrusMemory.js
@@ -7,14 +7,9 @@
 const sidebars = {
   walrusMemorySidebar: [
     {
-      type: "html",
-      value:
-        '<div style="font-weight:700;font-size:1.1rem;' +
-        "padding:0.6rem 0.75rem 0.4rem;" +
-        "color:var(--ifm-color-primary);" +
-        "border-bottom:1px solid var(--ifm-toc-border-color);" +
-        'margin-bottom:0.5rem">Walrus Memory</div>',
-      defaultStyle: true,
+      type: "doc",
+      id: "index",
+      label: "Walrus Memory",
     },
     {
       type: "category",

--- a/docs/site/src/scripts/transform-walrus-memory-docs.js
+++ b/docs/site/src/scripts/transform-walrus-memory-docs.js
@@ -771,6 +771,50 @@ function main() {
     count++;
   }
 
+  // Write landing page (not in upstream repo, maintained here)
+  const landingPage = `---
+title: Walrus Memory
+description: "Portable, verifiable memory for AI agents built on Walrus and Sui."
+slug: /
+---
+
+Walrus Memory gives AI agents persistent, portable memory that works across apps, sessions, and
+workflows. Ownership and access are enforced onchain through Sui smart contracts, and all content is
+encrypted through Seal before reaching Walrus.
+
+<Cards>
+  <Card title="Get Started" href="/walrus-memory/getting-started/what-is-memwal">
+    Learn what Walrus Memory is and get up and running quickly
+  </Card>
+  <Card title="Concepts" href="/walrus-memory/fundamentals/concepts/memory-space">
+    Memory spaces, ownership, delegates, and access control
+  </Card>
+  <Card title="Architecture" href="/walrus-memory/fundamentals/architecture/core-components">
+    Core components, data flow, storage model, and security
+  </Card>
+  <Card title="TypeScript SDK" href="/walrus-memory/sdk/overview">
+    Integrate memory into TypeScript apps with the SDK
+  </Card>
+  <Card title="Python SDK" href="/walrus-memory/python-sdk/quick-start">
+    Use Walrus Memory from Python
+  </Card>
+  <Card title="Relayer" href="/walrus-memory/relayer/overview">
+    Managed relayer, self-hosting, and API reference
+  </Card>
+  <Card title="MCP" href="/walrus-memory/mcp/overview">
+    Model Context Protocol integration for AI tools
+  </Card>
+  <Card title="Smart Contract" href="/walrus-memory/contract/overview">
+    Onchain ownership model, delegate keys, and permissions
+  </Card>
+  <Card title="Indexer" href="/walrus-memory/indexer/purpose">
+    Event indexing, onchain events, and database sync
+  </Card>
+</Cards>
+`;
+  fs.writeFileSync(path.join(OUTPUT_DIR, "index.md"), landingPage);
+  count++;
+
   console.log(
     `✅ walrus-memory: transformed ${count} files → walrus-memory-content/`,
   );


### PR DESCRIPTION
## Summary
- Adds a landing page at `/walrus-memory` with cards linking to each subsection (Get Started, Concepts, Architecture, TypeScript SDK, Python SDK, Relayer, MCP, Smart Contract, Indexer)
- Replaces the static HTML sidebar header with a clickable "Walrus Memory" doc link at the top of the sidebar
- Landing page is generated by the transform script since `walrus-memory-content/` is rebuilt from upstream on each build

## Test plan
- [ ] Run `pnpm build` in `docs/site/` and verify the build succeeds
- [ ] Confirm `/walrus-memory` loads the landing page with card links
- [ ] Verify the sidebar shows "Walrus Memory" as a clickable link at the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)