### PR TITLE
feat: Add paranoid file checks in RocksDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,7 +1931,7 @@ dependencies = [
  "mysten-metrics",
  "prometheus",
  "rand 0.8.5",
- "rocksdb",
+ "rocksdb 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_with",
  "sui-macros",
@@ -5375,6 +5375,7 @@ dependencies = [
  "libc",
  "libz-sys",
  "lz4-sys",
+ "pkg-config",
  "tikv-jemalloc-sys",
  "zstd-sys",
 ]
@@ -8938,6 +8939,19 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.22.0"
+dependencies = [
+ "bincode",
+ "libc",
+ "librocksdb-sys",
+ "pretty_assertions",
+ "serde",
+ "tempfile",
+ "trybuild",
+]
+
+[[package]]
+name = "rocksdb"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bd13e55d6d7b8cd0ea569161127567cd587676c99f4472f779a0279aa60a7a7"
 dependencies = [
@@ -10410,7 +10424,7 @@ dependencies = [
  "prometheus",
  "prost 0.14.3",
  "reqwest",
- "rocksdb",
+ "rocksdb 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-futures",
  "serde",
  "serde_json",
@@ -11505,7 +11519,7 @@ dependencies = [
  "prometheus",
  "prost 0.14.3",
  "roaring",
- "rocksdb",
+ "rocksdb 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "sui-consistent-store",
  "sui-default-config",
@@ -12075,6 +12089,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "target-triple"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+
+[[package]]
 name = "telemetry-subscribers"
 version = "0.2.0"
 source = "git+https://github.com/MystenLabs/sui?tag=testnet-v1.74.1#8fc60f1fa966e90398c93beb67ad4f42992889c7"
@@ -12547,10 +12567,12 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
 dependencies = [
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 1.0.0",
  "toml_datetime 0.7.0",
  "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
@@ -12600,6 +12622,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -13013,6 +13041,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "trybuild"
+version = "1.0.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f614c21bd3a61bad9501d75cbb7686f00386c806d7f456778432c25cf86948a"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml 0.9.5",
+]
+
+[[package]]
 name = "tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13067,7 +13110,7 @@ dependencies = [
  "mysten-metrics",
  "once_cell",
  "prometheus",
- "rocksdb",
+ "rocksdb 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "sui-macros",
  "tap",
@@ -13093,7 +13136,7 @@ dependencies = [
  "once_cell",
  "prometheus",
  "rand 0.8.5",
- "rocksdb",
+ "rocksdb 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rstest",
  "serde",
  "sui-macros",
@@ -13520,7 +13563,7 @@ dependencies = [
  "bcs",
  "clap",
  "rand 0.8.5",
- "rocksdb",
+ "rocksdb 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_json",
  "sui-types",
@@ -13737,7 +13780,7 @@ dependencies = [
  "regex",
  "reqwest",
  "ring",
- "rocksdb",
+ "rocksdb 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls",
  "rustls-native-certs",
  "scoped-futures",
@@ -13796,7 +13839,7 @@ dependencies = [
  "prometheus",
  "rand 0.8.5",
  "reqwest",
- "rocksdb",
+ "rocksdb 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sui-macros",
  "sui-protocol-config",
  "sui-rpc-api",

--- a/crates/typed-store/src/rocks.rs
+++ b/crates/typed-store/src/rocks.rs
@@ -77,8 +77,11 @@ const ENV_VAR_DB_WAL_SIZE: &str = "DB_WAL_SIZE_MB";
 const DEFAULT_DB_WAL_SIZE: usize = 1024;
 
 const ENV_VAR_DB_PARALLELISM: &str = "DB_PARALLELISM";
+const ENV_VAR_DB_PARANOID_FILE_CHECKS: &str = "DB_PARANOID_FILE_CHECKS";
 
 const SLOW_OP_SAMPLED_TRACING_INTERVAL: Duration = Duration::from_secs(60);
+
+const PARANOID_FILE_CHECKS_OPTION: &str = "paranoid_file_checks";
 
 #[cfg(test)]
 mod tests;
@@ -346,6 +349,43 @@ impl RocksDB {
         delegate_call!(self.db_options)
     }
 
+    fn apply_paranoid_file_checks_to_cf(
+        &self,
+        cf_name: &str,
+        enabled: bool,
+    ) -> Result<(), rocksdb::Error> {
+        if let Some(cf) = self.cf_handle(cf_name) {
+            // https://github.com/facebook/rocksdb/blob/v8.10.0/include/rocksdb/advanced_options.h
+            self.set_options_cf(
+                &cf,
+                &[(
+                    PARANOID_FILE_CHECKS_OPTION,
+                    if enabled { "true" } else { "false" },
+                )],
+            )?;
+        }
+        Ok(())
+    }
+
+    fn apply_env_options_to_cf(&self, cf_name: &str) -> Result<(), rocksdb::Error> {
+        if let Some(enabled) = read_bool_from_env(ENV_VAR_DB_PARANOID_FILE_CHECKS) {
+            self.apply_paranoid_file_checks_to_cf(cf_name, enabled)?;
+        }
+        Ok(())
+    }
+
+    fn apply_env_options_to_cfs<I>(&self, cf_names: I) -> Result<(), rocksdb::Error>
+    where
+        I: IntoIterator<Item = String>,
+    {
+        if let Some(enabled) = read_bool_from_env(ENV_VAR_DB_PARANOID_FILE_CHECKS) {
+            for cf_name in cf_names {
+                self.apply_paranoid_file_checks_to_cf(&cf_name, enabled)?;
+            }
+        }
+        Ok(())
+    }
+
     /// Get a value from the database.
     pub fn get<K: AsRef<[u8]>>(&self, key: K) -> Result<Option<Vec<u8>>, rocksdb::Error> {
         delegate_call!(self.get(key))
@@ -410,7 +450,9 @@ impl RocksDB {
         name: N,
         opts: &rocksdb::Options,
     ) -> Result<(), rocksdb::Error> {
-        delegate_call!(self.create_cf(name, opts))
+        let name = name.as_ref();
+        delegate_call!(self.create_cf(name, opts))?;
+        self.apply_env_options_to_cf(name)
     }
 
     /// Drop a column family.
@@ -2195,6 +2237,22 @@ pub fn read_size_from_env(var_name: &str) -> Option<usize> {
         .ok()
 }
 
+fn read_bool_from_env(var_name: &str) -> Option<bool> {
+    let value = env::var(var_name).ok()?;
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" => Some(false),
+        _ => {
+            tracing::warn!(
+                "Env var {} does not contain a valid boolean: {}",
+                var_name,
+                value
+            );
+            None
+        }
+    }
+}
+
 /// The read-write options.
 #[derive(Clone, Debug)]
 pub struct ReadWriteOptions {
@@ -2403,6 +2461,10 @@ pub fn open_cf_opts<P: AsRef<Path>>(
     // This is a no-op in non-simulator builds.
 
     let cfs = populate_missing_cfs(opt_cfs, path).map_err(typed_store_err_from_rocks_err)?;
+    let mut cf_names = cfs.iter().map(|(name, _)| name.clone()).collect::<Vec<_>>();
+    cf_names.push(rocksdb::DEFAULT_COLUMN_FAMILY_NAME.to_string());
+    cf_names.sort_unstable();
+    cf_names.dedup();
     sui_macros::nondeterministic!({
         let options = prepare_db_options(db_options);
         let rocksdb = {
@@ -2414,12 +2476,16 @@ pub fn open_cf_opts<P: AsRef<Path>>(
             )
             .map_err(typed_store_err_from_rocks_err)?
         };
-        Ok(Arc::new(RocksDB::DB(DBWithThreadModeWrapper::new(
+        let rocksdb = Arc::new(RocksDB::DB(DBWithThreadModeWrapper::new(
             rocksdb,
             metric_conf,
             PathBuf::from(path),
             options,
-        ))))
+        )));
+        rocksdb
+            .apply_env_options_to_cfs(cf_names)
+            .map_err(typed_store_err_from_rocks_err)?;
+        Ok(rocksdb)
     })
 }
 
@@ -2434,20 +2500,26 @@ pub fn open_cf_opts_optimistic<P: AsRef<Path>>(
 ) -> Result<Arc<RocksDB>, TypedStoreError> {
     let path = path.as_ref();
     let cfs = populate_missing_cfs(opt_cfs, path).map_err(typed_store_err_from_rocks_err)?;
+    let mut cf_names = cfs.iter().map(|(name, _)| name.clone()).collect::<Vec<_>>();
+    cf_names.push(rocksdb::DEFAULT_COLUMN_FAMILY_NAME.to_string());
+    cf_names.sort_unstable();
+    cf_names.dedup();
     sui_macros::nondeterministic!({
         let options = prepare_db_options(db_options);
-        rocksdb::OptimisticTransactionDB::open_cf_descriptors(
+        let rocksdb = rocksdb::OptimisticTransactionDB::open_cf_descriptors(
             &options,
             path,
             cfs.into_iter()
                 .map(|(name, opts)| ColumnFamilyDescriptor::new(name, opts)),
         )
-        .map(|db| {
-            Arc::new(RocksDB::OptimisticTransactionDB(
-                OptimisticTransactionDBWrapper::new(db, metric_conf, PathBuf::from(path), options),
-            ))
-        })
-        .map_err(typed_store_err_from_rocks_err)
+        .map_err(typed_store_err_from_rocks_err)?;
+        let rocksdb = Arc::new(RocksDB::OptimisticTransactionDB(
+            OptimisticTransactionDBWrapper::new(rocksdb, metric_conf, PathBuf::from(path), options),
+        ));
+        rocksdb
+            .apply_env_options_to_cfs(cf_names)
+            .map_err(typed_store_err_from_rocks_err)?;
+        Ok(rocksdb)
     })
 }
 

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -805,6 +805,60 @@ fn open_rocksdb<P: AsRef<Path>>(path: P, opt_cfs: &[&str]) -> Arc<RocksDB> {
     open_cf(path, None, MetricConf::default(), opt_cfs).expect("failed to open rocksdb")
 }
 
+struct EnvVarGuard {
+    name: &'static str,
+    previous: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(name: &'static str, value: &str) -> Self {
+        let previous = std::env::var(name).ok();
+        // SAFETY: typed-store RocksDB tests use a process-wide mutex to serialize env mutation.
+        unsafe {
+            std::env::set_var(name, value);
+        }
+        Self { name, previous }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: the guard is held while the same process-wide test mutex is held.
+        unsafe {
+            if let Some(value) = &self.previous {
+                std::env::set_var(self.name, value);
+            } else {
+                std::env::remove_var(self.name);
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn paranoid_file_checks_env_applies_to_opened_and_created_column_families() {
+    let _lock = global_test_lock();
+    let _env = EnvVarGuard::set(ENV_VAR_DB_PARANOID_FILE_CHECKS, "true");
+    let path = temp_dir();
+    let cf_options = rocksdb::Options::default();
+
+    let rocks = open_cf_opts(
+        &path,
+        None,
+        MetricConf::default(),
+        &[("existing_cf", cf_options.clone())],
+    )
+    .expect("failed to open rocksdb with env options");
+
+    rocks
+        .create_cf("created_cf", &cf_options)
+        .expect("failed to create column family with env options");
+
+    assert_eq!(
+        read_bool_from_env(ENV_VAR_DB_PARANOID_FILE_CHECKS),
+        Some(true)
+    );
+}
+
 #[tokio::test]
 async fn test_sampling() {
     let sampling_interval = SamplingInterval::new(Duration::ZERO, 10);


### PR DESCRIPTION
## Description

Add an option for paranoid file checks which lets RocksDB check block checksums after .sst file writes.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
