### PR TITLE
docs: add AgentPrompt to Walrus Memory quick-start page

### DIFF
--- a/docs/site/sidebarsWalrusMemory.js
+++ b/docs/site/sidebarsWalrusMemory.js
@@ -7,14 +7,9 @@
 const sidebars = {
   walrusMemorySidebar: [
     {
-      type: "html",
-      value:
-        '<div style="font-weight:700;font-size:1.1rem;' +
-        "padding:0.6rem 0.75rem 0.4rem;" +
-        "color:var(--ifm-color-primary);" +
-        "border-bottom:1px solid var(--ifm-toc-border-color);" +
-        'margin-bottom:0.5rem">Walrus Memory</div>',
-      defaultStyle: true,
+      type: "doc",
+      id: "index",
+      label: "Walrus Memory",
     },
     {
       type: "category",

--- a/docs/site/src/scripts/transform-walrus-memory-docs.js
+++ b/docs/site/src/scripts/transform-walrus-memory-docs.js
@@ -771,6 +771,50 @@ function main() {
     count++;
   }
 
+  // Write landing page (not in upstream repo, maintained here)
+  const landingPage = `---
+title: Walrus Memory
+description: "Portable, verifiable memory for AI agents built on Walrus and Sui."
+slug: /
+---
+
+Walrus Memory gives AI agents persistent, portable memory that works across apps, sessions, and
+workflows. Ownership and access are enforced onchain through Sui smart contracts, and all content is
+encrypted through Seal before reaching Walrus.
+
+<Cards>
+  <Card title="Get Started" href="/walrus-memory/getting-started/what-is-memwal">
+    Learn what Walrus Memory is and get up and running quickly
+  </Card>
+  <Card title="Concepts" href="/walrus-memory/fundamentals/concepts/memory-space">
+    Memory spaces, ownership, delegates, and access control
+  </Card>
+  <Card title="Architecture" href="/walrus-memory/fundamentals/architecture/core-components">
+    Core components, data flow, storage model, and security
+  </Card>
+  <Card title="TypeScript SDK" href="/walrus-memory/sdk/overview">
+    Integrate memory into TypeScript apps with the SDK
+  </Card>
+  <Card title="Python SDK" href="/walrus-memory/python-sdk/quick-start">
+    Use Walrus Memory from Python
+  </Card>
+  <Card title="Relayer" href="/walrus-memory/relayer/overview">
+    Managed relayer, self-hosting, and API reference
+  </Card>
+  <Card title="MCP" href="/walrus-memory/mcp/overview">
+    Model Context Protocol integration for AI tools
+  </Card>
+  <Card title="Smart Contract" href="/walrus-memory/contract/overview">
+    Onchain ownership model, delegate keys, and permissions
+  </Card>
+  <Card title="Indexer" href="/walrus-memory/indexer/purpose">
+    Event indexing, onchain events, and database sync
+  </Card>
+</Cards>
+`;
+  fs.writeFileSync(path.join(OUTPUT_DIR, "index.md"), landingPage);
+  count++;
+
   console.log(
     `✅ walrus-memory: transformed ${count} files → walrus-memory-content/`,
   );

--- a/docs/site/src/scripts/transform-walrus-memory-docs.js
+++ b/docs/site/src/scripts/transform-walrus-memory-docs.js
@@ -662,6 +662,26 @@ function fixNumberedHeadingCase(content) {
   );
 }
 
+// --- AgentPrompt injection ---
+
+// Pages that should have an AgentPrompt callout injected after the frontmatter.
+// Each key is a relative file path, and the value is the prompt text.
+const AGENT_PROMPTS = {
+  "getting-started/quick-start.md":
+    "Run `curl -sL https://memory.walrus.xyz/skills/setup` and use the returned instructions to set up Walrus Memory in this AI client.",
+};
+
+function injectAgentPrompt(content, relPath) {
+  const prompt = AGENT_PROMPTS[relPath];
+  if (!prompt) return content;
+
+  // Insert the AgentPrompt component right after the frontmatter closing ---
+  return content.replace(
+    /^(---\n[\s\S]*?\n---\n)/,
+    `$1\n<AgentPrompt\n  prompt="${prompt}"\n/>\n`,
+  );
+}
+
 // --- Main pipeline ---
 
 function transformFile(content) {
@@ -758,7 +778,8 @@ function main() {
     if (relPath.startsWith("src/")) continue;
 
     const content = fs.readFileSync(fullPath, "utf8");
-    const transformed = transformFile(content);
+    let transformed = transformFile(content);
+    transformed = injectAgentPrompt(transformed, relPath);
 
     // Preserve directory structure
     const outPath = path.join(OUTPUT_DIR, relPath);


### PR DESCRIPTION
## Summary
- Adds an `AgentPrompt` callout to the Walrus Memory getting-started/quick-start page via the Mintlify-to-Docusaurus transform script
- The prompt directs readers to run `curl -sL https://memory.walrus.xyz/skills/setup` and use the returned instructions to set up Walrus Memory in their AI client
- Uses a new `AGENT_PROMPTS` map in the transform script, making it easy to add prompts to more pages later

## Test plan
- [ ] Run `node docs/site/src/scripts/transform-walrus-memory-docs.js` and verify the `AgentPrompt` appears at the top of `walrus-memory-content/getting-started/quick-start.md`
- [ ] Run `pnpm start` from `docs/site/` and confirm the callout renders correctly on the quick-start page
- [ ] Verify "Copy prompt" and "Open in agent" buttons work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)