### PR TITLE
chore: run repeated single-test simtests in parallel

### DIFF
--- a/scripts/simtest/simtest-run.sh
+++ b/scripts/simtest/simtest-run.sh
@@ -64,18 +64,52 @@ echo "Test filter: $TEST_FILTER"
 echo "================================================"
 date
 
-# This command runs many different tests, so it already uses all CPUs fairly efficiently, and
-# don't need to be done inside of the for loop below.
-# TODO: this logs directly to stdout since it is not being run in parallel. is that ok?
+if [ "$TEST_FILTER" != "simtest" ] && [ "$TEST_NUM" -gt 1 ]; then
+  # A specific test is selected and multiple iterations are requested. MSIM_TEST_NUM runs the
+  # iterations sequentially inside a single test execution, so a single test would only use one
+  # CPU. Instead, run TEST_NUM jobs in parallel, each running the test once with a distinct seed.
 
-TMPDIR="$WALRUS_TMP_DIR" \
-MSIM_TEST_SEED="$SEED" \
-MSIM_TEST_NUM=${TEST_NUM} \
-MSIM_WATCHDOG_TIMEOUT_MS="$WATCHDOG_TIMEOUT_MS" \
-scripts/simtest/cargo-simtest simtest "$TEST_FILTER" \
-  --color never \
-  --test-threads "$NUM_CPUS" \
-  --profile simtestnightly 2>&1 | tee "$LOG_FILE"
+  # Build the test binaries once up front so that the parallel jobs don't race to compile.
+  TMPDIR="$WALRUS_TMP_DIR" \
+  scripts/simtest/cargo-simtest simtest build --tests 2>&1 | tee "$LOG_FILE"
+
+  # Each simtest iteration is single-threaded, so cap the number of concurrent jobs at NUM_CPUS.
+  MAX_PARALLEL_JOBS=${MAX_PARALLEL_JOBS:-$NUM_CPUS}
+  [ "$MAX_PARALLEL_JOBS" -lt 1 ] && MAX_PARALLEL_JOBS=1
+
+  for ((ITER = 0; ITER < TEST_NUM; ITER++)); do
+    # Wait for a free job slot before starting the next iteration.
+    while [ "$(jobs -rp | wc -l)" -ge "$MAX_PARALLEL_JOBS" ]; do
+      sleep 5
+    done
+
+    ITER_SEED=$((SEED + ITER))
+    ITER_LOG_FILE="$LOG_DIR/log-iteration-$ITER"
+    echo "Starting iteration $ITER with seed $ITER_SEED (log: $ITER_LOG_FILE)"
+
+    TMPDIR="$WALRUS_TMP_DIR" \
+    MSIM_TEST_SEED="$ITER_SEED" \
+    MSIM_TEST_NUM=1 \
+    MSIM_WATCHDOG_TIMEOUT_MS="$WATCHDOG_TIMEOUT_MS" \
+    scripts/simtest/cargo-simtest simtest "$TEST_FILTER" \
+      --color never \
+      --test-threads 1 \
+      --profile simtestnightly > "$ITER_LOG_FILE" 2>&1 &
+  done
+else
+  # This command runs many different tests, so it already uses all CPUs fairly efficiently, and
+  # don't need to be done inside of the for loop below.
+  # TODO: this logs directly to stdout since it is not being run in parallel. is that ok?
+
+  TMPDIR="$WALRUS_TMP_DIR" \
+  MSIM_TEST_SEED="$SEED" \
+  MSIM_TEST_NUM=${TEST_NUM} \
+  MSIM_WATCHDOG_TIMEOUT_MS="$WATCHDOG_TIMEOUT_MS" \
+  scripts/simtest/cargo-simtest simtest "$TEST_FILTER" \
+    --color never \
+    --test-threads "$NUM_CPUS" \
+    --profile simtestnightly 2>&1 | tee "$LOG_FILE"
+fi
 
 # wait for all the jobs to end
 wait


### PR DESCRIPTION
## Summary

When running `scripts/simtest/simtest-run.sh` with a `TEST_FILTER` that selects a single specific test and `TEST_NUM > 1`, the iterations previously ran **sequentially** on a single CPU.

This is because `MSIM_TEST_NUM=N` makes the `#[sim_test]` macro loop over the N iterations *inside a single test execution* (advancing the seed each time). With only one matching test, `--test-threads "$NUM_CPUS"` provides no parallelism, so N iterations run back-to-back on one core.

## Change

When `TEST_FILTER` is not the default `simtest` **and** `TEST_NUM > 1`, the script now:

1. Pre-builds the test binaries once (`cargo-simtest simtest build --tests`) so parallel jobs don't race on the build lock.
2. Spawns `TEST_NUM` background jobs, each running the test once with `MSIM_TEST_NUM=1` and a distinct seed (`SEED + iteration`).
3. Throttles concurrency to `NUM_CPUS` (overridable via `MAX_PARALLEL_JOBS`), since each msim iteration is single-threaded.
4. Writes per-iteration logs to `$LOG_DIR/log-iteration-$ITER` and prints each seed for reproducibility.

The default path (broad filter, or a single iteration) is unchanged. Existing failure detection greps `$LOG_DIR/*`, so the new per-iteration logs are picked up automatically, and the existing `wait` collects the background jobs.

## Usage

```bash
TEST_FILTER=test_repeated_node_crash TEST_NUM=8 ./scripts/simtest/simtest-run.sh
```

now runs 8 seeds concurrently instead of one after another.

## Test plan

- `bash -n` passes; shellcheck (pre-commit) passes.
- Not run live (a real invocation builds the simulator profile and clones the Sui repo).