### PR TITLE
fix: correct committee routing in shard recovery and harden sliver index check

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -8585,6 +8585,21 @@ mod tests {
         .await
     }
 
+    // Tests that a fetched sliver whose embedded sliver index is out of range for the committee
+    // is rejected without panicking the sync and is recovered through shard recovery instead.
+    #[tokio::test]
+    async fn sync_shard_recovers_sliver_with_out_of_range_index() -> TestResult {
+        assert_sync_shard_recovers_bad_source_sliver(|blob_details| {
+            let mut sliver = blob_details[2]
+                .assigned_sliver_pair(ShardIndex(0))
+                .secondary
+                .clone();
+            sliver.index = SliverIndex(u16::MAX);
+            Sliver::Secondary(sliver)
+        })
+        .await
+    }
+
     // Tests that fetched slivers are stored without verification when sliver verification is
     // disabled in the shard sync config.
     #[tokio::test]

--- a/crates/walrus-service/src/node/storage/shard.rs
+++ b/crates/walrus-service/src/node/storage/shard.rs
@@ -1462,19 +1462,23 @@ impl ShardStorage {
         // this check a corrupt source could return a valid sliver of the same blob for a
         // different sliver pair. This mirrors the `SliverIndexMismatch` check in the upload
         // path, and runs first since it is much cheaper than the metadata verification.
+        //
+        // The comparison converts the shard's trusted pair index to a sliver index, and not the
+        // other way around, since converting the untrusted sliver index with `to_pair_index`
+        // panics on indices that are out of range for the committee.
         let n_shards = node.encoding_config.n_shards();
         let expected_pair_index = self.id.to_pair_index(n_shards, blob_id);
-        let actual_pair_index = match sliver.r#type() {
-            SliverType::Primary => sliver.sliver_index().to_pair_index::<Primary>(n_shards),
-            SliverType::Secondary => sliver.sliver_index().to_pair_index::<Secondary>(n_shards),
+        let expected_sliver_index = match sliver.r#type() {
+            SliverType::Primary => expected_pair_index.to_sliver_index::<Primary>(n_shards),
+            SliverType::Secondary => expected_pair_index.to_sliver_index::<Secondary>(n_shards),
         };
-        if actual_pair_index != expected_pair_index {
+        if sliver.sliver_index() != expected_sliver_index {
             tracing::warn!(
                 walrus.blob_id = %blob_id,
                 walrus.shard_index = %self.id,
-                %expected_pair_index,
-                %actual_pair_index,
-                "fetched sliver has a pair index that does not belong to this shard"
+                %expected_sliver_index,
+                actual_sliver_index = %sliver.sliver_index(),
+                "fetched sliver has a sliver index that does not belong to this shard"
             );
             return Ok(SliverVerificationOutcome::Invalid);
         }

--- a/crates/walrus-service/src/node/storage/shard.rs
+++ b/crates/walrus-service/src/node/storage/shard.rs
@@ -953,8 +953,7 @@ impl ShardStorage {
             ShardLastSyncStatus::Recovery => {}
         }
 
-        self.recovery_any_missing_slivers(node, config, epoch)
-            .await?;
+        self.recovery_any_missing_slivers(node, config).await?;
 
         self.shard_status.write().await.with_shard_status_mut(
             |shard_status| -> Result<(), TypedStoreError> {
@@ -1579,7 +1578,6 @@ impl ShardStorage {
         &self,
         node: Arc<StorageNodeInner>,
         config: &ShardSyncConfig,
-        epoch: Epoch,
     ) -> Result<(), SyncShardClientError> {
         if self.pending_recover_slivers.is_empty() {
             return Ok(());
@@ -1615,8 +1613,7 @@ impl ShardStorage {
         }
 
         loop {
-            self.recover_missing_blobs(node.clone(), config, epoch)
-                .await?;
+            self.recover_missing_blobs(node.clone(), config).await?;
 
             if self.pending_recover_slivers.is_empty() {
                 // TODO: in test, check that we have recovered all the certified blobs.
@@ -1634,7 +1631,6 @@ impl ShardStorage {
         &self,
         node: Arc<StorageNodeInner>,
         config: &ShardSyncConfig,
-        epoch: Epoch,
     ) -> Result<(), SyncShardClientError> {
         let mut futures = FuturesUnordered::new();
         let inflight_gauge = walrus_utils::with_label!(
@@ -1679,7 +1675,7 @@ impl ShardStorage {
             } else if !skip_certified_check_in_test && !node.is_blob_certified(&blob_id)? {
                 self.skip_recover_blob(blob_id, sliver_type, &node, "not_certified")?;
             } else {
-                futures.push(self.recover_blob(blob_id, sliver_type, node.clone(), epoch));
+                futures.push(self.recover_blob(blob_id, sliver_type, node.clone()));
                 inflight_gauge.set(
                     i64::try_from(futures.len())
                         .expect("number of inflight recoveries should fit into an i64"),
@@ -1760,7 +1756,6 @@ impl ShardStorage {
         blob_id: BlobId,
         sliver_type: SliverType,
         node: Arc<StorageNodeInner>,
-        epoch: Epoch,
     ) -> Result<(), SyncShardClientError> {
         tracing_sampled::info!(
             shard_sync::SAMPLED_TRACING_INTERVAL,
@@ -1772,16 +1767,25 @@ impl ShardStorage {
         #[cfg(msim)]
         sui_macros::fail_point!("fail_point_shard_sync_recover_blob");
 
+        // Use the blob's initial certified epoch to fetch missing metadata and recovery symbols:
+        // during a committee transition, `read_committee` routes reads for blobs certified
+        // before the current epoch to the previous committee, which is the one guaranteed to
+        // hold the data while the new committee is still syncing.
+        let Some(certified_epoch) = node
+            .storage
+            .get_blob_info(&blob_id)?
+            .and_then(|blob_info| blob_info.initial_certified_epoch())
+        else {
+            self.skip_recover_blob(blob_id, sliver_type, &node, "blob_retired")?;
+            return Ok(());
+        };
+
         // Get the metadata for the blob. If metadata is not found, it will be recovered.
-        // TODO(zhewu): pass the blob's initial certified epoch instead of the sync target epoch
-        // to `get_or_recover_blob_metadata` and `recover_sliver` below, so that missing metadata
-        // and slivers are fetched from the correct committee during a committee transition; see
-        // `verify_fetched_sliver`. To be fixed in a follow-up PR.
         let metadata = {
             let result = node
                 .blob_retirement_notifier
                 .execute_with_retirement_check(&node, blob_id, || {
-                    node.get_or_recover_blob_metadata(&blob_id, epoch)
+                    node.get_or_recover_blob_metadata(&blob_id, certified_epoch)
                 })
                 .await?;
 
@@ -1813,7 +1817,7 @@ impl ShardStorage {
                     metadata.into(),
                     sliver_id,
                     sliver_type,
-                    epoch,
+                    certified_epoch,
                 )
             })
             .await?;


### PR DESCRIPTION
## Description

Two follow-up fixes to the shard sync sliver verification introduced in #3517.

### Use the blob's initial certified epoch in shard recovery

Address the TODO in `recover_blob`: during a committee transition, `read_committee` routes reads for blobs certified before the current epoch to the previous committee, which is the committee guaranteed to hold the data while the new committee is still syncing. `recover_blob` passed the shard sync target epoch instead, routing metadata and recovery-symbol requests for such blobs to the new committee, which can stall recovery under committee churn.

Look up the blob's initial certified epoch from the blob info and pass it to both `get_or_recover_blob_metadata` and `recover_sliver`, matching the sliver verification path from #3517 and `sync_single_blob_metadata`. If the blob has no certified epoch, recovery is skipped as retired. The sync target epoch is no longer needed anywhere in the recovery path, so the parameter is dropped from `recovery_any_missing_slivers`, `recover_missing_blobs`, and `recover_blob`.

### Avoid panic on fetched slivers with an out-of-range sliver index

The sliver pair index check from #3517 converted the untrusted sliver index embedded in the fetched sliver with `to_pair_index`, which panics when the index is out of range for the committee (`n_shards - index - 1` underflows for secondary slivers). A corrupt source returning a secondary sliver with such an index would abort shard sync instead of having the sliver scheduled for recovery.

Convert the shard's trusted pair index to a sliver index instead and compare sliver indices, so no arithmetic runs on untrusted input.

## Test plan

- New test `sync_shard_recovers_sliver_with_out_of_range_index`: plants a secondary sliver with index `u16::MAX` in the source shard. Without the fix it panics with `attempt to subtract with overflow` in `to_pair_index` and the sync stalls; with the fix the sliver is rejected and recovered.
- Shard recovery epoch routing is exercised by all existing recovery tests (`sync_shard_shard_recovery`, `sync_shard_partial_recovery`, `sync_shard_recovers_corrupted_sliver`, `sync_shard_recovers_sliver_with_wrong_pair_index`), which pass through `recover_blob` with the new lookup.
- All 31 shard sync tests pass; clippy and pre-commit hooks pass.
