### PR TITLE
docs: add agent prompt callouts to Walrus task pages

### DIFF
--- a/docs/content/getting-started/index.mdx
+++ b/docs/content/getting-started/index.mdx
@@ -4,6 +4,10 @@ description: "Complete getting started guide for Walrus including installation, 
 keywords: ["walrus", "getting started", "tutorial", "installation", "sui", "testnet", "mainnet", "store blob", "retrieve blob", "setup"]
 ---
 
+<AgentPrompt
+  prompt="I have a 200 GB archive of research data and a React dashboard that reads from it. I have never used Walrus. Explain what it is, and tell me which of the CLI, HTTP API, TypeScript SDK, or Move should handle each half of this."
+/>
+
 Walrus is a verifiable data platform for high-stakes systems like AI and onchain finance, where data is stored as blobs.
 
 Walrus uses an object storage architecture, where blobs are stored in a flat namespace rather than a hierarchy. There are no folders or directories. Each piece of data in an object storage model contains the data itself, metadata describing the data, and a unique identifier.

--- a/docs/content/http-api/storing-blobs.mdx
+++ b/docs/content/http-api/storing-blobs.mdx
@@ -4,6 +4,10 @@ description: Store blobs on Walrus using HTTP PUT requests through a publisher, 
 keywords: [ walrus, HTTP, API, publisher, store, blob, PUT, deletable, permanent, quilt ]
 ---
 
+<AgentPrompt
+  prompt="Store report.pdf on Testnet for 10 epochs as a permanent blob using nothing but curl, then read it back to out.pdf. Show me how to tell the difference between a first-time store and a store where the blob already existed."
+/>
+
 :::caution No public Mainnet publisher
 
 Walrus has no public unauthenticated publisher on Mainnet. There are no plans to create one. On Mainnet, run your own authenticated publisher (or use the [Upload Relay](/docs/operator-guide/upload-relay) or [TypeScript SDK](/docs/typescript-sdk/sdks) directly). The public publisher endpoints below are for Testnet, where WAL has no monetary value.

--- a/docs/content/sites/getting-started/publishing-your-first-site.mdx
+++ b/docs/content/sites/getting-started/publishing-your-first-site.mdx
@@ -4,6 +4,10 @@ description: "Tutorial for publishing, viewing, and updating your first Walrus S
 keywords: ["walrus sites", "publishing", "deployment", "view", "update", "site builder", "tutorial", "walrus snake", "examples"]
 ---
 
+<AgentPrompt
+  prompt="Deploy my Vite SPA in ./dist to Walrus Sites on Testnet for the maximum storage duration, make client-side routes like /dashboard resolve on direct navigation, then run a local portal so I can open the site in a browser."
+/>
+
 The Walrus Sites `site-builder` uploads your website's files to [Walrus](https://www.walrus.xyz/), where resources like HTML, CSS, JavaScript, and images are stored as blobs. A [Sui smart contract](https://docs.sui.io/guides/developer/getting-started/hello-world) serves as an onchain index that maps each resource path to its Walrus blob ID and records site ownership. [Portals](/docs/sites/portals/deploy-locally) read this onchain index to resolve and serve your site in the browser to visitors.
 
 To create a Walrus Site, your website's source files must include an `index.html` at the root to serve as the entry point. For example, the [`walrus-snake`](https://github.com/MystenLabs/example-walrus-sites/walrus-snake) site has the following assets:

--- a/docs/content/system-overview/storage-costs.mdx
+++ b/docs/content/system-overview/storage-costs.mdx
@@ -4,6 +4,10 @@ description: "Comprehensive guide to Walrus storage costs including fixed USD-de
 keywords: ["walrus", "storage costs", "encoded size", "erasure coding", "wal token", "sui gas", "cost optimization", "storage resources", "upload costs", "tokenomics", "pricing"]
 ---
 
+<AgentPrompt
+  prompt="Estimate what it costs to keep 50 GB on Mainnet for a year, in WAL and SUI. Break out the write fee, the encoding expansion, and the per-blob overhead separately, and check the estimate against a dry run before I spend anything."
+/>
+
 When choosing a platform to store and verify data, you should consider reliability, uptime, availability, programmability, and price predictability. Walrus offers a fixed, USD-denominated storage cost of **$0.023/GB/month**, allowing you to budget and scale with confidence.
 
 ## Estimate storage costs

--- a/docs/content/troubleshooting/index.mdx
+++ b/docs/content/troubleshooting/index.mdx
@@ -4,6 +4,10 @@ description: Troubleshooting guide for common Walrus issues including configurat
 keywords: [walrus, troubleshooting, debugging, errors, configuration, binary compatibility, network issues]
 ---
 
+<AgentPrompt
+  prompt="My store call fails with RetryableWalrusClientError: Too many failures while writing blob from a browser app, and sui move build on the same project fails with VMVerificationOrDeserializationError. Diagnose both and give me the fixes."
+/>
+
 Resolve common issues with the Walrus CLI, configuration, and network connectivity.
 
 ## Use the latest binary

--- a/docs/content/troubleshooting/index.mdx
+++ b/docs/content/troubleshooting/index.mdx
@@ -5,7 +5,7 @@ keywords: [walrus, troubleshooting, debugging, errors, configuration, binary com
 ---
 
 <AgentPrompt
-  prompt="My store call fails with RetryableWalrusClientError: Too many failures while writing blob from a browser app, and sui move build on the same project fails with VMVerificationOrDeserializationError. Diagnose both and give me the fixes."
+  prompt="My walrus store call on Testnet fails with could not retrieve enough confirmations to certify the blob, and which walrus shows two different binaries on my PATH. Diagnose both, fix them, and show me how to turn on debug logging to confirm which config file the client actually loaded."
 />
 
 Resolve common issues with the Walrus CLI, configuration, and network connectivity.

--- a/docs/content/typescript-sdk/sdks.mdx
+++ b/docs/content/typescript-sdk/sdks.mdx
@@ -5,10 +5,6 @@ description: Overview of official and community-maintained SDKs, tools, and expl
 keywords: ["walrus", "sdks", "development tools", "typescript", "rust", "go", "python", "php", "explorers", "community tools"]
 ---
 
-<AgentPrompt
-  prompt="Write a TypeScript script that stores a JSON payload on Mainnet for 30 epochs and reads it back by blob ID. It runs in a Vite browser app with a connected wallet, so configure whatever the browser needs."
-/>
-
 ## SDKs maintained by Mysten Labs
 
 Mysten Labs has built and published a [Walrus TypeScript SDK](https://sdk.mystenlabs.com/walrus), which supports a wide variety of operations. See also the related [examples](https://github.com/MystenLabs/ts-sdks/tree/main/packages/walrus/examples).

--- a/docs/content/typescript-sdk/sdks.mdx
+++ b/docs/content/typescript-sdk/sdks.mdx
@@ -5,6 +5,10 @@ description: Overview of official and community-maintained SDKs, tools, and expl
 keywords: ["walrus", "sdks", "development tools", "typescript", "rust", "go", "python", "php", "explorers", "community tools"]
 ---
 
+<AgentPrompt
+  prompt="Write a TypeScript script that stores a JSON payload on Mainnet for 30 epochs and reads it back by blob ID. It runs in a Vite browser app with a connected wallet, so configure whatever the browser needs."
+/>
+
 ## SDKs maintained by Mysten Labs
 
 Mysten Labs has built and published a [Walrus TypeScript SDK](https://sdk.mystenlabs.com/walrus), which supports a wide variety of operations. See also the related [examples](https://github.com/MystenLabs/ts-sdks/tree/main/packages/walrus/examples).

--- a/docs/content/walrus-client/managing-blobs.mdx
+++ b/docs/content/walrus-client/managing-blobs.mdx
@@ -4,6 +4,10 @@ description: Use the Walrus client to check, extend, delete, burn, share, and se
 keywords: [ walrus, cli, client, command line, delete, extend, burn, blob management, shared blobs, blob attributes, lifecycle, expiry, blob status, monitoring ]
 ---
 
+<AgentPrompt
+  prompt="I stored a blob 40 epochs ago and it expires in two. Extend it another 20 epochs, set content-type to application/pdf on it, then convert it to something anyone can top up when it runs low again."
+/>
+
 Use the Walrus client to manage blobs and their metadata.
 
 ## Check a blob's status and expiry

--- a/docs/content/walrus-client/quilts.mdx
+++ b/docs/content/walrus-client/quilts.mdx
@@ -6,7 +6,7 @@ keywords: [ walrus, cli, client, quilt, batch storage, QuiltPatchId ]
 ---
 
 <AgentPrompt
-  prompt="I have 400 JSON files averaging 3 KB in ./records/. Store them as one storage unit for 20 epochs, tag each by year, then show me how to pull back just the 2025 ones by identifier."
+  prompt="I have 400 JSON files averaging 3 KB in ./records/. Store them as one storage unit for 20 epochs, tag each one with the year it covers, then show me how to read back only the 2025 files without downloading the whole quilt."
 />
 
 For efficiently storing large numbers of small blobs, Walrus provides the quilt feature. A quilt batches multiple blobs into a single storage unit, significantly reducing overhead and cost. [Learn more about quilts](/docs/system-overview/quilt).

--- a/docs/content/walrus-client/quilts.mdx
+++ b/docs/content/walrus-client/quilts.mdx
@@ -5,6 +5,10 @@ description: Use the Walrus client to batch multiple blobs into quilts for effic
 keywords: [ walrus, cli, client, quilt, batch storage, QuiltPatchId ]
 ---
 
+<AgentPrompt
+  prompt="I have 400 JSON files averaging 3 KB in ./records/. Store them as one storage unit for 20 epochs, tag each by year, then show me how to pull back just the 2025 ones by identifier."
+/>
+
 For efficiently storing large numbers of small blobs, Walrus provides the quilt feature. A quilt batches multiple blobs into a single storage unit, significantly reducing overhead and cost. [Learn more about quilts](/docs/system-overview/quilt).
 
 You can interact with quilts using a dedicated set of `walrus` subcommands.

--- a/docs/content/walrus-client/walrus-cli.mdx
+++ b/docs/content/walrus-client/walrus-cli.mdx
@@ -4,6 +4,10 @@ description: Use the Walrus client through the command line to store and retriev
 keywords: [ walrus, cli, client, configuration, logging, json output ]
 ---
 
+<AgentPrompt
+  prompt="Install the Walrus CLI on my machine, point it at Testnet, and set up the client config. Then verify it works by printing the current epoch and storage price."
+/>
+
 Use the command-line interface (CLI) to interact with the Walrus client. The CLI is available by installing the `walrus` binary. To install Walrus, use the Mysten Labs [`suiup` tool](https://github.com/MystenLabs/suiup?tab=readme-ov-file#installation):
 ```sh
 $ curl -sSfL https://raw.githubusercontent.com/Mystenlabs/suiup/main/install.sh | sh


### PR DESCRIPTION
## Description

Adds an `AgentPrompt` callout to nine task pages: getting started, CLI, HTTP store,
TypeScript SDK, quilts, blob management, storage costs, first site, and troubleshooting.
Each prompt asks an agent to complete the page's core task rather than explain it.

These are the first uses of `AgentPrompt` in `docs/content/`. The component is already
registered globally in `theme/MDXContent/index.js`, and the Walrus Memory docs inject
one through `transform-walrus-memory-docs.js`.

Prompts are drawn from the twelve skills in `mystenlabs/walrus-skills`. Three have no
callout here: `walrus-memory` already gets one through the transform script,
`walrus-overview` routes rather than executes, and `walrus-move-integration` has no
page in `docs/content/`.

## Test plan

Ran `pnpm start` and confirmed the callout renders, Copy prompt copies to the clipboard,
and Open in agent opens a prefilled Claude session.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
