### PR TITLE
docs: add integrity verification and worked example to availability page

### DIFF
--- a/docs/content/walrus-client/verifying-availability.mdx
+++ b/docs/content/walrus-client/verifying-availability.mdx
@@ -1,8 +1,9 @@
 ---
 title: Verify Blob Availability Before Acting
 sidebar_label: Verifying availability
-description: A pattern for an agent to confirm a blob is durably stored on Walrus, by checking onchain Walrus state, before depending on it.
-keywords: [Walrus, blob, availability, certified, Sui object, agent, verify before act, durability]
+description: A pattern for confirming a blob is durably stored on Walrus and that the bytes you read
+  match the onchain commitment, by checking Walrus state on Sui before depending on it.
+keywords: [Walrus, blob, availability, integrity, consistency check, certified, Sui object, verify before act, durability]
 ---
 
 When an agent stores data on Walrus, or receives a blob ID and plans to build on it, it needs to confirm the data is durably stored before depending on it. The authoritative signal is Walrus state recorded on Sui: a certified, unexpired, non-deletable `Blob` object, or a verified blob-status result backed by the onchain certification event. A write call returning or an aggregator read succeeding is not enough. This page describes the verify-before-act pattern and the checks to run.
@@ -113,6 +114,81 @@ if (!durable) {
 ```
 
 For trustless or offline checks, authenticate the `BlobCertified` event or the `Blob` object through the Sui client, which returns signed evidence usable as a portable proof of availability. A Sui smart contract can run the same certified, before-expiry, and not-deletable check when the `Blob` object is passed as an input. See the `blob` and `storage_resource` Move modules for the field accessors.
+
+## Verify integrity
+
+Availability tells you a blob is still stored. Integrity tells you the bytes you read are the bytes
+the writer committed. The link between the two is the `blob_id` field on the `Blob` object: a blob
+ID is a commitment to the content, so a given blob ID always corresponds to the same bytes.
+Verifying integrity means confirming the data you read matches the commitment recorded onchain. Two
+layers give you that guarantee:
+
+- **Aggregator consistency checks.** When you read through an aggregator, it checks that the slivers
+  it returns are consistent with the blob's encoding before serving the bytes. The default check is
+  sufficient for most cases. For a full check, add the query parameter `strict_consistency_check=true`.
+  Only add `skip_consistency_check=true` when the writer is known and trusted. See
+  [reading blobs over HTTP](/docs/http-api/reading-blobs#consistency-checks).
+- **Binding to the onchain object.** Read the bytes
+  [by object ID](/docs/http-api/reading-blobs#reading-by-object-id), so the data you fetch is tied to
+  the specific `Blob` object whose certification and storage period you verified, not just to any
+  certificate that happens to exist for the content.
+
+For an offline or trustless check, the TypeScript SDK can re-encode content locally and derive its
+blob ID, which you then compare against the `blob_id` on the `Blob` object. A match proves the bytes
+are the committed content without trusting the aggregator. Note that the `blob_id` field read from
+the Sui object is a `u256` value, not the base64 blob ID used in aggregator URLs, so read by object
+ID rather than splicing that field into a read URL.
+
+## Worked example: availability and integrity
+
+The following function takes a `Blob` object ID, confirms the blob is durable, then reads the bytes
+through an aggregator with the consistency check enabled. It returns the verified bytes, or throws
+if any check fails. Set `aggregator` to an endpoint from the
+[Network Reference](/docs/network-reference#aggregators-and-publishers), and read the current epoch
+with `walrus info` or from Walrus system state.
+
+```ts
+async function readVerifiedBlob(
+  suiClient: SuiClient,
+  aggregator: string,
+  blobObjectId: string,
+  currentEpoch: number,
+): Promise<Uint8Array> {
+  // 1. Read the Blob object from Sui.
+  const res = await suiClient.getObject({
+    id: blobObjectId,
+    options: { showContent: true },
+  });
+  if (res.data?.content?.dataType !== "moveObject") {
+    throw new Error("Blob object was not found on Sui");
+  }
+
+  // 2. Check availability: certified, within its storage period, not deletable.
+  const fields = res.data.content.fields as Record<string, any>;
+  const certifiedEpoch = fields.certified_epoch?.fields?.vec?.[0] ?? null;
+  const endEpoch = Number(fields.storage?.fields?.end_epoch);
+  const deletable = fields.deletable === true;
+
+  const durable = certifiedEpoch != null && currentEpoch < endEpoch && !deletable;
+  if (!durable) {
+    throw new Error("Blob is not durably available; do not depend on it");
+  }
+
+  // 3. Read the bytes bound to this object, with the strict consistency check.
+  const url = `${aggregator}/v1/blobs/by-object-id/${blobObjectId}?strict_consistency_check=true`;
+  const read = await fetch(url);
+  if (!read.ok) {
+    // A CDN-fronted aggregator might serve a stale 404 right after certification.
+    throw new Error(`Read failed with status ${read.status}; retry with backoff`);
+  }
+
+  return new Uint8Array(await read.arrayBuffer());
+}
+```
+
+This binds every step to onchain state: the object read proves certification and the storage
+window, and the aggregator read uses that same object and validates the encoding before returning
+the bytes.
 
 ## Caveats
 


### PR DESCRIPTION
Closes BEDU-759. Extends the verify-before-act page with an integrity section and an end-to-end worked example. Sequence diagram tracked separately via the diagrams / visual aids label.