### PR TITLE
feat: verify fetched slivers against blob metadata during shard sync

### DIFF
--- a/crates/walrus-service/node_config_example.yaml
+++ b/crates/walrus-service/node_config_example.yaml
@@ -165,6 +165,7 @@ shard_sync_config:
   shard_sync_retry_switch_to_recovery_interval_secs: 43200
   restart_shard_sync_always_retry_transfer_first: true
   sst_ingestion_config: null
+  verify_fetched_slivers: true
 event_processor_config:
   pruning_interval_secs: 3600
   checkpoint_request_timeout_secs: 60

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -8029,16 +8029,27 @@ mod tests {
         shard_sync_config: Option<ShardSyncConfig>,
         keep_destination_shards: bool,
     ) -> TestResult<(TestCluster, Vec<EncodedBlob>, Storage, Arc<ShardStorageSet>)> {
-        let assignment = assignment.unwrap_or(&[&[0], &[1, 2, 3]]);
         let blobs: Vec<[u8; 32]> = (1..24).map(|i| [i; 32]).collect();
         let blobs: Vec<_> = blobs.iter().map(|b| &b[..]).collect();
-        let (cluster, _, blob_details) = cluster_with_initial_epoch_and_certified_blobs(
+        setup_cluster_for_shard_sync_tests_with_blobs(
             assignment,
-            &blobs,
-            2,
             shard_sync_config,
+            keep_destination_shards,
+            &blobs,
         )
-        .await?;
+        .await
+    }
+
+    async fn setup_cluster_for_shard_sync_tests_with_blobs(
+        assignment: Option<&[&[u16]]>,
+        shard_sync_config: Option<ShardSyncConfig>,
+        keep_destination_shards: bool,
+        blobs: &[&[u8]],
+    ) -> TestResult<(TestCluster, Vec<EncodedBlob>, Storage, Arc<ShardStorageSet>)> {
+        let assignment = assignment.unwrap_or(&[&[0], &[1, 2, 3]]);
+        let (cluster, _, blob_details) =
+            cluster_with_initial_epoch_and_certified_blobs(assignment, blobs, 2, shard_sync_config)
+                .await?;
 
         // Makes storage inner mutable so that we can manually add another shard to node 1.
         let node_inner = unsafe {
@@ -8481,6 +8492,245 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    // Tests that a fetched sliver that fails verification during shard sync is not stored and
+    // is recovered through shard recovery instead.
+    #[tokio::test]
+    async fn sync_shard_recovers_corrupted_sliver() -> TestResult {
+        let (cluster, blob_details, _) =
+            setup_shard_recovery_test_cluster(|_| true, |_| 42, |_| false).await?;
+
+        // Corrupts the primary sliver of one blob in the source shard by overwriting it with a
+        // sliver from a different blob.
+        let corrupted_blob_id = *blob_details[2].blob_id();
+        let wrong_sliver = Sliver::Primary(
+            blob_details[3]
+                .assigned_sliver_pair(ShardIndex(0))
+                .primary
+                .clone(),
+        );
+        cluster.nodes[0]
+            .storage_node
+            .inner
+            .storage
+            .shard_storage(ShardIndex(0))
+            .await
+            .expect("shard storage should exist")
+            .put_sliver(corrupted_blob_id, wrong_sliver)
+            .await?;
+
+        let node_inner = unsafe {
+            &mut *(Arc::as_ptr(&cluster.nodes[1].storage_node.inner) as *mut StorageNodeInner)
+        };
+        node_inner
+            .storage
+            .create_storage_for_shards_for_testing(&[ShardIndex(0)])
+            .await?;
+        let shard_storage_dst = node_inner
+            .storage
+            .shard_storage(ShardIndex(0))
+            .await
+            .expect("shard storage should exist");
+        shard_storage_dst
+            .update_status_in_test(ShardStatus::None)
+            .await?;
+
+        cluster.nodes[1]
+            .storage_node
+            .shard_sync_handler
+            .start_sync_shards(vec![ShardIndex(0)])
+            .await?;
+        wait_for_shard_in_active_state(shard_storage_dst.as_ref()).await?;
+
+        // All blobs, including the corrupted one, must contain the original slivers in the
+        // destination shard, since the corrupted sliver must have been recovered from the
+        // committee instead of being stored as fetched.
+        check_all_blobs_are_synced(
+            &blob_details,
+            &node_inner.storage,
+            shard_storage_dst.as_ref(),
+            &[],
+        )?;
+
+        Ok(())
+    }
+
+    // Tests that fetched slivers are stored without verification when sliver verification is
+    // disabled in the shard sync config.
+    #[tokio::test]
+    async fn sync_shard_stores_corrupted_sliver_when_verification_disabled() -> TestResult {
+        let shard_sync_config = ShardSyncConfig {
+            verify_fetched_slivers: false,
+            ..Default::default()
+        };
+        let (cluster, blob_details, _storage_dst, shard_storage_set) =
+            setup_cluster_for_shard_sync_tests(None, Some(shard_sync_config), false).await?;
+        let shard_storage_dst = shard_storage_set.shard_storage[0].clone();
+
+        // Corrupts the primary sliver of one blob in the source shard by overwriting it with a
+        // sliver from a different blob.
+        let corrupted_blob_id = *blob_details[2].blob_id();
+        let wrong_sliver_data = blob_details[3]
+            .assigned_sliver_pair(ShardIndex(0))
+            .primary
+            .clone();
+        cluster.nodes[0]
+            .storage_node
+            .inner
+            .storage
+            .shard_storage(ShardIndex(0))
+            .await
+            .expect("shard storage should exist")
+            .put_sliver(
+                corrupted_blob_id,
+                Sliver::Primary(wrong_sliver_data.clone()),
+            )
+            .await?;
+
+        cluster.nodes[1]
+            .storage_node
+            .shard_sync_handler
+            .start_sync_shards(vec![ShardIndex(0)])
+            .await?;
+        wait_for_shard_in_active_state(shard_storage_dst.as_ref()).await?;
+
+        // With verification disabled, all slivers are transferred, and the corrupted sliver is
+        // stored as fetched.
+        assert_eq!(shard_storage_dst.sliver_count(SliverType::Primary), Ok(23));
+        assert_eq!(
+            shard_storage_dst.sliver_count(SliverType::Secondary),
+            Ok(23)
+        );
+        let Sliver::Primary(dst_primary) = shard_storage_dst
+            .get_sliver(&corrupted_blob_id, SliverType::Primary)?
+            .expect("sliver should be present")
+        else {
+            panic!("must get primary sliver");
+        };
+        assert_eq!(dst_primary, wrong_sliver_data);
+
+        Ok(())
+    }
+
+    /// Sets up a shard sync destination for the given blobs and measures the time it takes to
+    /// sync shard 0 to the destination node.
+    async fn measure_shard_sync_duration(
+        assignment: Option<&[&[u16]]>,
+        blobs: &[&[u8]],
+        verify_fetched_slivers: bool,
+    ) -> TestResult<Duration> {
+        let shard_sync_config = ShardSyncConfig {
+            verify_fetched_slivers,
+            ..Default::default()
+        };
+        let (cluster, blob_details, _storage_dst, shard_storage_set) =
+            setup_cluster_for_shard_sync_tests_with_blobs(
+                assignment,
+                Some(shard_sync_config),
+                false,
+                blobs,
+            )
+            .await?;
+        let shard_storage_dst = shard_storage_set.shard_storage[0].clone();
+
+        let start = std::time::Instant::now();
+        cluster.nodes[1]
+            .storage_node
+            .shard_sync_handler
+            .start_sync_shards(vec![ShardIndex(0)])
+            .await?;
+
+        // Waits for the shard to finish syncing, with a longer timeout than the functional
+        // tests to accommodate the larger data volume.
+        tokio::time::timeout(Duration::from_secs(300), async {
+            loop {
+                let status = shard_storage_dst
+                    .status()
+                    .await
+                    .expect("shard status should be readable");
+                if status == ShardStatus::Active {
+                    break;
+                }
+                // Polls with a fine granularity so that the poll interval does not dominate
+                // the measured sync duration.
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+        })
+        .await?;
+        let elapsed = start.elapsed();
+
+        assert_eq!(
+            shard_storage_dst.sliver_count(SliverType::Primary),
+            Ok(blob_details.len())
+        );
+        assert_eq!(
+            shard_storage_dst.sliver_count(SliverType::Secondary),
+            Ok(blob_details.len())
+        );
+
+        Ok(elapsed)
+    }
+
+    /// Measures shard sync duration for the given workload with and without fetched-sliver
+    /// verification, and prints the comparison. The run with verification disabled corresponds
+    /// to the behavior before sliver verification was introduced (WAL-523).
+    async fn compare_shard_sync_performance(
+        assignment: Option<&[&[u16]]>,
+        blob_count: usize,
+        blob_size: usize,
+    ) -> TestResult {
+        let mut rng = StdRng::seed_from_u64(42);
+        let blob_data: Vec<Vec<u8>> = (0..blob_count)
+            .map(|_| {
+                let mut blob = vec![0u8; blob_size];
+                rng.fill(&mut blob[..]);
+                blob
+            })
+            .collect();
+        let blobs: Vec<&[u8]> = blob_data.iter().map(|blob| blob.as_slice()).collect();
+
+        let duration_without_verification =
+            measure_shard_sync_duration(assignment, &blobs, false).await?;
+        let duration_with_verification =
+            measure_shard_sync_duration(assignment, &blobs, true).await?;
+
+        println!("shard sync of {blob_count} blobs of {blob_size} bytes each:");
+        println!(
+            "- without sliver verification (previous behavior): \
+            {duration_without_verification:?}"
+        );
+        println!("- with sliver verification: {duration_with_verification:?}");
+
+        Ok(())
+    }
+
+    // Measures shard sync performance with and without fetched-sliver verification for many
+    // small blobs.
+    //
+    // Run manually with:
+    // cargo nextest run -r -p walrus-service sync_shard_verification_performance \
+    //     --run-ignored ignored-only --no-capture
+    #[ignore = "performance measurement; run manually"]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn sync_shard_verification_performance() -> TestResult {
+        compare_shard_sync_performance(None, 200, 256 * 1024).await
+    }
+
+    // Measures shard sync performance with and without fetched-sliver verification for large
+    // blobs.
+    //
+    // Run manually with:
+    // cargo nextest run -r -p walrus-service sync_shard_verification_performance_large_blobs \
+    //     --run-ignored ignored-only --no-capture
+    #[ignore = "performance measurement; run manually"]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn sync_shard_verification_performance_large_blobs() -> TestResult {
+        // The maximum blob size scales with the number of shards; 30 shards support blobs of
+        // up to roughly 16 MiB.
+        let node_1_shards: Vec<u16> = (1..30).collect();
+        let assignment: &[&[u16]] = &[&[0], &node_1_shards];
+        compare_shard_sync_performance(Some(assignment), 20, 10 * 1024 * 1024).await
     }
 
     // TODO(WAL-872): move failure injection test to src/tests/. Currently there is no way to run

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -8494,22 +8494,18 @@ mod tests {
         Ok(())
     }
 
-    // Tests that a fetched sliver that fails verification during shard sync is not stored and
-    // is recovered through shard recovery instead.
-    #[tokio::test]
-    async fn sync_shard_recovers_corrupted_sliver() -> TestResult {
+    /// Overwrites the sliver of one blob in the source shard with the sliver produced by
+    /// `make_bad_sliver`, syncs the shard to the destination node, and asserts that the
+    /// destination ends up with the original slivers for all blobs, since the bad sliver must
+    /// fail verification and be recovered from the committee instead of being stored as fetched.
+    async fn assert_sync_shard_recovers_bad_source_sliver(
+        make_bad_sliver: impl FnOnce(&[EncodedBlob]) -> Sliver,
+    ) -> TestResult {
         let (cluster, blob_details, _) =
             setup_shard_recovery_test_cluster(|_| true, |_| 42, |_| false).await?;
 
-        // Corrupts the primary sliver of one blob in the source shard by overwriting it with a
-        // sliver from a different blob.
-        let corrupted_blob_id = *blob_details[2].blob_id();
-        let wrong_sliver = Sliver::Primary(
-            blob_details[3]
-                .assigned_sliver_pair(ShardIndex(0))
-                .primary
-                .clone(),
-        );
+        let bad_blob_id = *blob_details[2].blob_id();
+        let bad_sliver = make_bad_sliver(&blob_details);
         cluster.nodes[0]
             .storage_node
             .inner
@@ -8517,7 +8513,7 @@ mod tests {
             .shard_storage(ShardIndex(0))
             .await
             .expect("shard storage should exist")
-            .put_sliver(corrupted_blob_id, wrong_sliver)
+            .put_sliver(bad_blob_id, bad_sliver)
             .await?;
 
         let node_inner = unsafe {
@@ -8543,9 +8539,8 @@ mod tests {
             .await?;
         wait_for_shard_in_active_state(shard_storage_dst.as_ref()).await?;
 
-        // All blobs, including the corrupted one, must contain the original slivers in the
-        // destination shard, since the corrupted sliver must have been recovered from the
-        // committee instead of being stored as fetched.
+        // All blobs, including the one with the bad source sliver, must contain the original
+        // slivers in the destination shard.
         check_all_blobs_are_synced(
             &blob_details,
             &node_inner.storage,
@@ -8554,6 +8549,40 @@ mod tests {
         )?;
 
         Ok(())
+    }
+
+    // Tests that a fetched sliver that fails verification during shard sync is not stored and
+    // is recovered through shard recovery instead.
+    #[tokio::test]
+    async fn sync_shard_recovers_corrupted_sliver() -> TestResult {
+        // A sliver from a different blob fails the metadata hash verification.
+        assert_sync_shard_recovers_bad_source_sliver(|blob_details| {
+            Sliver::Primary(
+                blob_details[3]
+                    .assigned_sliver_pair(ShardIndex(0))
+                    .primary
+                    .clone(),
+            )
+        })
+        .await
+    }
+
+    // Tests that a fetched sliver that belongs to the same blob but to a different sliver pair
+    // is not stored and is recovered through shard recovery instead.
+    #[tokio::test]
+    async fn sync_shard_recovers_sliver_with_wrong_pair_index() -> TestResult {
+        // A valid sliver of the same blob assigned to a different shard passes the metadata
+        // hash verification (which authenticates the sliver against its own pair index), and
+        // is only caught by the sliver pair index check.
+        assert_sync_shard_recovers_bad_source_sliver(|blob_details| {
+            Sliver::Primary(
+                blob_details[2]
+                    .assigned_sliver_pair(ShardIndex(1))
+                    .primary
+                    .clone(),
+            )
+        })
+        .await
     }
 
     // Tests that fetched slivers are stored without verification when sliver verification is

--- a/crates/walrus-service/src/node/config.rs
+++ b/crates/walrus-service/src/node/config.rs
@@ -1211,6 +1211,11 @@ pub struct ShardSyncConfig {
     /// Configuration for using SST ingestion during shard sync. None disables this feature.
     #[serde(default, skip_serializing_if = "defaults::is_none")]
     pub sst_ingestion_config: Option<SstIngestionConfig>,
+    /// Whether to verify slivers fetched during shard sync against the blob metadata before
+    /// storing them. If the metadata is missing locally, it is fetched from the committee.
+    /// Slivers that fail verification are not stored and are recovered from the committee
+    /// instead.
+    pub verify_fetched_slivers: bool,
 }
 
 impl Default for ShardSyncConfig {
@@ -1227,6 +1232,7 @@ impl Default for ShardSyncConfig {
             shard_sync_retry_switch_to_recovery_interval: Duration::from_hours(12),
             restart_shard_sync_always_retry_transfer_first: true,
             sst_ingestion_config: None,
+            verify_fetched_slivers: true,
         }
     }
 }

--- a/crates/walrus-service/src/node/metrics.rs
+++ b/crates/walrus-service/src/node/metrics.rs
@@ -91,6 +91,9 @@ walrus_utils::metrics::define_metric_set! {
         #[help = "Total number of slivers skipped during shard sync"]
         sync_shard_recover_sliver_skip_total: IntCounterVec["shard", "sliver_type", "reason"],
 
+        #[help = "Total number of fetched slivers that failed verification during shard sync"]
+        sync_shard_sliver_verification_error_total: IntCounterVec["shard", "sliver_type"],
+
         #[help = "The total number of slivers stored"]
         slivers_stored_total: IntCounterVec["sliver_type"],
 

--- a/crates/walrus-service/src/node/storage/shard.rs
+++ b/crates/walrus-service/src/node/storage/shard.rs
@@ -1405,10 +1405,23 @@ impl ShardStorage {
         let mut verification_futures = Vec::with_capacity(fetched_slivers.len());
         for (blob_id, sliver) in fetched_slivers {
             verification_futures.push(async move {
-                (
-                    *blob_id,
-                    self.verify_fetched_sliver(node, blob_id, sliver).await,
-                )
+                // Check that the sliver has the type requested by the sync. The verification in
+                // `verify_fetched_sliver` authenticates the sliver against its own embedded
+                // type, so without this check a corrupt source could return a valid sliver of
+                // the other type.
+                let outcome = if sliver.r#type() == sliver_type {
+                    self.verify_fetched_sliver(node, blob_id, sliver).await
+                } else {
+                    tracing::warn!(
+                        walrus.blob_id = %blob_id,
+                        walrus.shard_index = %self.id,
+                        expected_sliver_type = %sliver_type,
+                        actual_sliver_type = %sliver.r#type(),
+                        "fetched sliver has a different type than the requested sliver type"
+                    );
+                    Ok(SliverVerificationOutcome::Invalid)
+                };
+                (*blob_id, outcome)
             });
         }
         let mut verifications = futures::stream::iter(verification_futures)

--- a/crates/walrus-service/src/node/storage/shard.rs
+++ b/crates/walrus-service/src/node/storage/shard.rs
@@ -45,7 +45,7 @@ use walrus_utils::{metrics::Registry, tracing_sampled};
 
 use super::{
     DatabaseTableOptionsFactory,
-    blob_info::{BlobInfo, BlobInfoIterator},
+    blob_info::{BlobInfo, BlobInfoIterator, CertifiedBlobInfoApi},
     constants,
     metrics::{CommonDatabaseMetrics, Labels, OperationType},
 };
@@ -1080,7 +1080,7 @@ impl ShardStorage {
                     .await?;
 
                 let verification_results = if config.verify_fetched_slivers {
-                    self.verify_fetched_slivers(&node, &fetched_slivers, sliver_type, epoch, config)
+                    self.verify_fetched_slivers(&node, &fetched_slivers, sliver_type, config)
                         .await?
                 } else {
                     FetchedSliverVerificationResults::default()
@@ -1399,7 +1399,6 @@ impl ShardStorage {
         node: &Arc<StorageNodeInner>,
         fetched_slivers: &[(BlobId, Sliver)],
         sliver_type: SliverType,
-        epoch: Epoch,
         config: &ShardSyncConfig,
     ) -> Result<FetchedSliverVerificationResults, SyncShardClientError> {
         let mut results = FetchedSliverVerificationResults::default();
@@ -1408,8 +1407,7 @@ impl ShardStorage {
             verification_futures.push(async move {
                 (
                     *blob_id,
-                    self.verify_fetched_sliver(node, blob_id, sliver, epoch)
-                        .await,
+                    self.verify_fetched_sliver(node, blob_id, sliver).await,
                 )
             });
         }
@@ -1446,15 +1444,26 @@ impl ShardStorage {
         node: &Arc<StorageNodeInner>,
         blob_id: &BlobId,
         sliver: &Sliver,
-        epoch: Epoch,
     ) -> Result<SliverVerificationOutcome, SyncShardClientError> {
+        // Use the blob's initial certified epoch to fetch missing metadata: during a committee
+        // transition, `read_committee` routes reads for blobs certified before the current epoch
+        // to the previous committee, which is the one guaranteed to hold the data while the new
+        // committee is still syncing.
+        let Some(certified_epoch) = node
+            .storage
+            .get_blob_info(blob_id)?
+            .and_then(|blob_info| blob_info.initial_certified_epoch())
+        else {
+            return Ok(SliverVerificationOutcome::BlobRetired);
+        };
+
         // Fetching missing metadata is guarded by the blob retirement check, so that we neither
         // fetch metadata for blobs that are not certified nor keep fetching metadata for blobs
         // that are retired while the fetch is in progress.
         let result = node
             .blob_retirement_notifier
             .execute_with_retirement_check(node, *blob_id, || {
-                node.get_or_recover_blob_metadata(blob_id, epoch)
+                node.get_or_recover_blob_metadata(blob_id, certified_epoch)
             })
             .await?;
         let metadata = match result {
@@ -1729,6 +1738,10 @@ impl ShardStorage {
         sui_macros::fail_point!("fail_point_shard_sync_recover_blob");
 
         // Get the metadata for the blob. If metadata is not found, it will be recovered.
+        // TODO(zhewu): pass the blob's initial certified epoch instead of the sync target epoch
+        // to `get_or_recover_blob_metadata` and `recover_sliver` below, so that missing metadata
+        // and slivers are fetched from the correct committee during a committee transition; see
+        // `verify_fetched_sliver`. To be fixed in a follow-up PR.
         let metadata = {
             let result = node
                 .blob_retirement_notifier

--- a/crates/walrus-service/src/node/storage/shard.rs
+++ b/crates/walrus-service/src/node/storage/shard.rs
@@ -1254,6 +1254,9 @@ impl ShardStorage {
     ///
     /// Returns the updated iterator position together with the ids whose recovery deferrals can be
     /// cleared.
+    ///
+    /// TODO(zhewu): clean up this function to make it more readable, for example, by extracting
+    /// the per-sliver skip/store decision and the SST/plain-batch insertion paths into helpers.
     #[allow(clippy::too_many_arguments)]
     fn batch_fetched_slivers_and_check_missing_blobs(
         &self,

--- a/crates/walrus-service/src/node/storage/shard.rs
+++ b/crates/walrus-service/src/node/storage/shard.rs
@@ -1445,6 +1445,28 @@ impl ShardStorage {
         blob_id: &BlobId,
         sliver: &Sliver,
     ) -> Result<SliverVerificationOutcome, SyncShardClientError> {
+        // Check that the sliver is the one this shard must hold for the blob. The metadata
+        // verification below authenticates the sliver against its own pair index, so without
+        // this check a corrupt source could return a valid sliver of the same blob for a
+        // different sliver pair. This mirrors the `SliverIndexMismatch` check in the upload
+        // path, and runs first since it is much cheaper than the metadata verification.
+        let n_shards = node.encoding_config.n_shards();
+        let expected_pair_index = self.id.to_pair_index(n_shards, blob_id);
+        let actual_pair_index = match sliver.r#type() {
+            SliverType::Primary => sliver.sliver_index().to_pair_index::<Primary>(n_shards),
+            SliverType::Secondary => sliver.sliver_index().to_pair_index::<Secondary>(n_shards),
+        };
+        if actual_pair_index != expected_pair_index {
+            tracing::warn!(
+                walrus.blob_id = %blob_id,
+                walrus.shard_index = %self.id,
+                %expected_pair_index,
+                %actual_pair_index,
+                "fetched sliver has a pair index that does not belong to this shard"
+            );
+            return Ok(SliverVerificationOutcome::Invalid);
+        }
+
         // Use the blob's initial certified epoch to fetch missing metadata: during a committee
         // transition, `read_committee` routes reads for blobs certified before the current epoch
         // to the previous committee, which is the one guaranteed to hold the data while the new

--- a/crates/walrus-service/src/node/storage/shard.rs
+++ b/crates/walrus-service/src/node/storage/shard.rs
@@ -54,7 +54,7 @@ use crate::{
         StorageNodeInner,
         blob_retirement_notifier::ExecutionResultWithRetirementCheck,
         config::ShardSyncConfig,
-        errors::SyncShardClientError,
+        errors::{StoreSliverError, SyncShardClientError},
         shard_sync,
     },
     utils,
@@ -65,6 +65,27 @@ type ShardMetrics = CommonDatabaseMetrics;
 // Type aliases to simplify complex return types flagged by clippy::type_complexity.
 type NextBlobInfo = Option<(BlobId, BlobInfo)>;
 type BatchFetchedSliversOutcome = Result<NextBlobInfo, SyncShardClientError>;
+
+/// The result of verifying a single sliver fetched during shard sync.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SliverVerificationOutcome {
+    /// The sliver is consistent with the verified blob metadata.
+    Valid,
+    /// The sliver failed verification against the verified blob metadata.
+    Invalid,
+    /// The blob is not (or no longer) certified; the sliver does not need to be stored.
+    BlobRetired,
+}
+
+/// The blobs in a sync-shard response whose fetched slivers must not be stored.
+#[derive(Debug, Default)]
+struct FetchedSliverVerificationResults {
+    /// Blobs whose fetched slivers failed verification against the blob metadata. The slivers
+    /// are not stored, and the blobs are scheduled for recovery instead.
+    invalid_blob_ids: HashSet<BlobId>,
+    /// Blobs that are not (or no longer) certified. Their slivers are not stored.
+    retired_blob_ids: HashSet<BlobId>,
+}
 
 /// A cache of the family names created for an instance of a shard, to avoid recomputing them for
 /// metrics.
@@ -1058,10 +1079,18 @@ impl ShardStorage {
                     )
                     .await?;
 
+                let verification_results = if config.verify_fetched_slivers {
+                    self.verify_fetched_slivers(&node, &fetched_slivers, sliver_type, epoch, config)
+                        .await?
+                } else {
+                    FetchedSliverVerificationResults::default()
+                };
+
                 next_blob_info = self.batch_fetched_slivers_and_check_missing_blobs(
                     epoch,
                     &node,
                     &fetched_slivers,
+                    &verification_results,
                     sliver_type,
                     next_blob_info,
                     &mut blob_info_iter,
@@ -1231,6 +1260,7 @@ impl ShardStorage {
         epoch: Epoch,
         _node: &Arc<StorageNodeInner>,
         fetched_slivers: &[(BlobId, Sliver)],
+        verification_results: &FetchedSliverVerificationResults,
         sliver_type: SliverType,
         mut next_blob_info: NextBlobInfo,
         blob_info_iter: &mut BlobInfoIterator,
@@ -1246,11 +1276,40 @@ impl ShardStorage {
                 %sliver_type,
                 "synced blob",
             );
-            //TODO(WAL-523): verify sliver validity.
-            //  - blob is certified
-            //  - fetch metadata if missing (note that certified event may be processed after epoch
-            //    change, so we need to fetch metadata if missing)
-            //  - metadata is correct
+
+            if verification_results.retired_blob_ids.contains(blob_id) {
+                tracing::debug!(
+                    walrus.blob_id = %blob_id,
+                    "skip storing fetched sliver for a blob that is not certified"
+                );
+                next_blob_info = self.check_and_record_missing_blobs(
+                    blob_info_iter,
+                    next_blob_info,
+                    *blob_id,
+                    sliver_type,
+                    batch,
+                )?;
+                continue;
+            }
+
+            if verification_results.invalid_blob_ids.contains(blob_id) {
+                tracing::warn!(
+                    walrus.blob_id = %blob_id,
+                    "fetched sliver failed verification; scheduling the blob for recovery"
+                );
+                batch.insert_batch(
+                    &self.pending_recover_slivers,
+                    [((sliver_type, *blob_id), ())],
+                )?;
+                next_blob_info = self.check_and_record_missing_blobs(
+                    blob_info_iter,
+                    next_blob_info,
+                    *blob_id,
+                    sliver_type,
+                    batch,
+                )?;
+                continue;
+            }
 
             if use_sst {
                 let max_entries = config
@@ -1325,6 +1384,99 @@ impl ShardStorage {
             cleared_blob_ids.push(*blob_id);
         }
         Ok(next_blob_info)
+    }
+
+    /// Verifies the slivers fetched in a single sync-shard response against the corresponding
+    /// blob metadata, fetching the metadata from the committee if it is missing locally.
+    ///
+    /// Returns the blobs whose fetched slivers must not be stored, either because the sliver
+    /// failed verification or because the blob is not (or no longer) certified.
+    async fn verify_fetched_slivers(
+        &self,
+        node: &Arc<StorageNodeInner>,
+        fetched_slivers: &[(BlobId, Sliver)],
+        sliver_type: SliverType,
+        epoch: Epoch,
+        config: &ShardSyncConfig,
+    ) -> Result<FetchedSliverVerificationResults, SyncShardClientError> {
+        let mut results = FetchedSliverVerificationResults::default();
+        let mut verification_futures = Vec::with_capacity(fetched_slivers.len());
+        for (blob_id, sliver) in fetched_slivers {
+            verification_futures.push(async move {
+                (
+                    *blob_id,
+                    self.verify_fetched_sliver(node, blob_id, sliver, epoch)
+                        .await,
+                )
+            });
+        }
+        let mut verifications = futures::stream::iter(verification_futures)
+            .buffer_unordered(config.max_concurrent_metadata_fetch);
+
+        while let Some((blob_id, outcome)) = verifications.next().await {
+            match outcome? {
+                SliverVerificationOutcome::Valid => (),
+                SliverVerificationOutcome::Invalid => {
+                    walrus_utils::with_label!(
+                        node.metrics.sync_shard_sliver_verification_error_total,
+                        &self.id.to_string(),
+                        &sliver_type.to_string()
+                    )
+                    .inc();
+                    results.invalid_blob_ids.insert(blob_id);
+                }
+                SliverVerificationOutcome::BlobRetired => {
+                    results.retired_blob_ids.insert(blob_id);
+                }
+            }
+        }
+
+        Ok(results)
+    }
+
+    /// Verifies a single fetched sliver against the (possibly newly fetched) blob metadata.
+    ///
+    /// The verification itself runs on the node's thread pool to avoid blocking the tokio
+    /// runtime with the CPU-intensive sliver verification.
+    async fn verify_fetched_sliver(
+        &self,
+        node: &Arc<StorageNodeInner>,
+        blob_id: &BlobId,
+        sliver: &Sliver,
+        epoch: Epoch,
+    ) -> Result<SliverVerificationOutcome, SyncShardClientError> {
+        // Fetching missing metadata is guarded by the blob retirement check, so that we neither
+        // fetch metadata for blobs that are not certified nor keep fetching metadata for blobs
+        // that are retired while the fetch is in progress.
+        let result = node
+            .blob_retirement_notifier
+            .execute_with_retirement_check(node, *blob_id, || {
+                node.get_or_recover_blob_metadata(blob_id, epoch)
+            })
+            .await?;
+        let metadata = match result {
+            ExecutionResultWithRetirementCheck::Executed(metadata) => metadata?,
+            ExecutionResultWithRetirementCheck::BlobRetired => {
+                return Ok(SliverVerificationOutcome::BlobRetired);
+            }
+        };
+
+        match node
+            .verify_sliver_against_metadata(Arc::new(metadata), sliver.clone())
+            .await
+        {
+            Ok(_) => Ok(SliverVerificationOutcome::Valid),
+            Err(StoreSliverError::InvalidSliver(error)) => {
+                tracing::warn!(
+                    walrus.blob_id = %blob_id,
+                    walrus.shard_index = %self.id,
+                    %error,
+                    "fetched sliver failed verification during shard sync"
+                );
+                Ok(SliverVerificationOutcome::Invalid)
+            }
+            Err(error) => Err(anyhow::anyhow!(error).into()),
+        }
     }
 
     /// Given a iterator over blob info table that is currently pointing to `next_blob_info`,


### PR DESCRIPTION
## Description

Address TODO(WAL-523): slivers fetched during shard sync are now verified before being stored.

For each sliver returned by a `sync_shard_before_epoch` request, the destination node now:

1. **Checks that the blob is certified** through the blob retirement check; slivers of non-certified blobs are skipped instead of stored blindly.
2. **Fetches the blob metadata from the committee if it is missing locally** (the certified event may be processed after epoch change, so metadata may not be stored yet).
3. **Verifies the sliver against the verified metadata**, reusing `verify_sliver_against_metadata`, which runs `SliverData::verify` on the node's blocking thread pool so the CPU-heavy work does not occupy the tokio runtime. Verification runs with up to `max_concurrent_metadata_fetch` (default 100) slivers in flight, overlapping with the fetch.

Slivers that fail verification are **not stored**; the blob is added to `pending_recover_slivers` in the same DB batch, so the existing shard recovery path reconstructs the correct sliver from the committee. Sync progress still advances past the bad sliver, so a corrupt or malicious source cannot stall shard sync in a retry loop.

The verification is gated by the new `ShardSyncConfig::verify_fetched_slivers` config (default **enabled**, backward compatible for existing config files) and surfaced through the new `sync_shard_sliver_verification_error_total{shard, sliver_type}` metric plus a warn log per rejected sliver.

Resolve WAL-523

## Performance

Two `#[ignore]`d benchmark tests compare shard sync duration with verification disabled (the previous behavior) and enabled, on an in-process test cluster (release build, Apple Silicon):

| Workload | Shards | Slivers verified | Without verification | With verification | Overhead |
|---|---|---|---|---|---|
| 200 blobs x 256 KiB (50 MB) | 4 | 400 | 178 ms | 258 ms | +80 ms (+45%) |
| 20 blobs x 10 MiB (200 MB) | 30 | 40 | 165 ms | 195 ms | +30 ms (+18%) |

Observations:

- The per-sliver cost has two parts: a **fixed overhead** (metadata lookup, sliver clone, thread-pool round trip) and a **size-dependent term** — `SliverData::verify` Reed-Solomon-expands the sliver to all `n_shards` recovery symbols and recomputes the Blake2b256 Merkle root over them, so its CPU cost scales with sliver size. The fixed part dominates for small slivers (~0.2 ms per sliver in the 256 KiB workload); the size-dependent part becomes the main term for large slivers (~0.75 ms per sliver in the 10 MiB workload).
- The measured per-sliver wall-clock deltas understate the size-dependent CPU cost because verification runs up to 100 slivers concurrently on the multi-core thread pool and overlaps with fetching and storing.
- Per byte synced, verifying large blobs is still roughly 10x cheaper than small ones, because the fixed per-sliver costs amortize over more data.
- The relative overhead is a worst case: the test cluster runs all nodes in one process, so the fetch itself is nearly free. In production, network transfer of a sync batch dwarfs the verification cost, and verification overlaps with fetching.

Reproduce with:

```
cargo nextest run -r -p walrus-service sync_shard_verification_performance --run-ignored ignored-only --no-capture
```

## Test plan

- New test `sync_shard_recovers_corrupted_sliver`: corrupts a sliver in the source shard and asserts that the destination ends up with the original sliver through recovery (fails without this change).
- New test `sync_shard_stores_corrupted_sliver_when_verification_disabled`: asserts the config gate restores the previous behavior.
- All existing shard sync tests and simtests pass (`cargo nextest run -p walrus-service -E 'test(sync_shard)'`, `cargo simtest sync_shard`); the msim shard sync tests now exercise verification by default.
