### PR TITLE
docs: Walrus Memory troubleshooting and FAQ page (BEDU-612)

### DIFF
--- a/docs/content/data-security.mdx
+++ b/docs/content/data-security.mdx
@@ -39,6 +39,28 @@ Seal integrates seamlessly with Walrus and is recommended for any use cases invo
 - Sensitive off-chain content, for example, user documents, game assets, or private messages
 - Time-locked or token-gated data
 - Data shared between trusted parties or roles
+- Agent state and memory that an autonomous agent persists between runs
+
+:::tip Walk through it end to end
+
+The [Encrypting data with Seal](/docs/seal-encryption-tutorial) tutorial has working TypeScript that encrypts a message, stores the ciphertext on Walrus, reads it back, and decrypts it.
+
+:::
+
+### Encrypting agent state
+
+A common pattern for AI agents is to keep working memory or accumulated state durable across runs by storing it on Walrus. Because Walrus blobs are public, encrypt that state with Seal before storing it, and gate decryption with a `seal_approve` policy that only the agent's identity (or its operator) satisfies. The agent encrypts and uploads at the end of a run, then reads and decrypts at the start of the next one, keeping the state confidential while it lives on Walrus.
+
+### Seal concepts
+
+A few terms appear throughout the Seal documentation and the tutorial:
+
+- **Access policy.** A Move function named `seal_approve` (or `seal_approve_*`) that decides who may decrypt. Seal key servers evaluate it against current onchain state before releasing decryption shares.
+- **Allowlist.** A common policy where a shared object holds a list of authorized addresses. It suits private documents and invitational sharing. Other patterns include token gating and time locks.
+- **Policy ID (identity).** The byte string a piece of data is encrypted under. It must begin with the policy's namespace (for an allowlist, the allowlist object's ID) so the policy's prefix check passes.
+- **Key servers and threshold.** Seal splits the decryption key across key servers; the threshold is how many must each return a share to decrypt. No single server can decrypt on its own.
+
+These are summarized here only as orientation. For the authoritative definitions, the full API, and the security model, see [Using Seal](https://seal-docs.wal.app/UsingSeal).
 
 :::tip Seal transactions need an explicit sender
 
@@ -52,7 +74,13 @@ If the sender is missing or does not match, decryption can fail with `Transactio
 
 :::
 
-To get started, refer to [Seal SDK](https://www.npmjs.com/package/@mysten/seal).
+### Troubleshooting
+
+- **Decryption needs to be online.** Decryption is not an offline operation: the client must reach the Seal key servers and the relevant Sui network so the policy can be evaluated and shares retrieved. Plan for network access wherever you decrypt.
+- **`Requested package is not supported`.** The key servers do not recognize your package on the network they serve. Confirm the package is published on the same network as the key servers, and that decryption targets that same network. Seal key servers are network-specific: a Testnet key server does not serve keys for a Mainnet package, and vice versa.
+- **`Transaction was not signed by the correct sender`.** Set the PTB sender with `tx.setSender()` and ensure it matches the address requesting access (see the tip above).
+
+To get started, follow the [Encrypting data with Seal](/docs/seal-encryption-tutorial) tutorial or refer to the [Seal SDK](https://www.npmjs.com/package/@mysten/seal).
 
 ## Nautilus: Secure and verifiable off-chain computation
 

--- a/docs/content/seal-encryption-tutorial.mdx
+++ b/docs/content/seal-encryption-tutorial.mdx
@@ -1,0 +1,145 @@
+---
+title: Encrypting data with Seal
+description: "Step-by-step tutorial for end-to-end encryption with Seal and Walrus, with working TypeScript encrypt and decrypt code."
+keywords: ["walrus", "seal", "encryption", "tutorial", "typescript", "decrypt", "access control", "threshold encryption"]
+---
+
+Walrus stores blobs publicly: anyone with a blob ID can read the bytes. To keep
+data confidential, encrypt it before you store it. This tutorial walks through a
+complete round trip with [Seal](https://seal-docs.wal.app/): encrypt a message,
+store the ciphertext on Walrus, read it back, and decrypt it, with working
+TypeScript for both directions.
+
+Seal handles encryption and onchain access control; Walrus handles storage. The
+two are independent, so this page stays focused on how they fit together and
+links to the [Seal documentation](https://seal-docs.wal.app/UsingSeal) for the
+full API and security model. For the concepts behind the code, see
+[Data Security](/docs/data-security#seal-data-confidentiality-and-access-control).
+
+## How the pieces fit
+
+1. **Encrypt** the data with Seal. Seal applies threshold encryption: the
+   decryption key is split across key servers, and no single server can decrypt
+   on its own.
+2. **Store** the resulting ciphertext on Walrus. Only encrypted bytes ever reach
+   Walrus.
+3. **Read** the ciphertext back from Walrus by its blob ID.
+4. **Decrypt** with Seal. The key servers release decryption shares only after
+   an onchain `seal_approve` policy confirms the requester is allowed.
+
+## Prerequisites
+
+- Node.js and the `@mysten/sui`, `@mysten/seal`, and `@mysten/walrus` packages.
+- Testnet SUI for gas and WAL for storage. Acquire WAL with `walrus get-wal`.
+- An access-control policy deployed onchain that exposes a `seal_approve`
+  function. This tutorial uses the **allowlist** pattern from the Seal
+  repository. Deploy
+  [`allowlist.move`](https://github.com/MystenLabs/seal/blob/main/examples/move/sources/allowlist.move),
+  create an allowlist, and add your address to it. The Move side is documented in
+  full under [Using Seal](https://seal-docs.wal.app/UsingSeal); this page does not
+  duplicate it.
+
+:::info Why a Move policy is required
+
+Seal does not decide who may decrypt; your `seal_approve` function does. The key
+servers evaluate it against current onchain state before releasing shares. The
+allowlist pattern grants access to a fixed set of addresses, but any Move logic
+works: token gating, time locks, or custom conditions. See
+[access-control options](/docs/sites/security/access-control-options#seal-access-policy-patterns).
+
+:::
+
+## Configuration
+
+All four scripts share one Sui client (extended with the Walrus SDK), one Seal
+client, and the policy IDs you got when you deployed the allowlist. Seal key
+servers are network-specific, so the client, the policy, and the key servers
+must all be on the same network.
+
+<ImportContent source="docs/examples/seal/config.ts" mode="code" language="ts" org="MystenLabs" repo="walrus" />
+
+The keypair helper supplies a Testnet account with SUI and WAL. In a browser app
+you would sign with a wallet through `@mysten/dapp-kit` instead.
+
+<ImportContent source="docs/examples/seal/funded-keypair.ts" mode="code" language="ts" org="MystenLabs" repo="walrus" />
+
+## Encrypt and store
+
+Encryption needs a Seal **identity**: an arbitrary byte string that must begin
+with your policy's namespace so the `seal_approve` prefix check passes. For the
+allowlist pattern the namespace is the allowlist object's ID; appending a random
+nonce gives each message a distinct identity under the same policy.
+
+The core call is `sealClient.encrypt`, which returns the encrypted object to
+store and a symmetric backup key you can ignore:
+
+```ts
+const { encryptedObject } = await sealClient.encrypt({
+  threshold: THRESHOLD,
+  packageId: PACKAGE_ID,
+  id,
+  data: message,
+});
+```
+
+The full script encrypts the message and stores only the ciphertext on Walrus:
+
+<ImportContent source="docs/examples/seal/encrypt-and-store.ts" mode="code" language="ts" org="MystenLabs" repo="walrus" />
+
+Run it and note the printed blob ID:
+
+```sh
+SUI_PRIVATE_KEY=suiprivkey1... npx tsx encrypt-and-store.ts
+```
+
+## Read and decrypt
+
+Decryption has three moving parts: a `SessionKey` authorized once by the user's
+signature, a PTB that calls `seal_approve` so the key servers can check the
+policy, and the `decrypt` call itself.
+
+The PTB **must** have its sender set to the requesting address. The allowlist
+policy checks `ctx.sender()`, so a missing or mismatched sender fails with
+`Transaction was not signed by the correct sender`:
+
+```ts
+const tx = new Transaction();
+tx.setSender(address);
+tx.moveCall({
+  target: `${PACKAGE_ID}::${MODULE_NAME}::seal_approve`,
+  arguments: [tx.pure.vector('u8', fromHex(id)), tx.object(ALLOWLIST_ID)],
+});
+const txBytes = await tx.build({ client: suiClient, onlyTransactionKind: true });
+const decrypted = await sealClient.decrypt({ data: encryptedBytes, sessionKey, txBytes });
+```
+
+The full script reads the blob back from Walrus, recovers the identity from the
+encrypted object, authorizes a session key, fetches decryption shares, and
+decrypts:
+
+<ImportContent source="docs/examples/seal/read-and-decrypt.ts" mode="code" language="ts" org="MystenLabs" repo="walrus" />
+
+Run it with the blob ID from the previous step:
+
+```sh
+SUI_PRIVATE_KEY=suiprivkey1... npx tsx read-and-decrypt.ts <blobId>
+```
+
+If the requesting address is on the allowlist, the original message prints. If
+not, the key servers refuse and the SDK throws `NoAccessError`.
+
+## Troubleshooting
+
+- **`Transaction was not signed by the correct sender`** — call `tx.setSender()`
+  with the requester's address before building the PTB, and make sure that
+  address matches the session key's address.
+- **`Requested package is not supported`** — the key servers do not recognize
+  your package on this network. Confirm the package is published on the same
+  network as the key servers and that `PACKAGE_ID` is correct.
+- **`NoAccessError`** — the policy denied access. For the allowlist pattern,
+  confirm the requesting address was added to the allowlist.
+- **`InvalidParameter` right after creating objects** — a key server's full node
+  may not have indexed a just-created object yet. Wait a few seconds and retry.
+
+For the complete Seal API, key-server selection, and the security model, see
+[Using Seal](https://seal-docs.wal.app/UsingSeal).

--- a/docs/content/sites/security/access-control-options.mdx
+++ b/docs/content/sites/security/access-control-options.mdx
@@ -32,7 +32,7 @@ Seal protects content confidentiality at the application layer. It does not enfo
  
 ### Seal access policy patterns
  
-Seal's access policies are Move functions (`seal_approve`), which means they are as flexible and composable as any other Move code. The following patterns cover the most common use cases for Walrus Sites. For implementation details and example code, see [Using Seal](https://seal-docs.wal.app/UsingSeal).
+Seal's access policies are Move functions (`seal_approve`), which means they are as flexible and composable as any other Move code. The following patterns cover the most common use cases for Walrus Sites. For implementation details and example code, see [Using Seal](https://seal-docs.wal.app/UsingSeal). For a worked Walrus integration, see the [Encrypting data with Seal](/docs/seal-encryption-tutorial) tutorial.
  
 #### Allowlist
  

--- a/docs/content/typescript-sdk/sdks.mdx
+++ b/docs/content/typescript-sdk/sdks.mdx
@@ -13,7 +13,7 @@ The SDK bundles the package and object IDs for each network, so selecting a netw
 
 The Walrus core team is actively working on a Rust SDK for Walrus.
 
-For data security, use the [TypeScript SDK](https://www.npmjs.com/package/@mysten/seal) for Seal. It provides threshold encryption and onchain access control for decentralized data protection. Also, refer to [data security](/docs/data-security) for details.
+For data security, use the [TypeScript SDK](https://www.npmjs.com/package/@mysten/seal) for Seal. It provides threshold encryption and onchain access control for decentralized data protection. See the [Encrypting data with Seal](/docs/seal-encryption-tutorial) tutorial for a worked example, and [data security](/docs/data-security) for details.
 
 ## Community-maintained SDKs
 

--- a/docs/content/walrus-client/storing-blobs.mdx
+++ b/docs/content/walrus-client/storing-blobs.mdx
@@ -4,7 +4,7 @@ description: Use the Walrus client to store blobs and set lifetimes.
 keywords: [ walrus, cli, client, command line, store, blob, permanence, lifetimes, optimizations ]
 ---
 
-All blobs stored in Walrus are public and discoverable by all. To store sensitive data, use [Seal](/docs/data-security#seal-data-confidentially-and-access-control) or [Nautilus](/docs/data-security#nautilus-secure-and-verifiable-off-chain-computation) to encrypt the data before storing it on Walrus.
+All blobs stored in Walrus are public and discoverable by all. To store sensitive data, use [Seal](/docs/data-security#seal-data-confidentiality-and-access-control) or [Nautilus](/docs/data-security#nautilus-secure-and-verifiable-off-chain-computation) to encrypt the data before storing it on Walrus. For a worked example, see [Encrypting data with Seal](/docs/seal-encryption-tutorial).
 
 Store blobs on Walrus with the following command:
 

--- a/docs/examples/seal/README.md
+++ b/docs/examples/seal/README.md
@@ -1,0 +1,32 @@
+# Encrypting data with Seal and Walrus
+
+A minimal, runnable example showing the full round trip: encrypt with
+[Seal](https://seal-docs.wal.app/), store the ciphertext on Walrus, read it
+back, and decrypt it.
+
+The narrative walkthrough lives in the Walrus docs under **Encrypting data with
+Seal**. This directory holds the code that page imports.
+
+## Files
+
+- `config.ts` — network, policy IDs, and the shared Sui/Seal/Walrus clients.
+- `funded-keypair.ts` — a Testnet keypair with SUI and WAL for the example.
+- `encrypt-and-store.ts` — encrypt a message and store it on Walrus.
+- `read-and-decrypt.ts` — read it back and decrypt it.
+
+## Prerequisites
+
+1. Deploy an access-control policy that exposes a `seal_approve` function. This
+   example uses the `allowlist` pattern from the Seal repository:
+   <https://github.com/MystenLabs/seal/blob/main/examples/move/sources/allowlist.move>.
+   Publish it, create an allowlist, and add your address to it.
+2. Put the published package ID and allowlist object ID into `config.ts`.
+3. Acquire Testnet SUI (faucet) and WAL (`walrus get-wal`).
+
+## Run
+
+```sh
+npm install
+SUI_PRIVATE_KEY=suiprivkey1... npm run encrypt
+SUI_PRIVATE_KEY=suiprivkey1... npm run decrypt -- <blobId>
+```

--- a/docs/examples/seal/config.ts
+++ b/docs/examples/seal/config.ts
@@ -1,0 +1,56 @@
+// Copyright (c) Walrus Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// Shared configuration for the end-to-end Seal + Walrus example.
+//
+// These IDs come from the access-control policy you deploy yourself. The
+// example uses the `allowlist` pattern from the Seal repository; deploy it and
+// fill in the two values below before running the scripts. See the tutorial
+// (Encrypting data with Seal) for the deployment steps and links.
+
+import { getJsonRpcFullnodeUrl, SuiJsonRpcClient } from '@mysten/sui/jsonRpc';
+import { SealClient } from '@mysten/seal';
+import { walrus } from '@mysten/walrus';
+
+// The network all three services run on. Seal key servers are network-specific:
+// a Testnet key server will not serve keys for a Mainnet package and vice versa.
+export const NETWORK = 'testnet' as const;
+
+// The Move package that contains your `seal_approve` function (here, the
+// `allowlist` module). Replace with the package ID printed when you publish.
+export const PACKAGE_ID = '0xYOUR_PACKAGE_ID';
+
+// The shared policy object that gates access (the `Allowlist` object). Replace
+// with the object ID created when you call `create_allowlist_entry`.
+export const ALLOWLIST_ID = '0xYOUR_ALLOWLIST_OBJECT_ID';
+
+// The Move module inside PACKAGE_ID that defines `seal_approve`.
+export const MODULE_NAME = 'allowlist';
+
+// One Sui client, extended with the Walrus SDK, reused everywhere. The same
+// client instance is passed to Seal and to SessionKey so that policy checks and
+// blob reads/writes all target the same network.
+export const suiClient = new SuiJsonRpcClient({
+  network: NETWORK,
+  url: getJsonRpcFullnodeUrl(NETWORK),
+}).$extend(walrus());
+
+// A Seal client configured against a single Testnet key server. For threshold
+// configurations across multiple servers and for current key-server object IDs,
+// see https://seal-docs.wal.app/UsingSeal#configure-a-seal-client
+// (the SDK's removed `getAllowlistedKeyServers` helper is no longer used;
+// list the key-server object IDs explicitly instead).
+export const sealClient = new SealClient({
+  suiClient,
+  serverConfigs: [
+    {
+      objectId: '0xb35a7228d8cf224ad1e828c0217c95a5153bafc2906d6f9c178197dce26fbcf8',
+      weight: 1,
+    },
+  ],
+  verifyKeyServers: false,
+});
+
+// Threshold = how many key servers must each return a share to decrypt. With a
+// single configured server this must be 1.
+export const THRESHOLD = 1;

--- a/docs/examples/seal/encrypt-and-store.ts
+++ b/docs/examples/seal/encrypt-and-store.ts
@@ -1,0 +1,50 @@
+// Copyright (c) Walrus Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// Step 1 of the tutorial: encrypt a message with Seal, then store the
+// ciphertext on Walrus. Run with:
+//   SUI_PRIVATE_KEY=suiprivkey1... npx tsx encrypt-and-store.ts
+
+import { fromHex, toHex } from '@mysten/sui/utils';
+
+import { ALLOWLIST_ID, PACKAGE_ID, THRESHOLD, sealClient, suiClient } from './config';
+import { getFundedKeypair } from './funded-keypair';
+
+async function encryptAndStore() {
+  const keypair = await getFundedKeypair();
+
+  const message = new TextEncoder().encode('This message is encrypted end-to-end with Seal.');
+
+  // The Seal identity must start with the policy's namespace so that the
+  // `allowlist::seal_approve` prefix check passes. For the allowlist pattern the
+  // namespace is the allowlist object's ID; we append a random nonce so each
+  // encryption gets a distinct identity under the same policy.
+  const nonce = crypto.getRandomValues(new Uint8Array(5));
+  const id = toHex(new Uint8Array([...fromHex(ALLOWLIST_ID), ...nonce]));
+
+  // `encrypt` returns the encrypted object (store this) and a symmetric backup
+  // key (optional disaster-recovery handle that we ignore here).
+  const { encryptedObject } = await sealClient.encrypt({
+    threshold: THRESHOLD,
+    packageId: PACKAGE_ID,
+    id,
+    data: message,
+  });
+
+  // Store the ciphertext on Walrus. Only the encrypted bytes ever touch Walrus.
+  const { blobId } = await suiClient.walrus.writeBlob({
+    blob: encryptedObject,
+    deletable: true,
+    epochs: 3,
+    signer: keypair,
+  });
+
+  console.log('Stored encrypted blob:', blobId);
+  console.log('Seal identity:', id);
+  return { blobId };
+}
+
+encryptAndStore().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/docs/examples/seal/funded-keypair.ts
+++ b/docs/examples/seal/funded-keypair.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Walrus Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// Returns a keypair that has SUI (for gas) and WAL (to pay for storage) on
+// Testnet. In a browser app you would instead use a wallet via @mysten/dapp-kit;
+// here we sign with a local keypair so the example can run end-to-end in Node.
+
+import { getFaucetHost, requestSuiFromFaucetV2 } from '@mysten/sui/faucet';
+import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
+import { MIST_PER_SUI } from '@mysten/sui/utils';
+
+import { NETWORK, suiClient } from './config';
+
+export async function getFundedKeypair(): Promise<Ed25519Keypair> {
+  // Load your key from the environment. Generate one with:
+  //   sui client new-address ed25519
+  // then export it as SUI_PRIVATE_KEY (a `suiprivkey1...` string).
+  const secret = process.env.SUI_PRIVATE_KEY;
+  if (!secret) {
+    throw new Error('Set SUI_PRIVATE_KEY to a testnet keypair secret (suiprivkey1...).');
+  }
+  const keypair = Ed25519Keypair.fromSecretKey(secret);
+  const address = keypair.toSuiAddress();
+
+  // Top up SUI from the faucet if the balance is low.
+  const { totalBalance } = await suiClient.getBalance({ owner: address });
+  if (BigInt(totalBalance) < MIST_PER_SUI) {
+    await requestSuiFromFaucetV2({
+      host: getFaucetHost(NETWORK),
+      recipient: address,
+    });
+  }
+
+  // You also need WAL to pay for storage. Acquire it with the Walrus CLI
+  // (`walrus get-wal`) or by swapping SUI for WAL; see the Walrus docs.
+  return keypair;
+}

--- a/docs/examples/seal/package.json
+++ b/docs/examples/seal/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "walrus-seal-example",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "End-to-end encrypt/decrypt example using Seal and Walrus.",
+  "scripts": {
+    "encrypt": "tsx encrypt-and-store.ts",
+    "decrypt": "tsx read-and-decrypt.ts"
+  },
+  "dependencies": {
+    "@mysten/seal": "^1.2.1",
+    "@mysten/sui": "^2.19.0",
+    "@mysten/walrus": "^1.2.1"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/docs/examples/seal/read-and-decrypt.ts
+++ b/docs/examples/seal/read-and-decrypt.ts
@@ -1,0 +1,80 @@
+// Copyright (c) Walrus Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// Step 2 of the tutorial: read the ciphertext back from Walrus and decrypt it
+// with Seal. The caller must satisfy the onchain policy (be on the allowlist).
+// Run with:
+//   SUI_PRIVATE_KEY=suiprivkey1... npx tsx read-and-decrypt.ts <blobId>
+
+import { EncryptedObject, SessionKey } from '@mysten/seal';
+import { Transaction } from '@mysten/sui/transactions';
+import { fromHex } from '@mysten/sui/utils';
+
+import {
+  ALLOWLIST_ID,
+  MODULE_NAME,
+  PACKAGE_ID,
+  THRESHOLD,
+  sealClient,
+  suiClient,
+} from './config';
+import { getFundedKeypair } from './funded-keypair';
+
+// Builds the PTB that Seal evaluates as the access check. It must call only
+// `seal_approve*` functions on PACKAGE_ID. The transaction's sender is set to
+// the requester, because `allowlist::seal_approve` checks `ctx.sender()`.
+function buildApproveTx(id: string, sender: string): Transaction {
+  const tx = new Transaction();
+  // Set the sender before building, or decryption fails with
+  // "Transaction was not signed by the correct sender".
+  tx.setSender(sender);
+  tx.moveCall({
+    target: `${PACKAGE_ID}::${MODULE_NAME}::seal_approve`,
+    arguments: [tx.pure.vector('u8', fromHex(id)), tx.object(ALLOWLIST_ID)],
+  });
+  return tx;
+}
+
+async function readAndDecrypt(blobId: string) {
+  const keypair = await getFundedKeypair();
+  const address = keypair.toSuiAddress();
+
+  // 1. Read the ciphertext back from Walrus.
+  const encryptedBytes = await suiClient.walrus.readBlob({ blobId });
+
+  // 2. Recover the Seal identity that was embedded at encryption time.
+  const id = EncryptedObject.parse(encryptedBytes).id;
+
+  // 3. Create a session key and authorize it once with a personal-message
+  //    signature. In a browser this is a wallet pop-up; here we sign locally.
+  const sessionKey = await SessionKey.create({
+    address,
+    packageId: PACKAGE_ID,
+    ttlMin: 10,
+    suiClient,
+  });
+  const { signature } = await keypair.signPersonalMessage(sessionKey.getPersonalMessage());
+  await sessionKey.setPersonalMessageSignature(signature);
+
+  // 4. Build the access-check PTB and fetch decryption shares from key servers.
+  const tx = buildApproveTx(id, address);
+  const txBytes = await tx.build({ client: suiClient, onlyTransactionKind: true });
+  await sealClient.fetchKeys({ ids: [id], txBytes, sessionKey, threshold: THRESHOLD });
+
+  // 5. Decrypt locally using the fetched shares.
+  const decrypted = await sealClient.decrypt({ data: encryptedBytes, sessionKey, txBytes });
+
+  console.log('Decrypted message:', new TextDecoder().decode(decrypted));
+  return decrypted;
+}
+
+const blobId = process.argv[2];
+if (!blobId) {
+  console.error('Usage: npx tsx read-and-decrypt.ts <blobId>');
+  process.exit(1);
+}
+
+readAndDecrypt(blobId).catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/docs/site/sidebars.js
+++ b/docs/site/sidebars.js
@@ -98,6 +98,7 @@ const sidebars = {
     "typescript-sdk/sdks",
     'large-uploads',
     'data-security',
+    'seal-encryption-tutorial',
     'tusky-migration-guide',
     'glossary',
     {

--- a/docs/troubleshooting/overview.md
+++ b/docs/troubleshooting/overview.md
@@ -1,0 +1,164 @@
+---
+title: "Troubleshooting & FAQ"
+description: "Symptom → cause → fix for common Walrus Memory issues: delegate-key auth (401 / AUTH_REJECTED), MCP connection problems, and save/analyze timeouts."
+keywords: [Walrus Memory, MemWal, troubleshooting, 401, AUTH_REJECTED, delegate key, MCP, timeout, memwal_analyze]
+---
+
+<!--
+MAINTAINER NOTE (remove before publishing if desired)
+Seeded from BEDU-612 (Discord support thread: Daniel Lam, Dan D, Kenton).
+Two real cases drove this page:
+  1. 401 AUTH_REJECTED on a fresh dashboard delegate key (SDK ~0.0.7).
+     The reporter SELF-RESOLVED but did NOT record the actual fix
+     ("user does not know what the solution was, only used Claude to solve it"
+     — FAQ tracking sheet). So the root cause for THAT specific case is unconfirmed.
+     The "401 / AUTH_REJECTED" entry below therefore enumerates every documented
+     cause from the auth model (relayer api-reference + delegate-key-management),
+     ordered by likelihood for the reported fingerprint (fresh dashboard key +
+     account ID from localStorage). Leading suspects: (a) delegate not yet
+     registered/indexed on-chain, (b) account-ID mismatch, (c) env/relayer mismatch.
+     TODO: confirm the actual fix with the reporter / Dio and tighten the ordering.
+  2. memwal_analyze timed out twice while recall worked. Grounded in the async
+     job model (relayer api-reference) + MCP reference.
+Grounding sources (MystenLabs/MemWal @ dev):
+  docs/contract/delegate-key-management.md, docs/contract/ownership-and-permissions.md,
+  docs/relayer/api-reference.md, docs/sdk/api-reference.md, docs/mcp/reference.md,
+  docs/getting-started/quick-start.md
+-->
+
+This page collects the support questions we see most often and the fastest way to resolve them. Each entry follows the same shape so you can scan to the symptom that matches yours:
+
+**Symptom** (what you observe) → **Cause** (why it happens) → **Fix** (what to do).
+
+If your issue isn't here, set `MEMWAL_MCP_DEBUG=1` (MCP) or enable `debug` in the SDK config to get verbose logs, and open an issue on the repo with that output.
+
+---
+
+## How authentication works (read this first)
+
+Most auth problems make sense once the model is clear. Walrus Memory never uses your owner wallet for day-to-day calls. Instead:
+
+1. You **generate a delegate keypair** (an Ed25519 key) — for example from the [dashboard](https://memory.walrus.xyz).
+2. The delegate's **public key is registered on-chain** in your `MemWalAccount` by the account owner.
+3. The SDK or MCP client signs each request with the delegate **private key**.
+4. On every request, the relayer verifies the signature and then **looks up that public key in your account's on-chain `delegate_keys` list** to resolve the owner.
+
+The key word is *registered*. A delegate key that exists locally but has not been added to your account on-chain — or has been added to a *different* account, or on a *different* network — will be rejected. That single fact explains the large majority of `401 / AUTH_REJECTED` reports.
+
+Every signed request also carries a timestamp with a **5-minute validity window** and a one-time nonce (replay protection), which is the second most common source of surprise rejections.
+
+---
+
+## Authentication & delegate keys
+
+### 401 / `AUTH_REJECTED` — requests rejected even with a fresh delegate key
+
+**Symptom.** You generated a delegate key (often from the dashboard), confirmed your account ID, and every authenticated call still returns `401` / `AUTH_REJECTED`. `memwal_health` (or `MemWal.health()`) succeeds, because the health endpoint is unauthenticated — so the relayer is reachable, but your *signed* requests are not being accepted.
+
+**Cause.** The relayer could not match your signed request to an **active, registered delegate key on the account you named**. It verifies the Ed25519 signature, then resolves the owner by finding your public key in that account's on-chain `delegate_keys`. Anything that breaks that lookup produces the same `401`. In order of likelihood for a freshly generated key:
+
+| # | Cause | How to check | Fix |
+| --- | --- | --- | --- |
+| 1 | **Delegate key not registered on-chain yet** (or the registration transaction hasn't landed/been indexed). Generating a keypair is *not* the same as adding it to the account. | Confirm the key appears under your account's delegate keys in the [dashboard](https://memory.walrus.xyz). If you scripted setup, confirm `addDelegateKey` actually executed and the tx succeeded. | Register the public key on-chain (owner-signed) via the dashboard or `addDelegateKey(...)`. If you just registered it, wait a few seconds for indexing and retry. |
+| 2 | **Account-ID mismatch.** The `accountId` you're passing (e.g. copied from `localStorage`) isn't the account the key is registered under — a common result of stale `localStorage` from a previous account or copying the wrong field. | Compare the `accountId` in your config against the account that owns the delegate key in the dashboard. | Use the account ID that *you* generated and that owns this delegate key. Don't reuse an account ID copied from docs or another project. |
+| 3 | **Environment / relayer mismatch.** The key + account live on one network but you're pointed at another relayer — e.g. registered on staging (testnet) but calling the production relayer, or vice versa. The relayer only sees on-chain state for its own network. | Check `serverUrl` (SDK) or your preset (`--prod` / `--staging`) against where the account was created. Prod = `https://relayer.memory.walrus.xyz`; staging = `https://relayer-staging.memory.walrus.xyz`. | Point the client at the relayer for the network where the account/key live, or re-create the account/key in the environment you intend to use. For MCP, `--logout` then `login --<env>`. |
+| 4 | **Clock skew / expired request.** The signed timestamp must be within a **5-minute window**. A client clock that's off by more than that gets rejected. | Check that the machine's clock is accurate (NTP synced). | Sync the system clock and retry. |
+| 5 | **Key revoked or account frozen.** The delegate was removed, or the owner deactivated (froze) the account — which denies access for *all* keys. | Check the dashboard for the key's presence and the account's active state. | Re-add the delegate key, or reactivate the account (owner only). |
+
+<Note>
+SDK version is rarely the cause here. The relayer reports its `minSupportedSdk` (TypeScript `0.0.4` at time of writing), so `0.0.7` is supported. A genuine version mismatch surfaces as `MemWalCompatibilityError`, not `AUTH_REJECTED`.
+</Note>
+
+<Tip>
+Quick triage order: (1) is the key listed under the right account in the dashboard? (2) does your `accountId` match that account exactly? (3) is your relayer/env the same one the account was created in? Those three resolve almost every case.
+</Tip>
+
+---
+
+## MCP connection issues
+
+### Only `memwal_login` shows up (or memory tools error until you sign in)
+
+**Symptom.** After connecting the MCP server, the agent only sees `memwal_login`, or memory tools return an "auth required" error.
+
+**Cause.** No credentials file exists at `~/.memwal/credentials.json`. When launched by an MCP host without credentials, the package starts in an auth-required mode that intentionally exposes `memwal_login` first.
+
+**Fix.** Ask the agent to call `memwal_login` (it returns a one-time sign-in URL valid for **5 minutes**), or run `npx -y @mysten-incubation/memwal-mcp login --prod` in your terminal. Make sure your browser is logged into the wallet you intend to use before clicking. If the URL expires, call the tool again to mint a fresh one.
+
+### The MCP tools aren't visible to the agent at all
+
+**Symptom.** None of the `memwal_*` tools appear.
+
+**Cause.** MCP servers are loaded only at client startup, so a server added mid-session won't appear.
+
+**Fix.** Fully quit and relaunch the MCP client. If you registered via `claude mcp add`, run `claude mcp list` to confirm `memwal` is registered before restarting.
+
+---
+
+## Saving & timeouts
+
+### `memwal_analyze` (or a milestone save) times out, but recall works
+
+**Symptom.** Recall is fine, but saving via `memwal_analyze` times out — sometimes on repeated attempts — while `memwal_recall` returns quickly.
+
+**Cause.** Recall is a single search round-trip, so it's fast. Saving is much heavier, and `analyze` is the heaviest save of all: it runs an **LLM extraction** over your text and then enqueues **each extracted fact as its own background job**, where every job embeds → SEAL-encrypts → uploads to Walrus → indexes. Under load this fan-out can exceed the MCP host's tool-call timeout even though the work is proceeding normally on the relayer.
+
+<Warning>
+**A client-side timeout does not mean the save failed.** The relayer accepts the work as background jobs (HTTP `202 Accepted`) and keeps processing after your client gives up. Blindly re-running the same `analyze` can create **duplicate** memories. Verify before retrying.
+</Warning>
+
+**Fix.**
+
+1. **Verify instead of resubmitting.** Wait a few seconds (indexing can lag briefly under load), then run `memwal_recall` for the fact you tried to save. If it's there, the save succeeded despite the timeout.
+2. **Use the right tool for the job.** To save a single discrete fact (a "milestone"), prefer `memwal_remember` — it's one write, not an extract-and-fan-out. Reserve `analyze` for longer passages where you actually want multiple facts extracted, and keep those passages reasonably sized.
+3. **Confirm connectivity first.** Run `memwal_health` — it hits the unauthenticated `/health` endpoint and is the fastest way to confirm the relayer is reachable (use this rather than a full `recall` round-trip).
+4. **For SDK callers**, remember that `remember()` and `analyze()` return immediately with job IDs; do the waiting yourself with `waitForRememberJob` / `analyzeAndWait` and a sensible timeout, or poll the job status, rather than wrapping the whole thing in one short blocking call.
+5. If it persists, set `MEMWAL_MCP_DEBUG=1` (MCP) or `debug: true` (SDK) and capture the per-request logs.
+
+### Recall returns "no matching memories" right after a save
+
+**Symptom.** You save something and an immediate recall finds nothing.
+
+**Cause.** The write returns once the Walrus upload completes, but the embedding/indexing step can lag a few seconds behind under load, so the memory isn't searchable for a moment.
+
+**Fix.** Wait briefly and retry the recall. If a memory is genuinely missing from the search index later (e.g. after a re-index need), `memwal_restore` / `restore(namespace)` rebuilds the index for that namespace from Walrus.
+
+---
+
+## Quick reference
+
+| Thing | Value |
+| --- | --- |
+| Production relayer | `https://relayer.memory.walrus.xyz` |
+| Staging relayer (testnet) | `https://relayer-staging.memory.walrus.xyz` |
+| Dashboard (accounts, delegate keys) | `https://memory.walrus.xyz` |
+| MCP env presets | `--prod`, `--staging`, `--local` |
+| Local credentials file | `~/.memwal/credentials.json` |
+| Verbose MCP logs | `MEMWAL_MCP_DEBUG=1` |
+| Unauthenticated health check | `memwal_health` / `MemWal.health()` |
+| Delegate keys per account (max) | 20 |
+| Request timestamp window | 5 minutes |
+
+---
+
+## FAQ (for the product page)
+
+These are written for a lighter-weight, product-page audience. Lift them as-is or trim.
+
+**Do I need a registration step after generating a delegate key?**
+Yes. Generating a delegate key creates the keypair; it only works once its public key has been **registered on your account on-chain** (the dashboard does this when you create the key there). The relayer checks for that registration on every request, so a key that was generated but not registered — or registered on a different account or network — will be rejected.
+
+**I'm getting `401 / AUTH_REJECTED` with a brand-new key. What's wrong?**
+Almost always one of three things: the key isn't registered on the account yet (or the registration is still settling), your account ID doesn't match the account the key belongs to, or your client is pointed at a different environment (prod vs. staging) than where the account was created. Check those in that order. (A skewed system clock can also do it, since requests are time-stamped with a 5-minute window.)
+
+**Is the dashboard's testnet account the same as my production account?**
+No. Accounts and delegate keys are per-network. A key created on staging/testnet won't authenticate against the production relayer, and vice versa. Make sure your relayer URL (or `--prod` / `--staging` preset) matches where you created the account.
+
+**Saving a memory timed out — did I lose it?**
+Probably not. Saves are processed as background jobs and the server keeps working after the client times out. Don't immediately re-save (that can duplicate the memory) — wait a few seconds and recall it to confirm. For a single fact, use the lighter "remember" rather than "analyze," which extracts and stores many facts at once and is the slowest operation.
+
+**Why does recall work instantly but saving feel slow?**
+Recall is one search request. Saving embeds, encrypts, uploads to Walrus, and indexes — and "analyze" does that for every fact it extracts. It's normal for saves to take longer; they run asynchronously in the background.
+
+**How do I check whether the service is up?**
+Run a health check (`memwal_health`, or `MemWal.health()`). It doesn't require auth, so it isolates "is the relayer reachable?" from "are my credentials valid?"


### PR DESCRIPTION
Adds a symptom, cause, and fix troubleshooting page plus a product-page FAQ for Walrus Memory, seeded from the Discord support thread (BEDU-612). Covers 401 AUTH_REJECTED and the delegate-key registration flow, MCP connection issues, and memwal_analyze save timeouts. Grounded in the existing docs (contract/delegate-key-management, relayer/api-reference, sdk/api-reference, mcp/reference). Note: the original reporter self-resolved the 401 without recording the fix, so that entry lists all documented causes rather than a single confirmed one; flagged inline with a TODO to confirm with the reporter.