### PR TITLE
docs: add Related Topics module to doc pages

### DIFF
--- a/docs/site/src/components/AutoRelatedLinks/index.tsx
+++ b/docs/site/src/components/AutoRelatedLinks/index.tsx
@@ -1,0 +1,327 @@
+// Copyright (c) Walrus Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// Generates a "Related topics" card grid by resolving internal links from
+// the page's rendered markdown body against the descriptions plugin metadata.
+//
+// Injected globally via the DocItem/Layout theme wrapper — no MDX imports needed.
+//
+// Rules:
+//  - Does NOT render if the page has a <DocCardList /> or .next-steps-module
+//  - Prefers internal docs links; skips external links
+//  - Deduplicates by normalized path AND by resolved title
+//  - Maximum of 4 cards by default
+
+import React, { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import Link from "@docusaurus/Link";
+import { usePluginData } from "@docusaurus/useGlobalData";
+import { useLocation } from "@docusaurus/router";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type Meta = {
+  id: string;
+  path?: string;
+  title?: string;
+  description?: string;
+  href?: string;
+};
+
+type ResolvedLink = {
+  href: string;
+  title: string;
+  description?: string;
+  external: boolean;
+  score: number;
+};
+
+// ── Canonical casing ──────────────────────────────────────────────────────────
+
+const SPECIAL_CASING = new Map<string, string>([
+  ["grpc", "gRPC"], ["graphql", "GraphQL"], ["webrtc", "WebRTC"],
+  ["websocket", "WebSocket"], ["devnet", "Devnet"], ["testnet", "Testnet"],
+  ["mainnet", "Mainnet"], ["localnet", "Localnet"],
+  ["sui", "Sui"], ["move", "Move"], ["walrus", "Walrus"],
+  ["npm", "npm"], ["pnpm", "pnpm"], ["docker", "docker"],
+  ["curl", "curl"], ["cargo", "cargo"], ["git", "git"],
+]);
+
+const LOWERCASE_WORDS = new Set([
+  "a", "an", "the", "and", "but", "or", "nor", "for", "so", "yet",
+  "at", "by", "in", "of", "on", "to", "up", "as", "is", "it",
+  "via", "vs", "with", "from", "into", "onto", "over", "than", "upon",
+]);
+
+function toTitleCase(str: string): string {
+  return str.trim().split(/\s+/).map((word, i, arr) => {
+    const canonical = SPECIAL_CASING.get(word.toLowerCase());
+    if (canonical !== undefined) return canonical;
+    if (i === 0 || i === arr.length - 1)
+      return word.charAt(0).toUpperCase() + word.slice(1);
+    if (word === word.toUpperCase() && word.length > 1) return word;
+    if (/[A-Z]/.test(word.slice(1))) return word;
+    const lower = word.toLowerCase();
+    return LOWERCASE_WORDS.has(lower)
+      ? lower
+      : lower.charAt(0).toUpperCase() + lower.slice(1);
+  }).join(" ");
+}
+
+function humanize(href: string): string {
+  const seg = href.replace(/\/$/, "").split("/").filter(Boolean).pop() ?? href;
+  return toTitleCase(seg.split(/[-_]/).join(" "));
+}
+
+// ── Path helpers ──────────────────────────────────────────────────────────────
+
+function normalizePath(raw: string): string {
+  let p = raw.split("#")[0].split("?")[0].replace(/\.(mdx?|MDX?)$/, "");
+  if (p.endsWith("/")) p = p.slice(0, -1);
+  return (p || "/").toLowerCase();
+}
+
+function isExternal(url: string): boolean {
+  return /^https?:\/\//i.test(url);
+}
+
+// ── Link validation ───────────────────────────────────────────────────────────
+
+function isValidInternalLink(href: string): boolean {
+  if (!href) return false;
+  if (/^(#|mailto:|tel:|javascript:|data:)/i.test(href)) return false;
+  if (isExternal(href)) return false;
+  const path = href.split("#")[0].split("?")[0];
+  if (!path || path === "/") return false;
+  if (/\.(png|jpe?g|gif|svg|webp|pdf|zip|tar|gz|exe|dmg|pkg|css|js|woff2?)$/i.test(path))
+    return false;
+  return true;
+}
+
+function containsCodeArtifacts(text: string): boolean {
+  if (/[{}()<>;=]|=>/.test(text)) return true;
+  if (/^\s*(export|import|const|let|var|function|class|return)\s/i.test(text)) return true;
+  if (/^https?:\/\//i.test(text)) return true;
+  if (/&[a-z]+;|&#\d+;/i.test(text)) return true;
+  if ((text.match(/[^a-zA-Z0-9\s.,!?:;'"()-]/g) ?? []).length > text.length * 0.15) return true;
+  return false;
+}
+
+const GENERIC_TEXT = new Set([
+  "here", "link", "this", "click here", "read more", "more", "source",
+  "reference", "details", "learn more", "see more", "release", "releases",
+  "changelog", "docs", "documentation", "example", "examples", "github",
+  "github.com", "download", "downloads", "repository", "repo",
+]);
+
+function isCleanTitle(text: string): boolean {
+  if (!text || text.length < 3 || text.length > 120) return false;
+  if (containsCodeArtifacts(text)) return false;
+  if (GENERIC_TEXT.has(text.toLowerCase().trim())) return false;
+  if (/^(from|on|in|at|see|the |this |that )\s/i.test(text.toLowerCase())) return false;
+  return true;
+}
+
+function isCleanDescription(text: string): boolean {
+  if (!text || text.length < 10 || text.length > 300) return false;
+  if (containsCodeArtifacts(text)) return false;
+  return true;
+}
+
+// ── Metadata resolution ───────────────────────────────────────────────────────
+
+function useMetaSafe(): Meta[] | null {
+  try {
+    const raw = usePluginData("sui-description-plugin") as any;
+    if (!raw) return null;
+    if (Array.isArray(raw)) return raw as Meta[];
+    if (Array.isArray(raw?.items)) return raw.items as Meta[];
+    if (Array.isArray(raw?.descriptions)) return raw.descriptions as Meta[];
+    if (Array.isArray(raw?.data)) return raw.data as Meta[];
+    if (raw?.byId && typeof raw.byId === "object")
+      return Object.values(raw.byId) as Meta[];
+    if (typeof raw === "object") {
+      const vals = Object.values(raw);
+      if (vals.length && typeof vals[0] === "object" && "id" in (vals[0] as any))
+        return vals as Meta[];
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function resolveMeta(href: string, data: Meta[] | null): Meta | undefined {
+  if (!data) return undefined;
+  const norm = normalizePath(href);
+  const noLead = norm.startsWith("/") ? norm.slice(1) : norm;
+  const withLead = norm.startsWith("/") ? norm : "/" + norm;
+  return data.find(
+    (m) =>
+      (m.id?.toLowerCase() === noLead) ||
+      (m.id?.toLowerCase() === withLead) ||
+      (m.path?.toLowerCase() === norm) ||
+      (m.path?.toLowerCase() === withLead),
+  );
+}
+
+// ── Link collection ──────────────────────────────────────────────────────────
+
+function shouldSkipPage(): boolean {
+  if (document.querySelector(".next-steps-module") !== null) return true;
+  if (document.querySelector("[class*='docCardList']") !== null) return true;
+  return false;
+}
+
+function collectLinks(
+  articleEl: Element,
+  currentPath: string,
+  meta: Meta[] | null,
+): ResolvedLink[] {
+  const seenPaths = new Set<string>();
+  const seenTitles = new Set<string>();
+  const results: ResolvedLink[] = [];
+
+  const contentArea = articleEl.querySelector(".theme-doc-markdown") ?? articleEl;
+
+  for (const a of Array.from(contentArea.querySelectorAll("a[href]"))) {
+    const href = a.getAttribute("href") ?? "";
+
+    if (!isValidInternalLink(href)) continue;
+
+    const normalized = normalizePath(href);
+
+    if (normalized === normalizePath(currentPath)) continue;
+
+    if (seenPaths.has(normalized)) continue;
+
+    const resolved = resolveMeta(normalized, meta);
+    let title: string | undefined;
+    let description: string | undefined;
+
+    const candidates = [
+      resolved?.title,
+      a.textContent?.trim(),
+      humanize(normalized),
+    ];
+
+    for (const raw of candidates) {
+      if (raw && isCleanTitle(raw)) {
+        title = toTitleCase(raw);
+        break;
+      }
+    }
+
+    if (!title) continue;
+
+    if (resolved?.description && isCleanDescription(resolved.description)) {
+      description = resolved.description;
+    }
+
+    const titleKey = title.toLowerCase();
+    if (seenTitles.has(titleKey)) continue;
+
+    seenPaths.add(normalized);
+    seenTitles.add(titleKey);
+
+    let score = resolved?.title ? 10 : 5;
+
+    if (description) score += 2;
+
+    results.push({
+      href: normalized,
+      title,
+      description,
+      external: false,
+      score,
+    });
+  }
+
+  return results;
+}
+
+// ── Card component ────────────────────────────────────────────────────────────
+
+function LinkCard({ link }: { link: ResolvedLink }) {
+  return (
+    <Link to={link.href}>
+      <div className="card__header">
+        <span className="card__title">{link.title}</span>
+      </div>
+      {link.description && link.description !== link.title && (
+        <div className="card__copy">{link.description}</div>
+      )}
+    </Link>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+interface AutoRelatedLinksProps {
+  title?: string;
+  description?: string;
+  maxLinks?: number;
+  contentSelector?: string;
+}
+
+export default function AutoRelatedLinks({
+  title = "Related topics",
+  description,
+  maxLinks = 4,
+  contentSelector = "article .theme-doc-markdown",
+}: AutoRelatedLinksProps) {
+  const meta = useMetaSafe();
+  const { pathname } = useLocation();
+  const [links, setLinks] = useState<ResolvedLink[]>([]);
+  const [portalTarget, setPortalTarget] = useState<Element | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      const article = document.querySelector("article");
+      const content = document.querySelector(contentSelector);
+      if (!article || !content) return;
+      if (shouldSkipPage()) return;
+
+      const collected = collectLinks(article, pathname, meta);
+
+      collected.sort((a, b) => b.score - a.score);
+      setLinks(collected.slice(0, maxLinks));
+
+      let mount = content.querySelector<HTMLElement>(".auto-related-links-mount");
+      if (!mount) {
+        mount = document.createElement("div");
+        mount.className = "auto-related-links-mount";
+        content.appendChild(mount);
+      }
+      containerRef.current = mount as HTMLDivElement;
+      setPortalTarget(mount);
+    }, 100);
+
+    return () => {
+      clearTimeout(timer);
+      containerRef.current?.remove();
+      containerRef.current = null;
+      setPortalTarget(null);
+    };
+  }, [pathname, meta, maxLinks, contentSelector]);
+
+  if (links.length === 0 || !portalTarget) return null;
+
+  return createPortal(
+    <div className="next-steps-module">
+      <div className="next-steps-header">
+        <h3>{title}</h3>
+      </div>
+      {description && (
+        <p className="next-steps-description">{description}</p>
+      )}
+      <div className="next-steps-grid">
+        {links.map((link) => (
+          <LinkCard key={link.href} link={link} />
+        ))}
+      </div>
+    </div>,
+    portalTarget,
+  );
+}

--- a/docs/site/src/css/custom.css
+++ b/docs/site/src/css/custom.css
@@ -1597,3 +1597,185 @@ html.kapa-sidebar-open .col[class*="docItemCol"] {
 [data-theme="dark"] .docusaurus-mermaid-container .messageLine1 {
   stroke: #FAF8F5 !important;
 }
+
+/* ── AutoRelatedLinks / Related topics module ─────────────────────────────── */
+
+.next-steps-module {
+  margin: 3rem 0 2rem;
+  padding: 2rem;
+  border-radius: 1rem;
+  background: linear-gradient(135deg, #ffffff 0%, #f5f3ff 100%);
+  border: 1px solid #cab1ff;
+  position: relative;
+  overflow: hidden;
+}
+
+.next-steps-module::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, #613dff 0%, #cab1ff 50%, rgba(97, 61, 255, 0) 100%);
+}
+
+.next-steps-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+  position: relative;
+  z-index: 1;
+}
+
+.next-steps-header::before {
+  content: '\2192';
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  background: #613dff;
+  color: white;
+  font-size: 1.25rem;
+  font-weight: 700;
+  border-radius: 0.625rem;
+}
+
+.next-steps-header h3 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #613dff;
+}
+
+.next-steps-description {
+  margin-bottom: 1.5rem;
+  color: #343940;
+  font-size: 0.938rem;
+  line-height: 1.6;
+  position: relative;
+  z-index: 1;
+}
+
+.next-steps-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
+  position: relative;
+  z-index: 1;
+}
+
+.next-steps-grid > a {
+  position: relative;
+  padding: 1.25rem;
+  border: 1px solid #e0e2e6;
+  border-radius: 0.75rem;
+  background: rgba(255, 255, 255, 0.8);
+  backdrop-filter: blur(10px);
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  text-decoration: none;
+  display: block;
+}
+
+.next-steps-grid > a::before {
+  content: '\2192';
+  position: absolute;
+  right: 1.25rem;
+  top: 50%;
+  transform: translateY(-50%) translateX(0);
+  color: #613dff;
+  font-size: 1.25rem;
+  font-weight: 700;
+  opacity: 0;
+  transition: all 0.3s ease;
+}
+
+.next-steps-grid > a:hover {
+  border-color: #613dff;
+  background: rgba(255, 255, 255, 1);
+  box-shadow: 0 8px 24px rgba(97, 61, 255, 0.15), 0 0 0 1px #cab1ff;
+  transform: translateY(-4px);
+  text-decoration: none;
+}
+
+.next-steps-grid > a:hover::before {
+  opacity: 1;
+  transform: translateY(-50%) translateX(4px);
+}
+
+.next-steps-grid .card__header {
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  color: #343940;
+}
+
+.next-steps-grid .card__copy {
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: #343940;
+  opacity: 0.8;
+  margin-right: 2rem;
+}
+
+/* Dark mode */
+[data-theme='dark'] .next-steps-module {
+  background: linear-gradient(135deg, #1a1a2e 0%, #1e1e3a 100%);
+  border-color: #98EFDD;
+}
+
+[data-theme='dark'] .next-steps-module::before {
+  background: linear-gradient(90deg, #98EFDD 0%, #613dff 50%, rgba(152, 239, 221, 0) 100%);
+}
+
+[data-theme='dark'] .next-steps-header::before {
+  background: #98EFDD;
+  color: #1a1a2e;
+}
+
+[data-theme='dark'] .next-steps-header h3 {
+  color: #98EFDD;
+}
+
+[data-theme='dark'] .next-steps-description {
+  color: #e0e2e6;
+}
+
+[data-theme='dark'] .next-steps-grid > a {
+  border-color: #343940;
+  background: rgba(26, 26, 46, 0.8);
+}
+
+[data-theme='dark'] .next-steps-grid > a::before {
+  color: #98EFDD;
+}
+
+[data-theme='dark'] .next-steps-grid > a:hover {
+  border-color: #98EFDD;
+  background: rgba(26, 26, 46, 1);
+  box-shadow: 0 8px 24px rgba(152, 239, 221, 0.15), 0 0 0 1px #98EFDD;
+}
+
+[data-theme='dark'] .next-steps-grid .card__header {
+  color: #e0e2e6;
+}
+
+[data-theme='dark'] .next-steps-grid .card__copy {
+  color: #e0e2e6;
+  opacity: 0.8;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .next-steps-module {
+    padding: 1.5rem;
+  }
+  .next-steps-grid {
+    grid-template-columns: 1fr;
+  }
+  .next-steps-header h3 {
+    font-size: 1.25rem;
+  }
+}

--- a/docs/site/src/scripts/transform-walrus-memory-docs.js
+++ b/docs/site/src/scripts/transform-walrus-memory-docs.js
@@ -656,6 +656,40 @@ function injectAgentPrompt(content, relPath) {
   );
 }
 
+// --- Remove references to skipped pages ---
+
+// Slugs (without extension) of pages that are not emitted.
+const SKIPPED_SLUGS = new Set([
+  "sdk/example-map",
+  "sdk/research-app-example",
+  "sdk/changelog",
+  "python-sdk/changelog",
+  "mcp/changelog",
+  "openclaw/changelog",
+]);
+
+function removeSkippedPageLinks(content) {
+  // Remove markdown links on their own line: - [text](/slug) or - [text](/slug) — desc
+  let result = content.replace(
+    /^[ \t]*-\s+\[([^\]]*)\]\(\/([^)]+)\)[^\n]*\n?/gm,
+    (match, _text, target) => {
+      const clean = target.replace(/^walrus-memory\//, "").replace(/\/$/, "");
+      return SKIPPED_SLUGS.has(clean) ? "" : match;
+    },
+  );
+
+  // Remove <Card> blocks pointing to skipped pages
+  result = result.replace(
+    /<Card\s+[^>]*href="\/([^"]+)"[^>]*>[\s\S]*?<\/Card>\s*/gi,
+    (match, target) => {
+      const clean = target.replace(/^walrus-memory\//, "").replace(/\/$/, "");
+      return SKIPPED_SLUGS.has(clean) ? "" : match;
+    },
+  );
+
+  return result;
+}
+
 // --- Main pipeline ---
 
 function transformFile(content) {
@@ -674,6 +708,9 @@ function transformFile(content) {
   result = convertPrerequisites(result);
   result = fixStackedHeadings(result);
   result = fixNumberedHeadingCase(result);
+
+  // Remove links and cards pointing to skipped pages
+  result = removeSkippedPageLinks(result);
 
   // Rewrite links
   result = rewriteInternalLinks(result);

--- a/docs/site/src/theme/DocItem/Layout/index.tsx
+++ b/docs/site/src/theme/DocItem/Layout/index.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import Layout from "@theme-original/DocItem/Layout";
 import type LayoutType from "@theme/DocItem/Layout";
 import type { WrapperProps } from "@docusaurus/types";
+import AutoRelatedLinks from "@site/src/components/AutoRelatedLinks";
 
 type Props = WrapperProps<typeof LayoutType>;
 
@@ -12,6 +13,7 @@ export default function DocItemLayoutWrapper(props: Props) {
   return (
     <>
       <Layout {...props} />
+      <AutoRelatedLinks />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Ports the `AutoRelatedLinks` component from the Sui docs site, adapted to Walrus's purple/teal color scheme
- The component automatically scans internal links on each doc page, resolves titles and descriptions from the existing `sui-description-plugin`, and renders a styled "Related topics" card grid (max 4 cards) at the bottom
- Injected globally via the `DocItem/Layout` theme wrapper — no MDX changes needed
- Skips pages that already have a `DocCardList` or an existing `.next-steps-module`
- Also adds `removeSkippedPageLinks` to the Walrus Memory transform to strip references to removed pages (changelogs, consolidated examples) and prevent broken link errors

## Test plan
- [x] `pnpm run build` passes with no broken link errors
- [x] Component CSS and JS are present in the build output
- [ ] Visual check: run `pnpm run serve` and verify the Related Topics cards render at the bottom of doc pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)