### PR TITLE
ci: ensure docs build always fetches latest Walrus Memory content

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -7,6 +7,8 @@ on:
     paths:
       - "docs/**"
       - ".github/workflows/publish-docs.yaml"
+  repository_dispatch:
+    types: [memwal-docs-updated]
   workflow_dispatch:
     inputs:
       publish-pages:
@@ -20,8 +22,8 @@ on:
         required: true
         default: false
   schedule:
-    # Update Walrus Site every first day of the month at 03:14 UTC.
-    - cron: "14 3 1 * *"
+    # Rebuild daily to pick up upstream Walrus Memory doc changes.
+    - cron: "14 3 * * *"
 
 concurrency: ci-${{ github.ref }}
 

--- a/docs/site/src/scripts/fetch-walrus-memory-docs.js
+++ b/docs/site/src/scripts/fetch-walrus-memory-docs.js
@@ -72,7 +72,11 @@ function main() {
 
     console.log("✅ walrus-memory: fetched successfully");
   } catch (err) {
-    console.warn(`⚠️  walrus-memory: fetch failed (${err.message}). Skipping.`);
+    if (force) {
+      console.error(`❌ walrus-memory: fetch failed in CI (${err.message})`);
+      process.exit(1);
+    }
+    console.warn(`⚠️  walrus-memory: fetch failed (${err.message}). Using cached content.`);
   }
 }
 


### PR DESCRIPTION
## Summary
- **Fail hard in CI**: `fetch-walrus-memory-docs.js` now exits with code 1 when `FORCE_FETCH=1` and the MemWal clone fails, instead of silently falling back to stale/empty cache content
- **Daily schedule**: Changed cron from monthly (`1 * *`) to daily (`* * *`) to catch upstream MemWal doc changes within 24 hours
- **`repository_dispatch` trigger**: Added `memwal-docs-updated` event type so MemWal CI can trigger an instant Walrus docs rebuild via `POST /repos/MystenLabs/walrus/dispatches`

## Test plan
- [ ] Verify `pnpm run build` still succeeds locally (fetch + transform + docusaurus build)
- [ ] Confirm the daily cron schedule is valid
- [ ] After merge, trigger a manual `workflow_dispatch` to verify the full pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)