### PR TITLE
fix: do not hold shards lock while deleting column families

### DIFF
--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -542,11 +542,16 @@ impl Storage {
         &self,
         removed: &[ShardIndex],
     ) -> Result<(), TypedStoreError> {
-        let mut shard_map_lock = self.lock_shards().await;
         for shard_index in removed {
             tracing::info!(walrus.shard_index = %shard_index, "removing storage for shard");
-            if let Some(shard_storage) = shard_map_lock.shards_guard.remove(shard_index) {
-                // Do not hold the `shards` lock when deleting column families.
+            // Remove the shard from the map under the lock, then release the lock before
+            // deleting column families. Do not hold the `shards` lock when deleting column
+            // families, as that is a potentially long-running, blocking operation.
+            let shard_storage = {
+                let mut shard_map_lock = self.lock_shards().await;
+                shard_map_lock.shards_guard.remove(shard_index)
+            };
+            if let Some(shard_storage) = shard_storage {
                 shard_storage.delete_shard_storage()?;
             }
             tracing::info!(


### PR DESCRIPTION
## Description

`remove_storage_for_shards` was holding the `shards` write guard across the entire loop, including each blocking `delete_shard_storage()` call. This contradicted the long-standing `// Do not hold the shards lock when deleting column families` comment and was introduced when the lock was migrated from sync to async (#1680) as an unintended refactor oversight.

Holding the lock across deletion serializes all shard-map access and blocks the executor thread for the duration of the RocksDB column-family deletion.

This PR restores the original invariant: remove the entry under the lock, release the guard, then delete.

## Test plan


## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
