### PR TITLE
docs: fix llms.txt link resolution, tab serialization, and cache headers

### DIFF
--- a/docs/site/src/scripts/copy-markdown-files.js
+++ b/docs/site/src/scripts/copy-markdown-files.js
@@ -186,6 +186,14 @@ function cleanMdxComponents(content, filePath, baseDir) {
     '[$2]($1)',
   );
 
+  // ── Collapse <Tabs>: keep only the first <TabItem> content ────────────
+  cleaned = cleaned.replace(/<Tabs[^>]*>([\s\S]*?)<\/Tabs>/gi, (_match, inner) => {
+    const firstTab = inner.match(/<TabItem[^>]*>([\s\S]*?)<\/TabItem>/i);
+    return firstTab ? firstTab[1].trim() : inner;
+  });
+  // Remove any orphaned TabItem wrappers left over
+  cleaned = cleaned.replace(/<\/?TabItem[^>]*>/gi, '');
+
   // ── Remove paired JSX/HTML tags, keep content (loop for nesting) ───────
   let prev;
   do {

--- a/docs/site/src/scripts/generate-routes.js
+++ b/docs/site/src/scripts/generate-routes.js
@@ -105,20 +105,23 @@ function generateMarkdownRoutes(markdownDir) {
     // mdPath is like /examples/awesome-walrus.md or /blog/01_announcing_walrus.md
     const targetPath = "/markdown" + mdPath;
 
-    // Blog posts use /blog/*.md routes; docs use /docs/*.md routes
+    // Blog and walrus-memory paths keep their prefix; docs get /docs/ prepended
     const isBlog = mdPath.startsWith("/blog/");
-    const routeKey = isBlog ? mdPath : "/docs" + mdPath;
+    const isWalrusMemory = mdPath.startsWith("/walrus-memory/");
+    const routeKey = (isBlog || isWalrusMemory) ? mdPath : "/docs" + mdPath;
 
     routes[routeKey] = targetPath;
 
     // For index.md files, also add a short-form route:
     // /docs/sites/index.md -> also accessible as /docs/sites.md
+    // /walrus-memory/sdk/index.md -> also accessible as /walrus-memory/sdk.md
     if (!isBlog) {
       const basename = path.basename(mdPath, ".md");
       if (basename === "index") {
         const dir = path.dirname(mdPath);
         if (dir !== "/") {
-          routes["/docs" + dir + ".md"] = targetPath;
+          const prefix = isWalrusMemory ? "" : "/docs";
+          routes[prefix + dir + ".md"] = targetPath;
         }
       }
     }

--- a/docs/site/ws-resources.manual.json
+++ b/docs/site/ws-resources.manual.json
@@ -12,6 +12,30 @@
       "Content-Disposition": "inline",
       "content-type": "text/markdown; charset=utf-8",
       "Cache-Control": "public, max-age=3600, must-revalidate"
+    },
+    "/.well-known/api-catalog": {
+      "Cache-Control": "public, max-age=86400, must-revalidate",
+      "content-type": "application/linkset+json; charset=utf-8"
+    },
+    "/.well-known/mcp/server-card.json": {
+      "Cache-Control": "public, max-age=86400, must-revalidate",
+      "content-type": "application/json; charset=utf-8"
+    },
+    "/robots.txt": {
+      "Cache-Control": "public, max-age=86400, must-revalidate",
+      "content-type": "text/plain; charset=utf-8"
+    },
+    "/sitemap.xml": {
+      "Cache-Control": "public, max-age=86400, must-revalidate",
+      "content-type": "application/xml; charset=utf-8"
+    },
+    "/glossary.json": {
+      "Cache-Control": "public, max-age=3600, must-revalidate",
+      "content-type": "application/json; charset=utf-8"
+    },
+    "/portals.json": {
+      "Cache-Control": "public, max-age=3600, must-revalidate",
+      "content-type": "application/json; charset=utf-8"
     }
   },
   "routes": {


### PR DESCRIPTION
## Summary

Fixes four docs infrastructure issues flagged by the llms.txt audit:

- **llms-txt-links-resolve** (74 broken links): `generateMarkdownRoutes` in `generate-routes.js` was prepending `/docs/` to all non-blog markdown routes, including walrus-memory paths. Since `generate-llmstxt.mjs` emits walrus-memory URLs without the `/docs/` prefix (`/walrus-memory/sdk/quick-start.md`), the route keys didn't match and those links 404'd. Fixed by detecting `/walrus-memory/` paths and preserving their native prefix.

- **tabbed-content-serialization** (54 tab groups, worst page 116K chars) + **page-size-html** (1 page over 100K): `copy-markdown-files.js` stripped `<Tabs>`/`<TabItem>` tags via the generic JSX loop, which concatenated ALL tab content together (2-4x duplication). Added a `<Tabs>`-specific handler that runs before generic stripping and keeps only the first `<TabItem>` content per group.

- **cache-header-hygiene** (6 of 174 endpoints missing headers): Added `Cache-Control` + `content-type` headers in `ws-resources.manual.json` for `/.well-known/api-catalog`, `/.well-known/mcp/server-card.json`, `/robots.txt`, `/sitemap.xml`, `/glossary.json`, and `/portals.json`. Stable discovery files get 24h TTL; frequently-updated JSON files get 1h TTL.

## Test plan

- [ ] `pnpm build` completes without errors
- [ ] Verify `ws-resources.json` contains walrus-memory `.md` routes without `/docs/` prefix
- [ ] Spot-check a walrus-memory `.md` URL resolves after deploy
- [ ] Verify markdown export for a page with tabs (e.g., `slashing.mdx`) contains only one tab variant
- [ ] Confirm `release-notes.md` export is under 100K chars
- [ ] `curl -I` the 6 newly-headered endpoints to verify `Cache-Control` is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)