### PR TITLE
docs: redirect /usage/interacting to /walrus-client

### DIFF
--- a/docs/site/src/shared/components/AgentPrompt/styles.module.css
+++ b/docs/site/src/shared/components/AgentPrompt/styles.module.css
@@ -94,9 +94,17 @@
   color: #ffffff;
 }
 
+:global([data-theme='dark']) .agentBtn {
+  color: #1c2228;
+}
+
 .agentBtn:hover {
   background: var(--ifm-color-primary-dark);
   border-color: var(--ifm-color-primary-dark);
+}
+
+:global([data-theme='dark']) .agentBtn:hover {
+  color: #1c2228;
 }
 
 .caret {

--- a/docs/site/src/shared/components/AgentPrompt/styles.module.css
+++ b/docs/site/src/shared/components/AgentPrompt/styles.module.css
@@ -66,13 +66,14 @@
 }
 
 .copyBtn {
-  border: 1px solid var(--ifm-color-emphasis-300);
+  border: 1px solid var(--ifm-color-emphasis-500);
   background: transparent;
-  color: var(--ifm-color-emphasis-800);
+  color: var(--ifm-heading-color);
 }
 
 .copyBtn:hover {
-  border-color: var(--ifm-color-emphasis-500);
+  border-color: var(--ifm-color-emphasis-600);
+  background: var(--ifm-color-emphasis-200);
   color: var(--ifm-heading-color);
 }
 

--- a/docs/site/src/shared/components/AgentPrompt/styles.module.css
+++ b/docs/site/src/shared/components/AgentPrompt/styles.module.css
@@ -68,13 +68,24 @@
 .copyBtn {
   border: 1px solid var(--ifm-color-emphasis-500);
   background: transparent;
-  color: var(--ifm-heading-color);
+  color: var(--ifm-color-emphasis-900);
+}
+
+:global([data-theme='dark']) .copyBtn {
+  color: #faf8f5;
+  border-color: rgba(255, 255, 255, 0.25);
 }
 
 .copyBtn:hover {
   border-color: var(--ifm-color-emphasis-600);
   background: var(--ifm-color-emphasis-200);
-  color: var(--ifm-heading-color);
+  color: var(--ifm-color-emphasis-900);
+}
+
+:global([data-theme='dark']) .copyBtn:hover {
+  color: #ffffff;
+  border-color: rgba(255, 255, 255, 0.4);
+  background: rgba(255, 255, 255, 0.08);
 }
 
 .agentBtn {

--- a/docs/site/ws-resources.manual.json
+++ b/docs/site/ws-resources.manual.json
@@ -113,6 +113,7 @@
     "/docs/tusky-migration-guide.md": "/markdown/tusky-migration-guide.md",
     "/docs/typescript-sdk/sdks.md": "/markdown/typescript-sdk/sdks.md",
     "/docs/usage/client-cli.md": "/markdown/walrus-client/storing-blobs.md",
+    "/docs/usage/interacting.md": "/markdown/walrus-client/index.md",
     "/docs/usage/examples.md": "/markdown/examples/javascript.md",
     "/docs/usage/glossary.md": "/markdown/glossary.md",
     "/docs/usage/json-api.md": "/markdown/walrus-client/json-mode.md",
@@ -318,6 +319,10 @@
       "location": "/docs/examples",
       "status_code": 301
     },
+    "/docs/usage/interacting": {
+      "location": "/docs/walrus-client",
+      "status_code": 301
+    },
     "/docs/usage/glossary": {
       "location": "/docs/glossary",
       "status_code": 301
@@ -496,6 +501,10 @@
     },
     "/usage/examples": {
       "location": "/docs/examples",
+      "status_code": 301
+    },
+    "/usage/interacting": {
+      "location": "/docs/walrus-client",
       "status_code": 301
     },
     "/usage/glossary": {
@@ -832,6 +841,14 @@
     },
     "/usage/examples/index": {
       "location": "/docs/examples",
+      "status_code": 301
+    },
+    "/usage/interacting.html": {
+      "location": "/docs/walrus-client",
+      "status_code": 301
+    },
+    "/usage/interacting/index": {
+      "location": "/docs/walrus-client",
       "status_code": 301
     },
     "/usage/glossary.html": {


### PR DESCRIPTION
## Summary
- Adds redirect entries to `ws-resources.manual.json` for the legacy `/usage/interacting.html` path, pointing to `/docs/walrus-client` (covers bare, `.html`, `/index`, and `/docs/` prefix variants)
- Adds `.md` route entry for `/docs/usage/interacting.md` → `/markdown/walrus-client/index.md`
- Improves "Copy prompt" button contrast in dark mode for the `AgentPrompt` component (uses `--ifm-heading-color` for text, `--ifm-color-emphasis-500` for border)

## Test plan
- [ ] Run `pnpm build` from `docs/site/` and verify no broken-link errors
- [ ] Confirm `/usage/interacting.html` redirects to `/docs/walrus-client` after deploy
- [ ] Check AgentPrompt "Copy prompt" button is legible in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)