### PR TITLE
feat(cli): list committee commission receivers as CSV

### DIFF
--- a/crates/walrus-service/src/client/cli/args.rs
+++ b/crates/walrus-service/src/client/cli/args.rs
@@ -783,6 +783,15 @@ pub struct InfoCommitteeArgs {
     #[arg(long)]
     #[serde(default)]
     pub hide_details: bool,
+    /// List the commission receiver of every node in the previous, current, and next
+    /// committees, reading everything from the staking object.
+    ///
+    /// The output is only produced in CSV format, with three sections (current, previous, and
+    /// next committee), each labeled with its epoch number. The `--sort` and `--hide-details`
+    /// options have no effect on this output.
+    #[arg(long)]
+    #[serde(default)]
+    pub commission_receivers: bool,
 }
 
 /// Subcommands for the `node-admin` command.

--- a/crates/walrus-service/src/client/cli/cli_output.rs
+++ b/crates/walrus-service/src/client/cli/cli_output.rs
@@ -45,6 +45,7 @@ use crate::client::{
         BlobIdConversionOutput,
         BlobIdOutput,
         BlobStatusOutput,
+        CommitteeCommissionReceivers,
         DeleteOutput,
         DryRunOutput,
         EncodingDependentPriceInfo,
@@ -56,6 +57,7 @@ use crate::client::{
         GetBlobAttributeOutput,
         InfoBftOutput,
         InfoCoinOutput,
+        InfoCommissionReceiversOutput,
         InfoCommitteeOutput,
         InfoEpochOutput,
         InfoOutput,
@@ -666,6 +668,51 @@ impl CliOutput for InfoCommitteeOutput {
         print_storage_node_info(n_shards, next_storage_nodes, *print_details);
 
         print_committee_changes(current_storage_nodes, next_storage_nodes);
+    }
+}
+
+impl CliOutput for InfoCommissionReceiversOutput {
+    fn print_cli_output(&self) {
+        print_commission_receiver_section("current", &self.current);
+        println!();
+        print_commission_receiver_section("previous", &self.previous);
+        println!();
+        print_commission_receiver_section("next", &self.next);
+    }
+}
+
+/// Prints one committee's commission receivers as a labeled CSV section.
+fn print_commission_receiver_section(committee: &str, section: &CommitteeCommissionReceivers) {
+    if section.determined {
+        println!("# {committee} committee (epoch {})", section.epoch);
+    } else {
+        println!(
+            "# {committee} committee (epoch {}, not yet determined)",
+            section.epoch
+        );
+    }
+    println!("committee,epoch,node_id,node_name,receiver_type,receiver,receiver_owner");
+    for node in &section.nodes {
+        println!(
+            "{},{},{},{},{},{},{}",
+            csv_escape(committee),
+            section.epoch,
+            csv_escape(&node.node_id.to_string()),
+            csv_escape(&node.node_name),
+            node.receiver_type.as_str(),
+            csv_escape(&node.receiver),
+            csv_escape(node.receiver_owner.as_deref().unwrap_or("")),
+        );
+    }
+}
+
+/// Escapes a single CSV field per RFC 4180: when the value contains a comma, double quote, or
+/// line break, it is wrapped in double quotes and any embedded quotes are doubled.
+fn csv_escape(field: &str) -> String {
+    if field.contains([',', '"', '\n', '\r']) {
+        format!("\"{}\"", field.replace('"', "\"\""))
+    } else {
+        field.to_string()
     }
 }
 
@@ -1497,4 +1544,27 @@ fn print_list<T: ToString>(items: &[T]) -> String {
 /// Returns "s" if the number of items is not 1, otherwise an empty string.
 fn plural_ending<T>(items: &[T]) -> &'static str {
     if items.len() == 1 { "" } else { "s" }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::csv_escape;
+
+    #[test]
+    fn csv_escape_leaves_plain_fields_unchanged() {
+        assert_eq!(csv_escape("Blockscope.net"), "Blockscope.net");
+        assert_eq!(csv_escape("0xabc123"), "0xabc123");
+        assert_eq!(csv_escape(""), "");
+    }
+
+    #[test]
+    fn csv_escape_quotes_fields_with_special_characters() {
+        // A comma forces quoting.
+        assert_eq!(csv_escape("Coinage, DAIC"), "\"Coinage, DAIC\"");
+        // An embedded quote is doubled and the field is quoted.
+        assert_eq!(csv_escape("Node \"A\""), "\"Node \"\"A\"\"\"");
+        // Line breaks force quoting.
+        assert_eq!(csv_escape("line1\nline2"), "\"line1\nline2\"");
+        assert_eq!(csv_escape("line1\r\nline2"), "\"line1\r\nline2\"");
+    }
 }

--- a/crates/walrus-service/src/client/cli/runner.rs
+++ b/crates/walrus-service/src/client/cli/runner.rs
@@ -147,6 +147,7 @@ use crate::{
             GetBlobAttributeOutput,
             InfoBftOutput,
             InfoCoinOutput,
+            InfoCommissionReceiversOutput,
             InfoCommitteeOutput,
             InfoEpochOutput,
             InfoOutput,
@@ -1608,13 +1609,23 @@ impl ClientCommandRunner {
                     .await?
                     .print_output(self.json)
             }
-            Some(InfoCommands::Committee(args)) => InfoCommitteeOutput::get_committee_info(
-                &sui_read_client,
-                args.sort,
-                !args.hide_details,
-            )
-            .await?
-            .print_output(self.json),
+            Some(InfoCommands::Committee(args)) => {
+                if args.commission_receivers {
+                    // This output is only produced in CSV format, regardless of `--json`.
+                    InfoCommissionReceiversOutput::get_commission_receivers(&sui_read_client)
+                        .await?
+                        .print_cli_output();
+                    Ok(())
+                } else {
+                    InfoCommitteeOutput::get_committee_info(
+                        &sui_read_client,
+                        args.sort,
+                        !args.hide_details,
+                    )
+                    .await?
+                    .print_output(self.json)
+                }
+            }
             Some(InfoCommands::Bft) => InfoBftOutput::get_bft_info(&sui_read_client)
                 .await?
                 .print_output(self.json),

--- a/crates/walrus-service/src/client/responses.rs
+++ b/crates/walrus-service/src/client/responses.rs
@@ -59,7 +59,7 @@ use walrus_storage_node_client::{
     NodeError,
     api::{BlobStatus, ServiceHealthInfo},
 };
-use walrus_sui::types::move_structs::{StakingPool, VotingParams};
+use walrus_sui::types::move_structs::{Authorized, StakingPool, VotingParams};
 
 use super::cli::{BlobIdDecimal, BlobIdentity, HumanReadableBytes};
 use crate::client::cli::{HealthSortBy, HumanReadableFrost, NodeSortBy, SortBy};
@@ -517,6 +517,163 @@ impl InfoCommitteeOutput {
             current_storage_nodes,
             next_storage_nodes,
             print_details,
+        })
+    }
+}
+
+/// Whether a commission receiver is a plain Sui address or a Sui object.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum CommissionReceiverType {
+    /// The receiver is a Sui address.
+    Address,
+    /// The receiver is a Sui object.
+    Object,
+}
+
+impl CommissionReceiverType {
+    /// Returns the lowercase string representation used in CSV output.
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            Self::Address => "address",
+            Self::Object => "object",
+        }
+    }
+}
+
+/// The commission receiver of a single node, as read from its staking pool.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CommissionReceiverInfo {
+    /// The node ID (the staking pool object ID).
+    pub(crate) node_id: ObjectID,
+    /// The on-chain name of the node.
+    pub(crate) node_name: String,
+    /// Whether the commission receiver is an address or an object.
+    pub(crate) receiver_type: CommissionReceiverType,
+    /// The commission receiver address or object ID.
+    pub(crate) receiver: String,
+    /// When the receiver is an object, the address that owns it (the party that can collect the
+    /// commission). `None` for address receivers, or when the owner could not be resolved to an
+    /// address (for example, a shared, immutable, or object-owned receiver).
+    pub(crate) receiver_owner: Option<String>,
+}
+
+/// The commission receivers of every node in a single committee.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CommitteeCommissionReceivers {
+    /// The epoch number of this committee.
+    pub(crate) epoch: Epoch,
+    /// Whether this committee has been determined on chain. Always `true` except for the next
+    /// committee, which is not selected until partway through the current epoch.
+    pub(crate) determined: bool,
+    /// The per-node commission receivers.
+    pub(crate) nodes: Vec<CommissionReceiverInfo>,
+}
+
+/// The output of the `info committee --commission-receivers` command.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct InfoCommissionReceiversOutput {
+    /// The current committee.
+    pub(crate) current: CommitteeCommissionReceivers,
+    /// The previous committee.
+    pub(crate) previous: CommitteeCommissionReceivers,
+    /// The next committee, which may not yet be determined.
+    pub(crate) next: CommitteeCommissionReceivers,
+}
+
+impl InfoCommissionReceiversOutput {
+    pub async fn get_commission_receivers(
+        sui_read_client: &impl ReadClient,
+    ) -> anyhow::Result<Self> {
+        let staking_object = sui_read_client.read_client().get_staking_object().await?;
+        let current_epoch = staking_object.epoch();
+
+        let current_assignment = staking_object.current_committee_shard_assignment();
+        let previous_assignment = staking_object.previous_committee_shard_assignment();
+        let next_assignment = staking_object.next_committee_shard_assignment();
+
+        let all_node_ids = current_assignment
+            .iter()
+            .chain(previous_assignment.iter())
+            .chain(next_assignment.into_iter().flatten())
+            .map(|(node_id, _)| *node_id)
+            .unique();
+
+        let retriable_sui_client = sui_read_client.read_client().retriable_sui_client();
+        let staking_pools = retriable_sui_client.get_node_objects(all_node_ids).await?;
+
+        // Resolve the owner address of every distinct object commission receiver. Owners that do
+        // not resolve to an address (shared, immutable, or object-owned) are simply left out of
+        // the map and reported as `None`.
+        let object_receiver_ids = staking_pools
+            .values()
+            .filter_map(|pool| match &pool.commission_receiver {
+                Authorized::Object(object_id) => Some(*object_id),
+                Authorized::Address(_) => None,
+            })
+            .unique();
+        let receiver_owners: HashMap<ObjectID, SuiAddress> =
+            futures::future::join_all(object_receiver_ids.map(|object_id| async move {
+                retriable_sui_client
+                    .get_object_owner_address(object_id)
+                    .await
+                    .ok()
+                    .map(|owner| (object_id, owner))
+            }))
+            .await
+            .into_iter()
+            .flatten()
+            .collect();
+
+        let build_section = |assignment: &[(ObjectID, Vec<u16>)]| -> Vec<CommissionReceiverInfo> {
+            assignment
+                .iter()
+                .filter_map(|(node_id, _)| {
+                    staking_pools.get(node_id).map(|pool| {
+                        let (receiver_type, receiver, receiver_owner) = match &pool
+                            .commission_receiver
+                        {
+                            Authorized::Address(address) => {
+                                (CommissionReceiverType::Address, address.to_string(), None)
+                            }
+                            Authorized::Object(object_id) => {
+                                let owner = receiver_owners.get(object_id).map(ToString::to_string);
+                                (CommissionReceiverType::Object, object_id.to_string(), owner)
+                            }
+                        };
+                        CommissionReceiverInfo {
+                            node_id: *node_id,
+                            node_name: pool.node_info.name.clone(),
+                            receiver_type,
+                            receiver,
+                            receiver_owner,
+                        }
+                    })
+                })
+                .collect()
+        };
+
+        Ok(Self {
+            current: CommitteeCommissionReceivers {
+                epoch: current_epoch,
+                determined: true,
+                nodes: build_section(current_assignment),
+            },
+            previous: CommitteeCommissionReceivers {
+                epoch: current_epoch.saturating_sub(1),
+                determined: true,
+                nodes: build_section(previous_assignment),
+            },
+            next: CommitteeCommissionReceivers {
+                epoch: current_epoch.saturating_add(1),
+                determined: next_assignment.is_some(),
+                nodes: next_assignment
+                    .map(|a| build_section(a))
+                    .unwrap_or_default(),
+            },
         })
     }
 }

--- a/crates/walrus-service/src/client/responses.rs
+++ b/crates/walrus-service/src/client/responses.rs
@@ -607,7 +607,8 @@ impl InfoCommissionReceiversOutput {
 
         // Resolve the owner address of every distinct object commission receiver. Owners that do
         // not resolve to an address (shared, immutable, or object-owned) are simply left out of
-        // the map and reported as `None`.
+        // the map and reported as `None`. RPC errors, on the other hand, are propagated so the
+        // command fails rather than silently reporting an empty owner.
         let object_receiver_ids = staking_pools
             .values()
             .filter_map(|pool| match &pool.commission_receiver {
@@ -616,14 +617,13 @@ impl InfoCommissionReceiversOutput {
             })
             .unique();
         let receiver_owners: HashMap<ObjectID, SuiAddress> =
-            futures::future::join_all(object_receiver_ids.map(|object_id| async move {
+            futures::future::try_join_all(object_receiver_ids.map(|object_id| async move {
                 retriable_sui_client
                     .get_object_owner_address(object_id)
                     .await
-                    .ok()
-                    .map(|owner| (object_id, owner))
+                    .map(|owner| owner.map(|owner| (object_id, owner)))
             }))
-            .await
+            .await?
             .into_iter()
             .flatten()
             .collect();

--- a/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
+++ b/crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs
@@ -2285,25 +2285,25 @@ impl RetriableSuiClient {
     }
 
     /// Returns the owner address of the given object.
+    ///
+    /// Returns `Ok(None)` when the object resolves successfully but is not owned by an address
+    /// (for example, shared, immutable, or object-owned). RPC errors are propagated as `Err` so
+    /// callers can distinguish a transient failure from a genuine non-address owner.
     #[tracing::instrument(skip_all, level = Level::DEBUG)]
     pub async fn get_object_owner_address(
         &self,
         object_id: ObjectID,
-    ) -> SuiClientResult<SuiAddress> {
+    ) -> SuiClientResult<Option<SuiAddress>> {
         if self.grpc_migration_level >= GRPC_MIGRATION_LEVEL_GET_OBJECT {
             let object: sui_types::object::Object = self.get_object_by_grpc(object_id).await?;
-            Ok(object
-                .owner()
-                .get_owner_address()
-                .context("no object owner address returned from rpc")?)
+            Ok(object.owner().get_owner_address().ok())
         } else {
             let object: SuiObjectResponse = self
                 .get_object_with_json_rpc(object_id, SuiObjectDataOptions::default().with_owner())
                 .await?;
             Ok(object
                 .owner()
-                .context("no object owner returned from rpc")?
-                .get_owner_address()?)
+                .and_then(|owner| owner.get_owner_address().ok()))
         }
     }
 

--- a/crates/walrus-sui/src/client/transaction_builder.rs
+++ b/crates/walrus-sui/src/client/transaction_builder.rs
@@ -1231,7 +1231,7 @@ impl WalrusPtbBuilder {
                     .get_object_owner_address(receiver)
                     .await?;
                 ensure!(
-                    owner_address == self.sender_address,
+                    owner_address == Some(self.sender_address),
                     SuiClientError::NotAuthorizedForPool(node_id)
                 );
                 self.authenticate_with_object(receiver).await


### PR DESCRIPTION
## Description

Add a `--commission-receivers` flag to `walrus info committee` that lists the commission receiver of every node in the previous, current, and next committees, reading everything from the staking object.

As requested, output is CSV with three epoch-labeled sections. Each row reports the node id, on-chain node name, whether the receiver is an address or an object, the receiver value, and -- for object receivers -- the resolved owner address (the party that can collect the commission). The next committee is shown but marked when it is not yet determined on chain.

Owner resolution distinguishes a genuine non-address owner (shared, immutable, or object-owned receiver), reported as an empty `receiver_owner` cell, from a transient RPC error, which now fails the command rather than being silently reported as an empty owner.

## Test plan

- `cargo test -p walrus-sui -p walrus-service`
- Manual: `cargo run --bin walrus -- --config setup/client_config_mainnet.yaml info committee --commission-receivers` against mainnet, verifying the three CSV sections and resolved object owners.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [x] CLI: `walrus info committee` gains a `--commission-receivers` flag that prints, as CSV, the commission receiver of every node in the previous, current, and next committees (including the owning address for object receivers).
