### PR TITLE
ci: poll GCS for prebuilt binaries in attach-binaries-to-release

### DIFF
--- a/.github/workflows/attach-binaries-to-release.yml
+++ b/.github/workflows/attach-binaries-to-release.yml
@@ -161,32 +161,40 @@ jobs:
           # from prebuilt walrus images. amd64 lands at gs://mysten-walrus-binaries/walrus/<sha>/<basename>,
           # arm64 at gs://mysten-walrus-binaries/walrus-arm64/<sha>/<basename> — see mp3's
           # binary_upload_config in sui-operations/pulumi/apps/mp3 (walrus-service[-arm64] and
-          # walrus-upload-relay[-arm64] rules). Fails loudly if any binary in
-          # binary-build-list.json release_binaries is missing.
+          # walrus-upload-relay[-arm64] rules).
           mkdir -p ${{ env.TMP_BUILD_DIR }} ./tmp
           [ ! -f ${{ env.BINARY_LIST_FILE }} ] && echo "${{ env.BINARY_LIST_FILE }} cannot be found" && exit 1
 
           [ -z "${linux_prebuilt_path}" ] && echo "::error::linux_prebuilt_path is not configured for ${{ matrix.os }}" && exit 1
           gcs_prefix="gs://mysten-walrus-binaries/${linux_prebuilt_path}/${walrus_sha}"
 
-          missing=()
-          for binary in $(jq -r '.release_binaries[]' ${{ env.BINARY_LIST_FILE }}); do
-            binary=$(echo "${binary}" | tr -d $'\r')
-            src="${gcs_prefix}/${binary}"
-            dest="${{ env.TMP_BUILD_DIR }}/${binary}"
-            echo "Downloading ${src}"
-            if ! gcloud storage cp "${src}" "${dest}"; then
-              missing+=("${binary}")
-              continue
+          mapfile -t binaries < <(jq -r '.release_binaries[]' ${{ env.BINARY_LIST_FILE }} | tr -d $'\r')
+
+          # The release event that triggers this workflow also triggers the
+          # prebuild pipeline that uploads these binaries (~15 min), so poll
+          # instead of failing on the first miss.
+          deadline=$((SECONDS + 1800))
+          while true; do
+            missing=()
+            for binary in "${binaries[@]}"; do
+              gcloud storage ls "${gcs_prefix}/${binary}" >/dev/null 2>&1 || missing+=("${binary}")
+            done
+            [ ${#missing[@]} -eq 0 ] && break
+            if [ "${SECONDS}" -ge "${deadline}" ]; then
+              echo "::error::Missing prebuilt binaries at ${gcs_prefix}/ after 30 minutes: ${missing[*]}"
+              echo "::error::These must be produced by sui-operations/prebuild-walrus-images.yml + mp3:binary_upload_config."
+              exit 1
             fi
-            chmod +x "${dest}"
+            echo "Waiting for ${#missing[@]} binaries at ${gcs_prefix}/: ${missing[*]} (retrying in 30s)"
+            sleep 30
           done
 
-          if [ ${#missing[@]} -ne 0 ]; then
-            echo "::error::Missing prebuilt binaries at ${gcs_prefix}/: ${missing[*]}"
-            echo "::error::These must be produced by sui-operations/prebuild-walrus-images.yml + mp3:binary_upload_config before tagging."
-            exit 1
-          fi
+          for binary in "${binaries[@]}"; do
+            dest="${{ env.TMP_BUILD_DIR }}/${binary}"
+            echo "Downloading ${gcs_prefix}/${binary}"
+            gcloud storage cp "${gcs_prefix}/${binary}" "${dest}"
+            chmod +x "${dest}"
+          done
 
           tar -cvzf ./tmp/walrus-${{ env.walrus_tag }}-${{ env.os_type }}.tgz -C ${{ env.TMP_BUILD_DIR }} .
 


### PR DESCRIPTION
## Summary

The `release` event that triggers this workflow also triggers the prebuild pipeline (`sui-operations/prebuild-walrus-images.yml` + mp3 binary extraction) that produces the Linux binaries it downloads. On a fresh branch-cut release the binaries land in GCS ~15 minutes after the release is created, so the single-shot `gcloud storage cp` always loses the race and the run has to be manually re-run.

Concrete instance: [devnet-v1.52.0 run](https://github.com/MystenLabs/walrus/actions/runs/29061076950) — the arm64 leg failed at 00:53:54 UTC, 32 seconds after the prebuild for `c24b85fa` started; the binaries arrived in `gs://mysten-walrus-binaries/walrus-arm64/c24b85fa.../` at 01:07 UTC. A re-run then passed untouched.

This changes the "Download prebuilt binaries from GCS (Linux)" step to poll for all `release_binaries` with a 30-minute deadline (30s interval) before downloading. The loud error is kept if the binaries never appear (job timeout is 120 min, so the added wait is well within bounds).

## Test plan

- `actionlint` on the workflow — no new findings (remaining findings are pre-existing: custom runner labels, other steps)
- Verified the failure timeline from run 29061076950 logs + GCS object creation timestamps
- Poll logic exercised locally against the real GCS prefixes (existing sha → immediate pass; nonexistent sha → waits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)