### PR TITLE
feat: use shard sync for gained shards during node recovery epoch change

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -938,6 +938,7 @@ impl StorageNode {
         let node_recovery_handler = NodeRecoveryHandler::new(
             inner.clone(),
             blob_sync_handler.clone(),
+            shard_sync_handler.clone(),
             config.node_recovery_config.clone(),
         );
         node_recovery_handler.restart_recovery().await?;
@@ -2255,13 +2256,14 @@ impl StorageNode {
         {
             // If the node is already in recovery mode, we need to restart node recovery to recover
             // to the latest epoch. This is to make sure that the node is always recovering to the
-            // latest epoch.
+            // latest epoch. Since the node is up-to-date with events, newly gained shards are
+            // synced from their previous owners instead of being filled by blob recovery.
             tracing::info!(
                 "node is currently recovering to epoch {recovering_epoch}, restarting \
                 node recovery to recover to the latest epoch {}",
                 event.epoch
             );
-            self.process_shard_changes_in_new_epoch_and_start_node_recovery(
+            self.process_shard_changes_in_new_epoch_while_recovering(
                 event_handle,
                 event,
                 shard_map_lock,
@@ -2347,6 +2349,88 @@ impl StorageNode {
                     event_handle,
                     event,
                     shard_diff_calculator.shards_to_remove().to_vec(),
+                    committees,
+                    true,
+                );
+        } else {
+            event_handle.mark_as_complete();
+        }
+
+        Ok(())
+    }
+
+    /// Processes the shard changes in the new epoch while node recovery is already in progress.
+    ///
+    /// In contrast to [`Self::process_shard_changes_in_new_epoch_and_start_node_recovery`], which
+    /// handles a node that has lost track of the previous epoch's shard assignment, the node here
+    /// is up-to-date with events, so newly gained shards are filled using shard sync from their
+    /// previous owners instead of per-blob recovery. The restarted node recovery task waits for
+    /// these shard syncs to finish before recovering blobs, and attests epoch sync done once both
+    /// are complete.
+    ///
+    /// As all functions that are passed an [`EventHandle`], this is responsible for marking the
+    /// event as completed.
+    async fn process_shard_changes_in_new_epoch_while_recovering(
+        &self,
+        event_handle: EventHandle,
+        event: &EpochChangeStart,
+        shard_map_lock: StorageShardLock,
+    ) -> anyhow::Result<()> {
+        // Advance the recovery target so that the recovery task attests epoch sync done for the
+        // latest epoch; a stale attestation would be dropped by the contract service. This must
+        // happen before starting the shard syncs and restarting the recovery task below.
+        self.inner
+            .set_node_status(NodeStatus::RecoveryInProgress(event.epoch))?;
+
+        sui_macros::fail_point!("fail_point_shard_changes_in_new_epoch_while_recovering");
+
+        let public_key = self.inner.public_key();
+        let committees = self.inner.committee_service.active_committees();
+        let shard_diff_calculator =
+            ShardDiffCalculator::new(&committees, public_key, shard_map_lock.existing_shards());
+
+        let shards_gained = shard_diff_calculator.gained_shards_from_prev_epoch();
+        tracing::info!(
+            ?shards_gained,
+            "processing shard changes in new epoch while node recovery is in progress"
+        );
+
+        // Note that the shard_map_lock will be unlocked after this function returns.
+        self.create_new_shards_and_start_sync(shard_map_lock, shards_gained, &committees, false)
+            .await?;
+
+        // For shards that just moved out, we need to lock them to not store more data in them.
+        for shard_id in shard_diff_calculator.shards_to_lock() {
+            let Some(shard_storage) = self.inner.storage.shard_storage(*shard_id).await else {
+                tracing::info!("skipping lost shard during epoch change as it is not stored");
+                continue;
+            };
+            tracing::info!(
+                walrus.shard_index = %shard_id,
+                epoch = event.epoch,
+                "locking shard for epoch change"
+            );
+            shard_storage
+                .lock_shard_for_epoch_change()
+                .await
+                .context("failed to lock shard")?;
+        }
+
+        // Restart node recovery to recover to the latest epoch. The recovery task waits for the
+        // shard syncs started above to finish before scanning for blobs to recover.
+        self.node_recovery_handler
+            .start_node_recovery(event.epoch)
+            .await?;
+
+        // The recovery task is in charge of attesting epoch sync done, so the finisher is always
+        // told that there are ongoing shard syncs.
+        let shards_to_remove = shard_diff_calculator.shards_to_remove();
+        if !shards_to_remove.is_empty() {
+            self.start_epoch_change_finisher
+                .start_finish_epoch_change_tasks(
+                    event_handle,
+                    event,
+                    shards_to_remove.to_vec(),
                     committees,
                     true,
                 );

--- a/crates/walrus-service/src/node/node_recovery.rs
+++ b/crates/walrus-service/src/node/node_recovery.rs
@@ -14,6 +14,7 @@ use super::{
     StorageNodeInner,
     blob_sync::{BlobSyncHandler, SyncStatus},
     config::NodeRecoveryConfig,
+    shard_sync::ShardSyncHandler,
 };
 use crate::node::{NodeStatus, storage::blob_info::CertifiedBlobInfoApi};
 
@@ -28,6 +29,10 @@ const SHARD_NOT_CREATED_BACKOFF_MAX: Duration = Duration::from_secs(60);
 pub struct NodeRecoveryHandler {
     node: Arc<StorageNodeInner>,
     blob_sync_handler: Arc<BlobSyncHandler>,
+    // Used to wait for ongoing shard syncs before recovering blobs: shard sync fills
+    // newly gained shards far more cheaply than per-blob recovery, so recovery defers
+    // to it.
+    shard_sync_handler: ShardSyncHandler,
 
     // There can be at most one background shard removal task at a time.
     task_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
@@ -40,11 +45,13 @@ impl NodeRecoveryHandler {
     pub fn new(
         node: Arc<StorageNodeInner>,
         blob_sync_handler: Arc<BlobSyncHandler>,
+        shard_sync_handler: ShardSyncHandler,
         config: NodeRecoveryConfig,
     ) -> Self {
         Self {
             node,
             blob_sync_handler,
+            shard_sync_handler,
             task_handle: Arc::new(Mutex::new(None)),
             config,
         }
@@ -72,6 +79,7 @@ impl NodeRecoveryHandler {
 
         let node = self.node.clone();
         let blob_sync_handler = self.blob_sync_handler.clone();
+        let shard_sync_handler = self.shard_sync_handler.clone();
         let max_concurrent_blob_syncs_during_recovery =
             self.config.max_concurrent_blob_syncs_during_recovery;
         let task_handle = tokio::spawn(async move {
@@ -93,7 +101,7 @@ impl NodeRecoveryHandler {
             loop {
                 // Block until the node is ready to run a recovery scan pass. Stops the recovery
                 // task if the node started catching up.
-                match wait_until_ready_to_scan(&node).await {
+                match wait_until_ready_to_scan(&node, &shard_sync_handler).await {
                     ScanReadiness::Ready => {}
                     ScanReadiness::CatchingUp => return,
                 }
@@ -243,6 +251,11 @@ impl NodeRecoveryHandler {
                 // and we can avoid the extra loop of all the blob syncs finished successfully.
             }
 
+            // A shard sync may have been started by an epoch change after the last scan
+            // pass began. The node is fully synced for the epoch only once both blob
+            // recovery and all shard syncs are complete, so drain them before attesting.
+            shard_sync_handler.wait_until_no_sync_in_progress().await;
+
             let current_node_status = node
                 .storage
                 .node_status()
@@ -298,19 +311,28 @@ enum ScanReadiness {
 }
 
 /// Blocks until the node is ready to run a recovery scan pass ([`ScanReadiness::Ready`]), or
-/// returns [`ScanReadiness::CatchingUp`] if the node started catching up. Both conditions are
-/// re-checked on every backoff iteration, so catch-up that begins while waiting also stops the
-/// task.
+/// returns [`ScanReadiness::CatchingUp`] if the node started catching up. All conditions are
+/// re-checked on every iteration, so catch-up that begins while waiting also stops the task.
 ///
-/// A node can own a shard at the latest committee epoch whose local storage does not exist yet: the
-/// committee advanced to a newer epoch, but event processing has not yet handled that epoch's
-/// `EpochChangeStart`, which is what creates the shard. Recovery must not create it here: blob sync
-/// targets `owned_shards_at_epoch(current_event_epoch)`, which still excludes the shard, and shard
-/// creation is part of the ordered epoch transition owned by event processing. If the scan ran in
-/// this state, every blob would read "not stored" on the missing shard, producing futile syncs and
-/// repeated full re-scans (and, on the single-threaded simulator, starving event processing
-/// entirely). So back off and re-check until the shard exists; the sleep also yields the executor.
-async fn wait_until_ready_to_scan(node: &StorageNodeInner) -> ScanReadiness {
+/// Readiness requires, besides the node not catching up:
+///
+/// - No shard sync is in progress. Shard sync fills newly gained shards far more cheaply than
+///   per-blob recovery (and per-blob recovery would redundantly decode slivers for shards that
+///   shard sync is copying in bulk), so recovery defers to it.
+/// - Local storage exists for every shard the node owns at the latest committee epoch. A node can
+///   own a shard whose local storage does not exist yet: the committee advanced to a newer epoch,
+///   but event processing has not yet handled that epoch's `EpochChangeStart`, which is what
+///   creates the shard. Recovery must not create it here: blob sync targets
+///   `owned_shards_at_epoch(current_event_epoch)`, which still excludes the shard, and shard
+///   creation is part of the ordered epoch transition owned by event processing. If the scan ran
+///   in this state, every blob would read "not stored" on the missing shard, producing futile
+///   syncs and repeated full re-scans (and, on the single-threaded simulator, starving event
+///   processing entirely). So back off and re-check until the shard exists; the sleep also yields
+///   the executor.
+async fn wait_until_ready_to_scan(
+    node: &StorageNodeInner,
+    shard_sync_handler: &ShardSyncHandler,
+) -> ScanReadiness {
     // Exponential backoff, recreated per stall episode so a fresh stall starts at the small bound.
     // The seed only feeds the jitter offset; a constant keeps it deterministic under the simulator.
     let mut backoff = ExponentialBackoff::new_with_seed(
@@ -329,6 +351,13 @@ async fn wait_until_ready_to_scan(node: &StorageNodeInner) -> ScanReadiness {
         {
             tracing::info!("node recovery encountered node is in catching up; skip recovery");
             break ScanReadiness::CatchingUp;
+        }
+
+        if shard_sync_handler.has_sync_in_progress() {
+            tracing::info!("waiting for ongoing shard syncs before scanning blobs to recover");
+            shard_sync_handler.wait_until_no_sync_in_progress().await;
+            // Loop back to re-check the catch-up status, which may have changed while waiting.
+            continue;
         }
 
         let existing_shards = node.storage.existing_shards().await;

--- a/crates/walrus-service/src/node/node_recovery.rs
+++ b/crates/walrus-service/src/node/node_recovery.rs
@@ -264,6 +264,11 @@ impl NodeRecoveryHandler {
                 tracing::info!("node recovery task finished; set node status to active");
                 match node.set_node_status(NodeStatus::Active) {
                     Ok(()) => {
+                        // While the node is recovering, this is the only place that attests
+                        // epoch sync done: shard sync skips its own attestation in
+                        // RecoveryInProgress state (see the epoch_sync_done handling in
+                        // shard_sync.rs), so that the attestation covers both the recovered
+                        // blobs and all synced shards.
                         node.contract_service
                             .epoch_sync_done(certified_before_epoch, node.node_capability())
                             .await
@@ -343,6 +348,13 @@ async fn wait_until_ready_to_scan(
     );
     let mut total_wait = Duration::ZERO;
     let readiness = loop {
+        // Wait for ongoing shard syncs to finish first, so that the status check below always
+        // runs after the (possibly long) wait and picks up catch-up that began while parked.
+        if shard_sync_handler.has_sync_in_progress() {
+            tracing::info!("waiting for ongoing shard syncs before scanning blobs to recover");
+            shard_sync_handler.wait_until_no_sync_in_progress().await;
+        }
+
         if node
             .storage
             .node_status()
@@ -351,13 +363,6 @@ async fn wait_until_ready_to_scan(
         {
             tracing::info!("node recovery encountered node is in catching up; skip recovery");
             break ScanReadiness::CatchingUp;
-        }
-
-        if shard_sync_handler.has_sync_in_progress() {
-            tracing::info!("waiting for ongoing shard syncs before scanning blobs to recover");
-            shard_sync_handler.wait_until_no_sync_in_progress().await;
-            // Loop back to re-check the catch-up status, which may have changed while waiting.
-            continue;
         }
 
         let existing_shards = node.storage.existing_shards().await;

--- a/crates/walrus-service/src/node/shard_sync.rs
+++ b/crates/walrus-service/src/node/shard_sync.rs
@@ -11,7 +11,7 @@ use futures::{StreamExt, stream::FuturesUnordered};
 #[cfg(msim)]
 use sui_macros::{fail_point_arg, fail_point_async, fail_point_if};
 use tokio::{
-    sync::{Mutex, Semaphore},
+    sync::{Mutex, Semaphore, watch},
     time::Instant,
 };
 use walrus_core::{BlobId, Epoch, ShardIndex};
@@ -46,6 +46,28 @@ enum SyncShardResult {
     Failed,
 }
 
+/// RAII guard tracking a running shard-sync-related task in the sync task count watch channel.
+///
+/// Increments the count on creation and decrements it on drop, so that the count stays accurate
+/// even if the tracked task is aborted or panics.
+#[derive(Debug)]
+struct SyncTaskCountGuard(Arc<watch::Sender<usize>>);
+
+impl SyncTaskCountGuard {
+    fn new(counter: Arc<watch::Sender<usize>>) -> Self {
+        counter.send_modify(|count| *count += 1);
+        sui_macros::fail_point!("fail_point_shard_sync_task_started");
+        Self(counter)
+    }
+}
+
+impl Drop for SyncTaskCountGuard {
+    fn drop(&mut self) {
+        self.0.send_modify(|count| *count = count.saturating_sub(1));
+        sui_macros::fail_point!("fail_point_shard_sync_task_finished");
+    }
+}
+
 /// Manages tasks for syncing shards during epoch change.
 #[derive(Debug, Clone)]
 pub struct ShardSyncHandler {
@@ -53,6 +75,10 @@ pub struct ShardSyncHandler {
     shard_sync_in_progress: Arc<Mutex<HashMap<ShardIndex, tokio::task::JoinHandle<()>>>>,
     task_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
     shard_sync_semaphore: Arc<Semaphore>,
+    // Tracks the number of currently running shard sync tasks, including the task that starts
+    // the individual per-shard syncs. Used by node recovery to wait until all shard syncs have
+    // finished (successfully or not) before recovering blobs.
+    sync_task_count: Arc<watch::Sender<usize>>,
     config: ShardSyncConfig,
 }
 
@@ -63,8 +89,27 @@ impl ShardSyncHandler {
             shard_sync_in_progress: Arc::new(Mutex::new(HashMap::new())),
             task_handle: Arc::new(Mutex::new(None)),
             shard_sync_semaphore: Arc::new(Semaphore::new(config.shard_sync_concurrency)),
+            sync_task_count: Arc::new(watch::channel(0).0),
             config,
         }
+    }
+
+    /// Returns `true` if any shard sync task is currently running.
+    pub fn has_sync_in_progress(&self) -> bool {
+        *self.sync_task_count.borrow() > 0
+    }
+
+    /// Waits until no shard sync task is running.
+    ///
+    /// A shard sync that failed terminally (requiring a node restart to be retried) does not
+    /// count as running; its shard remains in `ActiveSync` status and missing blobs in it are
+    /// recovered through the regular blob recovery path.
+    pub async fn wait_until_no_sync_in_progress(&self) {
+        let mut receiver = self.sync_task_count.subscribe();
+        receiver
+            .wait_for(|count| *count == 0)
+            .await
+            .expect("the sender is owned by self and cannot be dropped while waiting");
     }
 
     /// Starts sync shards. If the node status is [`NodeStatus::RecoverMetadata`], syncs certified
@@ -86,7 +131,13 @@ impl ShardSyncHandler {
             old_task.abort();
         }
 
-        let new_task = tokio::spawn(async move { sync_handler.sync_shards_task(shards).await });
+        // Count the task that starts the individual shard syncs as a running sync, so that
+        // waiters cannot observe a zero count before the per-shard sync tasks are spawned.
+        let count_guard = SyncTaskCountGuard::new(self.sync_task_count.clone());
+        let new_task = tokio::spawn(async move {
+            let _count_guard = count_guard;
+            sync_handler.sync_shards_task(shards).await
+        });
 
         *task_handle = Some(new_task);
 
@@ -365,7 +416,9 @@ impl ShardSyncHandler {
         };
 
         let shard_sync_handler_clone = self.clone();
+        let count_guard = SyncTaskCountGuard::new(self.sync_task_count.clone());
         let shard_sync_task = tokio::spawn(async move {
+            let _count_guard = count_guard;
             let shard_index = shard_storage.id();
             let mut last_progress_time = Instant::now();
 
@@ -453,7 +506,17 @@ impl ShardSyncHandler {
                 false
             };
 
-            if epoch_sync_done {
+            // While the node is recovering, node recovery owns the epoch sync done
+            // attestation: it waits for all shard syncs to finish and attests only once
+            // the recovery itself is complete.
+            let node_is_recovering = shard_sync_handler_clone
+                .node
+                .storage
+                .node_status()
+                .expect("failed to read node status from db")
+                .is_recovering();
+
+            if epoch_sync_done && !node_is_recovering {
                 shard_sync_handler_clone
                     .node
                     .contract_service

--- a/crates/walrus-service/src/node/shard_sync.rs
+++ b/crates/walrus-service/src/node/shard_sync.rs
@@ -508,7 +508,8 @@ impl ShardSyncHandler {
 
             // While the node is recovering, node recovery owns the epoch sync done
             // attestation: it waits for all shard syncs to finish and attests only once
-            // the recovery itself is complete.
+            // the recovery itself is complete (see the recovery task's completion in
+            // node_recovery.rs).
             let node_is_recovering = shard_sync_handler_clone
                 .node
                 .storage

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -139,6 +139,11 @@ impl NodeStatus {
         matches!(self, NodeStatus::Active)
     }
 
+    /// Returns `true` if the node is recovering missing slivers for its shards.
+    pub fn is_recovering(&self) -> bool {
+        matches!(self, NodeStatus::RecoveryInProgress(_))
+    }
+
     /// Returns `true` if the node is catching up.
     pub fn is_catching_up(&self) -> bool {
         matches!(

--- a/crates/walrus-simtest/tests/simtest_core.rs
+++ b/crates/walrus-simtest/tests/simtest_core.rs
@@ -1082,6 +1082,241 @@ mod tests {
         clear_fail_point("start_node_recovery_entry");
     }
 
+    // Tests that an epoch change occurring while node recovery is in progress fills newly
+    // gained shards using shard sync, and that node recovery does not start any blob syncs
+    // while shard syncs are running.
+    //
+    // The test crashes a node long enough for it to enter RecoveryInProgress state, holds the
+    // recovery task using a fail point, stakes additional weight on the node so that it gains
+    // shards at a subsequent epoch change (which it processes while recovering), and then
+    // releases the recovery task.
+    #[ignore = "ignore integration simtests by default"]
+    #[walrus_simtest]
+    async fn test_node_recovery_across_epoch_change_with_shard_gain() {
+        let (_sui_cluster, walrus_cluster, client, _, _) = test_cluster::E2eTestSetupBuilder::new()
+            .with_epoch_duration(Duration::from_secs(30))
+            .with_test_nodes_config(
+                TestNodesConfig::builder()
+                    .with_node_weights(&[1, 2, 3, 3, 4])
+                    .build(),
+            )
+            .with_communication_config(
+                ClientCommunicationConfig::default_for_test_with_reqwest_timeout(
+                    Duration::from_secs(2),
+                ),
+            )
+            .with_default_num_checkpoints_per_blob()
+            .build_generic::<SimStorageNodeHandle>()
+            .await
+            .unwrap();
+
+        let blob_info_consistency_check = BlobInfoConsistencyCheck::new();
+
+        let client_arc = Arc::new(client);
+
+        // Starts a background workload that a client keeps writing and retrieving data.
+        let workload_handle =
+            simtest_utils::start_background_workload(client_arc.clone(), false, None, None);
+
+        // Run the workload to get some data in the system.
+        tokio::time::sleep(Duration::from_mins(1)).await;
+
+        let target_node_id = walrus_cluster.nodes[0]
+            .node_id
+            .expect("node id should be set");
+        let initial_owned_shard_count =
+            simtest_utils::get_nodes_health_info([&walrus_cluster.nodes[0]]).await[0]
+                .shard_detail
+                .as_ref()
+                .expect("shard detail should be set")
+                .owned
+                .len();
+
+        // Tracks the number of shard sync tasks currently running on the target node, the
+        // total number of shard syncs started on it, and whether node recovery started a
+        // blob sync while a shard sync was running (which must never happen).
+        let active_shard_syncs = Arc::new(AtomicU64::new(0));
+        let total_shard_syncs_started = Arc::new(AtomicU64::new(0));
+        let ordering_violation = Arc::new(AtomicBool::new(false));
+        {
+            let active_shard_syncs = active_shard_syncs.clone();
+            let total_shard_syncs_started = total_shard_syncs_started.clone();
+            register_fail_point("fail_point_shard_sync_task_started", move || {
+                if sui_simulator::current_simnode_id() == target_node_id {
+                    active_shard_syncs.fetch_add(1, Ordering::SeqCst);
+                    total_shard_syncs_started.fetch_add(1, Ordering::SeqCst);
+                }
+            });
+        }
+        {
+            let active_shard_syncs = active_shard_syncs.clone();
+            register_fail_point("fail_point_shard_sync_task_finished", move || {
+                if sui_simulator::current_simnode_id() == target_node_id {
+                    active_shard_syncs.fetch_sub(1, Ordering::SeqCst);
+                }
+            });
+        }
+        {
+            let active_shard_syncs = active_shard_syncs.clone();
+            let ordering_violation = ordering_violation.clone();
+            register_fail_point("fail_point_node_recovery_start_sync", move || {
+                if sui_simulator::current_simnode_id() == target_node_id
+                    && active_shard_syncs.load(Ordering::SeqCst) > 0
+                {
+                    ordering_violation.store(true, Ordering::SeqCst);
+                }
+            });
+        }
+
+        // Tracks that the target node processed an epoch change through the recovering path.
+        let recovering_path_hit = Arc::new(AtomicBool::new(false));
+        {
+            let recovering_path_hit = recovering_path_hit.clone();
+            register_fail_point(
+                "fail_point_shard_changes_in_new_epoch_while_recovering",
+                move || {
+                    if sui_simulator::current_simnode_id() == target_node_id {
+                        recovering_path_hit.store(true, Ordering::SeqCst);
+                    }
+                },
+            );
+        }
+
+        // Holds the recovery task of the target node so that the recovery reliably spans
+        // multiple epoch changes; released once the node has gained shards while recovering.
+        let hold_recovery = Arc::new(AtomicBool::new(true));
+        {
+            let hold_recovery = hold_recovery.clone();
+            register_fail_point_async("start_node_recovery_entry", move || {
+                let hold_recovery = hold_recovery.clone();
+                async move {
+                    if sui_simulator::current_simnode_id() != target_node_id {
+                        return;
+                    }
+                    tracing::info!("holding node recovery until released by the test");
+                    while hold_recovery.load(Ordering::SeqCst) {
+                        tokio::time::sleep(Duration::from_secs(1)).await;
+                    }
+                    tracing::info!("node recovery released by the test");
+                }
+            });
+        }
+
+        // Crash the target node for more than two epochs so that it enters recovery mode when
+        // it comes back.
+        let fail_triggered = Arc::new(AtomicBool::new(false));
+        let fail_triggered_clone = fail_triggered.clone();
+        register_fail_points(CRASH_NODE_FAIL_POINTS, move || {
+            crash_target_node(
+                target_node_id,
+                fail_triggered_clone.clone(),
+                Duration::from_mins(1),
+            );
+        });
+
+        // Wait until the target node is back and in RecoveryInProgress state.
+        wait_until(
+            Duration::from_mins(4),
+            "target node should enter recovery",
+            || async {
+                simtest_utils::try_get_nodes_health_info([&walrus_cluster.nodes[0]]).await[0]
+                    .as_ref()
+                    .is_ok_and(|info| info.node_status.starts_with("RecoveryInProgress"))
+            },
+        )
+        .await;
+
+        // Stake additional weight on the recovering node so that it gains shards at a
+        // subsequent epoch change, which it processes while still recovering.
+        client_arc
+            .as_ref()
+            .as_ref()
+            .stake_with_node_pool(
+                walrus_cluster.nodes[0]
+                    .storage_node_capability
+                    .as_ref()
+                    .unwrap()
+                    .node_id,
+                test_cluster::FROST_PER_NODE_WEIGHT * 3,
+            )
+            .await
+            .expect("stake with node pool should not fail");
+
+        // Wait until the node gains shards and starts syncing them. Since the recovery task is
+        // held, any shard sync here necessarily starts while the node is recovering.
+        wait_until(
+            Duration::from_mins(4),
+            "target node should start syncing gained shards while recovering",
+            || async { total_shard_syncs_started.load(Ordering::SeqCst) > 0 },
+        )
+        .await;
+
+        // Release the recovery task; it must wait for the shard syncs to finish before
+        // recovering blobs, and eventually transition the node to Active.
+        hold_recovery.store(false, Ordering::SeqCst);
+
+        wait_until(
+            Duration::from_mins(4),
+            "target node should finish recovery and become active",
+            || async {
+                simtest_utils::try_get_nodes_health_info([&walrus_cluster.nodes[0]]).await[0]
+                    .as_ref()
+                    .is_ok_and(|info| info.node_status == "Active")
+            },
+        )
+        .await;
+
+        assert!(
+            recovering_path_hit.load(Ordering::SeqCst),
+            "an epoch change should have been processed while node recovery was in progress"
+        );
+        assert!(
+            !ordering_violation.load(Ordering::SeqCst),
+            "node recovery must not start blob syncs while shard syncs are running"
+        );
+
+        // The gained shards should be owned by the node and be ready to serve traffic.
+        let node_health_info =
+            simtest_utils::get_nodes_health_info([&walrus_cluster.nodes[0]]).await;
+        let owned_shards = &node_health_info[0]
+            .shard_detail
+            .as_ref()
+            .expect("shard detail should be set")
+            .owned;
+        assert!(
+            owned_shards.len() > initial_owned_shard_count,
+            "the node should have gained shards during recovery"
+        );
+        for shard in owned_shards {
+            assert_eq!(shard.status, ShardStatus::Ready);
+        }
+
+        workload_handle.abort();
+
+        blob_info_consistency_check.check_storage_node_consistency();
+
+        clear_fail_point("start_node_recovery_entry");
+    }
+
+    /// Repeatedly polls `condition` until it returns `true`, panicking with `description` if
+    /// `timeout` elapses first.
+    async fn wait_until<F, Fut>(timeout: Duration, description: &str, condition: F)
+    where
+        F: Fn() -> Fut,
+        Fut: std::future::Future<Output = bool>,
+    {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if condition().await {
+                return;
+            }
+            if Instant::now() > deadline {
+                panic!("timeout waiting until: {description}");
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    }
+
     // Tests upgrading the walrus contracts from testnet-contracts to the development branch
     // contracts. Whether a migration epoch is needed or not depends on the specific contract
     // upgrade path.


### PR DESCRIPTION
## Description

When a node in `RecoveryInProgress` processes an epoch change, it force-sets all owned shards (including newly gained ones) to `Active` and fills them via per-blob erasure recovery — even though on an incremental transition the previous owner is known and bulk shard sync is far cheaper.

This PR adds a dedicated epoch-change path for recovering nodes:

- **Gained shards are filled via shard sync** from their previous owners instead of per-blob recovery. The catch-up path (previous shard assignment unknown) is unchanged.
- **Node recovery waits for ongoing shard syncs** before each scan pass and before completing, using a watch counter of running sync tasks (abort/panic-safe; a terminally failed sync does not block recovery).
- **Single `epoch_sync_done` attestation**: while recovering, only the recovery task attests, and only after both blob recovery and all shard syncs finish. Shard sync's own attestation is suppressed in that state.


A follow-up PR will make the recovery task survive epoch changes without restarting (avoiding the full blob-info re-scan).

Resolve WAL-1261

## Test plan

- New simtest `test_node_recovery_across_epoch_change_with_shard_gain`: a node gains shards at an epoch change processed while recovering; asserts the gained shards are filled by shard sync, recovery starts no blob syncs while shard syncs run, and the node ends `Active` with all shards `Ready`. Passes on seeds 1 and 2.
- Regression simtests pass: `test_long_node_recovery`, `test_recovery_in_progress_with_node_restart`, `test_lagging_node_recovery`.

