### PR TITLE
fix: seed client-build backoff from ThreadRng instead of from_entropy

### DIFF
--- a/crates/walrus-sui/src/client/retry_client/retriable_rpc_client.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_rpc_client.rs
@@ -13,8 +13,6 @@ use std::{
 
 use rand::{
     Rng as _,
-    RngCore,
-    SeedableRng,
     rngs::{StdRng, ThreadRng},
 };
 use sui_rpc_api::{Client, client::ResponseExt};
@@ -142,13 +140,20 @@ impl LazyClientBuilder<FallibleRpcClient> for LazyFallibleRpcClientBuilder {
                 rpc_url,
                 ensure_experimental_rest_endpoint,
             } => {
+                // Seed the backoff from `ThreadRng` (matching `get_strategy` below) rather than
+                // `StdRng::from_entropy()`. Under mysten-sim, `from_entropy()` has been observed
+                // to produce nondeterministic backoff schedules on Linux CI, which makes the
+                // simulation nondeterministic and causes intermittent failures at a fixed seed.
+                // The seed is bound to a local first because `ThreadRng` is `!Send` and must not
+                // be held across the await below.
+                let backoff_seed: u64 = ThreadRng::default().r#gen();
                 let rpc_client = retry_rpc_errors(
                     ExponentialBackoffConfig::new(
                         CLIENT_BUILD_RETRY_MIN_DELAY,
                         CLIENT_BUILD_RETRY_MAX_DELAY,
                         Some(RPC_MAX_TRIES),
                     )
-                    .get_strategy(StdRng::from_entropy().next_u64()),
+                    .get_strategy(backoff_seed),
                     || async {
                         let rpc_client = FallibleRpcClient::new(rpc_url.to_owned())?;
                         if *ensure_experimental_rest_endpoint {

--- a/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
@@ -19,8 +19,6 @@ use futures::{Stream, StreamExt, stream};
 use move_core_types::language_storage::StructTag;
 use rand::{
     Rng as _,
-    RngCore,
-    SeedableRng,
     rngs::{StdRng, ThreadRng},
 };
 use serde::{Serialize, de::DeserializeOwned};
@@ -174,13 +172,20 @@ impl LazyClientBuilder<DualClient> for LazySuiClientBuilder {
             }
         }
 
+        // Seed the backoff from `ThreadRng` (matching `get_strategy` below) rather than
+        // `StdRng::from_entropy()`. Under mysten-sim, `from_entropy()` has been observed to
+        // produce nondeterministic backoff schedules on Linux CI, which makes the simulation
+        // nondeterministic and causes intermittent failures at a fixed seed. The seed is bound to
+        // a local first because `ThreadRng` is `!Send` and must not be held across the await
+        // below.
+        let backoff_seed: u64 = ThreadRng::default().r#gen();
         let dual_client = retry_rpc_errors(
             ExponentialBackoffConfig::new(
                 CLIENT_BUILD_RETRY_MIN_DELAY,
                 CLIENT_BUILD_RETRY_MAX_DELAY,
                 Some(RPC_MAX_TRIES),
             )
-            .get_strategy(StdRng::from_entropy().next_u64()),
+            .get_strategy(backoff_seed),
             || async { DualClient::new(self.rpc_url.as_str(), self.request_timeout).await },
             None,
             "build_sui_client",


### PR DESCRIPTION
## Problem

The simtest `simtest_test_checkpoint_downloader_with_additional_fullnodes` fails intermittently in CI (`Run all simtests`, seed=1, `WALRUS_GRPC_MIGRATION_LEVEL=0`). The failure is an msim deadlock, not an assertion:

```
msim::sim::runtime: deadlock detected, aborting()
(test aborted with signal 6: SIGABRT)
```

It is flaky at a **fixed** seed on the same architecture (full simtest runs on `main` pass at seed 1), which means something is escaping msim's deterministic RNG.

## Root cause

The lazy Sui and RPC client builders seed their client-build retry backoff with `StdRng::from_entropy()`:

- `crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs`
- `crates/walrus-sui/src/client/retry_client/retriable_rpc_client.rs`

`from_entropy()` reads OS entropy that, under mysten-sim on Linux, is not fully controlled by the simulator, so the backoff schedule (and therefore the simulation) becomes nondeterministic. This test is the one that surfaces it because it forces every primary-RPC client build to fail and injects failover errors, hammering the `from_entropy()`-seeded retry path far more than other tests.

Notably, both files already seed the backoff with `ThreadRng` in their `get_strategy()` defaults, and that path is reproducible under simtest — the two `from_entropy()` call sites are the outliers.

## Fix

Seed the backoff from `ThreadRng` at both sites, matching the existing `get_strategy()` pattern. The seed is bound to a local `u64` before the `await` because `ThreadRng` is `!Send` and must not be held across the await (doing so otherwise makes the surrounding futures `!Send` and fails to compile). Production behavior is unchanged — still randomized jitter, now from a thread-local CSPRNG.

## Validation

- `cargo check -p walrus-sui` and `cargo clippy -p walrus-sui` are clean; the now-unused `RngCore`/`SeedableRng` imports were removed.
- `MSIM_TEST_SEED=1 WALRUS_GRPC_MIGRATION_LEVEL=0 cargo simtest test_checkpoint_downloader_with_additional_fullnodes` passes with the change (no regression).

Note: the original deadlock could not be reproduced locally on aarch64 macOS, where mysten-sim intercepts entropy deterministically (`getentropy`); the failure is specific to Linux CI. The fix removes the only uncontrolled entropy source on that path and aligns it with the reproducible `ThreadRng` pattern already used for backoff seeding in these files.