### PR TITLE
refactor: select package env honestly instead of forcing testnet

### DIFF
--- a/crates/walrus-sui/src/client.rs
+++ b/crates/walrus-sui/src/client.rs
@@ -786,11 +786,11 @@ impl SuiContractClient {
         package_path: PathBuf,
         build_config: MoveBuildConfig,
     ) -> SuiClientResult<(CompiledPackage, MoveBuildConfig, RootPackage<SuiFlavor>)> {
-        let chain_id = self
-            .retriable_sui_client()
-            .get_chain_identifier()
-            .await
-            .ok();
+        // Propagate a failure to fetch the chain id rather than swallowing it into `None`: a
+        // missing chain id makes `select_environment` fall back to `testnet`, which on mainnet
+        // would compute the digest (used for upgrade votes) against the wrong `[published.<env>]`
+        // addresses.
+        let chain_id = self.retriable_sui_client().get_chain_identifier().await?;
         Ok(system_setup::compile_package(
             package_path,
             build_config,
@@ -1506,11 +1506,11 @@ impl SuiContractClientInner {
         // published address from `Published.toml`): Sui's upgrade transaction substitutes those
         // 0x0 placeholders with the new package id when it runs. `sui_package_management`'s
         // `upgrade_command` sets the same flag for the same reason.
-        let chain_id = self
-            .retriable_sui_client()
-            .get_chain_identifier()
-            .await
-            .ok();
+        //
+        // Propagate a chain-id fetch failure rather than swallowing it into `None`: a missing chain
+        // id makes `select_environment` fall back to `testnet`, which on mainnet would compile the
+        // upgrade against the wrong `[published.<env>]` addresses.
+        let chain_id = self.retriable_sui_client().get_chain_identifier().await?;
         let build_config = MoveBuildConfig {
             root_as_zero: true,
             ..Default::default()

--- a/crates/walrus-sui/src/system_setup.rs
+++ b/crates/walrus-sui/src/system_setup.rs
@@ -116,11 +116,11 @@ pub(crate) async fn publish_package_with_default_build_config(
 ///  - a custom or local network the operator has registered by adding an
 ///    `[environments] <alias> = "<chain id>"` entry to each package's `Move.toml`.
 ///
-/// When no declared environment matches the wallet's chain id, it falls back to `testnet`. This
-/// keeps the previous behavior for unregistered networks — addresses are written and read under the
-/// `testnet` env key — and is the only case that pairs an env name with a possibly-different chain
-/// id. Automated test clusters mint a fresh chain id per run that no manifest declares, so they
-/// take this fallback; that is acceptable because they publish to throwaway local networks.
+/// When no declared environment matches the wallet's chain id, it falls back to `testnet`:
+/// addresses are written and read under the `testnet` env key. This is the only case that pairs an
+/// env name with a possibly-different chain id. Automated test clusters mint a fresh chain id per
+/// run that no manifest declares, so they take this fallback; that is acceptable because they
+/// publish to throwaway local networks.
 fn select_environment(
     package_path: &Path,
     chain_id: String,

--- a/crates/walrus-sui/src/system_setup.rs
+++ b/crates/walrus-sui/src/system_setup.rs
@@ -14,7 +14,15 @@ use anyhow::{Context, Result, anyhow, bail};
 use move_core_types::language_storage::StructTag;
 use move_package_alt::{
     RootPackage,
-    schema::{Environment, OriginalID, Publication, PublishAddresses, PublishedID},
+    schema::{
+        Environment,
+        EnvironmentID,
+        EnvironmentName,
+        OriginalID,
+        Publication,
+        PublishAddresses,
+        PublishedID,
+    },
 };
 use move_package_alt_compilation::build_config::BuildConfig as MoveBuildConfig;
 use sui_move_build::{CompiledPackage, PackageDependencies};
@@ -96,31 +104,72 @@ pub(crate) async fn publish_package_with_default_build_config(
     publish_package(wallet, package_path, Default::default(), gas_budget).await
 }
 
-/// Maps the wallet's active env alias to the env name used to load the package.
+/// Selects the package-system environment to compile and publish under.
 ///
-/// We don't pass the wallet's alias directly to `PackageLoader` because our `Move.toml`s only
-/// declare the two env names that come from `SuiFlavor`'s defaults — `mainnet` and `testnet` —
-/// and an unknown name (notably the test cluster's `localnet`) would fail dep-package validation.
-/// `mainnet` passes through (so production mainnet upgrades read each dep's
-/// `[published.mainnet]` entry). Everything else — `testnet`, `localnet`, custom aliases — maps
-/// to `testnet`, which is the env name our `testnet-contracts/` `Published.toml` files key on
-/// and the env name we write for fresh publishes during tests.
-fn compile_env_name_for_alias(alias: &str) -> &'static str {
-    match alias {
-        "mainnet" => "mainnet",
-        _ => "testnet",
+/// Mirrors `sui_package_alt::find_environment`: it prefers an environment the package manifest
+/// declares (the `[environments]` table plus `SuiFlavor`'s `testnet`/`mainnet` defaults) whose
+/// chain id matches the wallet's active chain id. When such an environment exists, the env *name*
+/// and the chain id are consistent, so the env name and chain id agree and each dependency's
+/// published addresses resolve under the matching `[published.<env>]` key. Two scenarios reach
+/// this honest path:
+///  - production `testnet`/`mainnet`, where the wallet alias and chain id match a default env;
+///  - a custom or local network the operator has registered by adding an
+///    `[environments] <alias> = "<chain id>"` entry to each package's `Move.toml`.
+///
+/// When no declared environment matches the wallet's chain id, it falls back to `testnet`. This
+/// keeps the previous behavior for unregistered networks — addresses are written and read under the
+/// `testnet` env key — and is the only case that pairs an env name with a possibly-different chain
+/// id. Automated test clusters mint a fresh chain id per run that no manifest declares, so they
+/// take this fallback; that is acceptable because they publish to throwaway local networks.
+fn select_environment(
+    package_path: &Path,
+    chain_id: Option<String>,
+    wallet: &Wallet,
+) -> Result<Environment> {
+    let alias = wallet.get_active_env().alias.clone();
+    let chain_id = chain_id.unwrap_or_default();
+    let manifest_envs: Vec<(EnvironmentName, EnvironmentID)> =
+        RootPackage::<SuiFlavor>::environments(package_path, &wallet.sui_flavor())
+            .context("failed to read the package environments from the manifest")?
+            .into_iter()
+            .collect();
+    Ok(resolve_environment(&manifest_envs, alias, chain_id))
+}
+
+/// Pure environment-selection logic for `select_environment`; see its docs for the rationale.
+fn resolve_environment(
+    manifest_envs: &[(EnvironmentName, EnvironmentID)],
+    alias: String,
+    chain_id: String,
+) -> Environment {
+    // 1. Exact match: the manifest declares the active alias with the active chain id.
+    if manifest_envs
+        .iter()
+        .any(|(name, id)| *name == alias && *id == chain_id)
+    {
+        return Environment::new(alias, chain_id);
     }
+
+    // 2. Unique match by chain id: exactly one declared environment uses this chain id.
+    let mut by_chain_id = manifest_envs.iter().filter(|(_, id)| id == &chain_id);
+    if let Some((name, id)) = by_chain_id.next()
+        && by_chain_id.next().is_none()
+    {
+        return Environment::new(name.clone(), id.clone());
+    }
+
+    // 3. Fall back to `testnet` for an unregistered network.
+    Environment::new("testnet".to_string(), chain_id)
 }
 
 /// Compiles a package and returns the compiled package, and build config.
 ///
-/// Loads the root package in persistent mode. The env name is chosen from the wallet's active
-/// alias via `compile_env_name_for_alias` so that production mainnet upgrades read
-/// `[published.mainnet]` from each dep's `Published.toml` while everything else (including
-/// `testnet-contracts/` and test-cluster fresh publishes) goes through `[published.testnet]`.
-/// The wallet's actual `chain_id` is bound to that env name so the resulting publish transaction
-/// still reaches the correct chain. Package addresses propagate between sibling packages via
-/// each one's per-directory `Published.toml`.
+/// Loads the root package in persistent mode under the environment chosen by `select_environment`
+/// from the wallet's active alias and chain id. Production `testnet`/`mainnet` resolve to a default
+/// environment whose name and chain id agree; an unregistered network (such as a test cluster's
+/// `localnet`) falls back to the `testnet` env name. The selected env name keys the
+/// `[published.<env>]` lookups, so package addresses propagate between sibling packages via each
+/// one's per-directory `Published.toml`.
 pub async fn compile_package(
     package_path: PathBuf,
     build_config: MoveBuildConfig,
@@ -136,8 +185,7 @@ pub async fn compile_package(
         tokio::task::spawn_blocking(move || pin_framework_revs(&package_path)).await??;
     }
 
-    let env_name = compile_env_name_for_alias(&wallet.get_active_env().alias);
-    let env = Environment::new(env_name.to_string(), chain_id.clone().unwrap_or_default());
+    let env = select_environment(&package_path, chain_id.clone(), wallet)?;
 
     let build_config_clone = build_config.clone();
     let package_path_clone = package_path.clone();
@@ -851,39 +899,60 @@ pub async fn create_system_and_staking_objects(
 
 #[cfg(test)]
 mod tests {
-    use super::compile_env_name_for_alias;
+    use super::resolve_environment;
 
-    #[test]
-    fn mainnet_alias_passes_through() {
-        // Mainnet upgrades must read `[published.mainnet]` from each dep's `Published.toml`
-        // (notably `mainnet-contracts/wal/Published.toml` only has that block); reading a
-        // `[published.testnet]` entry — or none — would either silently link against the wrong
-        // dep address or fail the unpublished-dependency assertion.
-        assert_eq!(compile_env_name_for_alias("mainnet"), "mainnet");
+    /// `SuiFlavor`'s default environments, as they appear in `manifest_envs` when a package
+    /// declares no `[environments]` table of its own.
+    fn defaults() -> Vec<(String, String)> {
+        vec![
+            ("testnet".to_string(), "4c78adac".to_string()),
+            ("mainnet".to_string(), "35834a8a".to_string()),
+        ]
     }
 
     #[test]
-    fn testnet_alias_uses_testnet_env() {
-        assert_eq!(compile_env_name_for_alias("testnet"), "testnet");
+    fn production_env_matches_by_alias_and_chain_id() {
+        // testnet/mainnet wallets hit the exact-match path: the alias is a declared env and the
+        // chain id agrees, so the env name and chain id stay consistent.
+        let env = resolve_environment(&defaults(), "testnet".to_string(), "4c78adac".to_string());
+        assert_eq!(env.name(), "testnet");
+        assert_eq!(env.id(), "4c78adac");
+
+        let env = resolve_environment(&defaults(), "mainnet".to_string(), "35834a8a".to_string());
+        assert_eq!(env.name(), "mainnet");
+        assert_eq!(env.id(), "35834a8a");
     }
 
     #[test]
-    fn localnet_alias_falls_back_to_testnet() {
-        // The Sui test cluster's wallet alias is `localnet`, but our contract source trees only
-        // record publications under `mainnet` / `testnet` env names, and fresh test-cluster
-        // publishes write `[published.testnet]` entries to match the lockfile's `[pinned.testnet]`
-        // block. Mapping `localnet` to `testnet` lets the test cluster publish + read addresses
-        // through the same env key.
-        assert_eq!(compile_env_name_for_alias("localnet"), "testnet");
+    fn registered_localnet_is_selected_honestly() {
+        // When an operator registers `[environments] localnet = "<chain id>"`, the wallet alias and
+        // chain id match it exactly, so we build under `localnet` rather than masquerading as
+        // `testnet`.
+        let mut envs = defaults();
+        envs.push(("localnet".to_string(), "deadbeef".to_string()));
+        let env = resolve_environment(&envs, "localnet".to_string(), "deadbeef".to_string());
+        assert_eq!(env.name(), "localnet");
+        assert_eq!(env.id(), "deadbeef");
     }
 
     #[test]
-    fn unknown_alias_falls_back_to_testnet() {
-        // Any custom wallet alias a user might set (e.g. a self-hosted devnet) lands on the
-        // testnet env name so publish writes a `[published.testnet]` entry and subsequent
-        // compiles can read it back. The actual chain id is still bound separately.
-        assert_eq!(compile_env_name_for_alias("custom"), "testnet");
-        assert_eq!(compile_env_name_for_alias("devnet"), "testnet");
-        assert_eq!(compile_env_name_for_alias(""), "testnet");
+    fn registered_env_matches_by_chain_id_when_alias_differs() {
+        // A declared env whose chain id matches is picked even when the wallet alias differs, as
+        // long as the match is unique.
+        let mut envs = defaults();
+        envs.push(("localnet".to_string(), "deadbeef".to_string()));
+        let env = resolve_environment(&envs, "custom-alias".to_string(), "deadbeef".to_string());
+        assert_eq!(env.name(), "localnet");
+        assert_eq!(env.id(), "deadbeef");
+    }
+
+    #[test]
+    fn unregistered_network_falls_back_to_testnet() {
+        // A fresh local network whose chain id isn't declared falls back to the `testnet` env key,
+        // preserving the previous behavior. This is the only case where the env name and chain id
+        // can disagree.
+        let env = resolve_environment(&defaults(), "localnet".to_string(), "deadbeef".to_string());
+        assert_eq!(env.name(), "testnet");
+        assert_eq!(env.id(), "deadbeef");
     }
 }

--- a/crates/walrus-sui/src/system_setup.rs
+++ b/crates/walrus-sui/src/system_setup.rs
@@ -123,11 +123,10 @@ pub(crate) async fn publish_package_with_default_build_config(
 /// take this fallback; that is acceptable because they publish to throwaway local networks.
 fn select_environment(
     package_path: &Path,
-    chain_id: Option<String>,
+    chain_id: String,
     wallet: &Wallet,
 ) -> Result<Environment> {
     let alias = wallet.get_active_env().alias.clone();
-    let chain_id = chain_id.unwrap_or_default();
     let manifest_envs: Vec<(EnvironmentName, EnvironmentID)> =
         RootPackage::<SuiFlavor>::environments(package_path, &wallet.sui_flavor())
             .context("failed to read the package environments from the manifest")?
@@ -173,7 +172,7 @@ fn resolve_environment(
 pub async fn compile_package(
     package_path: PathBuf,
     build_config: MoveBuildConfig,
-    chain_id: Option<String>,
+    chain_id: String,
     wallet: &Wallet,
 ) -> Result<(CompiledPackage, MoveBuildConfig, RootPackage<SuiFlavor>)> {
     // Under simtest, pre-resolve framework `rev`s in the staged manifests to commit SHAs so the
@@ -344,7 +343,7 @@ fn pin_framework_revs(package_path: &Path) -> Result<()> {
 fn compile_package_inner_blocking(
     package_path: PathBuf,
     build_config: MoveBuildConfig,
-    chain_id: Option<String>,
+    chain_id: String,
     root_pkg: RootPackage<SuiFlavor>,
 ) -> Result<(CompiledPackage, MoveBuildConfig, RootPackage<SuiFlavor>)> {
     let mut stdout = std::io::stdout();
@@ -467,7 +466,7 @@ pub(crate) async fn publish_package(
     let chain_id = retry_client.get_chain_identifier().await?;
 
     let (compiled_package, final_build_config, mut root_package) =
-        compile_package(package_path, build_config, Some(chain_id.clone()), wallet).await?;
+        compile_package(package_path, build_config, chain_id.clone(), wallet).await?;
 
     let compiled_modules = compiled_package.get_package_bytes(false);
     let transaction_kind = {


### PR DESCRIPTION
## Description

Follow-up to #3400 addressing the review comment that `compile_package` relied on a missing chain-id check in the Sui package system.

Previously `compile_package` forced the package-system environment **name** to `testnet` for every non-mainnet wallet (`compile_env_name_for_alias`) while binding the wallet's **actual** chain id. This only worked because the package system did not (yet) verify that an environment's expected chain id matches the chain being published to — it pairs the `testnet` name with a different chain's id.

This replaces that with `select_environment`, mirroring `sui_package_alt::find_environment`:

1. exact match on (active alias, chain id),
2. unique match by chain id,
3. fall back to `testnet` for an unregistered network.

### Behavior

- **Production `testnet`/`mainnet`** now resolve to a default environment whose name and chain id genuinely agree, so they no longer depend on the missing check. This is the scenario the review comment was concerned about (publishing to one chain while thinking it's another).
- **Custom or local networks**: an operator registers the network by adding an `[environments] <alias> = "<chain id>"` entry to each package's `Move.toml`; `select_environment` then picks it via the exact / unique-by-chain-id paths.
- **Automated test clusters** mint a fresh chain id per run that no manifest declares, so they take the `testnet` fallback. This is unchanged from the current behavior and is acceptable because they publish to throwaway local networks.

### Follow-up

Test-cluster publishing still uses the `testnet`-name fallback. If/when Sui enforces a publish-time chain-id check, those tests will need the environment registered at runtime (or a fixed localnet chain id committed). The selector is structured so re-adding that is a localized change.

## Test plan

- New unit tests for `resolve_environment` covering the exact-match, unique-by-chain-id, and fallback paths.
- `cargo nextest run` and `cargo clippy --all-features --tests` pass via pre-commit hooks.
- `walrus-simtest` compiles under msim.

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI: