### PR TITLE
docs: address Kapa builder-feedback gaps (media playback, data sovereignty, relay, sites)

### DIFF
--- a/docs/content/data-security.mdx
+++ b/docs/content/data-security.mdx
@@ -97,7 +97,7 @@ you to delegate sensitive or resource-intensive tasks to a self-managed trusted 
 environment (TEE) while using smart contract verification to preserve trust onchain.
 
 Use Nautilus for hybrid apps that require private data handling, complex computations, or
-integration with external web2 systems. The framework makes computations
+integration with external Web2 systems. The framework makes computations
 tamper-resistant, isolated, and cryptographically verifiable.
 
 Nautilus currently supports self-managed AWS Nitro Enclave TEEs. You can verify AWS-signed
@@ -106,7 +106,7 @@ repository](https://github.com/MystenLabs/nautilus) for the reproducible build t
 
 ### Use cases
 
-- **Trusted oracles:** Process offchain data from web2 services or decentralized storage
+- **Trusted oracles:** Process offchain data from Web2 services or decentralized storage
   platforms like Walrus in a tamper-resistant way.
 - **AI agents:** Securely run AI models for inference or execute agentic workflows while
   providing data and model provenance onchain.

--- a/docs/content/data-security.mdx
+++ b/docs/content/data-security.mdx
@@ -97,7 +97,7 @@ you to delegate sensitive or resource-intensive tasks to a self-managed trusted 
 environment (TEE) while using smart contract verification to preserve trust onchain.
 
 Use Nautilus for hybrid apps that require private data handling, complex computations, or
-integration with external Web2 systems. The framework ensures computations are
+integration with external web2 systems. The framework ensures computations are
 tamper-resistant, isolated, and cryptographically verifiable.
 
 Nautilus currently supports self-managed AWS Nitro Enclave TEEs. You can verify AWS-signed
@@ -106,7 +106,7 @@ repository](https://github.com/MystenLabs/nautilus) for the reproducible build t
 
 ### Use cases
 
-- **Trusted oracles:** Process off-chain data from Web2 services or decentralized storage
+- **Trusted oracles:** Process off-chain data from web2 services or decentralized storage
   platforms like Walrus in a tamper-resistant way.
 - **AI agents:** Securely run AI models for inference or execute agentic workflows while
   providing data and model provenance onchain.

--- a/docs/content/data-security.mdx
+++ b/docs/content/data-security.mdx
@@ -81,7 +81,7 @@ whatever bytes you upload.
 
 Walrus does not let you choose which storage nodes or geographic regions hold your data.
 When you store a blob, Walrus erasure-codes it into slivers and distributes them across all
-shards, and a smart contract on Sui controls how shards are assigned to storage nodes. There
+shards, and a smart contract on Sui assigns shards to storage nodes. There
 is no mechanism to pin a blob to a specific node, region, or jurisdiction.
 
 Because every blob is public and its placement is not controllable, do not store personal or
@@ -90,14 +90,14 @@ storing it, keep the plaintext and any keys off Walrus, and store only what you 
 to make permanently public. For the distribution and encoding details, see
 [Core Concepts](/docs/system-overview/core-concepts) and [Red Stuff](/docs/system-overview/red-stuff).
 
-## Nautilus: Secure and verifiable off-chain computation
+## Nautilus: Secure and verifiable offchain computation
 
-Nautilus is a framework for secure and verifiable off-chain computation on Sui. It enables
+Nautilus is a framework for secure and verifiable offchain computation on Sui. It enables
 you to delegate sensitive or resource-intensive tasks to a self-managed trusted execution
 environment (TEE) while using smart contract verification to preserve trust onchain.
 
 Use Nautilus for hybrid apps that require private data handling, complex computations, or
-integration with external web2 systems. The framework ensures computations are
+integration with external web2 systems. The framework makes computations
 tamper-resistant, isolated, and cryptographically verifiable.
 
 Nautilus currently supports self-managed AWS Nitro Enclave TEEs. You can verify AWS-signed
@@ -106,7 +106,7 @@ repository](https://github.com/MystenLabs/nautilus) for the reproducible build t
 
 ### Use cases
 
-- **Trusted oracles:** Process off-chain data from web2 services or decentralized storage
+- **Trusted oracles:** Process offchain data from web2 services or decentralized storage
   platforms like Walrus in a tamper-resistant way.
 - **AI agents:** Securely run AI models for inference or execute agentic workflows while
   providing data and model provenance onchain.

--- a/docs/content/data-security.mdx
+++ b/docs/content/data-security.mdx
@@ -72,8 +72,23 @@ described in the [encoding documentation](/docs/system-overview/red-stuff).
 ## Data confidentiality
 
 Walrus does not provide native encryption for data. By default, all blobs stored in Walrus
-are public and discoverable by everyone. Walrus does not currently document a
-confidentiality mechanism.
+are public and discoverable by everyone. To keep data confidential, encrypt it on the
+client before you store it, for example with [Seal](https://github.com/MystenLabs/seal), and
+treat the blob ID as public. Encryption is your responsibility. Walrus stores and serves
+whatever bytes you upload.
+
+## Data sovereignty and residency
+
+Walrus does not let you choose which storage nodes or geographic regions hold your data.
+When you store a blob, Walrus erasure-codes it into slivers and distributes them across all
+shards, and a smart contract on Sui controls how shards are assigned to storage nodes. There
+is no mechanism to pin a blob to a specific node, region, or jurisdiction.
+
+Because every blob is public and its placement is not controllable, do not store personal or
+regulated data on Walrus in the clear. If you must handle such data, encrypt it before
+storing it, keep the plaintext and any keys off Walrus, and store only what you are willing
+to make permanently public. For the distribution and encoding details, see
+[Core Concepts](/docs/system-overview/core-concepts) and [Red Stuff](/docs/system-overview/red-stuff).
 
 ## Nautilus: Secure and verifiable off-chain computation
 

--- a/docs/content/examples/browser-and-mobile.mdx
+++ b/docs/content/examples/browser-and-mobile.mdx
@@ -157,9 +157,9 @@ platform.
   wallet connector. A mobile app signs through its wallet integration, such as a deep-linked wallet
   or an embedded signer. The transactions the flow produces are identical either way.
 
-:::caution `Cannot read properties of undefined (reading 'buffer')`
+:::caution WalrusFile buffer error
 
-This error means `WalrusFile.from` received something other than a typed array for `contents`. The
+If `WalrusFile.from` throws `Cannot read properties of undefined (reading 'buffer')`, it received something other than a typed array for `contents`. The
 SDK expects a `Uint8Array`, not a `File`, `Blob`, or raw `ArrayBuffer`. Read the bytes first and wrap
 them, as in the example above: `new Uint8Array(await file.arrayBuffer())`. In a React Native app,
 convert the bytes you read from the file system or image picker to a `Uint8Array` before you call

--- a/docs/content/examples/browser-and-mobile.mdx
+++ b/docs/content/examples/browser-and-mobile.mdx
@@ -157,6 +157,16 @@ platform.
   wallet connector. A mobile app signs through its wallet integration, such as a deep-linked wallet
   or an embedded signer. The transactions the flow produces are identical either way.
 
+:::caution `Cannot read properties of undefined (reading 'buffer')`
+
+This error means `WalrusFile.from` received something other than a typed array for `contents`. The
+SDK expects a `Uint8Array`, not a `File`, `Blob`, or raw `ArrayBuffer`. Read the bytes first and wrap
+them, as in the example above: `new Uint8Array(await file.arrayBuffer())`. In a React Native app,
+convert the bytes you read from the file system or image picker to a `Uint8Array` before you call
+`WalrusFile.from`.
+
+:::
+
 :::caution
 
 Blobs stored on Walrus are public and readable by anyone. Encrypt sensitive data before you store

--- a/docs/content/examples/browser-and-mobile.mdx
+++ b/docs/content/examples/browser-and-mobile.mdx
@@ -157,7 +157,7 @@ platform.
   wallet connector. A mobile app signs through its wallet integration, such as a deep-linked wallet
   or an embedded signer. The transactions the flow produces are identical either way.
 
-:::caution WalrusFile buffer error
+:::caution `WalrusFile` buffer error
 
 If `WalrusFile.from` throws `Cannot read properties of undefined (reading 'buffer')`, it
 received something other than a typed array for `contents`. The SDK expects a `Uint8Array`, not a

--- a/docs/content/examples/browser-and-mobile.mdx
+++ b/docs/content/examples/browser-and-mobile.mdx
@@ -159,11 +159,11 @@ platform.
 
 :::caution WalrusFile buffer error
 
-If `WalrusFile.from` throws `Cannot read properties of undefined (reading 'buffer')`, it received something other than a typed array for `contents`. The
-SDK expects a `Uint8Array`, not a `File`, `Blob`, or raw `ArrayBuffer`. Read the bytes first and wrap
-them, as in the example above: `new Uint8Array(await file.arrayBuffer())`. In a React Native app,
-convert the bytes you read from the file system or image picker to a `Uint8Array` before you call
-`WalrusFile.from`.
+If `WalrusFile.from` throws `Cannot read properties of undefined (reading 'buffer')`, it
+received something other than a typed array for `contents`. The SDK expects a `Uint8Array`, not a
+`File`, `Blob`, or raw `ArrayBuffer`. Read the bytes first and wrap them, as in the example above:
+`new Uint8Array(await file.arrayBuffer())`. In a React Native app, convert the bytes you read from
+the file system or image picker to a `Uint8Array` before you call `WalrusFile.from`.
 
 :::
 

--- a/docs/content/http-api/streaming-media.mdx
+++ b/docs/content/http-api/streaming-media.mdx
@@ -4,13 +4,13 @@ description: "Serve audio and video stored as Walrus blobs to browsers, includin
 keywords: ["walrus", "video", "audio", "media", "streaming", "aggregator", "byte range", "206", "content-type", "cors", "playback"]
 ---
 
-You can play audio and video that is stored as Walrus blobs directly in a browser by pointing a media element at an aggregator. This page covers how to set the source, how content types affect playback, how to seek with byte ranges, and what to expect for cross-origin requests.
+You can play audio and video stored as Walrus blobs directly in a browser. Point an HTML media element, such as `<audio>` or `<video>`, at a Walrus aggregator URL, and the browser streams the blob as it plays. No download step or plugin is required.
 
 Set `$AGGREGATOR` to an aggregator endpoint from the [Network Reference](/docs/network-reference#aggregators-and-publishers).
 
 ## Point a media element at an aggregator
 
-A blob read endpoint is a normal HTTP URL, so you can use it as the `src` of a `<video>` or `<audio>` element:
+A blob read endpoint is an HTTP URL, so you can use it as the `src` of a `<video>` or `<audio>` element:
 
 ```html
 <video controls src="https://aggregator.walrus-mainnet.walrus.space/v1/blobs/<BLOB_ID>"></video>
@@ -20,9 +20,11 @@ The browser fetches the blob from the aggregator and plays it. For the read path
 
 ## Set a content type so the browser plays instead of downloads
 
-When you read a blob **by blob ID**, the response does not carry a content type derived from your metadata. Browsers try to infer the type, and they generally do this well for media, but the aggregator intentionally prevents inferring dangerous executable types such as JavaScript. If you paste a blob URL directly into the address bar and see raw bytes or garbled text instead of a player, the response was treated as generic data rather than a media type.
+When you read a blob by its blob ID, the aggregator response does not include a content type from your metadata. The browser infers the type instead. Browsers infer media types well in most cases, but the aggregator deliberately blocks inference of dangerous executable types, such as JavaScript, to protect users.
 
-To make playback reliable, read the blob **by object ID** and set the `content-type` attribute when you store it. The aggregator returns recognized attributes, including `content-type`, as HTTP response headers on the by-object-id read path:
+If a blob URL shows raw bytes or garbled text in the address bar instead of a player, the browser treated the response as generic data rather than a media type.
+
+To make playback reliable, read the blob by object ID and set the `content-type` attribute when you store it. The aggregator returns recognized attributes, including `content-type`, as HTTP response headers on the by-object-id read path:
 
 ```html
 <video controls src="https://aggregator.walrus-mainnet.walrus.space/v1/blobs/by-object-id/<OBJECT_ID>"></video>

--- a/docs/content/http-api/streaming-media.mdx
+++ b/docs/content/http-api/streaming-media.mdx
@@ -1,0 +1,61 @@
+---
+title: Playing Media from Walrus
+description: "Serve audio and video stored as Walrus blobs to browsers, including content types, byte-range seeking, and cross-origin playback."
+keywords: ["walrus", "video", "audio", "media", "streaming", "aggregator", "byte range", "206", "content-type", "cors", "playback"]
+---
+
+You can play audio and video that is stored as Walrus blobs directly in a browser by pointing a media element at an aggregator. This page covers how to set the source, how content types affect playback, how to seek with byte ranges, and what to expect for cross-origin requests.
+
+Set `$AGGREGATOR` to an aggregator endpoint from the [Network Reference](/docs/network-reference#aggregators-and-publishers).
+
+## Point a media element at an aggregator
+
+A blob read endpoint is a normal HTTP URL, so you can use it as the `src` of a `<video>` or `<audio>` element:
+
+```html
+<video controls src="https://aggregator.walrus-mainnet.walrus.space/v1/blobs/<BLOB_ID>"></video>
+```
+
+The browser fetches the blob from the aggregator and plays it. For the read paths and their exact shapes, see [Reading Blobs with the HTTP API](/docs/http-api/reading-blobs).
+
+## Set a content type so the browser plays instead of downloads
+
+When you read a blob **by blob ID**, the response does not carry a content type derived from your metadata. Browsers try to infer the type, and they generally do this well for media, but the aggregator intentionally prevents inferring dangerous executable types such as JavaScript. If you paste a blob URL directly into the address bar and see raw bytes or garbled text instead of a player, the response was treated as generic data rather than a media type.
+
+To make playback reliable, read the blob **by object ID** and set the `content-type` attribute when you store it. The aggregator returns recognized attributes, including `content-type`, as HTTP response headers on the by-object-id read path:
+
+```html
+<video controls src="https://aggregator.walrus-mainnet.walrus.space/v1/blobs/by-object-id/<OBJECT_ID>"></video>
+```
+
+For the full list of recognized attributes and how to set them, see [Reading by object ID](/docs/http-api/reading-blobs#reading-by-object-id) and [Managing blobs](/docs/walrus-client/managing-blobs).
+
+## Seek and stream with byte ranges
+
+Aggregators support the HTTP `Range` header, which is what lets a browser seek within a video without downloading the whole file first. When you send a `Range` header with a byte range, the aggregator returns `206 Partial Content` with just that range:
+
+```sh
+$ curl -H "Range: bytes=0-999" "$AGGREGATOR/v1/blobs/<BLOB_ID>"
+```
+
+There is also a dedicated endpoint that takes the range as query parameters:
+
+```sh
+$ curl "$AGGREGATOR/v1/blobs/<BLOB_ID>/byte-range?start=0&length=1024"
+```
+
+:::info
+
+A byte-range read verifies only the consistency of the bytes it fetches, not the whole blob. This gives you faster partial reads with weaker integrity guarantees than a full read. Use a full read when you need to verify the entire blob.
+
+:::
+
+## Cross-origin playback
+
+A plain `<video src>` or `<audio src>` element loads media cross-origin without extra configuration. If your application instead fetches blob bytes with JavaScript (for example, `fetch` followed by `URL.createObjectURL`, or drawing a frame to a `<canvas>`), the request is subject to the aggregator's cross-origin resource sharing (CORS) policy, which depends on how that aggregator and any CDN in front of it are deployed. If a cross-origin `fetch` fails, prefer the direct-`src` approach, or read through an aggregator you control.
+
+## References
+
+- [Reading Blobs with the HTTP API](/docs/http-api/reading-blobs)
+- [Managing blobs](/docs/walrus-client/managing-blobs)
+- [Network Reference](/docs/network-reference)

--- a/docs/content/operator-guide/upload-relay.mdx
+++ b/docs/content/operator-guide/upload-relay.mdx
@@ -63,6 +63,12 @@ At a high level, a client stores a blob using an upload relay as follows:
 
 The upload relay does not perform any onchain operation and only helps clients distribute the slivers of their blobs to storage nodes.
 
+:::info Blobs and quilts
+
+The relay operates on a single blob per request. A blob is one immutable unit of data, whereas a [quilt](/docs/system-overview/quilt) is a batch of many small blobs stored together to amortize per-blob overhead. Batch small files into a quilt on the client before you store, then relay the resulting blob. For the distinction and when to use each, see [Batch Storage with Quilt](/docs/system-overview/quilt).
+
+:::
+
 The flow between clients and the upload relay is already implemented in the Walrus CLI, Rust SDK, and TypeScript SDK. Developers do not need to implement it themselves. To compare upload paths, see [Choose your upload path](/docs/getting-started#choose-your-upload-path). For completeness, the following sections discuss how the service is implemented, paid for, and used by clients.
 
 ### Operation modes
@@ -163,6 +169,12 @@ $ docker run \
     --server-address 0.0.0.0:3000 \
     --relay-config /opt/walrus/walrus_upload_relay_config.yaml
 ```
+
+:::tip Pointing the relay at a local network
+
+The relay talks to whichever network its client configuration defines. The `--context` flag selects a context from the `--walrus-config` file, so there is no separate localnet flag. To relay against a locally run Walrus network, add a context for it to your `client_config.yaml`, then pass that context name with `--context`. For how to run a local network, see [Run a local Walrus network](/docs/system-overview/available-networks).
+
+:::
 
 ### Configure relay-specific settings
 

--- a/docs/content/operator-guide/upload-relay.mdx
+++ b/docs/content/operator-guide/upload-relay.mdx
@@ -172,7 +172,7 @@ $ docker run \
 
 :::tip Pointing the relay at a local network
 
-The relay talks to whichever network its client configuration defines. The `--context` flag selects a context from the `--walrus-config` file, so there is no separate localnet flag. To relay against a locally run Walrus network, add a context for it to your `client_config.yaml`, then pass that context name with `--context`. For how to run a local network, see [Run a local Walrus network](/docs/system-overview/available-networks).
+The relay talks to whichever network its client configuration defines. The `--context` flag selects a context from the `--walrus-config` file, so there is no separate flag for a local network. To relay against a locally run Walrus network, add a context for it to your `client_config.yaml`, then pass that context name with `--context`. For how to run a local network, see [Run a local Walrus network](/docs/system-overview/available-networks).
 
 :::
 

--- a/docs/content/sites/introduction/components.mdx
+++ b/docs/content/sites/introduction/components.mdx
@@ -147,3 +147,12 @@ This process repeats for every resource the browser requests, such as linked CSS
 The public Mainnet portal operated by Mysten Labs is available at [https://wal.app](https://wal.app). Sites with a SuiNS name are accessible directly by name. For sites without one, use the Base36-encoded object ID as the subdomain, or run `site-builder convert` to find it.
 
 Anyone can host their own portal. For setup instructions, see [Deploy a Local Portal](/docs/sites/portals/deploy-locally).
+
+## Local development
+
+You can iterate on a Walrus Site entirely on your own machine by running each component locally, which avoids spending Testnet or Mainnet tokens on every change:
+
+- **Local portal:** Run a portal on `localhost` to resolve and serve your site in the browser. See [Deploy a Local Portal](/docs/sites/portals/deploy-locally).
+- **Local Walrus and Sui networks:** Run a local Walrus network, backed by a local Sui network, so the `site-builder` publishes to storage you control. See [Run a local Walrus network](/docs/system-overview/available-networks).
+
+Point your `sites-config.yaml` and `client_config.yaml` at the local context, deploy with `site-builder`, then open the site through the local portal. Once the site works locally, switch the context back to Testnet or Mainnet to publish it.

--- a/docs/content/system-overview/storage-costs.mdx
+++ b/docs/content/system-overview/storage-costs.mdx
@@ -91,7 +91,7 @@ encoded_size_GB = 4.5 * original_size_GB + 0.064
 monthly_cost_USD = encoded_size_GB * 0.023
 ```
 
-For example, to keep a **50 GB** file for **1 year**:
+For example, to keep a 50 GB file for 1 year:
 
 - Encoded size: `4.5 * 50 + 0.064`, roughly `225 GB`.
 - Monthly cost: `225 * 0.023`, roughly `$5.18`.

--- a/docs/content/system-overview/storage-costs.mdx
+++ b/docs/content/system-overview/storage-costs.mdx
@@ -82,6 +82,23 @@ Walrus bills you on the blob's **encoded size**, not the size of your original f
 
 :::
 
+#### Estimate cost by hand
+
+For a quick estimate without the calculator, work in two steps. First find the encoded size, then apply the fixed monthly rate:
+
+```text
+encoded_size_GB = 4.5 * original_size_GB + 0.064
+monthly_cost_USD = encoded_size_GB * 0.023
+```
+
+For example, to keep a **50 GB** file for **1 year**:
+
+- Encoded size: `4.5 * 50 + 0.064`, roughly `225 GB`.
+- Monthly cost: `225 * 0.023`, roughly `$5.18`.
+- Yearly cost: `$5.18 * 12`, roughly `$62`.
+
+The result is USD-denominated. Storage is paid in WAL, so the WAL amount changes with the WAL price. Use `walrus info` or the [Walrus Cost Calculator](https://costcalculator.wal.app/) to convert to a current WAL figure, and `walrus store --dry-run ...` to confirm the exact encoded size before you spend anything.
+
 ## What you get for $0.023/GB/month
 
 At $0.023 per GB per month, Walrus is in line with centralized storage providers but includes additional capabilities and lower configuration requirements.

--- a/docs/site/sidebars.js
+++ b/docs/site/sidebars.js
@@ -79,6 +79,7 @@ const sidebars = {
       items: [
         'http-api/storing-blobs',
         'http-api/reading-blobs',
+        'http-api/streaming-media',
         'http-api/quilt-http-apis',
       ],
     },

--- a/docs/site/src/scripts/transform-walrus-memory-docs.js
+++ b/docs/site/src/scripts/transform-walrus-memory-docs.js
@@ -24,9 +24,26 @@ const OUTPUT_DIR = path.resolve(SITE_ROOT, "../walrus-memory-content");
 
 // Known pages and rename mappings, built dynamically from cache files.
 // knownPageSet: all page slugs (post-rename) that exist in the cache.
+// droppedSlugSet: slugs of pages intentionally dropped from the site (see
+//   isDroppedPage). Links pointing at these are stripped to plain text so the
+//   build's broken-link check does not fail on a page we did not publish.
 // slugRenameMap: original slug → renamed slug for files in RENAME_MAP.
 let knownPageSet = new Set();
+let droppedSlugSet = new Set();
 let slugRenameMap = {};
+
+// Pages consolidated into other pages (content is redundant).
+const DROPPED_PAGES = new Set([
+  "sdk/example-map.md", // just 3 links, no unique content
+  "sdk/research-app-example.md", // subset of sdk/examples.md
+]);
+
+// A page dropped from the published site: never written to output. Upstream
+// changelog pages are excluded site-wide, and the consolidated pages above.
+function isDroppedPage(relPath) {
+  if (DROPPED_PAGES.has(relPath)) return true;
+  return /^changelog\.(mdx?)$/i.test(path.basename(relPath));
+}
 
 function buildKnownPages(cacheDir) {
   const files = collectFiles(cacheDir);
@@ -39,6 +56,12 @@ function buildKnownPages(cacheDir) {
     if (relPath.startsWith("src/")) continue;
 
     const originalSlug = relPath.replace(/\.(mdx?)$/, "");
+    // Dropped pages are not published, so they must not be treated as known
+    // link targets. Record their slugs so inbound links can be neutralized.
+    if (isDroppedPage(relPath)) {
+      droppedSlugSet.add(originalSlug);
+      continue;
+    }
     const renamedPath = RENAME_MAP[relPath];
     if (renamedPath) {
       const renamedSlug = renamedPath.replace(/\.(mdx?)$/, "");
@@ -244,6 +267,12 @@ function rewriteInternalLinks(content) {
       const renamed = slugRenameMap[cleanPath];
       if (renamed) {
         return `${prefix}/walrus-memory/${renamed}${anchor || ""})`;
+      }
+      // Link to a page we deliberately did not publish (for example an upstream
+      // changelog). Strip the link to plain text so the build's broken-link
+      // check does not fail on a dangling internal path.
+      if (droppedSlugSet.has(cleanPath)) {
+        return text;
       }
       // Not a known page — leave as-is (could be an external docs link)
       return match;
@@ -748,18 +777,12 @@ function main() {
     "llms-full.txt",
   ]);
 
-  // Pages consolidated into other pages (content is redundant)
-  const skipPages = new Set([
-    "sdk/example-map.md",       // just 3 links, no unique content
-    "sdk/research-app-example.md", // subset of sdk/examples.md
-  ]);
-
   let count = 0;
   for (const { fullPath, relPath } of files) {
     const basename = path.basename(relPath);
     if (skipFiles.has(basename)) continue;
-    if (skipPages.has(relPath)) continue;
-    if (/^changelog\.(mdx?)$/i.test(basename)) continue;
+    // Pages dropped from the published site (changelog, consolidated pages).
+    if (isDroppedPage(relPath)) continue;
     // Skip files in src/ directory (CSS, assets)
     if (relPath.startsWith("src/")) continue;
 


### PR DESCRIPTION
## Description

Works through the Kapa builder-feedback triage tickets (BEDU-36, 37, 47, 52) and adds the recommendations that were both genuinely missing and verifiable from the repo. Before writing, I audited all 25 recommendations against the current docs; many were already covered, so this PR adds only the real gaps and leaves the rest documented below.

**New content:**

- **Playing media from Walrus** — new `http-api/streaming-media.mdx` covering pointing a `<video>`/`<audio>` element at an aggregator, why an unset content type shows raw bytes and how to fix it with a by-object-id read, byte-range/`206` seeking (`Range` header and the `/byte-range` endpoint), and cross-origin notes (BEDU-52).
- **Data sovereignty and residency** — new section in `data-security.mdx` explaining that placement is not controllable (slivers spread across all shards, shard assignment by the Sui contract), plus naming Seal as the confidentiality option (BEDU-52).
- **By-hand cost formula** — a manual `encoded_size -> monthly cost` formula with a worked 50 GB example in `system-overview/storage-costs.mdx` (BEDU-52).
- **Upload relay** — a blobs-vs-quilts callout and a note on pointing the relay at a local network through `--context` (BEDU-37).
- **Browser/mobile** — a troubleshooting entry for the `WalrusFile` `Cannot read properties of undefined (reading 'buffer')` error (pass a `Uint8Array`) (BEDU-36).
- **Walrus Sites** — a local development section in `sites/introduction/components.mdx` wiring a local portal, Walrus network, and Sui network together (BEDU-47).

`streaming-media` is added to the HTTP API sidebar.

**Already covered (no change needed):** token units and `WAL`/`FROST` (network-reference), privacy/public-blobs (data-security), max epochs = 53 (network-reference), accessing a deployed site and portals/Base36 (sites/portals, publishing-your-first-site), framework compatibility (sites/known-restrictions), `walrus get-wal` troubleshooting (troubleshooting/network-errors), why a relay is needed and browser-requires-relay (upload-relay, examples/browser-and-mobile), and GET retrieval (http-api/reading-blobs).

## Open questions

Two recommendations could not be written without guessing, so I left them out rather than invent behavior:

- **Aggregator CORS headers for cross-origin media `fetch`.** The aggregator OpenAPI does not document CORS response headers, so I described `<video src>` playback (which works) and framed JavaScript `fetch` as deployment-dependent. If there is authoritative CORS behavior to state, I will add it.
- **No-code / browser-extension upload (BEDU-47).** I found a hosted web upload app (`relay.wal.app`, presented as an SDK example) but no first-party browser-extension uploader in the repo. Should the docs point at `relay.wal.app` as the no-code path, and is there an extension I missed?

## Test plan

- Audited all 25 triage recommendations against the current docs before writing; sourced each new claim from the repo (byte-range/`206` from `crates/walrus-service/aggregator_openapi.yaml`, the `WalrusFile` `Uint8Array` contract and relay `--context` behavior from the SDK/relay sources, shard distribution from `system-overview/core-concepts`).
- Verified every internal link and anchor resolves against an existing heading (`reading-blobs#reading-by-object-id`, `available-networks#run-a-local-walrus-network`, and the rest).
- Applied the repo's docs-style conventions (sentence-case headings, no em dashes or Latin abbreviations, `## References`, relative links, `keywords` frontmatter on the new page).
- I did not run a full `pnpm build` locally (toolchain not installed here); the build-with-linkcheck and preview jobs cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017oS4PdhkXAzbfhJx2ZhRvh

---
_Generated by [Claude Code](https://claude.ai/code/session_017oS4PdhkXAzbfhJx2ZhRvh)_