### PR TITLE
docs: fix what-is-memwal Card href to what-is-walrus-memory

### DIFF
--- a/docs/site/src/scripts/transform-walrus-memory-docs.js
+++ b/docs/site/src/scripts/transform-walrus-memory-docs.js
@@ -812,7 +812,7 @@ workflows. Ownership and access are enforced onchain through Sui smart contracts
 encrypted through Seal before reaching Walrus.
 
 <Cards>
-  <Card title="Get Started" href="/walrus-memory/getting-started/what-is-memwal">
+  <Card title="Get Started" href="/walrus-memory/getting-started/what-is-walrus-memory">
     Learn what Walrus Memory is and get up and running quickly
   </Card>
   <Card title="Concepts" href="/walrus-memory/fundamentals/concepts/memory-space">


### PR DESCRIPTION
## Summary
- Fixes the Card component `href` in `transform-walrus-memory-docs.js` that still pointed to `/walrus-memory/getting-started/what-is-memwal` instead of the canonical `/walrus-memory/getting-started/what-is-walrus-memory` path.
- The redirect in `ws-resources.manual.json` and the rename map are intentional and left unchanged.

## Test plan
- [ ] Verify the "Get Started" card on the Walrus Memory landing page links directly to `/walrus-memory/getting-started/what-is-walrus-memory`

🤖 Generated with [Claude Code](https://claude.com/claude-code)