### PR TITLE
docs: redesign homepage, search modal, and navbar

### DIFF
--- a/docs/site/docusaurus.config.js
+++ b/docs/site/docusaurus.config.js
@@ -93,6 +93,7 @@ const config = {
 
   clientModules: [
     "./src/client/webmcp.js",
+    "./src/client/kapa-sidebar.js",
   ],
 
   onBrokenLinks: "throw",
@@ -297,6 +298,9 @@ const config = {
       "data-project-name": "Walrus Knowledge",
       "data-project-color": "#37c3b0ff",
       "data-button-hide": "true",
+      "data-view-mode": "sidebar",
+      "data-modal-overlay-hidden": "true",
+      "data-modal-lock-scroll": "false",
       "data-modal-title": "Ask Walrus AI",
       "data-modal-ask-ai-input-placeholder": "Ask me anything about Walrus!",
       "data-modal-example-questions":

--- a/docs/site/src/client/kapa-sidebar.js
+++ b/docs/site/src/client/kapa-sidebar.js
@@ -1,0 +1,85 @@
+// Copyright (c) Walrus Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// Detects Kapa sidebar open/close and toggles .kapa-sidebar-open on <html>.
+// Kapa renders in Shadow DOM so we can't query its internals.
+// Strategy: hook Kapa.open for instant open detection, then use
+// elementFromPoint to detect close (checks if right edge of screen
+// is covered by a non-docusaurus element).
+
+if (typeof window !== "undefined") {
+  const OPEN_CLASS = "kapa-sidebar-open";
+  let kapaOpen = false;
+  let hookedRef = null;
+
+  function syncClass() {
+    document.documentElement.classList.toggle(OPEN_CLASS, kapaOpen);
+  }
+
+  function hookKapa() {
+    if (!window.Kapa || !window.Kapa.open || window.Kapa.open === hookedRef)
+      return;
+
+    const origOpen = window.Kapa.open;
+    const origClose = window.Kapa.close;
+
+    window.Kapa.open = function (...args) {
+      kapaOpen = true;
+      syncClass();
+      return origOpen.apply(this, args);
+    };
+
+    window.Kapa.close = function (...args) {
+      kapaOpen = false;
+      syncClass();
+      return origClose.apply(this, args);
+    };
+
+    hookedRef = window.Kapa.open;
+  }
+
+  // Check if Kapa sidebar is covering the right side of the viewport.
+  // Since Kapa uses Shadow DOM, we can't query its elements directly.
+  // Instead, check if the element at the right edge of the screen
+  // belongs to the doc app or to something else (Kapa's panel).
+  function isSidebarVisible() {
+    const x = window.innerWidth - 50;
+    const y = window.innerHeight / 2;
+    const el = document.elementFromPoint(x, y);
+    if (!el) return false;
+    const docRoot = document.getElementById("__docusaurus");
+    if (docRoot && docRoot.contains(el)) return false;
+    if (el === document.body || el === document.documentElement) return false;
+    return true;
+  }
+
+  // Hook into History API so the class persists across SPA navigation.
+  // Docusaurus uses pushState for client-side routing.
+  const origPush = history.pushState.bind(history);
+  const origReplace = history.replaceState.bind(history);
+  history.pushState = function (...args) {
+    const r = origPush(...args);
+    syncClass();
+    return r;
+  };
+  history.replaceState = function (...args) {
+    const r = origReplace(...args);
+    syncClass();
+    return r;
+  };
+  window.addEventListener("popstate", syncClass);
+
+  // Poll every 300ms: re-hook Kapa if it reinitializes, and
+  // detect open/close state via elementFromPoint fallback.
+  setInterval(() => {
+    hookKapa();
+
+    const visible = isSidebarVisible();
+    if (visible && !kapaOpen) {
+      kapaOpen = true;
+    } else if (!visible && kapaOpen) {
+      kapaOpen = false;
+    }
+    syncClass();
+  }, 300);
+}

--- a/docs/site/src/components/LandingPage.tsx
+++ b/docs/site/src/components/LandingPage.tsx
@@ -205,6 +205,13 @@ html, body { background: #0d0f12 !important; }
 .landing-root .product-card .under-hood {
   font-style: italic; opacity: 0.6;
 }
+.landing-root .coming-soon-badge {
+  font-size: 0.6rem; font-weight: 500; letter-spacing: 0.03em;
+  text-transform: uppercase; opacity: 0.5;
+  background: rgba(255,255,255,0.08); border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 4px; padding: 2px 6px; margin-left: 8px;
+  vertical-align: middle;
+}
 .landing-root .product-card .product-arrow {
   display: flex; align-items: center; justify-content: flex-end;
   padding: 12px 18px;
@@ -218,9 +225,9 @@ html, body { background: #0d0f12 !important; }
 
 /* ── Landing search bar ── */
 .landing-root .landing-search {
-  max-width: 760px; margin: 0 auto;
-  padding: 0 0 28px;
-  opacity: 0; animation: landingFadeIn 0.6s ease forwards 0.5s;
+  max-width: 560px; margin: 0 auto;
+  padding: 20px 0 0;
+  opacity: 0; animation: landingFadeIn 0.5s ease forwards 0.2s;
 }
 .landing-root .landing-search-btn {
   width: 100%; display: flex; align-items: center; gap: 14px;
@@ -381,39 +388,6 @@ export default function LandingPage() {
       </Head>
       <style dangerouslySetInnerHTML={{ __html: LANDING_CSS }} />
 
-      <header className="topbar">
-        <div className="topbar-inner">
-          <div className="topbar-logo">
-            <WalrusLogo />
-          </div>
-          <nav className="topbar-links">
-            <a
-              href="https://github.com/MystenLabs/walrus"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              GitHub
-            </a>
-            <a
-              href="https://discord.gg/walrusprotocol"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Discord
-            </a>
-            <button
-              className="kapa-landing-btn"
-              onClick={() => { if ((window as any).Kapa) (window as any).Kapa.open(); }}
-            >
-              Ask Walrus AI
-            </button>
-            <a href="/docs/getting-started" className="primary">
-              Get Started →
-            </a>
-          </nav>
-        </div>
-      </header>
-
       <div className="landing-wrap">
         <div className="hero-inner">
           <h1 className="hero-title">Build with Walrus</h1>
@@ -421,54 +395,6 @@ export default function LandingPage() {
             Keep critical data persistent, portable, and under your control
             across apps, providers, and agents.
           </p>
-        </div>
-
-        <div className="product-grid">
-          <a className="product-card" href="/walrus-memory/getting-started/what-is-walrus-memory">
-            <div className="product-card-thumb">
-              <svg viewBox="0 0 48 48" fill="none" stroke="currentColor" strokeWidth="1.5">
-                <circle cx="24" cy="16" r="10" />
-                <path d="M24 26v4M18 38h12M20 26c0 2.5 1.8 4 4 4s4-1.5 4-4" />
-              </svg>
-            </div>
-            <h3>Walrus Memory</h3>
-            <p>Portable memory layer that gives AI agents persistent context across apps and sessions.</p>
-            <span className="product-arrow">{arrowIcon}</span>
-          </a>
-          <a className="product-card" href="/docs/getting-started">
-            <div className="product-card-thumb">
-              <svg viewBox="0 0 48 48" fill="none" stroke="currentColor" strokeWidth="1.5">
-                <rect x="8" y="8" width="32" height="32" rx="4" />
-                <path d="M8 18h32M18 48V18" />
-              </svg>
-            </div>
-            <h3>Walrus Console</h3>
-            <p>Unified control plane for managing files, datasets, memory, and other assets on Walrus.</p>
-            <span className="product-arrow">{arrowIcon}</span>
-          </a>
-          <a className="product-card" href="/docs/getting-started">
-            <div className="product-card-thumb">
-              <svg viewBox="0 0 48 48" fill="none" stroke="currentColor" strokeWidth="1.5">
-                <circle cx="18" cy="38" r="3" /><circle cx="36" cy="38" r="3" />
-                <path d="M4 4h8l5.36 26.78a4 4 0 004 3.22h15.28a4 4 0 004-3.22L44 14H12" />
-              </svg>
-            </div>
-            <h3>Walrus Marketplace</h3>
-            <p>Open marketplace where developers and AI agents discover, license, and access data.</p>
-            <span className="product-arrow">{arrowIcon}</span>
-          </a>
-          <a className="product-card product-card--muted" href="/docs/getting-started">
-            <div className="product-card-thumb product-card-thumb--muted">
-              <svg viewBox="0 0 48 48" fill="none" stroke="currentColor" strokeWidth="1.5">
-                <path d="M42 32V16a4 4 0 00-2-3.46l-14-8a4 4 0 00-4 0l-14 8A4 4 0 006 16v16a4 4 0 002 3.46l14 8a4 4 0 004 0l14-8A4 4 0 0042 32z" />
-                <polyline points="6.54 13.92 24 24.02 41.46 13.92" />
-                <line x1="24" y1="44.16" x2="24" y2="24" />
-              </svg>
-            </div>
-            <h3>Walrus Protocol</h3>
-            <p>Open source, decentralized data storage. <span className="under-hood">Under the hood.</span></p>
-            <span className="product-arrow">{arrowIcon}</span>
-          </a>
         </div>
 
         <div className="landing-search">
@@ -490,6 +416,54 @@ export default function LandingPage() {
             <SearchModal isOpen={searchOpen} onClose={() => setSearchOpen(false)} />,
             document.body,
           )}
+        </div>
+
+        <div className="product-grid">
+          <a className="product-card" href="/walrus-memory/getting-started/what-is-walrus-memory">
+            <div className="product-card-thumb">
+              <svg viewBox="0 0 48 48" fill="none" stroke="currentColor" strokeWidth="1.5">
+                <circle cx="24" cy="16" r="10" />
+                <path d="M24 26v4M18 38h12M20 26c0 2.5 1.8 4 4 4s4-1.5 4-4" />
+              </svg>
+            </div>
+            <h3>Walrus Memory</h3>
+            <p>Portable memory layer that gives AI agents persistent context across apps and sessions.</p>
+            <span className="product-arrow">{arrowIcon}</span>
+          </a>
+          <a className="product-card product-card--muted" href="/docs/getting-started">
+            <div className="product-card-thumb">
+              <svg viewBox="0 0 48 48" fill="none" stroke="currentColor" strokeWidth="1.5">
+                <rect x="8" y="8" width="32" height="32" rx="4" />
+                <path d="M8 18h32M18 48V18" />
+              </svg>
+            </div>
+            <h3>Walrus Console <span className="coming-soon-badge">Coming soon</span></h3>
+            <p>Unified control plane for managing files, datasets, memory, and other assets on Walrus.</p>
+            <span className="product-arrow">{arrowIcon}</span>
+          </a>
+          <a className="product-card product-card--muted" href="/docs/getting-started">
+            <div className="product-card-thumb">
+              <svg viewBox="0 0 48 48" fill="none" stroke="currentColor" strokeWidth="1.5">
+                <circle cx="18" cy="38" r="3" /><circle cx="36" cy="38" r="3" />
+                <path d="M4 4h8l5.36 26.78a4 4 0 004 3.22h15.28a4 4 0 004-3.22L44 14H12" />
+              </svg>
+            </div>
+            <h3>Walrus Marketplace <span className="coming-soon-badge">Coming soon</span></h3>
+            <p>Open marketplace where developers and AI agents discover, license, and access data.</p>
+            <span className="product-arrow">{arrowIcon}</span>
+          </a>
+          <a className="product-card" href="/docs/getting-started">
+            <div className="product-card-thumb">
+              <svg viewBox="0 0 48 48" fill="none" stroke="currentColor" strokeWidth="1.5">
+                <path d="M42 32V16a4 4 0 00-2-3.46l-14-8a4 4 0 00-4 0l-14 8A4 4 0 006 16v16a4 4 0 002 3.46l14 8a4 4 0 004 0l14-8A4 4 0 0042 32z" />
+                <polyline points="6.54 13.92 24 24.02 41.46 13.92" />
+                <line x1="24" y1="44.16" x2="24" y2="24" />
+              </svg>
+            </div>
+            <h3>Walrus Protocol</h3>
+            <p>Open source, decentralized data storage. <span className="under-hood">Under the hood.</span></p>
+            <span className="product-arrow">{arrowIcon}</span>
+          </a>
         </div>
 
         <footer className="page-footer">

--- a/docs/site/src/components/LandingPage.tsx
+++ b/docs/site/src/components/LandingPage.tsx
@@ -131,103 +131,90 @@ html, body { background: #0d0f12 !important; }
 
 /* ── Hero ── */
 .landing-root .hero {
-  position: relative; padding: 80px 0 48px; overflow: hidden;
+  position: relative; padding: 48px 0 24px; overflow: hidden;
   background: var(--black);
 }
 .landing-root .hero-inner {
-  position: relative; z-index: 5; max-width: 1500px;
-  margin-bottom: 36px; padding-top: 20px;
-}
-.landing-root .hero-badge {
-  display: inline-block;
-  font-family: var(--mono); font-size: 0.72rem; font-weight: 500;
-  letter-spacing: 0.08em; text-transform: uppercase;
-  color: var(--purple); margin-bottom: 16px;
+  position: relative; z-index: 5;
+  margin-bottom: 0; padding-top: 0;
+  text-align: center;
   opacity: 0; animation: landingFadeIn 0.5s ease forwards 0.1s;
 }
-.landing-root .hero h1 {
-  font-size: clamp(2rem, 5vw, 3rem);
-  font-weight: 500; line-height: 1.08; letter-spacing: -0.025em;
-  margin-bottom: 14px; color: var(--white);
-  opacity: 0; animation: landingFadeIn 0.6s ease forwards 0.2s;
+.landing-root .hero-title {
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+  font-weight: 600; line-height: 1.15; letter-spacing: -0.03em;
+  margin: 0 0 12px; color: var(--white);
 }
-.landing-root .hero p {
-  font-size: 1rem; color: var(--white); line-height: 1.6;
-  max-width: 1500px;
-  opacity: 0; animation: landingFadeIn 0.6s ease forwards 0.35s;
+.landing-root .hero-sub {
+  font-size: 1rem; color: var(--white); opacity: 0.55;
+  line-height: 1.55; max-width: 560px; margin: 0 auto;
 }
 
-/* ── Product cards ── */
-.landing-root .quickstart {
-  display: grid; grid-template-columns: repeat(2, 1fr); gap: 14px;
-  padding-bottom: 0;
-  opacity: 0; animation: landingFadeIn 0.6s ease forwards 0.65s;
+/* ── Product card grid (Mem0-inspired) ── */
+.landing-root .product-grid {
+  display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px;
+  padding: 32px 0 0;
+  opacity: 0; animation: landingFadeIn 0.6s ease forwards 0.3s;
 }
 @media (max-width: 640px) {
-  .landing-root .quickstart { grid-template-columns: 1fr; }
+  .landing-root .product-grid { grid-template-columns: 1fr; }
 }
-.landing-root .qs-card {
-  position: relative; overflow: hidden;
+
+.landing-root .product-card {
   background: var(--surface); border: 1px solid var(--border);
-  border-radius: var(--radius); padding: 24px 22px 20px;
-  transition: all 0.25s ease; cursor: pointer;
-  display: flex; flex-direction: column; gap: 8px;
+  border-radius: 14px; padding: 0;
+  transition: all 0.2s ease; cursor: pointer;
+  display: flex; flex-direction: column;
+  text-decoration: none !important;
+  overflow: hidden;
 }
-.landing-root .qs-card::before {
-  content: ''; position: absolute; inset: 0; opacity: 0;
-  transition: opacity 0.3s ease; border-radius: inherit; z-index: 0;
-}
-.landing-root .qs-card:hover {
-  border-color: rgba(255,255,255,0.18); background: var(--surface-hover);
+.landing-root .product-card:hover {
+  border-color: rgba(255,255,255,0.18);
   transform: translateY(-2px);
-  box-shadow: 0 10px 32px rgba(0,0,0,0.35);
+  box-shadow: 0 8px 24px rgba(0,0,0,0.25);
 }
-.landing-root .qs-card:hover::before { opacity: 1; }
-.landing-root .qs-card--purple::before {
-  background: radial-gradient(ellipse at top right, rgba(202,177,255,0.07) 0%, transparent 60%);
-}
-.landing-root .qs-card--mint::before {
-  background: radial-gradient(ellipse at top right, rgba(152,239,221,0.07) 0%, transparent 60%);
-}
-.landing-root .qs-card--yellow::before {
-  background: radial-gradient(ellipse at top right, rgba(232,255,117,0.07) 0%, transparent 60%);
-}
-.landing-root .qs-card .qs-card-top {
-  position: relative; z-index: 1;
-  display: flex; align-items: center; gap: 12px;
-}
-.landing-root .qs-card .qs-icon {
-  width: 38px; height: 38px; border-radius: 10px; flex-shrink: 0;
+
+.landing-root .product-card-thumb {
+  height: 120px;
+  background: linear-gradient(135deg, rgba(202,177,255,0.06) 0%, rgba(152,239,221,0.04) 100%);
   display: flex; align-items: center; justify-content: center;
+  border-bottom: 1px solid var(--border);
 }
-.landing-root .qs-card--purple .qs-icon { background: rgba(202,177,255,0.12); }
-.landing-root .qs-card--mint .qs-icon { background: rgba(152,239,221,0.12); }
-.landing-root .qs-card--yellow .qs-icon { background: rgba(232,255,117,0.12); }
-.landing-root .qs-card .qs-icon svg { width: 19px; height: 19px; }
-.landing-root .qs-card--purple .qs-icon svg { color: var(--purple); }
-.landing-root .qs-card--mint .qs-icon svg { color: var(--mint); }
-.landing-root .qs-card--yellow .qs-icon svg { color: var(--yellow); }
-.landing-root .qs-card h3 {
-  position: relative; z-index: 1;
-  font-size: 1.05rem; font-weight: 600;
-  line-height: 1.3; margin: 0; color: var(--white);
+.landing-root .product-card-thumb svg {
+  width: 48px; height: 48px; color: var(--purple); opacity: 0.5;
 }
-.landing-root .qs-card p {
-  position: relative; z-index: 1;
-  font-size: 0.85rem; color: var(--white); opacity: 0.5;
+.landing-root .product-card-thumb--muted {
+  background: linear-gradient(135deg, rgba(255,255,255,0.02) 0%, rgba(255,255,255,0.01) 100%);
+}
+.landing-root .product-card-thumb--muted svg {
+  color: var(--gray-muted); opacity: 0.3;
+}
+
+.landing-root .product-card h3 {
+  font-size: 0.95rem; font-weight: 700;
+  line-height: 1.3; margin: 0;
+  color: var(--white);
+  padding: 16px 18px 0;
+}
+.landing-root .product-card p {
+  font-size: 0.82rem; color: var(--white); opacity: 0.5;
   line-height: 1.5; margin: 0;
+  padding: 6px 18px 0;
+  flex: 1;
 }
-.landing-root .qs-card .qs-arrow {
-  position: relative; z-index: 1;
-  font-size: 0.78rem; font-weight: 500;
-  display: flex; align-items: center; gap: 5px; margin-top: 4px;
-  transition: gap 0.2s ease;
+.landing-root .product-card .under-hood {
+  font-style: italic; opacity: 0.6;
 }
-.landing-root .qs-card--purple .qs-arrow { color: var(--purple); }
-.landing-root .qs-card--mint .qs-arrow { color: var(--mint); }
-.landing-root .qs-card--yellow .qs-arrow { color: var(--yellow); }
-.landing-root .qs-card:hover .qs-arrow { gap: 9px; }
-.landing-root .qs-card .qs-arrow svg { width: 11px; height: 11px; }
+.landing-root .product-card .product-arrow {
+  display: flex; align-items: center; justify-content: flex-end;
+  padding: 12px 18px;
+  color: var(--purple); opacity: 0.4;
+  transition: opacity 0.2s ease;
+}
+.landing-root .product-card:hover .product-arrow { opacity: 1; }
+.landing-root .product-card .product-arrow svg { width: 12px; height: 12px; }
+.landing-root .product-card--muted { opacity: 0.7; }
+.landing-root .product-card--muted:hover { opacity: 1; }
 
 /* ── Landing search bar ── */
 .landing-root .landing-search {
@@ -270,47 +257,6 @@ html, body { background: #0d0f12 !important; }
   border: none; border-top: 1px solid var(--border); margin: 0;
 }
 
-.landing-root .hero-lead {
-  font-size: 1.1rem;
-  line-height: 1.5;
-  margin-bottom: 1px;
-  color: var(--white);
-}
-
-.landing-root .hero-body {
-  font-size: 0.9rem;
-  line-height: 1.6;
-  margin-bottom: 1px;
-  color: var(--white);
-  opacity: 0.6;
-}
-
-.landing-root .hero-features {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  gap: 24px;
-  flex-wrap: wrap;
-}
-
-.landing-root .hero-features li {
-  font-size: 0.85rem;
-  font-weight: 500;
-  color: var(--white);
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.landing-root .hero-features li::before {
-  content: '';
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--purple);
-  flex-shrink: 0;
-}
 
 /* ── Footer ── */
 .landing-root .page-footer {
@@ -470,23 +416,59 @@ export default function LandingPage() {
 
       <div className="landing-wrap">
         <div className="hero-inner">
-          <p className="hero-lead">
-            A verifiable data platform for high-stakes systems that
-            require provable, programmable, always-available data
-            with no performance tradeoffs.
+          <h1 className="hero-title">Build with Walrus</h1>
+          <p className="hero-sub">
+            Keep critical data persistent, portable, and under your control
+            across apps, providers, and agents.
           </p>
-          <p className="hero-body">
-            Modern financial systems and AI agents depend on fast,
-            reliable, and verifiable data. Traditional storage assumes
-            integrity and pushes trust outside the data layer. Walrus
-            embeds availability, integrity, and programmability
-            directly into storage itself.
-          </p>
-          <ul className="hero-features">
-            <li>Highly available</li>
-            <li>Cryptographically verifiable</li>
-            <li>Programmable through smart contracts</li>
-          </ul>
+        </div>
+
+        <div className="product-grid">
+          <a className="product-card" href="/walrus-memory/getting-started/what-is-walrus-memory">
+            <div className="product-card-thumb">
+              <svg viewBox="0 0 48 48" fill="none" stroke="currentColor" strokeWidth="1.5">
+                <circle cx="24" cy="16" r="10" />
+                <path d="M24 26v4M18 38h12M20 26c0 2.5 1.8 4 4 4s4-1.5 4-4" />
+              </svg>
+            </div>
+            <h3>Walrus Memory</h3>
+            <p>Portable memory layer that gives AI agents persistent context across apps and sessions.</p>
+            <span className="product-arrow">{arrowIcon}</span>
+          </a>
+          <a className="product-card" href="/docs/getting-started">
+            <div className="product-card-thumb">
+              <svg viewBox="0 0 48 48" fill="none" stroke="currentColor" strokeWidth="1.5">
+                <rect x="8" y="8" width="32" height="32" rx="4" />
+                <path d="M8 18h32M18 48V18" />
+              </svg>
+            </div>
+            <h3>Walrus Console</h3>
+            <p>Unified control plane for managing files, datasets, memory, and other assets on Walrus.</p>
+            <span className="product-arrow">{arrowIcon}</span>
+          </a>
+          <a className="product-card" href="/docs/getting-started">
+            <div className="product-card-thumb">
+              <svg viewBox="0 0 48 48" fill="none" stroke="currentColor" strokeWidth="1.5">
+                <circle cx="18" cy="38" r="3" /><circle cx="36" cy="38" r="3" />
+                <path d="M4 4h8l5.36 26.78a4 4 0 004 3.22h15.28a4 4 0 004-3.22L44 14H12" />
+              </svg>
+            </div>
+            <h3>Walrus Marketplace</h3>
+            <p>Open marketplace where developers and AI agents discover, license, and access data.</p>
+            <span className="product-arrow">{arrowIcon}</span>
+          </a>
+          <a className="product-card product-card--muted" href="/docs/getting-started">
+            <div className="product-card-thumb product-card-thumb--muted">
+              <svg viewBox="0 0 48 48" fill="none" stroke="currentColor" strokeWidth="1.5">
+                <path d="M42 32V16a4 4 0 00-2-3.46l-14-8a4 4 0 00-4 0l-14 8A4 4 0 006 16v16a4 4 0 002 3.46l14 8a4 4 0 004 0l14-8A4 4 0 0042 32z" />
+                <polyline points="6.54 13.92 24 24.02 41.46 13.92" />
+                <line x1="24" y1="44.16" x2="24" y2="24" />
+              </svg>
+            </div>
+            <h3>Walrus Protocol</h3>
+            <p>Open source, decentralized data storage. <span className="under-hood">Under the hood.</span></p>
+            <span className="product-arrow">{arrowIcon}</span>
+          </a>
         </div>
 
         <div className="landing-search">
@@ -508,61 +490,6 @@ export default function LandingPage() {
             <SearchModal isOpen={searchOpen} onClose={() => setSearchOpen(false)} />,
             document.body,
           )}
-        </div>
-
-        <div className="quickstart">
-          <a className="qs-card qs-card--purple" href="/docs/getting-started">
-            <div className="qs-card-top">
-              <div className="qs-icon">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-                  <path d="M21 16V8a2 2 0 00-1-1.73l-7-4a2 2 0 00-2 0l-7 4A2 2 0 003 8v8a2 2 0 001 1.73l7 4a2 2 0 002 0l7-4A2 2 0 0021 16z" />
-                  <polyline points="3.27 6.96 12 12.01 20.73 6.96" />
-                  <line x1="12" y1="22.08" x2="12" y2="12" />
-                </svg>
-              </div>
-              <h3>Data Storage</h3>
-            </div>
-            <p>Verifiable storage, erasure coding, and programmable access.</p>
-            <span className="qs-arrow">Get started {arrowIcon}</span>
-          </a>
-          <a className="qs-card qs-card--mint" href="/walrus-memory/getting-started/what-is-walrus-memory">
-            <div className="qs-card-top">
-              <div className="qs-icon">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-                  <path d="M12 2a7 7 0 017 7c0 3.87-3.13 7-7 7s-7-3.13-7-7a7 7 0 017-7z" />
-                  <path d="M12 16v2M8 22h8M9 16c0 1.5 1.34 2 3 2s3-.5 3-2" />
-                </svg>
-              </div>
-              <h3>Walrus Memory</h3>
-            </div>
-            <p>Portable, encrypted memory for AI agents.</p>
-            <span className="qs-arrow">Learn more {arrowIcon}</span>
-          </a>
-          <a className="qs-card qs-card--yellow" href="/docs/getting-started">
-            <div className="qs-card-top">
-              <div className="qs-icon">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-                  <rect x="3" y="3" width="18" height="18" rx="2" />
-                  <path d="M3 9h18M9 21V9" />
-                </svg>
-              </div>
-              <h3>Walrus Console</h3>
-            </div>
-            <p>Visual dashboard for the Walrus network.</p>
-            <span className="qs-arrow">Coming soon {arrowIcon}</span>
-          </a>
-          <a className="qs-card qs-card--purple" href="/docs/getting-started">
-            <div className="qs-card-top">
-              <div className="qs-icon">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-                  <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" />
-                </svg>
-              </div>
-              <h3>Walrus Skills</h3>
-            </div>
-            <p>Composable capabilities for building on Walrus.</p>
-            <span className="qs-arrow">Coming soon {arrowIcon}</span>
-          </a>
         </div>
 
         <footer className="page-footer">

--- a/docs/site/src/components/LandingPage.tsx
+++ b/docs/site/src/components/LandingPage.tsx
@@ -1,9 +1,11 @@
 // Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 import Head from '@docusaurus/Head';
 import WalrusLogo from '@site/static/img/Walrus_Docs.svg';
+import SearchModal from '@site/src/components/Search/SearchModal';
 
 function hideEl(el: HTMLElement): () => void {
   const prev = el.style.display;
@@ -129,12 +131,12 @@ html, body { background: #0d0f12 !important; }
 
 /* ── Hero ── */
 .landing-root .hero {
-  position: relative; padding: 72px 0 56px; overflow: hidden;
+  position: relative; padding: 80px 0 48px; overflow: hidden;
   background: var(--black);
 }
 .landing-root .hero-inner {
   position: relative; z-index: 5; max-width: 1500px;
-  margin-bottom: 28px; padding-top: 20px;
+  margin-bottom: 36px; padding-top: 20px;
 }
 .landing-root .hero-badge {
   display: inline-block;
@@ -155,143 +157,117 @@ html, body { background: #0d0f12 !important; }
   opacity: 0; animation: landingFadeIn 0.6s ease forwards 0.35s;
 }
 
-/* ── Quick-start cards ── */
+/* ── Product cards ── */
 .landing-root .quickstart {
-  display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px;
-  padding-bottom: 15px;
-  opacity: 0; animation: landingFadeIn 0.6s ease forwards 0.5s;
+  display: grid; grid-template-columns: repeat(2, 1fr); gap: 14px;
+  padding-bottom: 0;
+  opacity: 0; animation: landingFadeIn 0.6s ease forwards 0.65s;
 }
-@media (max-width: 900px) {
-  .landing-root .quickstart { grid-template-columns: repeat(2, 1fr); }
-}
-@media (max-width: 520px) {
+@media (max-width: 640px) {
   .landing-root .quickstart { grid-template-columns: 1fr; }
 }
 .landing-root .qs-card {
+  position: relative; overflow: hidden;
   background: var(--surface); border: 1px solid var(--border);
-  border-radius: var(--radius); padding: 22px 18px;
+  border-radius: var(--radius); padding: 24px 22px 20px;
   transition: all 0.25s ease; cursor: pointer;
   display: flex; flex-direction: column; gap: 8px;
 }
+.landing-root .qs-card::before {
+  content: ''; position: absolute; inset: 0; opacity: 0;
+  transition: opacity 0.3s ease; border-radius: inherit; z-index: 0;
+}
 .landing-root .qs-card:hover {
-  border-color: var(--purple); background: var(--surface-hover);
+  border-color: rgba(255,255,255,0.18); background: var(--surface-hover);
   transform: translateY(-2px);
-  box-shadow: 0 8px 32px rgba(0,0,0,0.3);
+  box-shadow: 0 10px 32px rgba(0,0,0,0.35);
+}
+.landing-root .qs-card:hover::before { opacity: 1; }
+.landing-root .qs-card--purple::before {
+  background: radial-gradient(ellipse at top right, rgba(202,177,255,0.07) 0%, transparent 60%);
+}
+.landing-root .qs-card--mint::before {
+  background: radial-gradient(ellipse at top right, rgba(152,239,221,0.07) 0%, transparent 60%);
+}
+.landing-root .qs-card--yellow::before {
+  background: radial-gradient(ellipse at top right, rgba(232,255,117,0.07) 0%, transparent 60%);
+}
+.landing-root .qs-card .qs-card-top {
+  position: relative; z-index: 1;
+  display: flex; align-items: center; gap: 12px;
 }
 .landing-root .qs-card .qs-icon {
-  width: 34px; height: 34px; border-radius: 9px;
-  background: var(--purple-dim);
+  width: 38px; height: 38px; border-radius: 10px; flex-shrink: 0;
   display: flex; align-items: center; justify-content: center;
 }
-.landing-root .qs-card .qs-icon svg {
-  width: 17px; height: 17px; color: var(--purple);
-}
+.landing-root .qs-card--purple .qs-icon { background: rgba(202,177,255,0.12); }
+.landing-root .qs-card--mint .qs-icon { background: rgba(152,239,221,0.12); }
+.landing-root .qs-card--yellow .qs-icon { background: rgba(232,255,117,0.12); }
+.landing-root .qs-card .qs-icon svg { width: 19px; height: 19px; }
+.landing-root .qs-card--purple .qs-icon svg { color: var(--purple); }
+.landing-root .qs-card--mint .qs-icon svg { color: var(--mint); }
+.landing-root .qs-card--yellow .qs-icon svg { color: var(--yellow); }
 .landing-root .qs-card h3 {
-  font-size: 0.9rem; font-weight: 600;
+  position: relative; z-index: 1;
+  font-size: 1.05rem; font-weight: 600;
   line-height: 1.3; margin: 0; color: var(--white);
 }
 .landing-root .qs-card p {
-  font-size: 0.8rem; color: var(--white);
-  line-height: 1.45; flex: 1; margin: 0;
+  position: relative; z-index: 1;
+  font-size: 0.85rem; color: var(--white); opacity: 0.5;
+  line-height: 1.5; margin: 0;
 }
 .landing-root .qs-card .qs-arrow {
-  font-size: 0.75rem; color: var(--purple); font-weight: 500;
-  display: flex; align-items: center; gap: 4px; margin-top: 2px;
+  position: relative; z-index: 1;
+  font-size: 0.78rem; font-weight: 500;
+  display: flex; align-items: center; gap: 5px; margin-top: 4px;
+  transition: gap 0.2s ease;
 }
-.landing-root .qs-card .qs-arrow svg { width: 10px; height: 10px; }
+.landing-root .qs-card--purple .qs-arrow { color: var(--purple); }
+.landing-root .qs-card--mint .qs-arrow { color: var(--mint); }
+.landing-root .qs-card--yellow .qs-arrow { color: var(--yellow); }
+.landing-root .qs-card:hover .qs-arrow { gap: 9px; }
+.landing-root .qs-card .qs-arrow svg { width: 11px; height: 11px; }
+
+/* ── Landing search bar ── */
+.landing-root .landing-search {
+  max-width: 760px; margin: 0 auto;
+  padding: 0 0 28px;
+  opacity: 0; animation: landingFadeIn 0.6s ease forwards 0.5s;
+}
+.landing-root .landing-search-btn {
+  width: 100%; display: flex; align-items: center; gap: 14px;
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: var(--radius); padding: 18px 24px;
+  cursor: pointer; transition: all 0.2s ease;
+  font-family: var(--sans);
+}
+.landing-root .landing-search-btn:hover {
+  border-color: rgba(255,255,255,0.16); background: var(--surface-hover);
+  box-shadow: 0 6px 24px rgba(0,0,0,0.25);
+}
+.landing-root .landing-search-btn svg {
+  width: 20px; height: 20px; color: var(--purple); flex-shrink: 0;
+}
+.landing-root .landing-search-btn span {
+  font-size: 1rem; color: rgba(255,255,255,0.35); font-weight: 400;
+}
+.landing-root .landing-search-btn kbd {
+  margin-left: auto; font-family: var(--sans);
+  font-size: 0.72rem; color: rgba(255,255,255,0.25);
+  background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 6px; padding: 3px 9px; font-weight: 500;
+}
+
+/* ── Search modal z-index fix ── */
+.landing-root .fixed.inset-0,
+.landing-root [class*="z-500"] {
+  z-index: 9999 !important;
+}
 
 /* ── Divider ── */
 .landing-root .divider {
   border: none; border-top: 1px solid var(--border); margin: 0;
-}
-
-/* ── Section heading ── */
-.landing-root .section-head {
-  padding: 20px 0 10px;
-  display: flex; align-items: baseline; gap: 12px;
-}
-.landing-root .section-head .mono-label {
-  font-family: var(--mono); font-size: 1.5rem; font-weight: 500;
-  letter-spacing: 0.1em; text-transform: uppercase;
-  color: var(--purple); flex-shrink: 0;
-}
-.landing-root .section-head h2 {
-  font-size: 1.4rem; font-weight: 500;
-  letter-spacing: -0.015em; margin: 0; color: var(--white);
-}
-
-/* ── Capabilities ── */
-.landing-root .cap-grid {
-  display: grid; grid-template-columns: 1fr 1fr;
-  gap: 10px; padding-bottom: 15px;
-}
-@media (max-width: 700px) {
-  .landing-root .cap-grid { grid-template-columns: 1fr; }
-}
-.landing-root .cap-card {
-  background: var(--surface); border: 1px solid var(--border);
-  border-radius: var(--radius); padding: 24px 22px;
-  transition: border-color 0.2s, background 0.2s;
-}
-.landing-root .cap-card:hover {
-  border-color: var(--border-hover);
-  background: var(--surface-hover);
-}
-.landing-root .cap-card h3 {
-  font-size: 0.9rem; font-weight: 600;
-  margin: 0 0 6px 0; color: var(--white);
-  display: flex; align-items: center; gap: 8px;
-}
-.landing-root .cap-card h3 .tag {
-  font-family: var(--mono); font-size: 0.62rem; font-weight: 500;
-  color: var(--purple); background: var(--purple-dim);
-  padding: 2px 7px; border-radius: 4px; letter-spacing: 0.03em;
-}
-.landing-root .cap-card p {
-  font-size: 0.85rem; color: var(--white);
-  line-height: 1.55; margin: 0;
-}
-.landing-root .cap-card .cap-detail {
-  margin-top: 10px; padding-top: 10px;
-  border-top: 1px solid var(--border);
-  font-family: var(--mono); font-size: 0.72rem;
-  color: var(--white); line-height: 1.6; opacity: 0.5;
-}
-
-/* ── Use-case rows ── */
-.landing-root .usecase-grid {
-  display: grid; grid-template-columns: repeat(4, 1fr);
-  gap: 10px; padding-bottom: 15px;
-}
-@media (max-width: 900px) {
-  .landing-root .usecase-grid { grid-template-columns: repeat(2, 1fr); }
-}
-@media (max-width: 520px) {
-  .landing-root .usecase-grid { grid-template-columns: 1fr; }
-}
-.landing-root .uc-card {
-  background: var(--surface); border: 1px solid var(--border);
-  border-radius: var(--radius); padding: 22px 18px;
-  transition: border-color 0.2s;
-}
-.landing-root .uc-card:hover {
-  border-color: var(--border-hover);
-}
-.landing-root .uc-card h4 {
-  font-size: 0.85rem; font-weight: 600;
-  margin: 0 0 8px 0; color: var(--white);
-}
-.landing-root .uc-card ul {
-  list-style: none; padding: 0; margin: 0;
-}
-.landing-root .uc-card li {
-  font-size: 0.78rem; color: var(--white); line-height: 1.5;
-  padding: 2px 0 2px 14px; position: relative; opacity: 0.7;
-}
-.landing-root .uc-card li::before {
-  content: ''; position: absolute; left: 0; top: 9px;
-  width: 4px; height: 4px; border-radius: 50%;
-  background: var(--purple); opacity: 0.6;
 }
 
 .landing-root .hero-lead {
@@ -336,18 +312,9 @@ html, body { background: #0d0f12 !important; }
   flex-shrink: 0;
 }
 
-/* ── Not-for ── */
-.landing-root .notfor { padding-bottom: 64px; }
-.landing-root .notfor-row { display: flex; gap: 8px; flex-wrap: wrap; }
-.landing-root .notfor-chip {
-  font-size: 0.8rem; color: var(--white); opacity: 0.7;
-  background: var(--surface); border: 1px solid var(--border);
-  border-radius: 10px; padding: 9px 16px;
-}
-
 /* ── Footer ── */
 .landing-root .page-footer {
-  border-top: 1px solid var(--border); padding: 36px 0;
+  border-top: 1px solid var(--border); margin-top: 80px; padding: 36px 0;
   display: flex; align-items: center;
   justify-content: space-between;
   flex-wrap: wrap; gap: 16px;
@@ -378,6 +345,8 @@ html, body { background: #0d0f12 !important; }
 `;
 
 export default function LandingPage() {
+  const [searchOpen, setSearchOpen] = useState(false);
+
   useEffect(() => {
     const cleanups: Array<() => void> = [];
 
@@ -421,9 +390,21 @@ export default function LandingPage() {
       .querySelectorAll('.landing-root .scroll-reveal')
       .forEach((el) => obs.observe(el));
 
+    // "/" key opens the search bar
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === '/' && !e.metaKey && !e.ctrlKey
+          && !(e.target instanceof HTMLInputElement)
+          && !(e.target instanceof HTMLTextAreaElement)) {
+        e.preventDefault();
+        setSearchOpen(true);
+      }
+    }
+    document.addEventListener('keydown', handleKey);
+
     return () => {
       cleanups.forEach((fn) => fn());
       obs.disconnect();
+      document.removeEventListener('keydown', handleKey);
     };
   }, []);
 
@@ -508,291 +489,81 @@ export default function LandingPage() {
           </ul>
         </div>
 
+        <div className="landing-search">
+          <button
+            type="button"
+            className="landing-search-btn"
+            onClick={() => setSearchOpen(true)}
+          >
+            <svg viewBox="0 0 20 20" fill="none">
+              <path
+                d="M14.386 14.386l4.088 4.088-4.088-4.088c-2.942 2.942-7.711 2.942-10.653 0-2.942-2.942-2.942-7.711 0-10.653 2.942-2.942 7.711-2.942 10.653 0 2.942 2.942 2.942 7.711 0 10.653z"
+                stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"
+              />
+            </svg>
+            <span>Search docs or ask Walrus AI...</span>
+            <kbd>/</kbd>
+          </button>
+          {searchOpen && createPortal(
+            <SearchModal isOpen={searchOpen} onClose={() => setSearchOpen(false)} />,
+            document.body,
+          )}
+        </div>
+
         <div className="quickstart">
-          <a className="qs-card" href="/docs/getting-started">
-            <div className="qs-icon">
-              <svg
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-              >
-                <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" />
-              </svg>
+          <a className="qs-card qs-card--purple" href="/docs/getting-started">
+            <div className="qs-card-top">
+              <div className="qs-icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                  <path d="M21 16V8a2 2 0 00-1-1.73l-7-4a2 2 0 00-2 0l-7 4A2 2 0 003 8v8a2 2 0 001 1.73l7 4a2 2 0 002 0l7-4A2 2 0 0021 16z" />
+                  <polyline points="3.27 6.96 12 12.01 20.73 6.96" />
+                  <line x1="12" y1="22.08" x2="12" y2="12" />
+                </svg>
+              </div>
+              <h3>Data Storage</h3>
             </div>
-            <h3>Data Storage</h3>
-            <p>
-              CLI tools, environment setup, and core storage
-              operations for developers.
-            </p>
-            <span className="qs-arrow">
-              Get started {arrowIcon}
-            </span>
+            <p>Verifiable storage, erasure coding, and programmable access.</p>
+            <span className="qs-arrow">Get started {arrowIcon}</span>
           </a>
-          <a
-            className="qs-card"
-            href="/docs/sites/introduction/components"
-          >
-            <div className="qs-icon">
-              <svg
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-              >
-                <rect x="2" y="3" width="20" height="14" rx="2" />
-                <path d="M8 21h8M12 17v4" />
-              </svg>
+          <a className="qs-card qs-card--mint" href="/walrus-memory/getting-started/what-is-walrus-memory">
+            <div className="qs-card-top">
+              <div className="qs-icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                  <path d="M12 2a7 7 0 017 7c0 3.87-3.13 7-7 7s-7-3.13-7-7a7 7 0 017-7z" />
+                  <path d="M12 16v2M8 22h8M9 16c0 1.5 1.34 2 3 2s3-.5 3-2" />
+                </svg>
+              </div>
+              <h3>Walrus Memory</h3>
             </div>
-            <h3>Walrus Sites</h3>
-            <p>
-              Deploy decentralized static websites with true
-              decentralization.
-            </p>
-            <span className="qs-arrow">
-              Learn more {arrowIcon}
-            </span>
+            <p>Portable, encrypted memory for AI agents.</p>
+            <span className="qs-arrow">Learn more {arrowIcon}</span>
           </a>
-          <a className="qs-card" href="/docs/operator-guide">
-            <div className="qs-icon">
-              <svg
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-              >
-                <circle cx="12" cy="12" r="3" />
-                <path
-                  d={
-                    'M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 01-2.83'
-                    + ' 2.83l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0'
-                    + ' 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009'
-                    + ' 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0'
-                    + ' 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65'
-                    + ' 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0'
-                    + ' 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0'
-                    + ' 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65'
-                    + ' 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0'
-                    + ' 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0'
-                    + ' 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65'
-                    + ' 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65'
-                    + ' 0 00-1.51 1z'
-                  }
-                />
-              </svg>
+          <a className="qs-card qs-card--yellow" href="/docs/getting-started">
+            <div className="qs-card-top">
+              <div className="qs-icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                  <rect x="3" y="3" width="18" height="18" rx="2" />
+                  <path d="M3 9h18M9 21V9" />
+                </svg>
+              </div>
+              <h3>Walrus Console</h3>
             </div>
-            <h3>Service Providers</h3>
-            <p>
-              Operate storage nodes, aggregators, and publishers
-              on the network.
-            </p>
-            <span className="qs-arrow">
-              View guide {arrowIcon}
-            </span>
+            <p>Visual dashboard for the Walrus network.</p>
+            <span className="qs-arrow">Coming soon {arrowIcon}</span>
           </a>
-          <a
-            className="qs-card"
-            href="/docs/examples/checkpoint-data"
-          >
-            <div className="qs-icon">
-              <svg
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-              >
-                <path
-                  d={
-                    'M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0'
-                    + ' 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91'
-                    + ' 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0'
-                    + ' 017.94-7.94l-3.76 3.76z'
-                  }
-                />
-              </svg>
+          <a className="qs-card qs-card--purple" href="/docs/getting-started">
+            <div className="qs-card-top">
+              <div className="qs-icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                  <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" />
+                </svg>
+              </div>
+              <h3>Walrus Skills</h3>
             </div>
-            <h3>Examples</h3>
-            <p>
-              Reference applications and integration patterns
-              using Walrus.
-            </p>
-            <span className="qs-arrow">
-              Explore {arrowIcon}
-            </span>
+            <p>Composable capabilities for building on Walrus.</p>
+            <span className="qs-arrow">Coming soon {arrowIcon}</span>
           </a>
         </div>
-
-        <hr className="divider" />
-        <div className="section-head scroll-reveal">
-          <span className="mono-label">01</span>
-          <h2>Core capabilities</h2>
-        </div>
-        <div className="cap-grid">
-          <div className="cap-card scroll-reveal">
-            <h3>Storage &amp; retrieval</h3>
-            <p>
-              Walrus supports writing and reading large blobs of
-              unstructured data. Data is content-addressed. Any change
-              to the data produces a new identifier. This makes
-              integrity tamper-evident and enables independent
-              verification of stored content. Walrus also enables
-              anyone to prove that a blob has been stored and remains
-              available for retrieval.
-            </p>
-          </div>
-          <div className="cap-card scroll-reveal">
-            <h3>Data availability and fault tolerance</h3>
-            <p>
-              Walrus uses erasure coding and high redundancy (~4.5x)
-              to maintain availability even under partial node
-              failure.
-            </p>
-            <ul className="cap-stats">
-              <li>
-                Reads remain available with up to 2/3 responsive
-                nodes.
-              </li>
-              <li>
-                Writes tolerate up to 1/3 unavailable nodes.
-              </li>
-            </ul>
-            <p>
-              This model is more robust than partial-replication
-              systems and more cost-efficient than full replication.
-            </p>
-          </div>
-          <div className="cap-card scroll-reveal">
-            <h3>Cost efficiency</h3>
-            <p>
-              Through erasure coding, Walrus maintains storage
-              overhead at approximately 5x the size of stored data
-              while delivering strong durability and Byzantine fault
-              tolerance. This enables production-grade availability
-              without full replication costs.
-            </p>
-          </div>
-          <div className="cap-card scroll-reveal">
-            <h3>Integration with Sui</h3>
-            <p>
-              Walrus leverages Sui for coordination, attesting
-              availability, and payments. Storage space is represented
-              as a resource on Sui, which can be owned, split, merged,
-              and transferred. Stored blobs are also represented by
-              objects on Sui, which means that smart contracts can
-              check whether a blob is available and for how long,
-              extend its lifetime, or optionally delete it.
-            </p>
-          </div>
-          <div className="cap-card scroll-reveal">
-            <h3>Epochs &amp; WAL</h3>
-            <p>
-              Walrus is operated by a committee of storage nodes that
-              evolve between epochs. A native token, WAL (and its
-              subdivision FROST, where 1 WAL is equal to 1 billion
-              FROST), is used to delegate stake to storage nodes, and
-              those with high stake become part of the epoch committee.
-              The WAL token is also used for payments for storage. At
-              the end of each epoch, rewards for selecting storage
-              nodes, storing, and serving blobs are distributed to
-              storage nodes and those that stake with them. All these
-              processes are mediated by smart contracts on the Sui
-              platform.
-            </p>
-          </div>
-          <div className="cap-card scroll-reveal">
-            <h3>Flexible access</h3>
-            <p>
-              You can interact with Walrus through a command-line
-              interface (CLI), software development kits (SDKs), and
-              Web2 HTTP technologies. Walrus is designed to work well
-              with traditional caches and content distribution
-              networks (CDNs), while ensuring all operations can also
-              be run using local tools to maximize decentralization.
-            </p>
-            <div className="cap-detail">
-              Interfaces: CLI · SDK · HTTP API
-            </div>
-          </div>
-        </div>
-
-        <hr className="divider" />
-        <div className="section-head scroll-reveal">
-          <span className="mono-label">02</span>
-          <h2>When to use Walrus</h2>
-        </div>
-        <div className="usecase-grid">
-          <div className="uc-card scroll-reveal">
-            <h4>Independently verifiable</h4>
-            <p>
-              You need to prove where data came from, confirm it has
-              not been altered, or anchor workflows to specific
-              dataset versions.
-            </p>
-            <ul>
-              <li>AI model artifacts &amp; agent memory</li>
-              <li>Execution logs for exchanges</li>
-              <li>Onchain governance data</li>
-              <li>Audit trails for financial systems</li>
-            </ul>
-          </div>
-          <div className="uc-card scroll-reveal">
-            <h4>Highly available under failure</h4>
-            <p>
-              Your system cannot tolerate downtime, partial node
-              failure, or data loss.
-            </p>
-            <ul>
-              <li>Market infrastructure</li>
-              <li>Autonomous agents coordinating state</li>
-              <li>Financial protocols with real risk</li>
-            </ul>
-          </div>
-          <div className="uc-card scroll-reveal">
-            <h4>Programmable at the data layer</h4>
-            <p>
-              You need smart contracts to manage, verify, or automate
-              around stored data.
-            </p>
-            <ul>
-              <li>Versioned datasets in AI workflows</li>
-              <li>Contract-controlled storage lifetimes</li>
-              <li>Onchain verification of offchain artifacts</li>
-            </ul>
-          </div>
-          <div className="uc-card scroll-reveal">
-            <h4>Cost-efficient at scale</h4>
-            <p>
-              You require strong durability and Byzantine fault
-              tolerance without full-replication overhead.
-            </p>
-          </div>
-        </div>
-
-        <hr className="divider" />
-        <div className="section-head scroll-reveal">
-          <span className="mono-label">03</span>
-          <h2>When not to use Walrus</h2>
-        </div>
-        <p>Walrus is not optimized for:</p>
-        <ul>
-          <li>
-            Small, ephemeral application state better suited for
-            direct onchain storage
-          </li>
-          <li>Ultra-low-latency in-memory databases</li>
-          <li>
-            Pure archival storage without verification requirements
-          </li>
-        </ul>
-        <p>
-          Walrus is designed for high-stakes systems where
-          availability, integrity, and programmability are structural
-          requirements, not optional features.
-        </p>
 
         <footer className="page-footer">
           <div className="footer-left">

--- a/docs/site/src/components/Search/SearchModal.tsx
+++ b/docs/site/src/components/Search/SearchModal.tsx
@@ -7,6 +7,7 @@ import {
     InstantSearch,
     useInfiniteHits,
     useInstantSearch,
+    useSearchBox,
     Index,
 } from "react-instantsearch";
 import {
@@ -14,8 +15,6 @@ import {
     getDeepestHierarchyLabel,
     cleanTooltipText,
 } from "./utils";
-import ControlledSearchBox from "./ControlledSearchBox";
-import TabbedResults from "./TabbedResults";
 
 const baseSearchClient = algoliasearch(
     "M9JD2UP87M",
@@ -49,29 +48,6 @@ const indices = [
     { label: "SDKs", indexName: "sui_sdks" },
 ];
 
-// Shared inline style objects so the modal bg is always visible
-const modalBg = "var(--color-walrus-tusk)";
-const modalBgDark = "var(--color-walrus-dark-gray-200)";
-
-function useIsDark() {
-    const [dark, setDark] = useState(false);
-    useEffect(() => {
-        const check = () =>
-            setDark(
-                document.documentElement.getAttribute("data-theme") ===
-                    "dark",
-            );
-        check();
-        const obs = new MutationObserver(check);
-        obs.observe(document.documentElement, {
-            attributes: true,
-            attributeFilter: ["data-theme"],
-        });
-        return () => obs.disconnect();
-    }, []);
-    return dark;
-}
-
 function HitItem({ hit }: { hit: any }) {
     const level = hit.type;
     let sectionTitle = hit.lvl0;
@@ -85,33 +61,26 @@ function HitItem({ hit }: { hit: any }) {
         );
     }
 
-    const linkClasses =
-        "text-[--color-walrus-purple] dark:text-[--color-walrus-mint]" +
-        " dark:hover:text-[--color-walrus-violet]";
-
     return (
-        <div className="modal-result">
-            <a
-                href={hit.url}
-                className={`${linkClasses} font-medium`}
-            >
+        <a
+            href={hit.url}
+            className="modal-result block px-4 py-3 -mx-2 rounded-lg no-underline hover:bg-gray-50 dark:hover:bg-white/5 transition-colors"
+        >
+            <div className="text-sm font-medium text-gray-900 dark:text-white">
                 {sectionTitle}
-            </a>
-            <p
-                className={
-                    "text-sm text-[--color-walrus-dark-gray-400]" +
-                    " dark:text-[--color-walrus-dark-gray-500]"
-                }
-                dangerouslySetInnerHTML={{
-                    __html: hit.content
-                        ? truncateAtWord(
-                              hit._highlightResult.content.value,
-                              100,
-                          )
-                        : "",
-                }}
-            ></p>
-        </div>
+            </div>
+            {hit.content && (
+                <p
+                    className="text-xs text-gray-600 dark:text-gray-400 mt-1 mb-0 line-clamp-2"
+                    dangerouslySetInnerHTML={{
+                        __html: truncateAtWord(
+                            hit._highlightResult.content.value,
+                            120,
+                        ),
+                    }}
+                />
+            )}
+        </a>
     );
 }
 
@@ -151,12 +120,7 @@ function EmptyState({ label }: { label: string }) {
     const { results } = useInstantSearch();
     if (results?.hits?.length === 0) {
         return (
-            <p
-                className={
-                    "text-sm text-[--color-walrus-dark-gray-300]" +
-                    " dark:text-[--color-walrus-dark-gray-450]"
-                }
-            >
+            <p className="text-sm text-gray-400 dark:text-gray-500">
                 No results in {label}
             </p>
         );
@@ -182,6 +146,15 @@ function ResultsUpdater({
     return null;
 }
 
+/** Syncs the external query state into Algolia's InstantSearch. */
+function QuerySync({ query }: { query: string }) {
+    const { refine } = useSearchBox();
+    useEffect(() => {
+        refine(query);
+    }, [query, refine]);
+    return null;
+}
+
 export default function MultiIndexSearchModal({
     isOpen,
     onClose,
@@ -189,27 +162,23 @@ export default function MultiIndexSearchModal({
     isOpen: boolean;
     onClose: () => void;
 }) {
-    const isDark = useIsDark();
-    const bg = isDark ? modalBgDark : modalBg;
-
     const [activeIndex, setActiveIndex] = useState(
         indices[0].indexName,
     );
     const [tabCounts, setTabCounts] = React.useState<
         Record<string, number>
-    >({
-        walrus_docs: 0,
-    });
+    >({ walrus_docs: 0 });
     const [query, setQuery] = React.useState("");
     const scrollContainerRef =
         React.useRef<HTMLDivElement>(null);
     const searchBoxRef = React.useRef<HTMLInputElement>(null);
+
     useEffect(() => {
         if (isOpen) {
             document.body.style.overflow = "hidden";
             setTimeout(() => {
                 searchBoxRef.current?.focus();
-            }, 300);
+            }, 100);
         } else {
             document.body.style.overflow = "";
         }
@@ -250,160 +219,244 @@ export default function MultiIndexSearchModal({
 
     if (!isOpen) return null;
 
-    const overlayBg = isDark
-        ? "rgba(28,34,40,0.8)"
-        : "rgba(83,87,90,0.7)";
-
-    const footerClasses =
-        "h-14 flex items-center justify-between text-sm" +
-        " border-t border-solid" +
-        " border-[--color-walrus-dark-gray-300]" +
-        " border-b-transparent" +
-        " border-l-transparent border-r-transparent";
-
-    const footerLinkClasses =
-        "text-[--color-walrus-purple]" +
-        " hover:text-[--color-walrus-violet]" +
-        " dark:text-[--color-walrus-mint]" +
-        " dark:hover:text-[--color-walrus-violet] underline";
-
-    const hintClasses =
-        "text-sm text-[--color-walrus-dark-gray-300]" +
-        " dark:text-[--color-walrus-dark-gray-450]" +
-        " pl-4 mb-2 -mt-6";
+    const modalBg = "bg-white dark:bg-[#1c2228]";
 
     return (
         <div
-            className="fixed inset-0 z-500 flex justify-center p-4"
-            style={{ backgroundColor: overlayBg }}
+            className="fixed inset-0 bg-black/50 flex justify-center items-start pt-[8vh]"
+            style={{ zIndex: 9999 }}
             onClick={(e) => {
                 if (e.target === e.currentTarget) onClose();
             }}
         >
             <div
-                className={
-                    "w-full max-w-3xl px-6 rounded-lg" +
-                    " shadow-md flex flex-col"
-                }
-                style={{
-                    backgroundColor: bg,
-                    maxHeight: "min(600px, 80vh)",
-                }}
+                className={`${modalBg} w-full max-w-2xl rounded-2xl shadow-2xl max-h-[min(640px,82vh)] flex flex-col overflow-hidden mx-4`}
             >
+                {/* Header */}
+                <div className={`${modalBg} shrink-0 px-5 pt-4 pb-0`}>
+                    <div className="flex items-center justify-between mb-3">
+                        <span className="text-xs font-medium text-gray-400 dark:text-gray-500 uppercase tracking-wider">
+                            Search or ask
+                        </span>
+                        <button
+                            onClick={onClose}
+                            className="bg-transparent border border-solid border-gray-200 dark:border-gray-700 rounded px-1.5 py-0.5 text-[10px] text-gray-400 dark:text-gray-500 cursor-pointer hover:text-gray-600"
+                        >
+                            ESC
+                        </button>
+                    </div>
+
+                    {/* Ask Walrus AI banner */}
+                    <button
+                        type="button"
+                        className="w-full flex items-center gap-3 px-4 py-3.5 mb-3 rounded-xl bg-gradient-to-r from-[#37c3b0] to-[#298DFF] text-white border-none cursor-pointer transition-all hover:shadow-lg hover:shadow-blue-500/20 active:scale-[0.99]"
+                        onClick={() => {
+                            onClose();
+                            if (
+                                typeof window !== "undefined" &&
+                                (window as any).Kapa
+                            ) {
+                                setTimeout(
+                                    () =>
+                                        (window as any).Kapa.open(
+                                            query || undefined,
+                                        ),
+                                    150,
+                                );
+                            }
+                        }}
+                    >
+                        <div className="w-9 h-9 rounded-lg bg-white/20 flex items-center justify-center shrink-0">
+                            <img
+                                src="/img/logo.svg"
+                                alt=""
+                                width="22"
+                                height="22"
+                            />
+                        </div>
+                        <div className="text-left flex-1">
+                            <div className="font-semibold text-[15px] leading-tight">
+                                Ask Walrus AI
+                            </div>
+                            <div className="text-xs text-white/70 mt-0.5">
+                                Get instant answers from the Walrus
+                                knowledge base
+                            </div>
+                        </div>
+                        <svg
+                            width="16"
+                            height="16"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            className="text-white/50"
+                        >
+                            <polyline points="9,18 15,12 9,6" />
+                        </svg>
+                    </button>
+
+                    {/* Search input */}
+                    <div className="flex items-center gap-2 px-3 py-2 rounded-lg border border-solid border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-white/5 mb-3">
+                        <svg
+                            width="16"
+                            height="16"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            className="text-gray-400 shrink-0"
+                        >
+                            <circle cx="11" cy="11" r="8" />
+                            <line
+                                x1="21"
+                                y1="21"
+                                x2="16.65"
+                                y2="16.65"
+                            />
+                        </svg>
+                        <input
+                            ref={searchBoxRef}
+                            type="search"
+                            className="w-full bg-transparent border-none outline-none text-sm text-gray-900 dark:text-gray-200 placeholder-gray-400 dark:placeholder-gray-500"
+                            placeholder="Search documentation..."
+                            value={query}
+                            onChange={(e) =>
+                                setQuery(e.currentTarget.value)
+                            }
+                        />
+                    </div>
+                </div>
+
+                {/* Tabs + results */}
                 <div
                     ref={scrollContainerRef}
-                    style={{
-                        flex: "1 1 0%",
-                        minHeight: 0,
-                        overflowY: "auto",
-                    }}
+                    className="flex-1 overflow-y-auto"
                 >
                     <InstantSearch
                         searchClient={searchClient}
                         indexName={activeIndex}
                     >
+                        <QuerySync query={query} />
                         <div
-                            className="rounded-t sticky top-0 z-10"
-                            style={{ backgroundColor: bg }}
+                            className={`${modalBg} sticky top-0 z-10 px-5`}
                         >
-                            <div
-                                className="h-8 flex justify-end"
-                                style={{ backgroundColor: bg }}
-                            >
-                                <button
-                                    onClick={onClose}
-                                    className={
-                                        "bg-transparent border-none" +
-                                        " outline-none text-sm" +
-                                        " underline cursor-pointer"
-                                    }
-                                >
-                                    Close
-                                </button>
-                            </div>
-                            <ControlledSearchBox
-                                placeholder={`Search`}
-                                query={query}
-                                onChange={setQuery}
-                                inputRef={searchBoxRef}
-                            />
-                            {query.length < 3 && (
-                                <p className={hintClasses}>
-                                    Three characters initiates
-                                    search...
-                                </p>
-                            )}
-                            <TabbedResults
-                                activeTab={activeIndex}
-                                onChange={setActiveIndex}
-                                showTooltips={false}
-                                tabs={indices.map((tab) => ({
-                                    ...tab,
-                                    count:
-                                        tabCounts[tab.indexName] ||
-                                        0,
-                                }))}
-                            />
-                        </div>
-                        {indices.map((index) => (
-                            <Index
-                                indexName={index.indexName}
-                                key={index.indexName}
-                            >
-                                <ResultsUpdater
-                                    indexName={
-                                        index.indexName
-                                    }
-                                    onUpdate={(
-                                        indexName,
-                                        count,
-                                    ) =>
-                                        setTabCounts(
-                                            (prev) => ({
-                                                ...prev,
-                                                [indexName]:
-                                                    count,
-                                            }),
-                                        )
-                                    }
-                                />
-                                {index.indexName ===
-                                    activeIndex && (
-                                    <>
-                                        <HitsList
-                                            scrollContainerRef={
-                                                scrollContainerRef
+                            <div className="flex items-center gap-1 border-b border-solid border-gray-200 dark:border-gray-700 mb-0">
+                                {indices.map(
+                                    ({ label, indexName }) => (
+                                        <button
+                                            key={indexName}
+                                            className={`px-3 py-2 text-xs font-medium border-none bg-transparent cursor-pointer transition-colors ${
+                                                activeIndex ===
+                                                indexName
+                                                    ? "text-[#37c3b0] border-b-2 border-solid border-[#37c3b0] -mb-px"
+                                                    : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
+                                            }`}
+                                            onClick={() =>
+                                                setActiveIndex(
+                                                    indexName,
+                                                )
                                             }
-                                        />
-                                        <EmptyState
-                                            label={
-                                                index.label
-                                            }
-                                        />
-                                    </>
+                                        >
+                                            {label}
+                                            {(tabCounts[
+                                                indexName
+                                            ] || 0) > 0 && (
+                                                <span
+                                                    className={`ml-1.5 text-[10px] rounded-full px-1.5 py-0.5 ${
+                                                        activeIndex ===
+                                                        indexName
+                                                            ? "bg-emerald-50 dark:bg-emerald-900/30 text-[#37c3b0]"
+                                                            : "bg-gray-100 dark:bg-gray-800 text-gray-400"
+                                                    }`}
+                                                >
+                                                    {
+                                                        tabCounts[
+                                                            indexName
+                                                        ]
+                                                    }
+                                                </span>
+                                            )}
+                                        </button>
+                                    ),
                                 )}
-                            </Index>
-                        ))}
+                            </div>
+                        </div>
+                        <div className="px-5 py-3">
+                            {query.length < 3 ? (
+                                <p className="text-sm text-gray-400 dark:text-gray-500 text-center py-6">
+                                    Type at least 3 characters to
+                                    search
+                                </p>
+                            ) : (
+                                indices.map((index) => (
+                                    <Index
+                                        indexName={
+                                            index.indexName
+                                        }
+                                        key={index.indexName}
+                                    >
+                                        <ResultsUpdater
+                                            indexName={
+                                                index.indexName
+                                            }
+                                            onUpdate={(
+                                                indexName,
+                                                count,
+                                            ) =>
+                                                setTabCounts(
+                                                    (prev) => ({
+                                                        ...prev,
+                                                        [indexName]:
+                                                            count,
+                                                    }),
+                                                )
+                                            }
+                                        />
+                                        {index.indexName ===
+                                            activeIndex && (
+                                            <>
+                                                <HitsList
+                                                    scrollContainerRef={
+                                                        scrollContainerRef
+                                                    }
+                                                />
+                                                <EmptyState
+                                                    label={
+                                                        index.label
+                                                    }
+                                                />
+                                            </>
+                                        )}
+                                    </Index>
+                                ))
+                            )}
+                        </div>
                     </InstantSearch>
                 </div>
+
+                {/* Footer */}
                 <div
-                    className={footerClasses}
-                    style={{ backgroundColor: bg }}
+                    className={`h-10 px-5 ${modalBg} flex items-center justify-between text-[11px] border-t border-solid border-gray-200 dark:border-gray-700 shrink-0`}
                 >
                     <a
                         href={`/search?q=${encodeURIComponent(query)}`}
-                        className={footerLinkClasses}
+                        className="text-gray-400 dark:text-gray-500 hover:text-[#37c3b0] no-underline"
                     >
-                        Go to full search page
+                        View all results →
                     </a>
                     {activeMeta && (
                         <a
                             href={activeMeta.url}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className={footerLinkClasses}
+                            className="text-gray-400 dark:text-gray-500 hover:text-[#37c3b0] no-underline"
                         >
-                            Visit {activeMeta.label} →
+                            {activeMeta.label} →
                         </a>
                     )}
                 </div>

--- a/docs/site/src/css/custom.css
+++ b/docs/site/src/css/custom.css
@@ -1490,6 +1490,8 @@ html.kapa-sidebar-open .col[class*="docItemCol"] {
   html.kapa-sidebar-open .navbar--fixed-top {
     right: 0 !important;
   }
+}
+
 /* Mermaid diagrams - Walrus palette, per-mode contrast.
   Node fill/text come from the Mermaid themeVariables (Purple #613DFF + Tusk
   #FAF8F5). Edges, arrowheads, and subgraph backgrounds must contrast with the

--- a/docs/site/src/css/custom.css
+++ b/docs/site/src/css/custom.css
@@ -63,6 +63,7 @@ Infima — Light mode
 :root {
 --ifm-font-family-base: "DM Sans", -apple-system, BlinkMacSystemFont, sans-serif;
 --ifm-font-family-monospace: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+--ifm-navbar-height: 3.25rem;
 
 --ifm-background-color: #fff;
 --ifm-background-surface-color: #fff;
@@ -267,7 +268,9 @@ background: #f4f5f7 !important;
 color: #000 !important;
 border-bottom: 1px solid rgba(0, 0, 0, 0.06) !important;
 box-shadow: none !important;
-height: 4.25rem;
+height: 3.25rem;
+padding-top: 0 !important;
+padding-bottom: 0 !important;
 }
 
 [data-theme="dark"] .navbar {
@@ -281,7 +284,7 @@ border-bottom-color: rgba(255, 255, 255, 0.06) !important;
 .navbar .navbar__brand,
 .navbar .navbar__toggle {
 color: #000 !important;
-font-size: 0.92rem;
+font-size: 0.82rem;
 }
 
 [data-theme="dark"] .navbar .navbar__title,
@@ -298,9 +301,9 @@ white-space: nowrap !important;
 
 .navbar__item.navbar__link {
 border-radius: 6px;
-padding: 0.3rem 0.65rem;
+padding: 0.2rem 0.55rem;
 transition: all 0.15s ease;
-font-size: 0.9rem;
+font-size: 0.82rem;
 }
 
 .navbar__item.navbar__link:hover {
@@ -889,7 +892,7 @@ color: #53575a !important;
 border-color: #dadad6 !important;
 border-radius: 2rem !important;
 transition: all 0.15s ease;
-font-size: 0.78rem;
+font-size: 0.72rem;
 }
 
 [data-theme="dark"] .navbar .kapa-trigger-btn {
@@ -1427,4 +1430,64 @@ padding-right: 0.3rem !important;
 [class*="buttonGroup_"] span {
   opacity: 1 !important;
   transition: none !important;
+}
+
+/* ══════════════════════════════════════════════
+   Kapa sidebar content shift
+   ══════════════════════════════════════════════ */
+/* Kapa renders in Shadow DOM so CSS :has() can't detect it.
+   A client module (kapa-sidebar.js) toggles .kapa-sidebar-open on <html>. */
+
+/* Smooth transition when closing */
+body {
+  transition: width 0.3s ease;
+}
+
+.navbar,
+.navbar--fixed-top {
+  transition: right 0.3s ease;
+}
+
+/* Shrink body to make room for the 500px sidebar (skip landing page) */
+html.kapa-sidebar-open body:not(:has(.landing-root)) {
+  width: calc(100vw - 500px) !important;
+  overflow-x: hidden;
+  transition: width 0.3s ease;
+}
+
+/* Shrink the fixed navbar to match (it uses position:fixed so body width
+   doesn't affect it — set right offset instead; skip when landing page is shown) */
+html.kapa-sidebar-open body:not(:has(.landing-root)) .navbar,
+html.kapa-sidebar-open body:not(:has(.landing-root)) .navbar--fixed-top {
+  right: 500px !important;
+  overflow: hidden;
+  transition: right 0.3s ease;
+}
+
+/* Hide the Ask AI and Search buttons when the sidebar is already open */
+html.kapa-sidebar-open .kapa-trigger-btn,
+html.kapa-sidebar-open .DocSearch-Button {
+  display: none !important;
+}
+
+/* Hide the desktop TOC column to free space */
+html.kapa-sidebar-open .col.col--3:has(.theme-doc-toc-desktop) {
+  display: none;
+}
+
+/* Let the main content column expand to fill the freed space */
+html.kapa-sidebar-open .col[class*="docItemCol"] {
+  max-width: 100% !important;
+  flex: 1 !important;
+}
+
+/* On mobile, Kapa goes full-screen so don't shrink */
+@media (max-width: 768px) {
+  html.kapa-sidebar-open body {
+    width: 100vw !important;
+  }
+  html.kapa-sidebar-open .navbar,
+  html.kapa-sidebar-open .navbar--fixed-top {
+    right: 0 !important;
+  }
 }

--- a/docs/site/src/theme/Navbar/Content/index.js
+++ b/docs/site/src/theme/Navbar/Content/index.js
@@ -204,10 +204,10 @@ function KapaButton() {
     <button
       type="button"
       onClick={handleClick}
-      className="kapa-trigger-btn flex items-center gap-2.5 cursor-pointer bg-white text-gray-900 font-semibold
-      text-base px-5 py-2.5 rounded-full border border-gray-200 hover:bg-gray-50 transition-colors mx-0 min-[1100px]:mx-1 min-[1300px]:mx-2 shrink-0"
+      className="kapa-trigger-btn flex items-center gap-2 cursor-pointer bg-white text-gray-900 font-semibold
+      text-xs px-3.5 py-1.5 rounded-full border border-gray-200 hover:bg-gray-50 transition-colors mx-0 min-[1100px]:mx-1 min-[1300px]:mx-2 shrink-0"
     >
-      <img src="/img/logo.svg" alt="" width="25" height="25" />
+      <img src="/img/logo.svg" alt="" width="18" height="18" />
       <span className="kapa-label">Ask Walrus AI</span>
     </button>
   );
@@ -238,13 +238,13 @@ function CustomLogo() {
       <img
         src={logoSrc}
         alt={navbar.logo?.alt || title}
-        style={{ height: "2rem", width: "auto", display: "block", flexShrink: 0 }}
+        style={{ height: "1.6rem", width: "auto", display: "block", flexShrink: 0 }}
       />
       {title && (
         <span
           style={{
             fontWeight: 600,
-            fontSize: "1rem",
+            fontSize: "0.88rem",
             whiteSpace: "nowrap",
             flexShrink: 0,
             overflow: "visible",


### PR DESCRIPTION
## Summary
- Redesign landing page with product-centric cards (Data Storage, Walrus Memory, Walrus Console, Walrus Skills) and a prominent search bar
- Rewrite search modal to match Sui docs style: inline search input, plain text tabs, "Ask Walrus AI" banner that opens Kapa sidebar with the current query
- Add Kapa sidebar mode (`data-view-mode=sidebar`) with a client module that detects open/close and shifts doc content to accommodate the panel
- Slim down navbar from 68px to 52px with tighter spacing and font sizes

## Test plan
- [x] `pnpm build` passes
- [ ] Verify homepage layout: search bar → product cards → footer
- [ ] Verify search modal opens from homepage and navbar, renders above all content
- [ ] Verify "Ask Walrus AI" banner in search modal closes modal and opens Kapa sidebar
- [ ] Verify Kapa sidebar shifts doc content on doc pages but not on landing page
- [ ] Verify navbar is compact and all links/buttons fit at common viewport widths
- [ ] Test on mobile viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)