### PR TITLE
feat: keep node recovery task running across epoch changes

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -2295,13 +2295,14 @@ impl StorageNode {
         if let NodeStatus::RecoveryInProgress(recovering_epoch) =
             self.inner.storage.node_status()?
         {
-            // If the node is already in recovery mode, we need to restart node recovery to recover
-            // to the latest epoch. This is to make sure that the node is always recovering to the
-            // latest epoch. Since the node is up-to-date with events, newly gained shards are
-            // synced from their previous owners instead of being filled by blob recovery.
+            // If the node is already in recovery mode, we advance the recovery target to the
+            // latest epoch, so that the node always recovers to the latest epoch. Since the node
+            // is up-to-date with events, newly gained shards are synced from their previous
+            // owners instead of being filled by blob recovery, and the running recovery task
+            // keeps its progress instead of being restarted.
             tracing::info!(
-                "node is currently recovering to epoch {recovering_epoch}, restarting \
-                node recovery to recover to the latest epoch {}",
+                "node is currently recovering to epoch {recovering_epoch}, advancing the \
+                recovery target to the latest epoch {}",
                 event.epoch
             );
             self.process_shard_changes_in_new_epoch_while_recovering(
@@ -2405,9 +2406,9 @@ impl StorageNode {
     /// In contrast to [`Self::process_shard_changes_in_new_epoch_and_start_node_recovery`], which
     /// handles a node that has lost track of the previous epoch's shard assignment, the node here
     /// is up-to-date with events, so newly gained shards are filled using shard sync from their
-    /// previous owners instead of per-blob recovery. The restarted node recovery task waits for
-    /// these shard syncs to finish before recovering blobs, and attests epoch sync done once both
-    /// are complete.
+    /// previous owners instead of per-blob recovery. The running node recovery task is not
+    /// restarted: it waits for these shard syncs to finish before recovering blobs, and attests
+    /// epoch sync done for the advanced recovery target once both are complete.
     ///
     /// As all functions that are passed an [`EventHandle`], this is responsible for marking the
     /// event as completed.
@@ -2417,9 +2418,23 @@ impl StorageNode {
         event: &EpochChangeStart,
         shard_map_lock: StorageShardLock,
     ) -> anyhow::Result<()> {
+        // Advancing the recovery target and starting the shard syncs for gained shards must be
+        // atomic with respect to the recovery task's completion, which checks both under the
+        // same mutex: a completing task either observes the advanced target together with the
+        // new shard syncs, or completes entirely before this transition (detected below via the
+        // node status, in which case a new task is started).
+        let status_guard = self.node_recovery_handler.lock_status().await;
+
+        // If the running recovery task completed concurrently (after this event handler decided
+        // to take the recovering path), it has flipped the node status away from
+        // RecoveryInProgress; its completion no longer covers this epoch change.
+        let recovery_task_completed_concurrently = !matches!(
+            self.inner.storage.node_status()?,
+            NodeStatus::RecoveryInProgress(_)
+        );
+
         // Advance the recovery target so that the recovery task attests epoch sync done for the
-        // latest epoch; a stale attestation would be dropped by the contract service. This must
-        // happen before starting the shard syncs and restarting the recovery task below.
+        // latest epoch; a stale attestation would be dropped by the contract service.
         self.inner
             .set_node_status(NodeStatus::RecoveryInProgress(event.epoch))?;
 
@@ -2440,6 +2455,8 @@ impl StorageNode {
         self.create_new_shards_and_start_sync(shard_map_lock, shards_gained, &committees, false)
             .await?;
 
+        drop(status_guard);
+
         // For shards that just moved out, we need to lock them to not store more data in them.
         for shard_id in shard_diff_calculator.shards_to_lock() {
             let Some(shard_storage) = self.inner.storage.shard_storage(*shard_id).await else {
@@ -2457,10 +2474,11 @@ impl StorageNode {
                 .context("failed to lock shard")?;
         }
 
-        // Restart node recovery to recover to the latest epoch. The recovery task waits for the
-        // shard syncs started above to finish before scanning for blobs to recover.
+        // The recovery task keeps running across epoch changes: it waits for the shard syncs
+        // started above to finish before recovering blobs, and attests epoch sync done for the
+        // advanced target on completion. A new task is only started when none is running.
         self.node_recovery_handler
-            .start_node_recovery(event.epoch)
+            .ensure_recovery_task_running(event.epoch, recovery_task_completed_concurrently)
             .await?;
 
         // The recovery task is in charge of attesting epoch sync done, so the finisher is always

--- a/crates/walrus-service/src/node/node_recovery.rs
+++ b/crates/walrus-service/src/node/node_recovery.rs
@@ -37,6 +37,14 @@ pub struct NodeRecoveryHandler {
     // There can be at most one background shard removal task at a time.
     task_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
 
+    // Serializes recovery-related node status transitions: the epoch-change path advances the
+    // recovery target and starts shard syncs while holding this mutex, and the recovery task
+    // transitions the node to `Active` while holding it. This guarantees that a completing
+    // recovery task either observes the advanced target together with the new shard syncs, or
+    // has completed entirely before the transition (in which case the epoch-change path starts
+    // a new task).
+    status_mutex: Arc<Mutex<()>>,
+
     // Configuration for node recovery.
     config: NodeRecoveryConfig,
 }
@@ -53,13 +61,62 @@ impl NodeRecoveryHandler {
             blob_sync_handler,
             shard_sync_handler,
             task_handle: Arc::new(Mutex::new(None)),
+            status_mutex: Arc::new(Mutex::new(())),
             config,
         }
+    }
+
+    /// Locks the recovery status mutex.
+    ///
+    /// The epoch-change path must hold the returned guard across advancing the recovery target
+    /// (setting the node status to a newer `RecoveryInProgress` epoch) and starting the shard
+    /// syncs for newly gained shards, so that these are atomic with respect to the recovery
+    /// task's completion.
+    pub async fn lock_status(&self) -> tokio::sync::MutexGuard<'_, ()> {
+        self.status_mutex.lock().await
+    }
+
+    /// Ensures a recovery task is running to recover to the given epoch.
+    ///
+    /// The recovery task keeps running across epoch changes and picks up the advanced recovery
+    /// target on its own, so this normally does nothing. A new task is only started if the
+    /// caller observed that the previous task completed concurrently with the epoch change
+    /// (`task_completed_concurrently`), or if no task is running (for example, because it
+    /// stopped unexpectedly).
+    pub async fn ensure_recovery_task_running(
+        &self,
+        epoch: Epoch,
+        task_completed_concurrently: bool,
+    ) -> Result<(), TypedStoreError> {
+        let task_running = self
+            .task_handle
+            .lock()
+            .await
+            .as_ref()
+            .is_some_and(|handle| !handle.is_finished());
+
+        if task_completed_concurrently || !task_running {
+            tracing::info!(
+                walrus.epoch = epoch,
+                task_completed_concurrently,
+                task_running,
+                "no running node recovery task; starting a new one"
+            );
+            self.start_node_recovery(epoch).await?;
+        }
+
+        Ok(())
     }
 
     /// Starts the node recovery process to recover blobs that are certified before the given epoch.
     /// For blobs that are certified after `certified_before_epoch`, the event processing is in
     /// charge of making sure the blob is stored at all shards.
+    ///
+    /// The task keeps running across epoch changes: blobs certified after the scan bound are
+    /// covered by event processing, and shards gained at later epoch changes are covered by shard
+    /// sync (which the task waits for), so the scan bound stays valid. On completion, the task
+    /// attests epoch sync done for the recovery target currently recorded in the node status,
+    /// which the epoch-change path advances.
     ///
     /// Any existing recovery task will be canceled.
     // TODO(WAL-864): Refactor this function to make it readable.
@@ -80,6 +137,7 @@ impl NodeRecoveryHandler {
         let node = self.node.clone();
         let blob_sync_handler = self.blob_sync_handler.clone();
         let shard_sync_handler = self.shard_sync_handler.clone();
+        let status_mutex = self.status_mutex.clone();
         let max_concurrent_blob_syncs_during_recovery =
             self.config.max_concurrent_blob_syncs_during_recovery;
         let task_handle = tokio::spawn(async move {
@@ -99,6 +157,14 @@ impl NodeRecoveryHandler {
             fail_point_async!("start_node_recovery_entry");
 
             loop {
+                // Snapshot the shard sync generation before waiting: a completed pass may only
+                // attest if no shard sync started since this point. A shard sync that starts
+                // (and possibly terminally fails) during the pass leaves blobs behind that only
+                // a new scan pass finds, so a generation change forces a re-scan. Taking the
+                // snapshot before the wait errs towards a spurious re-scan when syncs start and
+                // drain while parked, never towards a missed one.
+                let sync_generation_before_scan = shard_sync_handler.sync_generation();
+
                 // Block until the node is ready to run a recovery scan pass. Stops the recovery
                 // task if the node started catching up.
                 match wait_until_ready_to_scan(&node, &shard_sync_handler).await {
@@ -127,6 +193,19 @@ impl NodeRecoveryHandler {
                             .ok()
                     })
                 {
+                    // An epoch change may have started shard syncs for newly gained shards while
+                    // this pass is running. Stop starting new blob syncs and park: per-blob
+                    // recovery would redundantly decode slivers for the shards that shard sync is
+                    // copying in bulk. Marking the pass as having more blobs makes the loop drain
+                    // the in-flight syncs and re-scan after the park.
+                    if shard_sync_handler.has_sync_in_progress() {
+                        tracing::info!(
+                            "shard sync started during recovery scan pass; pausing blob recovery"
+                        );
+                        has_more_blobs = true;
+                        break;
+                    }
+
                     node.metrics
                         .node_recovery_recover_blob_progress
                         .set(i64::from(blob_id.first_two_bytes()));
@@ -235,54 +314,77 @@ impl NodeRecoveryHandler {
                     }
                 }
 
-                if !has_more_blobs {
-                    tracing::info!("no recovery blob found; stop recovery task");
-                    break;
-                }
-
                 // Wait for all ongoing syncs to complete
                 while (ongoing_syncs.next().await).is_some() {
                     // Each sync completion automatically releases its permit
                 }
 
-                // TODO(WAL-669): right now, we have to do one more loop to check if all the blobs
-                // are recovered. This is not efficient because checking blob existence is
-                // expensive. It's better that blob sync handler can return the blob sync status
-                // and we can avoid the extra loop of all the blob syncs finished successfully.
-            }
-
-            // A shard sync may have been started by an epoch change after the last scan
-            // pass began. The node is fully synced for the epoch only once both blob
-            // recovery and all shard syncs are complete, so drain them before attesting.
-            shard_sync_handler.wait_until_no_sync_in_progress().await;
-
-            let current_node_status = node
-                .storage
-                .node_status()
-                .expect("reading node status should not fail");
-            if current_node_status == NodeStatus::RecoveryInProgress(certified_before_epoch) {
-                tracing::info!("node recovery task finished; set node status to active");
-                match node.set_node_status(NodeStatus::Active) {
-                    Ok(()) => {
-                        // While the node is recovering, this is the only place that attests
-                        // epoch sync done: shard sync skips its own attestation in
-                        // RecoveryInProgress state (see the epoch_sync_done handling in
-                        // shard_sync.rs), so that the attestation covers both the recovered
-                        // blobs and all synced shards.
-                        node.contract_service
-                            .epoch_sync_done(certified_before_epoch, node.node_capability())
-                            .await
-                    }
-                    Err(error) => {
-                        tracing::error!(?error, "failed to set node status to active");
-                    }
+                if has_more_blobs {
+                    // TODO(WAL-669): right now, we have to do one more loop to check if all the
+                    // blobs are recovered. This is not efficient because checking blob existence
+                    // is expensive. It's better that blob sync handler can return the blob sync
+                    // status and we can avoid the extra loop of all the blob syncs finished
+                    // successfully.
+                    continue;
                 }
-            } else {
-                tracing::warn!(
-                    node_status = %current_node_status,
-                    "node recovery task finished; but node status is not RecoveryInProgress; \
-                    skip setting node status to active"
+
+                // Completion attempt. The node is fully synced for the epoch only once both
+                // blob recovery and all shard syncs are complete. An epoch change can advance
+                // the recovery target and start new shard syncs at any time without restarting
+                // this task, so the checks below run under the status mutex, which serializes
+                // completion against the epoch-change path: either this task observes the new
+                // shard syncs (and runs another scan pass), or it completes entirely before the
+                // target is advanced (and the epoch-change path starts a new task).
+                let status_guard = status_mutex.lock().await;
+
+                // A shard sync that started since this pass began invalidates the pass: the
+                // sync may have terminally failed, leaving missing blobs behind that only a new
+                // scan pass finds. The epoch-change path starts shard syncs while holding the
+                // status mutex, so no sync can start between this check and the status update
+                // below.
+                if shard_sync_handler.has_sync_in_progress()
+                    || shard_sync_handler.sync_generation() != sync_generation_before_scan
+                {
+                    tracing::info!(
+                        "shard syncs started during the recovery scan pass; running another pass"
+                    );
+                    drop(status_guard);
+                    continue;
+                }
+
+                let current_node_status = node
+                    .storage
+                    .node_status()
+                    .expect("reading node status should not fail");
+                let NodeStatus::RecoveryInProgress(target_epoch) = current_node_status else {
+                    tracing::warn!(
+                        node_status = %current_node_status,
+                        "node recovery task finished; but node status is not RecoveryInProgress; \
+                        skip setting node status to active"
+                    );
+                    return;
+                };
+
+                tracing::info!(
+                    walrus.epoch = target_epoch,
+                    "node recovery task finished; set node status to active"
                 );
+                if let Err(error) = node.set_node_status(NodeStatus::Active) {
+                    tracing::error!(?error, "failed to set node status to active");
+                    return;
+                }
+                drop(status_guard);
+
+                // While the node is recovering, this is the only place that attests epoch sync
+                // done: shard sync skips its own attestation in RecoveryInProgress state (see
+                // the epoch_sync_done handling in shard_sync.rs), so that the attestation covers
+                // both the recovered blobs and all synced shards. The attested epoch is the
+                // recovery target currently recorded in the node status, which may be newer than
+                // the epoch this task was started with.
+                node.contract_service
+                    .epoch_sync_done(target_epoch, node.node_capability())
+                    .await;
+                return;
             }
         });
         *locked_task_handle = Some(task_handle);

--- a/crates/walrus-service/src/node/shard_sync.rs
+++ b/crates/walrus-service/src/node/shard_sync.rs
@@ -3,7 +3,10 @@
 
 use std::{
     collections::{HashMap, hash_map::Entry},
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
     time::Duration,
 };
 
@@ -49,13 +52,16 @@ enum SyncShardResult {
 /// RAII guard tracking a running shard-sync-related task in the sync task count watch channel.
 ///
 /// Increments the count on creation and decrements it on drop, so that the count stays accurate
-/// even if the tracked task is aborted or panics.
+/// even if the tracked task is aborted or panics. Creation also bumps the sync generation, which
+/// only ever increases and lets node recovery detect that a shard sync started during a scan
+/// pass, even if it also finished during that pass.
 #[derive(Debug)]
 struct SyncTaskCountGuard(Arc<watch::Sender<usize>>);
 
 impl SyncTaskCountGuard {
-    fn new(counter: Arc<watch::Sender<usize>>) -> Self {
+    fn new(counter: Arc<watch::Sender<usize>>, generation: &AtomicU64) -> Self {
         counter.send_modify(|count| *count += 1);
+        generation.fetch_add(1, Ordering::SeqCst);
         sui_macros::fail_point!("fail_point_shard_sync_task_started");
         Self(counter)
     }
@@ -79,6 +85,10 @@ pub struct ShardSyncHandler {
     // the individual per-shard syncs. Used by node recovery to wait until all shard syncs have
     // finished (successfully or not) before recovering blobs.
     sync_task_count: Arc<watch::Sender<usize>>,
+    // Total number of sync tasks ever started; only ever increases. Used by node recovery to
+    // detect whether any shard sync started during a scan pass (a terminally failed sync leaves
+    // missing blobs behind that only a new scan pass finds).
+    sync_task_generation: Arc<AtomicU64>,
     config: ShardSyncConfig,
 }
 
@@ -90,6 +100,7 @@ impl ShardSyncHandler {
             task_handle: Arc::new(Mutex::new(None)),
             shard_sync_semaphore: Arc::new(Semaphore::new(config.shard_sync_concurrency)),
             sync_task_count: Arc::new(watch::channel(0).0),
+            sync_task_generation: Arc::new(AtomicU64::new(0)),
             config,
         }
     }
@@ -97,6 +108,14 @@ impl ShardSyncHandler {
     /// Returns `true` if any shard sync task is currently running.
     pub fn has_sync_in_progress(&self) -> bool {
         *self.sync_task_count.borrow() > 0
+    }
+
+    /// Returns a generation number that increases every time a shard sync task starts.
+    ///
+    /// Comparing generations around a section of code detects whether any shard sync started
+    /// while it ran, including syncs that also finished within the section.
+    pub fn sync_generation(&self) -> u64 {
+        self.sync_task_generation.load(Ordering::SeqCst)
     }
 
     /// Waits until no shard sync task is running.
@@ -133,7 +152,8 @@ impl ShardSyncHandler {
 
         // Count the task that starts the individual shard syncs as a running sync, so that
         // waiters cannot observe a zero count before the per-shard sync tasks are spawned.
-        let count_guard = SyncTaskCountGuard::new(self.sync_task_count.clone());
+        let count_guard =
+            SyncTaskCountGuard::new(self.sync_task_count.clone(), &self.sync_task_generation);
         let new_task = tokio::spawn(async move {
             let _count_guard = count_guard;
             sync_handler.sync_shards_task(shards).await
@@ -416,7 +436,8 @@ impl ShardSyncHandler {
         };
 
         let shard_sync_handler_clone = self.clone();
-        let count_guard = SyncTaskCountGuard::new(self.sync_task_count.clone());
+        let count_guard =
+            SyncTaskCountGuard::new(self.sync_task_count.clone(), &self.sync_task_generation);
         let shard_sync_task = tokio::spawn(async move {
             let _count_guard = count_guard;
             let shard_index = shard_storage.id();

--- a/crates/walrus-simtest/tests/simtest_core.rs
+++ b/crates/walrus-simtest/tests/simtest_core.rs
@@ -1083,8 +1083,9 @@ mod tests {
     }
 
     // Tests that an epoch change occurring while node recovery is in progress fills newly
-    // gained shards using shard sync, and that node recovery does not start any blob syncs
-    // while shard syncs are running.
+    // gained shards using shard sync, that node recovery does not start any blob syncs while
+    // shard syncs are running, and that the recovery task keeps running across the epoch
+    // changes instead of being restarted.
     //
     // The test crashes a node long enough for it to enter RecoveryInProgress state, holds the
     // recovery task using a fail point, stakes additional weight on the node so that it gains
@@ -1184,15 +1185,21 @@ mod tests {
 
         // Holds the recovery task of the target node so that the recovery reliably spans
         // multiple epoch changes; released once the node has gained shards while recovering.
+        // Also counts how many recovery tasks are spawned on the target node: epoch changes
+        // processed while recovering must not restart the recovery task.
         let hold_recovery = Arc::new(AtomicBool::new(true));
+        let recovery_task_spawn_count = Arc::new(AtomicU64::new(0));
         {
             let hold_recovery = hold_recovery.clone();
+            let recovery_task_spawn_count = recovery_task_spawn_count.clone();
             register_fail_point_async("start_node_recovery_entry", move || {
                 let hold_recovery = hold_recovery.clone();
+                let recovery_task_spawn_count = recovery_task_spawn_count.clone();
                 async move {
                     if sui_simulator::current_simnode_id() != target_node_id {
                         return;
                     }
+                    recovery_task_spawn_count.fetch_add(1, Ordering::SeqCst);
                     tracing::info!("holding node recovery until released by the test");
                     while hold_recovery.load(Ordering::SeqCst) {
                         tokio::time::sleep(Duration::from_secs(1)).await;
@@ -1273,6 +1280,11 @@ mod tests {
         assert!(
             !ordering_violation.load(Ordering::SeqCst),
             "node recovery must not start blob syncs while shard syncs are running"
+        );
+        assert_eq!(
+            recovery_task_spawn_count.load(Ordering::SeqCst),
+            1,
+            "the recovery task must not be restarted by epoch changes processed while recovering"
         );
 
         // The gained shards should be owned by the node and be ready to serve traffic.


### PR DESCRIPTION
## Description

Follow-up to #3464. When an epoch change started while node recovery was in progress, the recovery task was canceled and restarted from scratch — re-scanning the full blob info table on every epoch change even though the previous progress was still valid.

The recovery task now keeps running across epoch changes:

- **The epoch-change path only advances the recovery target** (`RecoveryInProgress` epoch) and starts shard syncs for gained shards, both under a new status mutex so they are atomic with respect to the recovery task's completion. A new task is only started if the running one completed concurrently or stopped unexpectedly.
- **The scan bound stays frozen at the epoch the task was started with**: blobs certified later are covered by event processing, and shards gained at later epoch changes are covered by shard sync, which the task waits for.
- **Completion attests `epoch_sync_done` for the current recovery target** recorded in the node status (advanced by epoch changes), instead of the frozen spawn epoch, whose attestation would be dropped as stale.
- **Attestation requires a clean scan pass during which no shard sync started**, tracked by a new shard sync generation counter: a sync that starts and terminally fails during a pass leaves missing blobs that only a new pass finds. The blob scan also pauses promptly when a shard sync starts mid-pass.

## Test plan

- `test_node_recovery_across_epoch_change_with_shard_gain` now additionally asserts the recovery task is spawned exactly once across the epoch changes processed while recovering. Passes on seeds 1 and 2.
- Regression simtests pass: `test_long_node_recovery`, `test_recovery_in_progress_with_node_restart`, `test_lagging_node_recovery`.
- All 646 `walrus-service` unit tests pass; clippy and fmt clean.