### PR TITLE
fix: yield in node recovery when an owned shard is not yet created

### DIFF
--- a/crates/walrus-service/src/node/metrics.rs
+++ b/crates/walrus-service/src/node/metrics.rs
@@ -215,11 +215,15 @@ walrus_utils::metrics::define_metric_set! {
         #[help = "The number of ongoing blob syncs during node recovery."]
         node_recovery_ongoing_blob_syncs: IntGauge[],
 
-        #[help = "The number of consecutive backoffs in the current node recovery caused by owning \
-        a shard at the latest epoch whose local storage has not been created yet. Reset to 0 when \
-        a recovery task starts; a large or growing value means event processing is not creating \
-        the gained shard."]
-        node_recovery_shard_not_created_backoff: IntGauge[],
+        #[help = "Seconds the current node recovery has spent waiting for the local storage of \
+        shards it owns at the latest epoch to be created. 0 when not waiting; a large or growing \
+        value means event processing is not creating the gained shard."]
+        node_recovery_shard_wait_seconds: IntGauge[],
+
+        #[help = "The number of shards the node owns at the latest epoch whose local storage has \
+        not been created yet, while node recovery is waiting for event processing to create them. \
+        0 once all owned shards exist."]
+        node_recovery_missing_owned_shards: IntGauge[],
 
         #[help = "The number of blob events pending processing in the queue between the \
         BackgroundEventProcessor and BlobEventProcessor."]

--- a/crates/walrus-service/src/node/metrics.rs
+++ b/crates/walrus-service/src/node/metrics.rs
@@ -215,6 +215,12 @@ walrus_utils::metrics::define_metric_set! {
         #[help = "The number of ongoing blob syncs during node recovery."]
         node_recovery_ongoing_blob_syncs: IntGauge[],
 
+        #[help = "The number of consecutive backoffs in the current node recovery caused by owning \
+        a shard at the latest epoch whose local storage has not been created yet. Reset to 0 when \
+        a recovery task starts; a large or growing value means event processing is not creating \
+        the gained shard."]
+        node_recovery_shard_not_created_backoff: IntGauge[],
+
         #[help = "The number of blob events pending processing in the queue between the \
         BackgroundEventProcessor and BlobEventProcessor."]
         pending_processing_blob_event_in_queue: IntGaugeVec["worker_index"],

--- a/crates/walrus-service/src/node/node_recovery.rs
+++ b/crates/walrus-service/src/node/node_recovery.rs
@@ -109,13 +109,11 @@ impl NodeRecoveryHandler {
                 // and the loop would spin without making progress. Back off so event processing can
                 // create the shard and restart recovery. The sleep yields the executor, which is
                 // what was missing during the stall on the single-threaded simulator.
-                let mut uncreated_owned_shard = None;
-                for shard in node.owned_shards_at_latest_epoch() {
-                    if node.storage.shard_storage(shard).await.is_none() {
-                        uncreated_owned_shard = Some(shard);
-                        break;
-                    }
-                }
+                let existing_shards = node.storage.existing_shards().await;
+                let uncreated_owned_shard = node
+                    .owned_shards_at_latest_epoch()
+                    .into_iter()
+                    .find(|shard| !existing_shards.contains(shard));
                 if let Some(shard) = uncreated_owned_shard {
                     tracing::warn!(
                         %shard,

--- a/crates/walrus-service/src/node/node_recovery.rs
+++ b/crates/walrus-service/src/node/node_recovery.rs
@@ -94,8 +94,9 @@ impl NodeRecoveryHandler {
             loop {
                 // Block until the node is ready to run a recovery scan pass. Stops the recovery
                 // task if the node started catching up.
-                if !wait_until_ready_to_scan(&node).await {
-                    return;
+                match wait_until_ready_to_scan(&node).await {
+                    ScanReadiness::Ready => {}
+                    ScanReadiness::CatchingUp => return,
                 }
 
                 // Keep track of ongoing blob syncs. Note that the memory usage of this list
@@ -287,11 +288,20 @@ impl NodeRecoveryHandler {
     }
 }
 
-/// Blocks until the node is ready to run a recovery scan pass and returns `true`, or returns
-/// `false` if the node started catching up, in which case the recovery task should stop. The node
-/// is ready once it has local storage for every shard it owns at the latest committee epoch. Both
-/// conditions are re-checked on every backoff iteration, so catch-up that begins while waiting also
-/// stops the task.
+/// Outcome of waiting for the node to become ready to run a recovery scan pass.
+enum ScanReadiness {
+    /// The node has local storage for every shard it owns at the latest committee epoch; the
+    /// caller should run a scan pass.
+    Ready,
+    /// The node started catching up; the recovery task should stop. It is restarted once the node
+    /// has caught up to the latest epoch.
+    CatchingUp,
+}
+
+/// Blocks until the node is ready to run a recovery scan pass ([`ScanReadiness::Ready`]), or
+/// returns [`ScanReadiness::CatchingUp`] if the node started catching up. Both conditions are
+/// re-checked on every backoff iteration, so catch-up that begins while waiting also stops the
+/// task.
 ///
 /// A node can own a shard at the latest committee epoch whose local storage does not exist yet: the
 /// committee advanced to a newer epoch, but event processing has not yet handled that epoch's
@@ -301,11 +311,9 @@ impl NodeRecoveryHandler {
 /// this state, every blob would read "not stored" on the missing shard, producing futile syncs and
 /// repeated full re-scans (and, on the single-threaded simulator, starving event processing
 /// entirely). So back off and re-check until the shard exists; the sleep also yields the executor.
-async fn wait_until_ready_to_scan(node: &StorageNodeInner) -> bool {
+async fn wait_until_ready_to_scan(node: &StorageNodeInner) -> ScanReadiness {
     let mut backoff_count: i64 = 0;
     loop {
-        // The node can enter recovery catch-up mode while waiting. In that case the recovery task
-        // should stop; it is restarted once the node has caught up to the latest epoch.
         if node
             .storage
             .node_status()
@@ -313,7 +321,7 @@ async fn wait_until_ready_to_scan(node: &StorageNodeInner) -> bool {
             .is_catching_up()
         {
             tracing::info!("node recovery encountered node is in catching up; skip recovery");
-            return false;
+            return ScanReadiness::CatchingUp;
         }
 
         let existing_shards = node.storage.existing_shards().await;
@@ -328,7 +336,7 @@ async fn wait_until_ready_to_scan(node: &StorageNodeInner) -> bool {
             if backoff_count != 0 {
                 node.metrics.node_recovery_shard_not_created_backoff.set(0);
             }
-            return true;
+            return ScanReadiness::Ready;
         };
 
         backoff_count += 1;

--- a/crates/walrus-service/src/node/node_recovery.rs
+++ b/crates/walrus-service/src/node/node_recovery.rs
@@ -87,6 +87,11 @@ impl NodeRecoveryHandler {
 
             fail_point_async!("start_node_recovery_entry");
 
+            // Number of consecutive backoffs caused by an owned shard whose storage is not created
+            // yet. Scoped to this recovery task, so it is reset here and grows only while stalled.
+            let mut shard_not_created_backoffs: i64 = 0;
+            node.metrics.node_recovery_shard_not_created_backoff.set(0);
+
             loop {
                 // Node can enter recovery catch up mode while recovery is in progress. In this
                 // case, we should skip recovery. Once the node is caught up to the latest epoch,
@@ -115,8 +120,13 @@ impl NodeRecoveryHandler {
                     .into_iter()
                     .find(|shard| !existing_shards.contains(shard));
                 if let Some(shard) = uncreated_owned_shard {
+                    shard_not_created_backoffs += 1;
+                    node.metrics
+                        .node_recovery_shard_not_created_backoff
+                        .set(shard_not_created_backoffs);
                     tracing::warn!(
                         %shard,
+                        backoff_count = shard_not_created_backoffs,
                         "owned shard storage not created yet; backing off for event processing"
                     );
                     tokio::time::sleep(SHARD_NOT_CREATED_BACKOFF).await;

--- a/crates/walrus-service/src/node/node_recovery.rs
+++ b/crates/walrus-service/src/node/node_recovery.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use futures::stream::{FuturesUnordered, StreamExt};
 use sui_macros::fail_point_async;
@@ -15,6 +15,11 @@ use super::{
     config::NodeRecoveryConfig,
 };
 use crate::node::{NodeStatus, storage::blob_info::CertifiedBlobInfoApi};
+
+/// How long node recovery backs off before re-scanning when it owns a shard at the latest epoch
+/// whose local storage has not been created yet. The sleep also yields the executor so event
+/// processing can create the shard and restart recovery.
+const SHARD_NOT_CREATED_BACKOFF: Duration = Duration::from_secs(1);
 
 #[derive(Debug, Clone)]
 pub struct NodeRecoveryHandler {
@@ -96,6 +101,28 @@ impl NodeRecoveryHandler {
                         "node recovery encountered node is in catching up; skip recovery"
                     );
                     return;
+                }
+
+                // If we own a shard at the latest epoch whose local storage has not been created
+                // yet (it was gained for a newer epoch whose EpochChangeStart has not been
+                // processed), do not scan or sync: every blob would read "not stored" on that shard
+                // and the loop would spin without making progress. Back off so event processing can
+                // create the shard and restart recovery. The sleep yields the executor, which is
+                // what was missing during the stall on the single-threaded simulator.
+                let mut uncreated_owned_shard = None;
+                for shard in node.owned_shards_at_latest_epoch() {
+                    if node.storage.shard_storage(shard).await.is_none() {
+                        uncreated_owned_shard = Some(shard);
+                        break;
+                    }
+                }
+                if let Some(shard) = uncreated_owned_shard {
+                    tracing::warn!(
+                        %shard,
+                        "owned shard storage not created yet; backing off for event processing"
+                    );
+                    tokio::time::sleep(SHARD_NOT_CREATED_BACKOFF).await;
+                    continue;
                 }
 
                 // Keep track of ongoing blob syncs. Note that the memory usage of this list

--- a/crates/walrus-service/src/node/node_recovery.rs
+++ b/crates/walrus-service/src/node/node_recovery.rs
@@ -87,50 +87,15 @@ impl NodeRecoveryHandler {
 
             fail_point_async!("start_node_recovery_entry");
 
-            // Number of consecutive backoffs caused by an owned shard whose storage is not created
-            // yet. Scoped to this recovery task, so it is reset here and grows only while stalled.
-            let mut shard_not_created_backoffs: i64 = 0;
+            // Clear any backoff count left over from a previous (aborted) recovery task on this
+            // node; `wait_until_owned_shards_exist` maintains it from here.
             node.metrics.node_recovery_shard_not_created_backoff.set(0);
 
             loop {
-                // Node can enter recovery catch up mode while recovery is in progress. In this
-                // case, we should skip recovery. Once the node is caught up to the latest epoch,
-                // the recovery task will be restarted.
-                if node
-                    .storage
-                    .node_status()
-                    .expect("reading node status should not fail")
-                    .is_catching_up()
-                {
-                    tracing::info!(
-                        "node recovery encountered node is in catching up; skip recovery"
-                    );
+                // Block until the node is ready to run a recovery scan pass. Stops the recovery
+                // task if the node started catching up.
+                if !wait_until_ready_to_scan(&node).await {
                     return;
-                }
-
-                // If we own a shard at the latest epoch whose local storage has not been created
-                // yet (it was gained for a newer epoch whose EpochChangeStart has not been
-                // processed), do not scan or sync: every blob would read "not stored" on that shard
-                // and the loop would spin without making progress. Back off so event processing can
-                // create the shard and restart recovery. The sleep yields the executor, which is
-                // what was missing during the stall on the single-threaded simulator.
-                let existing_shards = node.storage.existing_shards().await;
-                let uncreated_owned_shard = node
-                    .owned_shards_at_latest_epoch()
-                    .into_iter()
-                    .find(|shard| !existing_shards.contains(shard));
-                if let Some(shard) = uncreated_owned_shard {
-                    shard_not_created_backoffs += 1;
-                    node.metrics
-                        .node_recovery_shard_not_created_backoff
-                        .set(shard_not_created_backoffs);
-                    tracing::warn!(
-                        %shard,
-                        backoff_count = shard_not_created_backoffs,
-                        "owned shard storage not created yet; backing off for event processing"
-                    );
-                    tokio::time::sleep(SHARD_NOT_CREATED_BACKOFF).await;
-                    continue;
                 }
 
                 // Keep track of ongoing blob syncs. Note that the memory usage of this list
@@ -319,5 +284,62 @@ impl NodeRecoveryHandler {
         }
 
         Ok(())
+    }
+}
+
+/// Blocks until the node is ready to run a recovery scan pass and returns `true`, or returns
+/// `false` if the node started catching up, in which case the recovery task should stop. The node
+/// is ready once it has local storage for every shard it owns at the latest committee epoch. Both
+/// conditions are re-checked on every backoff iteration, so catch-up that begins while waiting also
+/// stops the task.
+///
+/// A node can own a shard at the latest committee epoch whose local storage does not exist yet: the
+/// committee advanced to a newer epoch, but event processing has not yet handled that epoch's
+/// `EpochChangeStart`, which is what creates the shard. Recovery must not create it here: blob sync
+/// targets `owned_shards_at_epoch(current_event_epoch)`, which still excludes the shard, and shard
+/// creation is part of the ordered epoch transition owned by event processing. If the scan ran in
+/// this state, every blob would read "not stored" on the missing shard, producing futile syncs and
+/// repeated full re-scans (and, on the single-threaded simulator, starving event processing
+/// entirely). So back off and re-check until the shard exists; the sleep also yields the executor.
+async fn wait_until_ready_to_scan(node: &StorageNodeInner) -> bool {
+    let mut backoff_count: i64 = 0;
+    loop {
+        // The node can enter recovery catch-up mode while waiting. In that case the recovery task
+        // should stop; it is restarted once the node has caught up to the latest epoch.
+        if node
+            .storage
+            .node_status()
+            .expect("reading node status should not fail")
+            .is_catching_up()
+        {
+            tracing::info!("node recovery encountered node is in catching up; skip recovery");
+            return false;
+        }
+
+        let existing_shards = node.storage.existing_shards().await;
+        let uncreated_owned_shard = node
+            .owned_shards_at_latest_epoch()
+            .into_iter()
+            .find(|shard| !existing_shards.contains(shard));
+
+        let Some(shard) = uncreated_owned_shard else {
+            // All owned shards exist; clear the stall gauge (if it was raised) and let the caller
+            // proceed with the scan.
+            if backoff_count != 0 {
+                node.metrics.node_recovery_shard_not_created_backoff.set(0);
+            }
+            return true;
+        };
+
+        backoff_count += 1;
+        node.metrics
+            .node_recovery_shard_not_created_backoff
+            .set(backoff_count);
+        tracing::warn!(
+            %shard,
+            backoff_count,
+            "owned shard storage not created yet; backing off for event processing"
+        );
+        tokio::time::sleep(SHARD_NOT_CREATED_BACKOFF).await;
     }
 }

--- a/crates/walrus-service/src/node/node_recovery.rs
+++ b/crates/walrus-service/src/node/node_recovery.rs
@@ -8,6 +8,7 @@ use sui_macros::fail_point_async;
 use tokio::sync::Mutex;
 use typed_store::TypedStoreError;
 use walrus_core::Epoch;
+use walrus_utils::backoff::{BackoffStrategy, ExponentialBackoff};
 
 use super::{
     StorageNodeInner,
@@ -16,10 +17,12 @@ use super::{
 };
 use crate::node::{NodeStatus, storage::blob_info::CertifiedBlobInfoApi};
 
-/// How long node recovery backs off before re-scanning when it owns a shard at the latest epoch
-/// whose local storage has not been created yet. The sleep also yields the executor so event
-/// processing can create the shard and restart recovery.
-const SHARD_NOT_CREATED_BACKOFF: Duration = Duration::from_secs(1);
+/// Exponential backoff bounds for re-checking shard creation while node recovery waits for event
+/// processing to create a shard it owns at the latest epoch. The wait starts small so the common
+/// case resumes quickly, and is capped at one minute. The sleep also yields the executor so
+/// event processing can create the shard and self-heal.
+const SHARD_NOT_CREATED_BACKOFF_MIN: Duration = Duration::from_secs(1);
+const SHARD_NOT_CREATED_BACKOFF_MAX: Duration = Duration::from_secs(60);
 
 #[derive(Debug, Clone)]
 pub struct NodeRecoveryHandler {
@@ -86,10 +89,6 @@ impl NodeRecoveryHandler {
             );
 
             fail_point_async!("start_node_recovery_entry");
-
-            // Clear any backoff count left over from a previous (aborted) recovery task on this
-            // node; `wait_until_owned_shards_exist` maintains it from here.
-            node.metrics.node_recovery_shard_not_created_backoff.set(0);
 
             loop {
                 // Block until the node is ready to run a recovery scan pass. Stops the recovery
@@ -312,8 +311,16 @@ enum ScanReadiness {
 /// repeated full re-scans (and, on the single-threaded simulator, starving event processing
 /// entirely). So back off and re-check until the shard exists; the sleep also yields the executor.
 async fn wait_until_ready_to_scan(node: &StorageNodeInner) -> ScanReadiness {
-    let mut backoff_count: i64 = 0;
-    loop {
+    // Exponential backoff, recreated per stall episode so a fresh stall starts at the small bound.
+    // The seed only feeds the jitter offset; a constant keeps it deterministic under the simulator.
+    let mut backoff = ExponentialBackoff::new_with_seed(
+        SHARD_NOT_CREATED_BACKOFF_MIN,
+        SHARD_NOT_CREATED_BACKOFF_MAX,
+        None,
+        0,
+    );
+    let mut total_wait = Duration::ZERO;
+    let readiness = loop {
         if node
             .storage
             .node_status()
@@ -321,33 +328,41 @@ async fn wait_until_ready_to_scan(node: &StorageNodeInner) -> ScanReadiness {
             .is_catching_up()
         {
             tracing::info!("node recovery encountered node is in catching up; skip recovery");
-            return ScanReadiness::CatchingUp;
+            break ScanReadiness::CatchingUp;
         }
 
         let existing_shards = node.storage.existing_shards().await;
-        let uncreated_owned_shard = node
+        let missing_owned_shards: Vec<_> = node
             .owned_shards_at_latest_epoch()
             .into_iter()
-            .find(|shard| !existing_shards.contains(shard));
+            .filter(|shard| !existing_shards.contains(shard))
+            .collect();
 
-        let Some(shard) = uncreated_owned_shard else {
-            // All owned shards exist; clear the stall gauge (if it was raised) and let the caller
-            // proceed with the scan.
-            if backoff_count != 0 {
-                node.metrics.node_recovery_shard_not_created_backoff.set(0);
-            }
-            return ScanReadiness::Ready;
+        let Some(first_missing) = missing_owned_shards.first().copied() else {
+            break ScanReadiness::Ready;
         };
 
-        backoff_count += 1;
+        let delay = backoff
+            .next_delay()
+            .unwrap_or(SHARD_NOT_CREATED_BACKOFF_MAX);
+        total_wait += delay;
         node.metrics
-            .node_recovery_shard_not_created_backoff
-            .set(backoff_count);
+            .node_recovery_shard_wait_seconds
+            .set(i64::try_from(total_wait.as_secs()).unwrap_or(i64::MAX));
+        node.metrics
+            .node_recovery_missing_owned_shards
+            .set(i64::try_from(missing_owned_shards.len()).unwrap_or(i64::MAX));
         tracing::warn!(
-            %shard,
-            backoff_count,
-            "owned shard storage not created yet; backing off for event processing"
+            shard = %first_missing,
+            missing_owned_shards = missing_owned_shards.len(),
+            wait_secs = total_wait.as_secs(),
+            "owned shard storage not created yet; waiting for event processing"
         );
-        tokio::time::sleep(SHARD_NOT_CREATED_BACKOFF).await;
-    }
+        tokio::time::sleep(delay).await;
+    };
+
+    node.metrics.node_recovery_shard_wait_seconds.set(0);
+    node.metrics.node_recovery_missing_owned_shards.set(0);
+
+    readiness
 }


### PR DESCRIPTION
## Description
`simtest_test_repeated_node_crash` got timeout occasionally.
While a node is RecoveryInProgress(N), the committee can advance to a newer epoch that assigns it a shard whose local ShardStorage doesn't exist yet. The new shards are created only when event processing reaches that epoch's EpochChangeStart. 
The completion check `is_stored_at_all_shards_at_latest_epoch` collapses "shard not created yet" into the same `Ok(false)` as "blob not stored", so recovery never converges and re-scans forever. 
On the single-threaded simulator this spin never yields, starving the event-processing task that would create the  shard. Consequently, it never gets created and the test times out.

The fix: 
Before scanning, the recovery loop checks whether any shard owned at the latest epoch has no local storage. If so, it backs off briefly instead of scanning. The sleep yields the executor, so event processing creates the shard and restarts recovery, and convergence resumes.

## Test plan
`simtest_test_repeated_node_crash` with 2000 different seeds pass in CI [ pipeline](https://github.com/MystenLabs/walrus/actions/runs/27122615449/job/80154796977?pr=3424) .

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
