### PR TITLE
docs: add multi-language blob operations quickstart (BEDU-178)

### DIFF
--- a/docs/content/blob-operations-quickstart.mdx
+++ b/docs/content/blob-operations-quickstart.mdx
@@ -8,23 +8,28 @@ This quickstart shows the core blob operations, store, read, and check status, t
 
 Walrus does not ship a dedicated Python SDK. A Python backend integrates with Walrus through the HTTP API, reading from an aggregator and writing to a publisher, or by driving the `walrus` CLI as a subprocess. This page uses the HTTP API for the Python examples because it needs nothing beyond the `requests` library.
 
-## Before you begin
+<div className="outlined-tabs">
 
-No API key is required. The public Walrus aggregator and publisher endpoints are open.
+<Tabs>
+<TabItem value="prereq" label="Prerequisites">
 
-Set the endpoints you use. The examples below use the Testnet endpoints from the [Network Reference](/docs/network-reference#aggregators-and-publishers):
+- [x] No API key required. The public Walrus aggregator and publisher endpoints are open.
+- [x] Set the endpoints you want to use. The examples below use the Testnet endpoints from the [Network Reference](/docs/network-reference#aggregators-and-publishers):
 
 ```sh
-# Reads go to an aggregator; writes go to a publisher.
 export AGGREGATOR=https://aggregator.walrus-testnet.walrus.space
 export PUBLISHER=https://publisher.walrus-testnet.walrus.space
 ```
 
-Each surface has its own prerequisites:
+- [x] Choose a surface and complete the necessary setup:
+  - **CLI:** Install and configure the `walrus` client. See [Getting Started](/docs/getting-started).
+  - **HTTP API:** Any HTTP client, such as `curl`.
+  - **Python:** Install the requests library with `pip install requests`.
 
-- **CLI:** Install and configure the `walrus` client. See [Getting Started](/docs/getting-started).
-- **HTTP API:** Any HTTP client, such as `curl`.
-- **Python:** Install the requests library with `pip install requests`.
+</TabItem>
+</Tabs>
+
+</div>
 
 :::caution Public endpoint limits
 
@@ -34,7 +39,7 @@ Public aggregators and publishers limit requests to 10 MiB, and Walrus does not 
 
 ## Store a blob
 
-Store a file for a number of epochs. The store returns a blob ID that you use to read the blob back.
+Store a file for a number of epochs. The store returns a blob ID.
 
 <Tabs>
 <TabItem label="CLI" value="cli">
@@ -50,7 +55,7 @@ $ walrus store ./report.pdf --epochs 5
 $ curl -X PUT "$PUBLISHER/v1/blobs?epochs=5" --upload-file ./report.pdf
 ```
 
-The response is JSON. A first-time store returns a `newlyCreated` object, and a store of a blob that already exists returns an `alreadyCertified` object. The blob ID is in both.
+The HTTP API returns JSON. A first-time store returns a `newlyCreated` object, and a store of a blob that already exists returns an `alreadyCertified` object. The blob ID is in both.
 
 </TabItem>
 <TabItem label="Python" value="python">
@@ -87,7 +92,7 @@ print(f"stored blob {blob_id}")
 
 ## Read a blob
 
-Read a blob back by its blob ID.
+Read a blob using its blob ID.
 
 <Tabs>
 <TabItem label="CLI" value="cli">
@@ -96,7 +101,7 @@ Read a blob back by its blob ID.
 $ walrus read <BLOB_ID> --out ./report.pdf
 ```
 
-Without `--out`, the blob is written to standard output.
+Without the flag `--out`, the blob is written to standard output.
 
 </TabItem>
 <TabItem label="HTTP API" value="http">
@@ -131,7 +136,7 @@ print(f"read {len(data)} bytes")
 
 ## Check a blob's status
 
-Check whether a blob is available and how it is registered onchain.
+Check whether a blob is available and its registered onchain information.
 
 <Tabs>
 <TabItem label="CLI" value="cli">
@@ -140,7 +145,7 @@ Check whether a blob is available and how it is registered onchain.
 $ walrus blob-status --blob-id <BLOB_ID>
 ```
 
-The CLI reports the blob's certification status and end epoch from its Sui object. See [Reading blobs](/docs/walrus-client/reading-blobs).
+The CLI reports the blob's certification status and end epoch from its Sui object. See [Reading blobs](/docs/walrus-client/reading-blobs) to learn more about certification status and Sui objects.
 
 </TabItem>
 <TabItem label="HTTP API" value="http">
@@ -173,7 +178,7 @@ print("available" if is_available(blob_id) else "not available")
 </TabItem>
 </Tabs>
 
-## Put it together in Python
+## Full Python example
 
 The following script stores a blob, reads it back, and verifies the round trip against a public Testnet publisher and aggregator.
 
@@ -215,7 +220,7 @@ if __name__ == "__main__":
 
 For more Python examples, including driving the CLI through its JSON interface and tracking Walrus events, see [Using Walrus with Python](/docs/examples/python).
 
-## Next steps
+## References
 
 - Store blobs with the CLI: [Store blobs with the Walrus client](/docs/walrus-client/storing-blobs)
 - Use the HTTP API in depth: [Storing blobs with the HTTP API](/docs/http-api/storing-blobs) and [Reading blobs with the HTTP API](/docs/http-api/reading-blobs)

--- a/docs/content/blob-operations-quickstart.mdx
+++ b/docs/content/blob-operations-quickstart.mdx
@@ -1,0 +1,223 @@
+---
+title: Blob Operations Quickstart
+description: "Store, read, and check the status of a Walrus blob three ways: the Walrus CLI, the HTTP API, and Python. A single multi-language quickstart for backend developers."
+keywords: [walrus, quickstart, python, http api, cli, store blob, read blob, blob status, backend]
+---
+
+This quickstart shows the core blob operations, store, read, and check status, three ways: the Walrus CLI, the HTTP API, and Python. Each operation appears in all three so you can pick the surface that fits your stack, or compare them side by side.
+
+Walrus does not ship a dedicated Python SDK. A Python backend integrates with Walrus through the HTTP API, reading from an aggregator and writing to a publisher, or by driving the `walrus` CLI as a subprocess. This page uses the HTTP API for the Python examples because it needs nothing beyond the `requests` library.
+
+## Before you begin
+
+No API key is required. The public Walrus aggregator and publisher endpoints are open.
+
+Set the endpoints you use. The examples below use the Testnet endpoints from the [Network Reference](/docs/network-reference#aggregators-and-publishers):
+
+```sh
+# Reads go to an aggregator; writes go to a publisher.
+export AGGREGATOR=https://aggregator.walrus-testnet.walrus.space
+export PUBLISHER=https://publisher.walrus-testnet.walrus.space
+```
+
+Each surface has its own prerequisites:
+
+- **CLI:** Install and configure the `walrus` client. See [Getting Started](/docs/getting-started).
+- **HTTP API:** Any HTTP client, such as `curl`.
+- **Python:** Install the requests library with `pip install requests`.
+
+:::caution Public endpoint limits
+
+Public aggregators and publishers limit requests to 10 MiB, and Walrus does not provide a public unauthenticated publisher on Mainnet. For larger blobs or production Mainnet writes, run your own publisher, use an upload relay, or drive the CLI. See the [Mainnet Publisher Production Guide](/docs/operator-guide/publishers/mainnet-production-guide).
+
+:::
+
+## Store a blob
+
+Store a file for a number of epochs. The store returns a blob ID that you use to read the blob back.
+
+<Tabs>
+<TabItem label="CLI" value="cli">
+
+```sh
+$ walrus store ./report.pdf --epochs 5
+```
+
+</TabItem>
+<TabItem label="HTTP API" value="http">
+
+```sh
+$ curl -X PUT "$PUBLISHER/v1/blobs?epochs=5" --upload-file ./report.pdf
+```
+
+The response is JSON. A first-time store returns a `newlyCreated` object, and a store of a blob that already exists returns an `alreadyCertified` object. The blob ID is in both.
+
+</TabItem>
+<TabItem label="Python" value="python">
+
+```python
+import requests
+
+PUBLISHER = "https://publisher.walrus-testnet.walrus.space"
+
+
+def store_blob(data: bytes, epochs: int = 5) -> str:
+    response = requests.put(
+        f"{PUBLISHER}/v1/blobs",
+        params={"epochs": epochs},
+        data=data,
+    )
+    response.raise_for_status()
+    result = response.json()
+
+    # A first-time store returns "newlyCreated"; an existing blob returns
+    # "alreadyCertified". The blob ID is available in both cases.
+    if "newlyCreated" in result:
+        return result["newlyCreated"]["blobObject"]["blobId"]
+    return result["alreadyCertified"]["blobId"]
+
+
+with open("report.pdf", "rb") as file:
+    blob_id = store_blob(file.read())
+print(f"stored blob {blob_id}")
+```
+
+</TabItem>
+</Tabs>
+
+## Read a blob
+
+Read a blob back by its blob ID.
+
+<Tabs>
+<TabItem label="CLI" value="cli">
+
+```sh
+$ walrus read <BLOB_ID> --out ./report.pdf
+```
+
+Without `--out`, the blob is written to standard output.
+
+</TabItem>
+<TabItem label="HTTP API" value="http">
+
+```sh
+$ curl "$AGGREGATOR/v1/blobs/<BLOB_ID>" -o ./report.pdf
+```
+
+</TabItem>
+<TabItem label="Python" value="python">
+
+```python
+import requests
+
+AGGREGATOR = "https://aggregator.walrus-testnet.walrus.space"
+
+
+def read_blob(blob_id: str) -> bytes:
+    response = requests.get(f"{AGGREGATOR}/v1/blobs/{blob_id}")
+    response.raise_for_status()
+    return response.content
+
+
+data = read_blob(blob_id)
+with open("report.pdf", "wb") as file:
+    file.write(data)
+print(f"read {len(data)} bytes")
+```
+
+</TabItem>
+</Tabs>
+
+## Check a blob's status
+
+Check whether a blob is available and how it is registered onchain.
+
+<Tabs>
+<TabItem label="CLI" value="cli">
+
+```sh
+$ walrus blob-status --blob-id <BLOB_ID>
+```
+
+The CLI reports the blob's certification status and end epoch from its Sui object. See [Reading blobs](/docs/walrus-client/reading-blobs).
+
+</TabItem>
+<TabItem label="HTTP API" value="http">
+
+The aggregator serves reads, so a successful `GET` confirms the blob is available. A `200` response means the blob is readable; a `404` means it is not available on that aggregator.
+
+```sh
+$ curl -o /dev/null -s -w "%{http_code}\n" "$AGGREGATOR/v1/blobs/<BLOB_ID>"
+```
+
+For the onchain certification status and end epoch, use the CLI `blob-status` command.
+
+</TabItem>
+<TabItem label="Python" value="python">
+
+```python
+import requests
+
+AGGREGATOR = "https://aggregator.walrus-testnet.walrus.space"
+
+
+def is_available(blob_id: str) -> bool:
+    response = requests.get(f"{AGGREGATOR}/v1/blobs/{blob_id}")
+    return response.status_code == 200
+
+
+print("available" if is_available(blob_id) else "not available")
+```
+
+</TabItem>
+</Tabs>
+
+## Put it together in Python
+
+The following script stores a blob, reads it back, and verifies the round trip against a public Testnet publisher and aggregator.
+
+```python
+import os
+
+import requests
+
+AGGREGATOR = "https://aggregator.walrus-testnet.walrus.space"
+PUBLISHER = "https://publisher.walrus-testnet.walrus.space"
+
+
+def store_blob(data: bytes, epochs: int = 5) -> str:
+    response = requests.put(
+        f"{PUBLISHER}/v1/blobs", params={"epochs": epochs}, data=data
+    )
+    response.raise_for_status()
+    result = response.json()
+    if "newlyCreated" in result:
+        return result["newlyCreated"]["blobObject"]["blobId"]
+    return result["alreadyCertified"]["blobId"]
+
+
+def read_blob(blob_id: str) -> bytes:
+    response = requests.get(f"{AGGREGATOR}/v1/blobs/{blob_id}")
+    response.raise_for_status()
+    return response.content
+
+
+if __name__ == "__main__":
+    original = os.urandom(1024)
+    blob_id = store_blob(original)
+    print(f"stored blob {blob_id}")
+
+    downloaded = read_blob(blob_id)
+    assert downloaded == original, "round trip mismatch"
+    print(f"read {len(downloaded)} bytes back, round trip verified")
+```
+
+For more Python examples, including driving the CLI through its JSON interface and tracking Walrus events, see [Using Walrus with Python](/docs/examples/python).
+
+## Next steps
+
+- Store blobs with the CLI: [Store blobs with the Walrus client](/docs/walrus-client/storing-blobs)
+- Use the HTTP API in depth: [Storing blobs with the HTTP API](/docs/http-api/storing-blobs) and [Reading blobs with the HTTP API](/docs/http-api/reading-blobs)
+- Run a publisher that pays for storage on behalf of your users: [Mainnet Publisher Production Guide](/docs/operator-guide/publishers/mainnet-production-guide)
+- Canonical endpoints and IDs: [Network Reference](/docs/network-reference)

--- a/docs/content/blob-operations-quickstart.mdx
+++ b/docs/content/blob-operations-quickstart.mdx
@@ -171,12 +171,12 @@ AGGREGATOR = "https://aggregator.walrus-testnet.walrus.space"
 
 def read_status(blob_id: str) -> str:
     # A 404 right after certification is usually transient on public
-    # aggregators; a 404 for a blob you did not just write is final. Treat 503
-    # and other 5xx responses as transient too.
+    # aggregators; a 404 for a blob you did not just write is final. Treat any
+    # 5xx as transient too.
     response = requests.get(f"{AGGREGATOR}/v1/blobs/{blob_id}")
     if response.status_code == 200:
         return "available"
-    if response.status_code in (404, 503):
+    if response.status_code == 404 or 500 <= response.status_code < 600:
         return "retry"
     return "unavailable"
 
@@ -213,7 +213,7 @@ def store_blob(data: bytes, epochs: int = 5) -> str:
 
 
 def read_blob(blob_id: str, attempts: int = 5, backoff: float = 1.0) -> bytes:
-    # A public aggregator can briefly return 404 or 503 right after a blob is
+    # A public aggregator can briefly return 404 or a 5xx right after a blob is
     # certified, before its read path catches up. Because you know the blob was
     # just stored, retry those statuses with backoff before giving up.
     response = None
@@ -221,7 +221,8 @@ def read_blob(blob_id: str, attempts: int = 5, backoff: float = 1.0) -> bytes:
         response = requests.get(f"{AGGREGATOR}/v1/blobs/{blob_id}")
         if response.status_code == 200:
             return response.content
-        if response.status_code not in (404, 503):
+        retryable = response.status_code == 404 or 500 <= response.status_code < 600
+        if not retryable:
             break
         time.sleep(backoff * (2**attempt))
     response.raise_for_status()

--- a/docs/content/blob-operations-quickstart.mdx
+++ b/docs/content/blob-operations-quickstart.mdx
@@ -101,7 +101,7 @@ Read a blob using its blob ID.
 $ walrus read <BLOB_ID> --out ./report.pdf
 ```
 
-Without the flag `--out`, the blob is written to standard output.
+Without the flag `--out`, the CLI writes the blob to standard output.
 
 </TabItem>
 <TabItem label="HTTP API" value="http">
@@ -134,6 +134,8 @@ print(f"read {len(data)} bytes")
 </TabItem>
 </Tabs>
 
+When you read a blob immediately after certifying it, a public aggregator can briefly return `404` before its read path catches up. Retry with backoff in that window, as the [full Python example](#full-python-example) shows. See [Reading blobs after upload](/docs/troubleshooting/reading-blobs-after-upload) for more.
+
 ## Check a blob's status
 
 Check whether a blob is available and its registered onchain information.
@@ -150,7 +152,7 @@ The CLI reports the blob's certification status and end epoch from its Sui objec
 </TabItem>
 <TabItem label="HTTP API" value="http">
 
-The aggregator serves reads, so a successful `GET` confirms the blob is available. A `200` response means the blob is readable; a `404` means it is not available on that aggregator.
+The aggregator serves reads, so a successful `GET` confirms availability. A `200` means you can read the blob. A `404` immediately after you certified the blob is usually transient on public, CDN-fronted aggregators, so retry with backoff; a `404` for a blob you did not just write is final. Treat `503` and other `5xx` responses as retryable.
 
 ```sh
 $ curl -o /dev/null -s -w "%{http_code}\n" "$AGGREGATOR/v1/blobs/<BLOB_ID>"
@@ -167,12 +169,19 @@ import requests
 AGGREGATOR = "https://aggregator.walrus-testnet.walrus.space"
 
 
-def is_available(blob_id: str) -> bool:
+def read_status(blob_id: str) -> str:
+    # A 404 right after certification is usually transient on public
+    # aggregators; a 404 for a blob you did not just write is final. Treat 503
+    # and other 5xx responses as transient too.
     response = requests.get(f"{AGGREGATOR}/v1/blobs/{blob_id}")
-    return response.status_code == 200
+    if response.status_code == 200:
+        return "available"
+    if response.status_code in (404, 503):
+        return "retry"
+    return "unavailable"
 
 
-print("available" if is_available(blob_id) else "not available")
+print(read_status(blob_id))  # "available", "retry", or "unavailable"
 ```
 
 </TabItem>
@@ -184,6 +193,7 @@ The following script stores a blob, reads it back, and verifies the round trip a
 
 ```python
 import os
+import time
 
 import requests
 
@@ -202,8 +212,18 @@ def store_blob(data: bytes, epochs: int = 5) -> str:
     return result["alreadyCertified"]["blobId"]
 
 
-def read_blob(blob_id: str) -> bytes:
-    response = requests.get(f"{AGGREGATOR}/v1/blobs/{blob_id}")
+def read_blob(blob_id: str, attempts: int = 5, backoff: float = 1.0) -> bytes:
+    # A public aggregator can briefly return 404 or 503 right after a blob is
+    # certified, before its read path catches up. Because you know the blob was
+    # just stored, retry those statuses with backoff before giving up.
+    response = None
+    for attempt in range(attempts):
+        response = requests.get(f"{AGGREGATOR}/v1/blobs/{blob_id}")
+        if response.status_code == 200:
+            return response.content
+        if response.status_code not in (404, 503):
+            break
+        time.sleep(backoff * (2**attempt))
     response.raise_for_status()
     return response.content
 

--- a/docs/site/sidebars.js
+++ b/docs/site/sidebars.js
@@ -33,6 +33,7 @@ const sidebars = {
         'getting-started/advanced-setup',
       ]
     },
+    'blob-operations-quickstart',
     {
       type: 'category',
       label: 'System Overview',


### PR DESCRIPTION
## Summary

Adds a single quickstart that shows the core blob operations three ways — the **Walrus CLI**, the **HTTP API**, and **Python** — closing [BEDU-178](https://linear.app/mysten-labs/issue/BEDU-178). The existing docs cover these surfaces separately (CLI under Walrus Client, HTTP under HTTP API, Python under Examples), but there was no unified, side-by-side quickstart, which is what backend developers asked for.

New page: **`docs/content/blob-operations-quickstart.mdx`** — *Blob Operations Quickstart*.

Each operation is shown in all three surfaces via tabs:

- **Store a blob** — `walrus store` / `curl -X PUT .../v1/blobs` / `requests.put`
- **Read a blob** — `walrus read` / `curl .../v1/blobs/<id>` / `requests.get`
- **Check a blob's status** — `walrus blob-status` / HTTP status code / `requests` availability check

Plus an end-to-end Python round-trip script and a next-steps section linking the deeper CLI, HTTP API, and Python-examples pages.

## Notes

- Python integrates through the HTTP API because Walrus has no dedicated Python SDK; the page states this up front. Code mirrors the existing `docs/examples/python/hello_walrus_webapi.py` patterns (including the `newlyCreated` / `alreadyCertified` response shapes).
- Endpoints and the 10 MiB / no-public-Mainnet-publisher caveats are sourced from the Network Reference.
- Added to the sidebar near the top (right after Getting Started).
- All internal links and anchors verified against `main`. No dependency on other open doc PRs.
- Docs-only; CI runs the Docusaurus build (link/anchor validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGnVrkhGgGkakumyqPHmu5

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGnVrkhGgGkakumyqPHmu5)_