### PR TITLE
feat: serialize blob info snapshot in-process at the epoch boundary (#3480)

### DIFF
--- a/crates/walrus-service/node_config_example.yaml
+++ b/crates/walrus-service/node_config_example.yaml
@@ -228,6 +228,8 @@ consistency_check:
   enable_blob_info_invariants_check: false
   enable_sliver_data_existence_check: true
   sliver_data_existence_check_sample_rate_percentage: 100
+blob_info_snapshot:
+  enabled: false
 checkpoint_config:
   max_db_checkpoints: 3
   db_checkpoint_interval:

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -7,6 +7,7 @@ use std::{
     collections::{BTreeMap, hash_map::Entry},
     future::Future,
     num::{NonZero, NonZeroU16, NonZeroUsize},
+    path::PathBuf,
     pin::Pin,
     sync::{
         Arc,
@@ -213,6 +214,7 @@ pub mod server;
 pub mod system_events;
 
 pub(crate) mod blob_event_processor;
+pub(crate) mod blob_info_snapshot_writer;
 pub(crate) mod consistency_check;
 pub(crate) mod db_checkpoint;
 pub(crate) mod errors;
@@ -691,6 +693,8 @@ pub struct StorageNodeInner {
     // Sender for updating the latest event epoch.
     latest_event_epoch_sender: watch::Sender<Option<Epoch>>,
     consistency_check_config: StorageNodeConsistencyCheckConfig,
+    blob_info_snapshot_config: blob_info_snapshot_writer::BlobInfoSnapshotWriterConfig,
+    blob_info_snapshot_dir: PathBuf,
     checkpoint_manager: Option<Arc<DbCheckpointManager>>,
     garbage_collection_config: GarbageCollectionConfig,
     // Server-side cap on the `sliver_count` a sync-shard request may ask for; `None` disables it.
@@ -893,6 +897,10 @@ impl StorageNode {
             latest_event_epoch_sender,
             latest_event_epoch_watcher,
             consistency_check_config: config.consistency_check.clone(),
+            blob_info_snapshot_config: config.blob_info_snapshot.clone(),
+            blob_info_snapshot_dir: blob_info_snapshot_writer::snapshot_base_dir(
+                &config.storage_path,
+            ),
             checkpoint_manager,
             garbage_collection_config: config.garbage_collection,
             max_sliver_count_per_sync_request: config
@@ -1945,9 +1953,44 @@ impl StorageNode {
         // phase 1's disk traffic on the same RocksDB instance.
         self.start_garbage_collection_task(event.epoch).await?;
 
-        // Capture the event index before the handle is moved into `execute_epoch_change` so
-        // we can later detect whether this event is being reprocessed.
+        // Compute this before the handle is moved into `execute_epoch_change`, whose finisher marks
+        // the event complete in the background: checking afterwards could misclassify first-time
+        // processing as reprocessing.
         let event_index = event_handle.index();
+        let node_is_reprocessing_events =
+            self.inner.storage.get_latest_handled_event_index()? >= event_index;
+
+        // Serialize only when enabled, not reprocessing, and not catching up (a catching-up node's
+        // blob info tables are not at the clean cross-node boundary). The node-status DB lookup
+        // runs only after the other two checks short-circuit.
+        let should_serialize = self.inner.blob_info_snapshot_config.enabled
+            && !node_is_reprocessing_events
+            && !self.inner.storage.node_status()?.is_catching_up();
+
+        // Serialize after GC phase 1 has settled the tables and before `execute_epoch_change`
+        // spawns the finisher that marks the event complete (so a crash before completion replays
+        // and re-creates it). Errors are logged and counted, never failing epoch processing.
+        //
+        // TODO(WAL-1250): this only writes the snapshot to local disk. Publishing and certifying it
+        // on-chain (encode, store the node's own slivers, attest, track to certified) is future
+        // work.
+        if should_serialize
+            && let Err(error) = blob_info_snapshot_writer::serialize_snapshot_at_epoch_boundary(
+                self.inner.clone(),
+                event.epoch,
+                // Mirror what the node persists after completing this event: the
+                // `EpochChangeStart`'s id, and its index + 1 as the next index to process.
+                EventStreamCursor::new(Some(event_handle.event_id()), event_index + 1),
+            )
+            .await
+        {
+            self.inner.metrics.blob_info_snapshot_error_total.inc();
+            tracing::warn!(
+                ?error,
+                walrus.epoch = event.epoch,
+                "failed to serialize the blob info snapshot in-process at the epoch boundary"
+            );
+        }
 
         // During epoch change, we need to lock the read access to shard map until all the new
         // shards are created.
@@ -1981,8 +2024,6 @@ impl StorageNode {
         // - consistency check is disabled
         // - node is reprocessing events (blob info table should not be affected by future
         //   events)
-        let node_is_reprocessing_events =
-            self.inner.storage.get_latest_handled_event_index()? >= event_index;
         if self.inner.consistency_check_config.enable_consistency_check
             && !node_is_reprocessing_events
             && let Err(err) = consistency_check::schedule_background_consistency_check(

--- a/crates/walrus-service/src/node/blob_info_snapshot_writer.rs
+++ b/crates/walrus-service/src/node/blob_info_snapshot_writer.rs
@@ -1,0 +1,244 @@
+// Copyright (c) Walrus Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Epoch-boundary in-process serialization of blob info snapshots.
+//!
+//! When enabled, this module serializes the three blob-info column families in-process at the
+//! post-GC-phase-1 epoch boundary and removes the previous epoch's snapshot, keeping at most one.
+//! The size and content digest are reported through metrics and a log line for cross-node
+//! comparison.
+
+use std::{
+    fs,
+    hash::Hasher as _,
+    io::{BufWriter, Read as _, Write as _},
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Instant,
+};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use twox_hash::XxHash64;
+use walrus_core::Epoch;
+
+use super::{
+    StorageNodeInner,
+    storage::blob_info_snapshot::{SnapshotHeader, SnapshotStats},
+};
+use crate::event::events::EventStreamCursor;
+
+/// Configuration for the blob info snapshot writer.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct BlobInfoSnapshotWriterConfig {
+    /// Whether to serialize a blob info snapshot at each epoch boundary.
+    ///
+    /// When enabled, the node serializes the three blob-info column families in-process at the
+    /// post-GC-phase-1 boundary and reports the serialization duration, size, and digest. Note
+    /// that disabling this flag leaves the last snapshot file on disk until it is removed
+    /// manually.
+    pub enabled: bool,
+}
+
+/// Returns the directory under which the writer keeps its snapshots.
+pub fn snapshot_base_dir(storage_path: &Path) -> PathBuf {
+    storage_path.join("blob_info_snapshots")
+}
+
+fn snapshot_file_path(base_dir: &Path, epoch: Epoch) -> PathBuf {
+    base_dir.join(format!("snapshot_epoch_{epoch}.bin"))
+}
+
+/// Parses the epoch out of a (possibly temporary) snapshot file name.
+fn snapshot_file_epoch(file_name: &str) -> Option<Epoch> {
+    file_name
+        .strip_suffix(".tmp")
+        .unwrap_or(file_name)
+        .strip_prefix("snapshot_epoch_")?
+        .strip_suffix(".bin")?
+        .parse()
+        .ok()
+}
+
+fn saturating_i64(value: u64) -> i64 {
+    i64::try_from(value).unwrap_or(i64::MAX)
+}
+
+/// Fsyncs a directory so that a preceding rename or create within it survives a crash.
+fn sync_dir(dir: &Path) -> std::io::Result<()> {
+    fs::File::open(dir)?.sync_all()
+}
+
+/// Computes the xxhash64 (seed 0) of a file's full contents, read in streaming chunks.
+///
+/// The digest is a separate pass over the finished file, not teed inline while writing. It is
+/// observability only: logged and compared across nodes, not stored in the file.
+fn hash_file(path: &Path) -> std::io::Result<u64> {
+    let mut file = fs::File::open(path)?;
+    // seed 0 is part of the digest contract: readers recompute the hash with it.
+    let mut hasher = XxHash64::with_seed(0);
+    let mut buffer = [0u8; 1 << 16];
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.write(&buffer[..read]);
+    }
+    Ok(hasher.finish())
+}
+
+/// Serializes the three blob info column families in-process at the epoch boundary, reports the
+/// duration, size, and digest, and removes older snapshot files.
+///
+/// Must be called at the post-GC-phase-1 point while event processing is blocked. `event_cursor`
+/// is the position of the `EpochChangeStart` being processed.
+pub(super) async fn serialize_snapshot_at_epoch_boundary(
+    node: Arc<StorageNodeInner>,
+    epoch: Epoch,
+    event_cursor: EventStreamCursor,
+) -> Result<()> {
+    let base_dir = node.blob_info_snapshot_dir.clone();
+    fs::create_dir_all(&base_dir)?;
+
+    let final_path = snapshot_file_path(&base_dir, epoch);
+    if final_path.exists() {
+        // Already created, e.g., because the epoch change event is being reprocessed after a
+        // restart. Still drop any older snapshots so that at most one remains.
+        //
+        // TODO(WAL-1252): once snapshots are published and certified, a present file no longer
+        // means the work is done. This early return should consider both the on-disk write and the
+        // publish/certify state, and resume publishing rather than returning early.
+        tracing::debug!(walrus.epoch = epoch, "blob info snapshot already exists");
+        remove_snapshot_files_matching(&base_dir, |snapshot_epoch| snapshot_epoch != epoch);
+        return Ok(());
+    }
+    let tmp_path = base_dir.join(format!("snapshot_epoch_{epoch}.bin.tmp"));
+    if tmp_path.exists() {
+        fs::remove_file(&tmp_path)?;
+    }
+
+    let start = Instant::now();
+    let storage_node = node.clone();
+    let serialize_tmp_path = tmp_path.clone();
+    let (stats, digest, size_bytes) =
+        tokio::task::spawn_blocking(move || -> Result<(SnapshotStats, u64, u64)> {
+            // A snapshot is taken right after processing the `EpochChangeStart` event, which always
+            // has an event id, so the cursor's event id is never the genesis `None`.
+            let event_id = event_cursor.event_id.expect(
+                "snapshot is taken after the EpochChangeStart event, which has an event id",
+            );
+            let header = SnapshotHeader::new(epoch, event_id, event_cursor.element_index);
+            let file = fs::File::create(&serialize_tmp_path)?;
+            let mut buf_writer = BufWriter::with_capacity(1 << 20, file);
+            let stats = storage_node
+                .storage
+                .write_blob_info_snapshot(&header, &mut buf_writer)?;
+            buf_writer.flush()?;
+            buf_writer
+                .into_inner()
+                .context("failed to flush the snapshot file")?
+                .sync_all()?;
+            // Compute the digest as a separate pass over the finished file, decoupled from writing.
+            let digest = hash_file(&serialize_tmp_path)?;
+            let size_bytes = fs::metadata(&serialize_tmp_path)?.len();
+            Ok((stats, digest, size_bytes))
+        })
+        .await
+        .context("snapshot serialization task panicked")??;
+    fs::rename(&tmp_path, &final_path)?;
+    // Fsync the directory so the rename is durable: the `sync_all` above flushes the file
+    // contents, but not the parent directory entry that the rename created.
+    sync_dir(&base_dir)?;
+    // Only now that the new snapshot is durably in place, remove older epochs' snapshots so that
+    // at most one remains. Deleting them after the rename (rather than before writing) means a
+    // write or rename failure leaves the previous snapshot intact instead of dropping it
+    // prematurely.
+    remove_snapshot_files_matching(&base_dir, |snapshot_epoch| snapshot_epoch != epoch);
+    let elapsed = start.elapsed();
+
+    node.metrics
+        .blob_info_snapshot_serialize_duration_seconds
+        .set(elapsed.as_secs_f64());
+    node.metrics
+        .blob_info_snapshot_size_bytes
+        .set(saturating_i64(size_bytes));
+    let digest_hex = format!("{digest:016x}");
+    tracing::info!(
+        walrus.epoch = epoch,
+        ?elapsed,
+        size_bytes,
+        per_object = stats.per_object_count,
+        per_object_pooled = stats.per_object_pooled_count,
+        storage_pool = stats.storage_pool_count,
+        digest = %digest_hex,
+        path = %final_path.display(),
+        "serialized blob info snapshot in-process"
+    );
+    Ok(())
+}
+
+/// Removes all snapshot files (including temporary ones) whose epoch matches `should_remove`.
+fn remove_snapshot_files_matching(base_dir: &Path, should_remove: impl Fn(Epoch) -> bool) {
+    let Ok(entries) = fs::read_dir(base_dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        if snapshot_file_epoch(&name).is_some_and(&should_remove)
+            && let Err(error) = fs::remove_file(entry.path())
+        {
+            tracing::warn!(
+                ?error,
+                path = %entry.path().display(),
+                "failed to remove blob info snapshot file"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn config_default_is_disabled() {
+        assert!(!BlobInfoSnapshotWriterConfig::default().enabled);
+        let parsed: BlobInfoSnapshotWriterConfig =
+            serde_yaml::from_str("enabled: true\n").expect("config should deserialize");
+        assert!(parsed.enabled);
+    }
+
+    #[test]
+    fn snapshot_file_epoch_parses_file_names() {
+        assert_eq!(snapshot_file_epoch("snapshot_epoch_7.bin"), Some(7));
+        assert_eq!(snapshot_file_epoch("snapshot_epoch_7.bin.tmp"), Some(7));
+        assert_eq!(snapshot_file_epoch("unrelated"), None);
+        assert_eq!(snapshot_file_epoch("snapshot_epoch_x.bin"), None);
+    }
+
+    #[test]
+    fn keep_latest_removes_other_epochs() -> Result<()> {
+        let dir = tempdir()?;
+        let base = dir.path();
+        fs::write(snapshot_file_path(base, 3), b"old")?;
+        fs::write(snapshot_file_path(base, 4), b"keep")?;
+        fs::write(base.join("snapshot_epoch_4.bin.tmp"), b"tmp")?;
+        fs::write(base.join("unrelated.file"), b"keep me")?;
+
+        remove_snapshot_files_matching(base, |epoch| epoch != 4);
+
+        assert!(!snapshot_file_path(base, 3).exists());
+        assert!(snapshot_file_path(base, 4).exists());
+        // The temporary file for epoch 4 is kept by this filter; the serialization's atomic
+        // rename replaces it otherwise.
+        assert!(base.join("snapshot_epoch_4.bin.tmp").exists());
+        assert!(base.join("unrelated.file").exists());
+        Ok(())
+    }
+}

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -44,6 +44,7 @@ use walrus_sui::types::{
 use walrus_utils::config::Config as _;
 
 use super::{
+    blob_info_snapshot_writer::BlobInfoSnapshotWriterConfig,
     consistency_check::StorageNodeConsistencyCheckConfig,
     garbage_collector::GarbageCollectionConfig,
     storage::DatabaseConfig,
@@ -317,6 +318,9 @@ pub struct StorageNodeConfig {
     /// Configuration for the consistency check.
     #[serde(default, skip_serializing_if = "defaults::is_default")]
     pub consistency_check: StorageNodeConsistencyCheckConfig,
+    /// Configuration for the blob info snapshot checkpoint writer.
+    #[serde(default, skip_serializing_if = "defaults::is_default")]
+    pub blob_info_snapshot: BlobInfoSnapshotWriterConfig,
     /// Configuration for the checkpointing task.
     #[serde(default, skip_serializing_if = "defaults::is_default")]
     pub checkpoint_config: DbCheckpointConfig,
@@ -546,6 +550,7 @@ impl Default for StorageNodeConfig {
             balance_check: Default::default(),
             thread_pool: Default::default(),
             consistency_check: Default::default(),
+            blob_info_snapshot: Default::default(),
             checkpoint_config: Default::default(),
             admin_socket_path: None,
             node_recovery_config: Default::default(),

--- a/crates/walrus-service/src/node/metrics.rs
+++ b/crates/walrus-service/src/node/metrics.rs
@@ -194,6 +194,16 @@ walrus_utils::metrics::define_metric_set! {
         blob info table."]
         per_object_blob_info_consistency_check_error: IntCounter[],
 
+        #[help = "The number of errors while creating blob info snapshots."]
+        blob_info_snapshot_error_total: IntCounter[],
+
+        #[help = "The duration of serializing the blob info snapshot in-process at the epoch \
+        boundary, in seconds."]
+        blob_info_snapshot_serialize_duration_seconds: Gauge[],
+
+        #[help = "The size in bytes of the in-process blob info snapshot."]
+        blob_info_snapshot_size_bytes: IntGauge[],
+
         #[help = "The number of certified per-object blobs scanned during the per-object blob info \
         consistency check."]
         per_object_blob_info_consistency_check_certified_scanned: IntCounterVec["epoch"],

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -44,6 +44,7 @@ use self::{
         PerObjectBlobInfoIterator,
         PerObjectPooledBlobInfo,
     },
+    blob_info_snapshot::{SnapshotError, SnapshotHeader, SnapshotStats},
     constants::{
         garbage_collector_last_completed_epoch_key,
         garbage_collector_last_started_epoch_key,
@@ -66,6 +67,7 @@ use super::{
 use crate::utils::{self, BatchProcessingResult};
 
 pub(crate) mod blob_info;
+pub(crate) mod blob_info_snapshot;
 pub(crate) mod constants;
 
 mod database_config;
@@ -473,6 +475,17 @@ impl Storage {
 
     pub(crate) fn clear_blob_info_table(&self) -> Result<(), TypedStoreError> {
         self.blob_info.clear()
+    }
+
+    /// Serializes the three snapshotted blob info column families into `writer`, returning
+    /// statistics. Must be called at the post-GC-phase-1 epoch boundary while event processing is
+    /// blocked.
+    pub(crate) fn write_blob_info_snapshot<W: std::io::Write + std::io::Seek>(
+        &self,
+        header: &SnapshotHeader,
+        writer: W,
+    ) -> Result<SnapshotStats, SnapshotError> {
+        self.blob_info.write_snapshot(header, writer)
     }
 
     /// Returns lock write access to the shards map, and returns the underlying shard map.

--- a/crates/walrus-service/src/node/storage/blob_info.rs
+++ b/crates/walrus-service/src/node/storage/blob_info.rs
@@ -57,7 +57,11 @@ use self::{
     per_object_pooled_blob_info::PerObjectPooledBlobInfoMergeOperand,
     storage_pool_info::StoragePoolInfoMergeOperand,
 };
-use super::{DatabaseTableOptionsFactory, constants};
+use super::{
+    DatabaseTableOptionsFactory,
+    blob_info_snapshot::{self, SnapshotError, SnapshotHeader, SnapshotStats},
+    constants,
+};
 use crate::{
     node::metrics::NodeMetricSet,
     utils::{self, process_items_in_batches},
@@ -435,6 +439,32 @@ impl BlobInfoTable {
                 blob_id,
                 &BlobInfoMergeOperand::MarkMetadataStored(metadata_stored).to_bytes(),
             )],
+        )
+    }
+
+    /// Serializes a blob info snapshot of the three snapshotted column families into `writer`.
+    /// See [`super::blob_info_snapshot`] for the format. Must be called directly after GC phase 1
+    /// at the epoch boundary, before processing any further events.
+    ///
+    /// All three column families are read through a single RocksDB engine snapshot, so they are
+    /// captured at one consistent sequence number.
+    pub fn write_snapshot<W: std::io::Write + std::io::Seek>(
+        &self,
+        header: &SnapshotHeader,
+        writer: W,
+    ) -> Result<SnapshotStats, SnapshotError> {
+        // The three column families share one database instance, so one engine snapshot covers
+        // them all.
+        let engine_snapshot = self.per_object_blob_info.rocksdb.snapshot();
+        blob_info_snapshot::write_snapshot(
+            writer,
+            header,
+            self.per_object_blob_info
+                .safe_iter_with_snapshot(&engine_snapshot)?,
+            self.per_object_pooled_blob_info
+                .safe_iter_with_snapshot(&engine_snapshot)?,
+            self.storage_pool_info
+                .safe_iter_with_snapshot(&engine_snapshot)?,
         )
     }
 

--- a/crates/walrus-service/src/node/storage/blob_info/per_object_pooled_blob_info.rs
+++ b/crates/walrus-service/src/node/storage/blob_info/per_object_pooled_blob_info.rs
@@ -155,6 +155,24 @@ impl From<PerObjectPooledBlobInfoV1> for PerObjectPooledBlobInfo {
     }
 }
 
+impl PerObjectPooledBlobInfo {
+    #[cfg(test)]
+    pub(crate) fn new_for_testing(
+        blob_id: BlobId,
+        registered_epoch: Epoch,
+        certified_epoch: Option<Epoch>,
+        storage_pool_id: ObjectID,
+        event: EventID,
+    ) -> Self {
+        Self::V1(PerObjectPooledBlobInfoV1 {
+            blob_id,
+            registered_epoch,
+            certified_epoch,
+            storage_pool_id,
+            event,
+        })
+    }
+}
 impl ToBytes for PerObjectPooledBlobInfo {}
 
 impl Mergeable for PerObjectPooledBlobInfo {

--- a/crates/walrus-service/src/node/storage/blob_info_snapshot.rs
+++ b/crates/walrus-service/src/node/storage/blob_info_snapshot.rs
@@ -1,0 +1,353 @@
+// Copyright (c) Walrus Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Serialization format for blob info snapshots.
+//!
+//! A blob info snapshot is a deterministic serialization of three blob info tables at the epoch
+//! boundary (after garbage-collection phase 1): `per_object_blob_info`,
+//! `per_object_pooled_blob_info`, and `storage_pool_info`. These are event-derived, so honest nodes
+//! serialize identical bytes. `aggregate_blob_info` is excluded because it carries node-local state
+//! (`is_metadata_stored`) and so differs across nodes.
+//!
+//! This module contains only the writer; deserialization belongs to the (not yet implemented)
+//! recovery workflow.
+//!
+//! The format is versioned and self-delimiting:
+//!
+//! ```text
+//! +----------------------+
+//! |    Magic (4 B, BE)   |
+//! +----------------------+
+//! |  Version (4 B, BE)   |
+//! +----------------------+
+//! | Header len (varint)  |
+//! +----------------------+
+//! |  Header (BCS bytes)  |
+//! +----------------------+
+//! |  Section (tag = 1)   |  per_object_blob_info
+//! +----------------------+
+//! |  Section (tag = 2)   |  storage_pool_info
+//! +----------------------+
+//! |  Section (tag = 3)   |  per_object_pooled_blob_info
+//! +----------------------+
+//!
+//! Section := tag (1 B)
+//!            entry count (8 B, BE)
+//!            { key len (varint) | key BCS | value len (varint) | value BCS } x count
+//! ```
+//!
+//! Each section starts with its entry count, then that many entries. The count is written as a
+//! fixed-width placeholder and back-patched after the section's entries are streamed. Key and value
+//! lengths are LEB128 varints; the magic, version, section tags, and per-section counts are
+//! fixed-width.
+//!
+//! Entries within a section are in strictly increasing key order (the natural RocksDB iteration
+//! order). The serialized bytes are consensus-critical. [`SNAPSHOT_FORMAT_VERSION`] versions only
+//! the framing (magic, header, sections, ordering, length encoding), not the value schema: each
+//! value is BCS of an append-only versioned enum (`PerObjectBlobInfoV1`, ...), so the leading
+//! variant tag identifies the version per entry and newer software still decodes older variants (as
+//! the on-disk tables already do). Adding a variant needs no format bump but must be epoch-gated so
+//! all nodes emit identical bytes at the same boundary. A released variant is never changed in
+//! place; any change to a value's fields goes in a new variant.
+//!
+//! The file carries no checksum; the cross-node content digest (xxhash64 of the whole file) is
+//! computed and logged by the writer, not stored.
+
+use std::io::{Seek, SeekFrom, Write};
+
+use byteorder::{BigEndian, WriteBytesExt};
+use integer_encoding::VarIntWriter;
+use serde::{Deserialize, Serialize};
+use sui_types::{base_types::ObjectID, event::EventID};
+use typed_store::TypedStoreError;
+use walrus_core::Epoch;
+
+use super::{
+    blob_info::{PerObjectBlobInfo, PerObjectPooledBlobInfo, StoragePoolInfo},
+    event_cursor_table::EventIdWithProgress,
+};
+
+/// The magic bytes at the start of a blob info snapshot.
+pub(crate) const SNAPSHOT_MAGIC: u32 = 0xB10B1F05;
+/// Version of the snapshot framing: the envelope layout (magic, header, section set, order, and
+/// tags, count and length encoding, key ordering), not the value schema. Bump it when that layout
+/// changes. A new blob info value variant does not bump it, because values are append-only
+/// versioned enums that are self-describing per entry; see the module docs.
+pub(crate) const SNAPSHOT_FORMAT_VERSION: u32 = 1;
+
+const SECTION_TAG_PER_OBJECT: u8 = 1;
+const SECTION_TAG_STORAGE_POOL: u8 = 2;
+const SECTION_TAG_PER_OBJECT_POOLED: u8 = 3;
+
+/// Errors occurring during blob info snapshot serialization.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum SnapshotError {
+    /// An I/O error occurred while writing the snapshot.
+    #[error("I/O error during snapshot serialization")]
+    Io(#[from] std::io::Error),
+    /// Reading from the underlying database failed.
+    #[error("database error during snapshot serialization")]
+    Storage(#[from] TypedStoreError),
+    /// BCS serialization of a header or entry failed.
+    #[error("BCS serialization error")]
+    Encoding(#[from] bcs::Error),
+    /// The entries of a section are not in strictly increasing key order.
+    #[error("keys are not in strictly increasing order in section with tag {0}")]
+    UnsortedKeys(u8),
+}
+
+/// The header of a blob info snapshot.
+///
+/// The header pins the exact event-stream position the snapshot corresponds to: the snapshot
+/// contains the table state after applying all events up to and including the `EpochChangeStart`
+/// for `epoch`, with the inline GC phase 1 for `epoch` applied. The position is stored as
+/// [`EventIdWithProgress`], the same versioned record the node persists as its event cursor, so a
+/// recovering node rehydrates the cursor directly and the format evolves with it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct SnapshotHeader {
+    /// The new (incoming) epoch this boundary begins; the `epoch` of the `EpochChangeStart` event
+    /// being processed.
+    pub epoch: Epoch,
+    /// The node's event cursor at the boundary: the event ID of the last included event (the
+    /// `EpochChangeStart` for `epoch`) and the index of the next event to process.
+    pub event_cursor: EventIdWithProgress,
+}
+
+impl SnapshotHeader {
+    /// Creates a snapshot header from the boundary epoch and the cursor's two fields.
+    pub fn new(epoch: Epoch, event_id: EventID, next_event_index: u64) -> Self {
+        Self {
+            epoch,
+            event_cursor: EventIdWithProgress::new(event_id, next_event_index),
+        }
+    }
+}
+
+/// Statistics about a written snapshot, for logging and metrics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) struct SnapshotStats {
+    /// The number of entries serialized from `per_object_blob_info`.
+    pub per_object_count: u64,
+    /// The number of entries serialized from `per_object_pooled_blob_info`.
+    pub per_object_pooled_count: u64,
+    /// The number of entries serialized from `storage_pool_info`.
+    pub storage_pool_count: u64,
+}
+
+/// A fallible `(ObjectID, value)` entry, as yielded by a RocksDB column-family iterator.
+type Entry<V> = Result<(ObjectID, V), TypedStoreError>;
+
+/// Serializes a blob info snapshot to `writer`.
+///
+/// The entry iterators must yield entries in strictly increasing key order, as produced by
+/// RocksDB iteration; this is checked and [`SnapshotError::UnsortedKeys`] is returned otherwise.
+pub(crate) fn write_snapshot<W: Write + Seek>(
+    mut writer: W,
+    header: &SnapshotHeader,
+    per_object: impl IntoIterator<Item = Entry<PerObjectBlobInfo>>,
+    per_object_pooled: impl IntoIterator<Item = Entry<PerObjectPooledBlobInfo>>,
+    storage_pools: impl IntoIterator<Item = Entry<StoragePoolInfo>>,
+) -> Result<SnapshotStats, SnapshotError> {
+    writer.write_u32::<BigEndian>(SNAPSHOT_MAGIC)?;
+    writer.write_u32::<BigEndian>(SNAPSHOT_FORMAT_VERSION)?;
+    let header_bytes = bcs::to_bytes(header)?;
+    writer.write_varint(header_bytes.len())?;
+    writer.write_all(&header_bytes)?;
+
+    let per_object_count = write_section(&mut writer, SECTION_TAG_PER_OBJECT, per_object)?;
+    let storage_pool_count = write_section(&mut writer, SECTION_TAG_STORAGE_POOL, storage_pools)?;
+    let per_object_pooled_count = write_section(
+        &mut writer,
+        SECTION_TAG_PER_OBJECT_POOLED,
+        per_object_pooled,
+    )?;
+
+    writer.flush()?;
+
+    Ok(SnapshotStats {
+        per_object_count,
+        per_object_pooled_count,
+        storage_pool_count,
+    })
+}
+
+fn write_section<W: Write + Seek, V: Serialize>(
+    writer: &mut W,
+    tag: u8,
+    entries: impl IntoIterator<Item = Entry<V>>,
+) -> Result<u64, SnapshotError> {
+    writer.write_u8(tag)?;
+    // The entry count leads the section, but it is only known after the streamed source is
+    // exhausted, so reserve a fixed-width placeholder here and back-patch it once the section is
+    // written. Fixed width (not a varint) is required so the patched value occupies the reserved
+    // space exactly.
+    let count_position = writer.stream_position()?;
+    writer.write_u64::<BigEndian>(0)?;
+
+    let mut count: u64 = 0;
+    let mut previous_key: Option<ObjectID> = None;
+
+    for entry in entries {
+        let (key, value) = entry?;
+        if previous_key.is_some_and(|previous| previous >= key) {
+            return Err(SnapshotError::UnsortedKeys(tag));
+        }
+        previous_key = Some(key);
+
+        let key_bytes = bcs::to_bytes(&key)?;
+        writer.write_varint(key_bytes.len())?;
+        writer.write_all(&key_bytes)?;
+        let value_bytes = bcs::to_bytes(&value)?;
+        writer.write_varint(value_bytes.len())?;
+        writer.write_all(&value_bytes)?;
+        count += 1;
+    }
+
+    let section_end = writer.stream_position()?;
+    writer.seek(SeekFrom::Start(count_position))?;
+    writer.write_u64::<BigEndian>(count)?;
+    writer.seek(SeekFrom::Start(section_end))?;
+    Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::hash::Hasher as _;
+
+    use twox_hash::XxHash64;
+    use walrus_core::test_utils::blob_id_from_u64;
+    use walrus_sui::test_utils::fixed_event_id_for_testing;
+
+    use super::*;
+
+    fn sample_header() -> SnapshotHeader {
+        SnapshotHeader::new(7, fixed_event_id_for_testing(3), 42)
+    }
+
+    // Rebuilt on every call so that two serializations exercise independent value instances.
+    fn sample_per_object() -> Vec<Result<(ObjectID, PerObjectBlobInfo), TypedStoreError>> {
+        vec![
+            Ok((
+                ObjectID::from_single_byte(1),
+                PerObjectBlobInfo::new_for_testing(
+                    blob_id_from_u64(10),
+                    1,
+                    Some(2),
+                    5,
+                    false,
+                    fixed_event_id_for_testing(1),
+                    false,
+                ),
+            )),
+            Ok((
+                ObjectID::from_single_byte(2),
+                PerObjectBlobInfo::new_for_testing(
+                    blob_id_from_u64(11),
+                    3,
+                    None,
+                    9,
+                    true,
+                    fixed_event_id_for_testing(2),
+                    true,
+                ),
+            )),
+        ]
+    }
+
+    fn sample_pooled() -> Vec<Result<(ObjectID, PerObjectPooledBlobInfo), TypedStoreError>> {
+        vec![Ok((
+            ObjectID::from_single_byte(3),
+            PerObjectPooledBlobInfo::new_for_testing(
+                blob_id_from_u64(20),
+                2,
+                Some(4),
+                ObjectID::from_single_byte(8),
+                fixed_event_id_for_testing(5),
+            ),
+        ))]
+    }
+
+    fn sample_pools() -> Vec<Result<(ObjectID, StoragePoolInfo), TypedStoreError>> {
+        vec![
+            Ok((ObjectID::from_single_byte(4), StoragePoolInfo::new(1, 100))),
+            Ok((ObjectID::from_single_byte(5), StoragePoolInfo::new(2, 50))),
+        ]
+    }
+
+    fn serialize_sample() -> Vec<u8> {
+        // `write_snapshot` back-patches the section counts, so it needs a seekable sink; `Vec` is
+        // `Write` but not `Seek`, so wrap it in a `Cursor`.
+        let mut cursor = std::io::Cursor::new(Vec::new());
+        write_snapshot(
+            &mut cursor,
+            &sample_header(),
+            sample_per_object(),
+            sample_pooled(),
+            sample_pools(),
+        )
+        .expect("serialization should succeed");
+        cursor.into_inner()
+    }
+
+    /// Determinism (R1): the same logical tables, built as independent instances, must serialize to
+    /// byte-identical output. This is the guard that would catch a value type ever gaining an
+    /// unordered collection (for example a `HashMap`), whose per-instance iteration order diverges.
+    #[test]
+    fn serialization_is_deterministic_across_independent_instances() {
+        assert_eq!(serialize_sample(), serialize_sample());
+    }
+
+    // TODO: this checks only that the bytes are stable, not that they decode back correctly. Add a
+    // serialize -> deserialize round-trip test that asserts a decoded snapshot matches the source
+    // table once the reader/decoder lands in a following PR (the round-trip exists on a separate
+    // branch and passes on testnet data).
+    /// Byte-stability: the on-disk encoding is consensus-critical, so any change to it must be a
+    /// deliberate act. If this golden digest changes, update it here and, once a reader exists,
+    /// bump `SNAPSHOT_FORMAT_VERSION`.
+    #[test]
+    fn serialization_is_byte_stable() {
+        let mut hasher = XxHash64::with_seed(0);
+        hasher.write(&serialize_sample());
+        assert_eq!(
+            hasher.finish(),
+            0x17cf49e2fd041371,
+            "blob info snapshot encoding changed; if intentional, update this golden digest",
+        );
+    }
+
+    /// The file opens with the magic and version a reader keys off.
+    #[test]
+    fn serialization_starts_with_magic_and_version() {
+        let bytes = serialize_sample();
+        assert_eq!(
+            u32::from_be_bytes(bytes[0..4].try_into().expect("4 bytes")),
+            SNAPSHOT_MAGIC,
+        );
+        assert_eq!(
+            u32::from_be_bytes(bytes[4..8].try_into().expect("4 bytes")),
+            SNAPSHOT_FORMAT_VERSION,
+        );
+    }
+
+    /// Strictly ascending key order is what makes the encoding a pure function of the table
+    /// contents; out-of-order keys are rejected rather than silently producing divergent bytes.
+    #[test]
+    fn unsorted_keys_are_rejected() {
+        let no_per_object: Vec<Result<(ObjectID, PerObjectBlobInfo), TypedStoreError>> = vec![];
+        let no_pooled: Vec<Result<(ObjectID, PerObjectPooledBlobInfo), TypedStoreError>> = vec![];
+        let unsorted_pools = vec![
+            Ok((ObjectID::from_single_byte(5), StoragePoolInfo::new(1, 2))),
+            Ok((ObjectID::from_single_byte(4), StoragePoolInfo::new(1, 2))),
+        ];
+        let mut buf = std::io::Cursor::new(Vec::new());
+        let err = write_snapshot(
+            &mut buf,
+            &sample_header(),
+            no_per_object,
+            no_pooled,
+            unsorted_pools,
+        )
+        .expect_err("unsorted keys must be rejected");
+        assert!(matches!(err, SnapshotError::UnsortedKeys(_)));
+    }
+}

--- a/crates/walrus-service/src/node/storage/event_cursor_table.rs
+++ b/crates/walrus-service/src/node/storage/event_cursor_table.rs
@@ -31,6 +31,14 @@ pub enum EventIdWithProgress {
 }
 
 impl EventIdWithProgress {
+    /// Creates a `V1` event cursor record.
+    pub fn new(event_id: EventID, next_event_index: u64) -> Self {
+        Self::V1(EventIdWithProgressV1 {
+            event_id,
+            next_event_index,
+        })
+    }
+
     pub fn event_id(&self) -> EventID {
         match self {
             EventIdWithProgress::V1(v1) => v1.event_id,

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -3289,6 +3289,7 @@ pub fn storage_node_config() -> WithTempDir<StorageNodeConfig> {
     WithTempDir {
         inner: StorageNodeConfig {
             name: "node".to_string(),
+            blob_info_snapshot: Default::default(),
             protocol_key_pair: walrus_core::test_utils::protocol_key_pair().into(),
             next_protocol_key_pair: None,
             network_key_pair: walrus_core::test_utils::network_key_pair().into(),

--- a/crates/walrus-service/src/testbed.rs
+++ b/crates/walrus-service/src/testbed.rs
@@ -716,6 +716,7 @@ pub async fn create_storage_node_configs(
             name: node.name.clone(),
             storage_path,
             blocklist_path: None,
+            blob_info_snapshot: Default::default(),
             protocol_key_pair,
             next_protocol_key_pair: None,
             network_key_pair: node.network_keypair.into(),


### PR DESCRIPTION
## Description

Cherry-pick #3480 into the release branch. Once enabled,  nodes will serialize blob info snapshot in-process at the epoch boundary.

## Test plan

- Unit: determinism (independent instances serialize identically), golden byte-stability, magic/version prefix, ascending-key enforcement.
- Offline, on real data (db-tool on a separate branch): serialized testnet (262K entries) and two PTN nodes' checkpoints; entry counts match the source tables and the output is byte-identical across the two nodes.
- decode-encode roundtrip passes in local experiments.

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
