### PR TITLE
fix: remove Move.lock in antithesis tests so that package won't get resolved to testnet/mainnet dependency

### DIFF
--- a/docker/walrus-antithesis/build-walrus-image-for-antithesis/update_move_toml.sh
+++ b/docker/walrus-antithesis/build-walrus-image-for-antithesis/update_move_toml.sh
@@ -24,4 +24,11 @@ for contract in "${contracts[@]}"; do
         rev\s*=\s*"[^"]+"\s*
         \}
     }{$1 = { local = "/opt/sui/$2" }}gx' "$toml_file"
+
+    # Delete the Move.lock. Under the new package management the loader resolves
+    # dependencies from the lockfile's `[pinned.testnet]` entries, which still point
+    # `std`/`sui` at git sources and trigger a network `git clone` that fails in the
+    # sealed antithesis environment. Removing the lockfile forces the loader to repin
+    # from the manifest above, which now references the local `/opt/sui` copy.
+    rm -f "/contracts/${contract}/Move.lock"
 done


### PR DESCRIPTION
## Description

Otherwise, the publishing tries to resolve to testnet Sui packages, which needs to be fetched from the internet.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
