### PR TITLE
feat: increase maximum committee size from 111 to 150

### DIFF
--- a/contracts/walrus/sources/init.move
+++ b/contracts/walrus/sources/init.move
@@ -82,7 +82,7 @@ public fun migrate(_staking: &mut Staking, _system: &mut System) {
 ///   - Create the slashing manager shared object.
 ///   - Do not use migration epoch.
 /// Migrate to version 4:
-///   - No additional steps beyond version bump.
+///   - Increase the max size of the active set to the updated `TEMP_ACTIVE_SET_SIZE_LIMIT`.
 entry fun migrate_v2(staking: &mut Staking, system: &mut System, _ctx: &mut TxContext) {
     staking.migrate();
     system.migrate();

--- a/contracts/walrus/sources/staking.move
+++ b/contracts/walrus/sources/staking.move
@@ -450,6 +450,12 @@ public(package) fun migrate(staking: &mut Staking) {
     // Set the new package id.
     assert!(staking.new_package_id.is_some(), EInvalidMigration);
     staking.package_id = staking.new_package_id.extract();
+
+    // Apply the updated `TEMP_ACTIVE_SET_SIZE_LIMIT` to the existing `ActiveSet`, since the
+    // limit is only read when the `ActiveSet` is created.
+    // Note that this step is needed for version 4. When upgrading to future versions, this
+    // step needs to be revisited.
+    staking.inner_mut().update_active_set_max_size();
 }
 
 // === Internals ===

--- a/contracts/walrus/sources/staking/active_set.move
+++ b/contracts/walrus/sources/staking/active_set.move
@@ -129,7 +129,6 @@ public(package) fun remove(set: &mut ActiveSet, node_id: ID) {
 }
 
 /// Sets the maximum size of the active set.
-#[test_only]
 public(package) fun set_max_size(set: &mut ActiveSet, max_size: u16) {
     set.max_size = max_size;
 }

--- a/contracts/walrus/sources/staking/staking_inner.move
+++ b/contracts/walrus/sources/staking/staking_inner.move
@@ -36,7 +36,7 @@ const MIN_STAKE: u64 = 0;
 // TODO: Remove once solutions are in place to prevent hitting move execution limits (#935).
 //
 /// Temporary upper limit for the number of storage nodes.
-const TEMP_ACTIVE_SET_SIZE_LIMIT: u16 = 111;
+const TEMP_ACTIVE_SET_SIZE_LIMIT: u16 = 150;
 
 /// The number of nodes from which a flat shards limit is applied.
 const MIN_NODES_FOR_SHARDS_LIMIT: u8 = 20;

--- a/contracts/walrus/sources/staking/staking_inner.move
+++ b/contracts/walrus/sources/staking/staking_inner.move
@@ -902,6 +902,14 @@ public(package) fun is_epoch_sync_done(self: &StakingInnerV1): bool {
     }
 }
 
+/// Sets the max size of the active set to the current `TEMP_ACTIVE_SET_SIZE_LIMIT`.
+///
+/// This is needed during migration since the limit is only read when the `ActiveSet` is
+/// created, so an updated limit must be applied to the existing `ActiveSet` explicitly.
+public(package) fun update_active_set_max_size(self: &mut StakingInnerV1) {
+    self.active_set.borrow_mut().set_max_size(TEMP_ACTIVE_SET_SIZE_LIMIT);
+}
+
 #[test_only]
 public(package) fun active_set(self: &mut StakingInnerV1): &mut ActiveSet {
     self.active_set.borrow_mut()

--- a/contracts/walrus/tests/staking/staking_inner_tests.move
+++ b/contracts/walrus/tests/staking/staking_inner_tests.move
@@ -101,6 +101,27 @@ fun test_staking_rejoin_active_set() {
 }
 
 #[test]
+fun test_update_active_set_max_size() {
+    let ctx = &mut tx_context::dummy();
+    let clock = clock::create_for_testing(ctx);
+    let mut staking = staking_inner::new(0, EPOCH_DURATION, 300, &clock, ctx);
+
+    // A new `ActiveSet` is created with the current `TEMP_ACTIVE_SET_SIZE_LIMIT`.
+    assert_eq!(staking.active_set().max_size(), 150);
+
+    // Simulate an `ActiveSet` created before the limit was increased.
+    staking.active_set().set_max_size(111);
+    assert_eq!(staking.active_set().max_size(), 111);
+
+    // The migration step applies the updated limit to the existing `ActiveSet`.
+    staking.update_active_set_max_size();
+    assert_eq!(staking.active_set().max_size(), 150);
+
+    destroy(staking);
+    clock.destroy_for_testing();
+}
+
+#[test]
 fun test_staking_active_set() {
     let ctx = &mut tx_context::dummy();
     let clock = clock::create_for_testing(ctx);


### PR DESCRIPTION
## Description

Increases `TEMP_ACTIVE_SET_SIZE_LIMIT` in the Walrus staking contract from 111 to 150, raising the maximum number of storage nodes in the active set.

The benchmark added in #3266 showed that the contracts support a committee size of up to 124 nodes with full committee replacement per epoch, and up to 186 nodes with 1/3 replacement per epoch, so 150 is safe under realistic churn assumptions.

## Test plan

All existing Move tests pass (`sui move test` in `contracts/walrus`: 254 passed).

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI: