### PR TITLE
Enable Docusaurus blog build to fix missing routes

### DIFF
--- a/docs/site/docusaurus.config.js
+++ b/docs/site/docusaurus.config.js
@@ -244,6 +244,9 @@ const config = {
         ],
         rehypePlugins: [rehypeKatex],
       },
+      blog: {
+        path: "../blog",
+      },
       sitemap: {
         ignorePatterns: [
           '/docs/walrus-sites/**',


### PR DESCRIPTION
## Summary
- The classic preset in `docusaurus.config.js` was missing blog configuration, so Docusaurus never built blog HTML pages
- The 8 blog routes in `ws-resources.manual.json` pointed to non-existent HTML files, causing `check-routes.sh` to fail
- Add `blog: { path: "../blog" }` to the preset-classic options so blog posts at `docs/blog/` get built

**Before:**
```
MISSING: /blog.html
MISSING: /blog/01_announcing_walrus.html
MISSING: /blog/02_devnet_update.html
MISSING: /blog/03_whitepaper.html
MISSING: /blog/04_testnet_update.html
MISSING: /blog/05_testnet_redeployment.html
MISSING: /blog/06_mainnet.html
MISSING: /blog/archive.html
```

**After:** `All route values exist as files!`

## Test plan
- [x] `pnpm run build` succeeds
- [x] `./check-routes.sh` passes with 0 missing files
- [x] Blog HTML files generated in `build/blog/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)