### PR TITLE
feat: Add an option to sync writes in RocksDB batch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,7 +1931,7 @@ dependencies = [
  "mysten-metrics",
  "prometheus",
  "rand 0.8.5",
- "rocksdb",
+ "rocksdb 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_with",
  "sui-macros",
@@ -5375,6 +5375,7 @@ dependencies = [
  "libc",
  "libz-sys",
  "lz4-sys",
+ "pkg-config",
  "tikv-jemalloc-sys",
  "zstd-sys",
 ]
@@ -8938,6 +8939,19 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.22.0"
+dependencies = [
+ "bincode",
+ "libc",
+ "librocksdb-sys",
+ "pretty_assertions",
+ "serde",
+ "tempfile",
+ "trybuild",
+]
+
+[[package]]
+name = "rocksdb"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bd13e55d6d7b8cd0ea569161127567cd587676c99f4472f779a0279aa60a7a7"
 dependencies = [
@@ -10410,7 +10424,7 @@ dependencies = [
  "prometheus",
  "prost 0.14.3",
  "reqwest",
- "rocksdb",
+ "rocksdb 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-futures",
  "serde",
  "serde_json",
@@ -11505,7 +11519,7 @@ dependencies = [
  "prometheus",
  "prost 0.14.3",
  "roaring",
- "rocksdb",
+ "rocksdb 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "sui-consistent-store",
  "sui-default-config",
@@ -12075,6 +12089,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "target-triple"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+
+[[package]]
 name = "telemetry-subscribers"
 version = "0.2.0"
 source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.74.1#8fc60f1fa966e90398c93beb67ad4f42992889c7"
@@ -12547,10 +12567,12 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
 dependencies = [
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 1.0.0",
  "toml_datetime 0.7.0",
  "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
@@ -12600,6 +12622,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -13013,6 +13041,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "trybuild"
+version = "1.0.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f614c21bd3a61bad9501d75cbb7686f00386c806d7f456778432c25cf86948a"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml 0.9.5",
+]
+
+[[package]]
 name = "tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13067,7 +13110,7 @@ dependencies = [
  "mysten-metrics",
  "once_cell",
  "prometheus",
- "rocksdb",
+ "rocksdb 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "sui-macros",
  "tap",
@@ -13093,7 +13136,7 @@ dependencies = [
  "once_cell",
  "prometheus",
  "rand 0.8.5",
- "rocksdb",
+ "rocksdb 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rstest",
  "serde",
  "sui-macros",
@@ -13520,7 +13563,7 @@ dependencies = [
  "bcs",
  "clap",
  "rand 0.8.5",
- "rocksdb",
+ "rocksdb 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_json",
  "sui-types",
@@ -13737,7 +13780,7 @@ dependencies = [
  "regex",
  "reqwest",
  "ring",
- "rocksdb",
+ "rocksdb 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls",
  "rustls-native-certs",
  "scoped-futures",
@@ -13796,7 +13839,7 @@ dependencies = [
  "prometheus",
  "rand 0.8.5",
  "reqwest",
- "rocksdb",
+ "rocksdb 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sui-macros",
  "sui-protocol-config",
  "sui-rpc-api",

--- a/crates/typed-store/src/rocks.rs
+++ b/crates/typed-store/src/rocks.rs
@@ -1582,6 +1582,16 @@ impl DBBatch {
         Ok(())
     }
 
+    /// Consume the batch and write its operations with an explicit WAL sync setting.
+    ///
+    /// This overrides the batch's configured `WriteOptions::sync` value for this commit only.
+    /// Passing `true` makes RocksDB sync the WAL as part of the batch write, avoiding a separate
+    /// `flush_wal(true)` call after the batch has already become visible.
+    pub fn write_with_sync(mut self, sync: bool) -> Result<(), TypedStoreError> {
+        self.opts.set_sync(sync);
+        self.write()
+    }
+
     /// Get the size of the batch in bytes.
     pub fn size_in_bytes(&self) -> usize {
         self.batch.size_in_bytes()

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -365,6 +365,23 @@ async fn test_insert_batch() {
 }
 
 #[tokio::test]
+async fn test_insert_batch_with_sync() {
+    let db = open_map(temp_dir(), None, None);
+    let keys_vals = (1..100).map(|i| (i, i.to_string()));
+    let mut insert_batch = db.batch();
+    insert_batch
+        .insert_batch(&db, keys_vals.clone())
+        .expect("Failed to batch insert");
+    insert_batch
+        .write_with_sync(true)
+        .expect("Failed to execute sync batch");
+    for (k, v) in keys_vals {
+        let val = db.get(&k).expect("Failed to get inserted key");
+        assert_eq!(Some(v), val);
+    }
+}
+
+#[tokio::test]
 async fn test_insert_batch_across_cf() {
     let rocks = open_rocksdb(temp_dir(), &["First_CF", "Second_CF"]);
 


### PR DESCRIPTION
## Description

Add an function `write_with_sync` where batch commit also sync the WAL. This is useful because you avoid the race between batch commit and invoking wal.sync().

## Test plan

Unit test