### PR TITLE
docs: add Kapa AI sidebar mode with content shift

### DIFF
--- a/docs/site/docusaurus.config.js
+++ b/docs/site/docusaurus.config.js
@@ -93,6 +93,7 @@ const config = {
 
   clientModules: [
     "./src/client/webmcp.js",
+    "./src/client/kapa-sidebar.js",
   ],
 
   onBrokenLinks: "throw",
@@ -297,6 +298,9 @@ const config = {
       "data-project-name": "Walrus Knowledge",
       "data-project-color": "#37c3b0ff",
       "data-button-hide": "true",
+      "data-view-mode": "sidebar",
+      "data-modal-overlay-hidden": "true",
+      "data-modal-lock-scroll": "false",
       "data-modal-title": "Ask Walrus AI",
       "data-modal-ask-ai-input-placeholder": "Ask me anything about Walrus!",
       "data-modal-example-questions":

--- a/docs/site/src/client/kapa-sidebar.js
+++ b/docs/site/src/client/kapa-sidebar.js
@@ -1,0 +1,85 @@
+// Copyright (c) Walrus Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// Detects Kapa sidebar open/close and toggles .kapa-sidebar-open on <html>.
+// Kapa renders in Shadow DOM so we can't query its internals.
+// Strategy: hook Kapa.open for instant open detection, then use
+// elementFromPoint to detect close (checks if right edge of screen
+// is covered by a non-docusaurus element).
+
+if (typeof window !== "undefined") {
+  const OPEN_CLASS = "kapa-sidebar-open";
+  let kapaOpen = false;
+  let hookedRef = null;
+
+  function syncClass() {
+    document.documentElement.classList.toggle(OPEN_CLASS, kapaOpen);
+  }
+
+  function hookKapa() {
+    if (!window.Kapa || !window.Kapa.open || window.Kapa.open === hookedRef)
+      return;
+
+    const origOpen = window.Kapa.open;
+    const origClose = window.Kapa.close;
+
+    window.Kapa.open = function (...args) {
+      kapaOpen = true;
+      syncClass();
+      return origOpen.apply(this, args);
+    };
+
+    window.Kapa.close = function (...args) {
+      kapaOpen = false;
+      syncClass();
+      return origClose.apply(this, args);
+    };
+
+    hookedRef = window.Kapa.open;
+  }
+
+  // Check if Kapa sidebar is covering the right side of the viewport.
+  // Since Kapa uses Shadow DOM, we can't query its elements directly.
+  // Instead, check if the element at the right edge of the screen
+  // belongs to the doc app or to something else (Kapa's panel).
+  function isSidebarVisible() {
+    const x = window.innerWidth - 50;
+    const y = window.innerHeight / 2;
+    const el = document.elementFromPoint(x, y);
+    if (!el) return false;
+    const docRoot = document.getElementById("__docusaurus");
+    if (docRoot && docRoot.contains(el)) return false;
+    if (el === document.body || el === document.documentElement) return false;
+    return true;
+  }
+
+  // Hook into History API so the class persists across SPA navigation.
+  // Docusaurus uses pushState for client-side routing.
+  const origPush = history.pushState.bind(history);
+  const origReplace = history.replaceState.bind(history);
+  history.pushState = function (...args) {
+    const r = origPush(...args);
+    syncClass();
+    return r;
+  };
+  history.replaceState = function (...args) {
+    const r = origReplace(...args);
+    syncClass();
+    return r;
+  };
+  window.addEventListener("popstate", syncClass);
+
+  // Poll every 300ms: re-hook Kapa if it reinitializes, and
+  // detect open/close state via elementFromPoint fallback.
+  setInterval(() => {
+    hookKapa();
+
+    const visible = isSidebarVisible();
+    if (visible && !kapaOpen) {
+      kapaOpen = true;
+    } else if (!visible && kapaOpen) {
+      kapaOpen = false;
+    }
+    syncClass();
+  }, 300);
+}

--- a/docs/site/src/css/custom.css
+++ b/docs/site/src/css/custom.css
@@ -1429,6 +1429,66 @@ padding-right: 0.3rem !important;
   transition: none !important;
 }
 
+/* ══════════════════════════════════════════════
+  Kapa sidebar content shift
+  ══════════════════════════════════════════════ */
+/* Kapa renders in Shadow DOM so CSS :has() can't detect it.
+  A client module (kapa-sidebar.js) toggles .kapa-sidebar-open on <html>. */
+
+/* Smooth transition when closing */
+body {
+  transition: width 0.3s ease;
+}
+
+.navbar,
+.navbar--fixed-top {
+  transition: right 0.3s ease;
+}
+
+/* Shrink body to make room for the 500px sidebar (skip landing page) */
+html.kapa-sidebar-open body:not(:has(.landing-root)) {
+  width: calc(100vw - 500px) !important;
+  overflow-x: hidden;
+  transition: width 0.3s ease;
+}
+
+/* Shrink the fixed navbar to match (it uses position:fixed so body width
+  doesn't affect it — set right offset instead; skip when landing page is shown) */
+html.kapa-sidebar-open body:not(:has(.landing-root)) .navbar,
+html.kapa-sidebar-open body:not(:has(.landing-root)) .navbar--fixed-top {
+  right: 500px !important;
+  overflow: hidden;
+  transition: right 0.3s ease;
+}
+
+/* Hide the Ask AI and Search buttons when the sidebar is already open */
+html.kapa-sidebar-open .kapa-trigger-btn,
+html.kapa-sidebar-open .DocSearch-Button {
+  display: none !important;
+}
+
+/* Hide the desktop TOC column to free space */
+html.kapa-sidebar-open .col.col--3:has(.theme-doc-toc-desktop) {
+  display: none;
+}
+
+/* Let the main content column expand to fill the freed space */
+html.kapa-sidebar-open .col[class*="docItemCol"] {
+  max-width: 100% !important;
+  flex: 1 !important;
+}
+
+/* On mobile, Kapa goes full-screen so don't shrink */
+@media (max-width: 768px) {
+  html.kapa-sidebar-open body {
+    width: 100vw !important;
+  }
+  html.kapa-sidebar-open .navbar,
+  html.kapa-sidebar-open .navbar--fixed-top {
+    right: 0 !important;
+  }
+}
+
 /* Mermaid diagrams - Walrus palette, per-mode contrast.
   Node fill/text come from the Mermaid themeVariables (Purple #613DFF + Tusk
   #FAF8F5). Edges, arrowheads, and subgraph backgrounds must contrast with the


### PR DESCRIPTION
## Summary
- Switch the Kapa AI widget from modal to sidebar view mode
- Add a client module (`kapa-sidebar.js`) that detects sidebar open/close state via `Kapa.open`/`Kapa.close` hooks and `elementFromPoint` fallback (Kapa renders in Shadow DOM)
- CSS shifts the page content and navbar when the sidebar is open, hides redundant Ask AI / Search buttons, and collapses the TOC column to free space
- Mobile stays full-screen (no content shift)

## Test plan
- [ ] Click "Ask Walrus AI" button — sidebar should open on the right
- [ ] Page content and navbar should shrink to make room
- [ ] Close the sidebar — content should smoothly return to full width
- [ ] On mobile, sidebar should go full-screen without content shift
- [ ] Navigate between pages while sidebar is open — should persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)