### PR TITLE
feat: enable blob info snapshot writing by default

### DIFF
--- a/crates/walrus-service/node_config_example.yaml
+++ b/crates/walrus-service/node_config_example.yaml
@@ -230,7 +230,7 @@ consistency_check:
   enable_sliver_data_existence_check: true
   sliver_data_existence_check_sample_rate_percentage: 100
 blob_info_snapshot:
-  enabled: false
+  enabled: true
 checkpoint_config:
   max_db_checkpoints: 3
   db_checkpoint_interval:

--- a/crates/walrus-service/src/node/blob_info_snapshot_writer.rs
+++ b/crates/walrus-service/src/node/blob_info_snapshot_writer.rs
@@ -29,16 +29,23 @@ use super::{
 use crate::event::events::EventStreamCursor;
 
 /// Configuration for the blob info snapshot writer.
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct BlobInfoSnapshotWriterConfig {
     /// Whether to serialize a blob info snapshot at each epoch boundary.
+    /// Defaults to `true`; set it explicitly to `false` to disable.
     ///
     /// When enabled, the node serializes the three blob-info column families in-process at the
     /// post-GC-phase-1 boundary and reports the serialization duration, size, and digest. Note
     /// that disabling this flag leaves the last snapshot file on disk until it is removed
     /// manually.
     pub enabled: bool,
+}
+
+impl Default for BlobInfoSnapshotWriterConfig {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
 }
 
 /// Returns the directory under which the writer keeps its snapshots.
@@ -207,11 +214,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn config_default_is_disabled() {
-        assert!(!BlobInfoSnapshotWriterConfig::default().enabled);
-        let parsed: BlobInfoSnapshotWriterConfig =
-            serde_yaml::from_str("enabled: true\n").expect("config should deserialize");
-        assert!(parsed.enabled);
+    fn config_default_is_enabled() {
+        // Default is enabled, and an omitted field falls back to it.
+        assert!(BlobInfoSnapshotWriterConfig::default().enabled);
+        let empty: BlobInfoSnapshotWriterConfig =
+            serde_yaml::from_str("{}\n").expect("config should deserialize");
+        assert!(empty.enabled);
+        // An explicit `enabled: false` still disables it.
+        let disabled: BlobInfoSnapshotWriterConfig =
+            serde_yaml::from_str("enabled: false\n").expect("config should deserialize");
+        assert!(!disabled.enabled);
     }
 
     #[test]


### PR DESCRIPTION
## Description

Flip the default of `BlobInfoSnapshotWriterConfig::enabled` from false to true so nodes serialize the blob info snapshot at each epoch boundary without extra configuration. The config field is retained: a node can still opt out by setting `blob_info_snapshot.enabled: false` explicitly.

Regenerate node_config_example.yaml and update the default unit test, which now also asserts that an explicit `enabled: false` disables it.

## Test plan
Two mainnet nodes reported successful creation of snapshot file of 213 MiB in less than 3 seconds.


## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
