### PR TITLE
test: run the client end-to-end against a Sui fullnode with JSON-RPC disabled

### DIFF
--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -4485,6 +4485,31 @@ async fn store_and_read_with_grpc_only_sui_fullnode() -> TestResult {
         })
         .await?;
 
+    // The WAL transfer above executed through the cluster's default fullnode; the gRPC-only
+    // fullnode only sees it after syncing the containing checkpoint. Wait until the client's
+    // own fullnode shows the funds, otherwise coin selection races the sync and fails with
+    // NoCompatiblePaymentCoin.
+    {
+        let read_client = contract_client.as_ref().read_client();
+        let sui_client = read_client.retriable_sui_client();
+        let address = contract_client.as_ref().address();
+        tokio::time::timeout(Duration::from_secs(60), async {
+            loop {
+                if matches!(
+                    sui_client
+                        .get_total_balance(address, read_client.wal_coin_type())
+                        .await,
+                    Ok(balance) if balance > 0
+                ) {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+        })
+        .await
+        .expect("the WAL transfer must become visible on the gRPC-only fullnode");
+    }
+
     let config = ClientConfig {
         contract_config: system_ctx.contract_config(),
         exchange_objects: vec![],

--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -92,10 +92,7 @@ use walrus_sui::{
         SuiClientError,
         SuiContractClient,
         dual_client::DEFAULT_CHECKPOINT_WAIT_TIMEOUT,
-        retry_client::{
-            RetriableSuiClient,
-            retriable_sui_client::{GrpcMigrationLevel, LazySuiClientBuilder},
-        },
+        retry_client::{RetriableSuiClient, retriable_sui_client::LazySuiClientBuilder},
     },
     coin::Coin,
     config::WalletConfig,
@@ -4437,15 +4434,6 @@ async fn test_store_and_read_with_grpc_only_sui_fullnode() -> TestResult {
 async fn store_and_read_with_grpc_only_sui_fullnode() -> TestResult {
     walrus_test_utils::init_tracing();
 
-    // At migration levels that still require the JSON-RPC client, the client cannot work
-    // against a gRPC-only endpoint by design; this test is only meaningful at levels where
-    // the client runs fully on gRPC (the default).
-    if GrpcMigrationLevel::default().requires_json_rpc_client() {
-        tracing::warn!(
-            "skipping test: the configured WALRUS_GRPC_MIGRATION_LEVEL still requires JSON-RPC"
-        );
-        return Ok(());
-    }
     let (sui_cluster_handle, _cluster, admin_client, system_ctx, _) =
         test_cluster::E2eTestSetupBuilder::new().build().await?;
 

--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -4452,8 +4452,8 @@ async fn store_and_read_with_grpc_only_sui_fullnode() -> TestResult {
     let Some(grpc_only_rpc_url) = sui_cluster_handle
         .lock()
         .await
-        .grpc_only_rpc_url()
-        .map(str::to_owned)
+        .spawn_grpc_only_fullnode()
+        .await
     else {
         tracing::warn!(
             "skipping test: running against an external Sui cluster without a gRPC-only fullnode"

--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -91,7 +91,11 @@ use walrus_sui::{
         ReadClient,
         SuiClientError,
         SuiContractClient,
-        retry_client::{RetriableSuiClient, retriable_sui_client::LazySuiClientBuilder},
+        dual_client::DEFAULT_CHECKPOINT_WAIT_TIMEOUT,
+        retry_client::{
+            RetriableSuiClient,
+            retriable_sui_client::{GrpcMigrationLevel, LazySuiClientBuilder},
+        },
     },
     coin::Coin,
     config::WalletConfig,
@@ -4416,4 +4420,87 @@ async fn test_list_dynamic_fields_pagination() -> TestResult {
     }
 
     Ok(())
+}
+
+/// Tests that the client works end to end against a Sui fullnode that serves only gRPC, like
+/// the public Sui fullnodes. The client under test receives only the gRPC-only fullnode's URL;
+/// the test scaffolding keeps using the cluster's default fullnode.
+///
+/// TODO: remove this test once Sui removes JSON-RPC from fullnodes entirely and test clusters are
+/// gRPC-only by themselves.
+#[ignore = "ignore E2E tests by default"]
+#[walrus_simtest]
+async fn test_store_and_read_with_grpc_only_sui_fullnode() -> TestResult {
+    Box::pin(store_and_read_with_grpc_only_sui_fullnode()).await
+}
+
+async fn store_and_read_with_grpc_only_sui_fullnode() -> TestResult {
+    walrus_test_utils::init_tracing();
+
+    // At migration levels that still require the JSON-RPC client, the client cannot work
+    // against a gRPC-only endpoint by design; this test is only meaningful at levels where
+    // the client runs fully on gRPC (the default).
+    if GrpcMigrationLevel::default().requires_json_rpc_client() {
+        tracing::warn!(
+            "skipping test: the configured WALRUS_GRPC_MIGRATION_LEVEL still requires JSON-RPC"
+        );
+        return Ok(());
+    }
+    let (sui_cluster_handle, _cluster, admin_client, system_ctx, _) =
+        test_cluster::E2eTestSetupBuilder::new().build().await?;
+
+    let Some(grpc_only_rpc_url) = sui_cluster_handle
+        .lock()
+        .await
+        .grpc_only_rpc_url()
+        .map(str::to_owned)
+    else {
+        tracing::warn!(
+            "skipping test: running against an external Sui cluster without a gRPC-only fullnode"
+        );
+        return Ok(());
+    };
+    let rpc_urls = [grpc_only_rpc_url.clone()];
+
+    // The wallet is only used for keys and signing; the client under test dials Sui exclusively
+    // through `rpc_urls`, which contains only the gRPC-only fullnode.
+    let wallet = test_utils::new_wallet_on_sui_test_cluster(sui_cluster_handle.clone()).await?;
+    admin_client
+        .as_ref()
+        .sui_client()
+        .send_wal(FROST_PER_NODE_WEIGHT, wallet.as_ref().active_address())
+        .await?;
+
+    let contract_client = wallet
+        .and_then_async(async |wallet| {
+            system_ctx
+                .new_contract_client(
+                    wallet,
+                    &rpc_urls,
+                    Default::default(),
+                    None,
+                    DEFAULT_CHECKPOINT_WAIT_TIMEOUT,
+                )
+                .await
+        })
+        .await?;
+
+    let config = ClientConfig {
+        contract_config: system_ctx.contract_config(),
+        exchange_objects: vec![],
+        wallet_config: None,
+        rpc_urls: vec![grpc_only_rpc_url],
+        communication_config: ClientCommunicationConfig::default_for_test(),
+        refresh_config: Default::default(),
+        quilt_client_config: Default::default(),
+        byte_range_read_client_config: Default::default(),
+        streaming_config: Default::default(),
+    };
+    let client = contract_client
+        .and_then_async(|contract_client| {
+            WalrusNodeClient::new_contract_client_with_refresher(config, contract_client)
+        })
+        .await?;
+
+    basic_store_and_read(&client, 2, 31415, None, || Ok(())).await
 }

--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -4423,8 +4423,8 @@ async fn test_list_dynamic_fields_pagination() -> TestResult {
 /// the public Sui fullnodes. The client under test receives only the gRPC-only fullnode's URL;
 /// the test scaffolding keeps using the cluster's default fullnode.
 ///
-/// TODO: remove this test once Sui removes JSON-RPC from fullnodes entirely and test clusters are
-/// gRPC-only by themselves.
+/// TODO(WAL-1264): remove this test once Sui removes JSON-RPC from fullnodes entirely and test
+/// clusters are gRPC-only by themselves.
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_store_and_read_with_grpc_only_sui_fullnode() -> TestResult {

--- a/crates/walrus-sui/src/test_utils.rs
+++ b/crates/walrus-sui/src/test_utils.rs
@@ -151,46 +151,9 @@ pub struct TestClusterHandle {
     wallet_path: Mutex<PathBuf>,
     cluster: LocalOrExternalTestCluster,
     additional_fullnodes: Vec<FullNodeHandle>,
-    grpc_only_rpc_url: Option<String>,
 
     #[cfg(msim)]
     node_handle: NodeHandle,
-}
-
-/// Spawns an additional fullnode with JSON-RPC disabled and returns its RPC URL once its gRPC
-/// service is reachable. Panics on failure.
-///
-/// Only used by `test_store_and_read_with_grpc_only_sui_fullnode`. Spawned through the swarm
-/// because the cluster's primary fullnode cannot run without JSON-RPC (the Sui test harness
-/// handshakes with it over JSON-RPC during construction).
-async fn spawn_grpc_only_fullnode(test_cluster: &mut TestCluster) -> String {
-    let config = test_cluster
-        .fullnode_config_builder()
-        .with_disable_json_rpc(true)
-        .build(&mut rand::rngs::OsRng, test_cluster.swarm.config());
-    let rpc_url = format!("http://{}", config.json_rpc_address);
-    test_cluster.swarm.spawn_new_node(config).await;
-
-    // Poll with the raw gRPC client (not walrus's) so this does not depend on the
-    // `WALRUS_GRPC_MIGRATION_LEVEL` environment variable.
-    let mut grpc_client =
-        sui_rpc::Client::new(rpc_url.clone()).expect("creating gRPC client must succeed");
-    tokio::time::timeout(Duration::from_secs(60), async {
-        loop {
-            if grpc_client
-                .ledger_client()
-                .get_service_info(sui_rpc::proto::sui::rpc::v2::GetServiceInfoRequest::default())
-                .await
-                .is_ok()
-            {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(500)).await;
-        }
-    })
-    .await
-    .expect("gRPC-only fullnode must become ready within 60 seconds");
-    rpc_url
 }
 
 impl Debug for TestClusterHandle {
@@ -223,25 +186,17 @@ impl TestClusterHandle {
                 }
             }
 
-            let grpc_only_rpc_url = Some(spawn_grpc_only_fullnode(&mut test_cluster).await);
-
-            tx.send((
-                test_cluster,
-                wallet_path,
-                full_node_handles,
-                grpc_only_rpc_url,
-            ))
-            .expect("can send test cluster");
+            tx.send((test_cluster, wallet_path, full_node_handles))
+                .expect("can send test cluster");
         });
 
-        let (cluster, wallet_path, full_node_handles, grpc_only_rpc_url) =
+        let (cluster, wallet_path, full_node_handles) =
             rx.recv().expect("should receive test_cluster");
 
         Self {
             wallet_path: Mutex::new(wallet_path),
             cluster: LocalOrExternalTestCluster::Local { cluster },
             additional_fullnodes: full_node_handles,
-            grpc_only_rpc_url,
         }
     }
 
@@ -263,7 +218,6 @@ impl TestClusterHandle {
             cluster: LocalOrExternalTestCluster::External { rpc_url },
             wallet_path,
             additional_fullnodes: Vec::new(),
-            grpc_only_rpc_url: None,
         })
     }
 
@@ -320,20 +274,13 @@ impl TestClusterHandle {
                             full_node_handles.push(full_node_handle);
                         }
                     }
-                    let grpc_only_rpc_url = Some(spawn_grpc_only_fullnode(&mut test_cluster).await);
-                    tx.send((
-                        test_cluster,
-                        wallet_path,
-                        full_node_handles,
-                        grpc_only_rpc_url,
-                    ))
-                    .await
-                    .expect("Notifying cluster creation must succeed");
+                    tx.send((test_cluster, wallet_path, full_node_handles))
+                        .await
+                        .expect("Notifying cluster creation must succeed");
                 }
             })
             .build();
-        let Some((cluster, wallet_path, full_node_handles, grpc_only_rpc_url)) = rx.recv().await
-        else {
+        let Some((cluster, wallet_path, full_node_handles)) = rx.recv().await else {
             panic!("Unexpected end of channel");
         };
         Self {
@@ -341,7 +288,6 @@ impl TestClusterHandle {
             cluster: LocalOrExternalTestCluster::Local { cluster },
             node_handle,
             additional_fullnodes: full_node_handles,
-            grpc_only_rpc_url,
         }
     }
 
@@ -383,10 +329,59 @@ impl TestClusterHandle {
         &self.additional_fullnodes
     }
 
-    /// Returns the RPC URL of the fullnode that has JSON-RPC disabled; `None` on an external
-    /// Sui cluster.
-    pub fn grpc_only_rpc_url(&self) -> Option<&str> {
-        self.grpc_only_rpc_url.as_deref()
+    /// Spawns an additional fullnode with JSON-RPC disabled and returns its RPC URL once its
+    /// gRPC service is reachable; `None` on an external Sui cluster. Panics on failure.
+    ///
+    /// Only used by `test_store_and_read_with_grpc_only_sui_fullnode`; spawned on demand so
+    /// that other tests keep their cluster topology unchanged. Spawned through the swarm
+    /// because the cluster's primary fullnode cannot run without JSON-RPC (the Sui test
+    /// harness handshakes with it over JSON-RPC during construction).
+    pub async fn spawn_grpc_only_fullnode(&mut self) -> Option<String> {
+        let LocalOrExternalTestCluster::Local { cluster } = &mut self.cluster else {
+            return None;
+        };
+
+        // The new node starts with no state; everything created before this call (contracts,
+        // system objects) only becomes visible on it once it has synced up to the primary
+        // fullnode's current checkpoint. Capture that height as the readiness target.
+        let target_height = sui_rpc::Client::new(cluster.fullnode_handle.rpc_url.clone())
+            .expect("creating gRPC client must succeed")
+            .ledger_client()
+            .get_service_info(sui_rpc::proto::sui::rpc::v2::GetServiceInfoRequest::default())
+            .await
+            .expect("primary fullnode must answer GetServiceInfo")
+            .into_inner()
+            .checkpoint_height;
+
+        let config = cluster
+            .fullnode_config_builder()
+            .with_disable_json_rpc(true)
+            .build(&mut rand::rngs::OsRng, cluster.swarm.config());
+        let rpc_url = format!("http://{}", config.json_rpc_address);
+        cluster.swarm.spawn_new_node(config).await;
+
+        // Poll with the raw gRPC client (not walrus's) so this does not depend on the
+        // `WALRUS_GRPC_MIGRATION_LEVEL` environment variable.
+        let mut grpc_client =
+            sui_rpc::Client::new(rpc_url.clone()).expect("creating gRPC client must succeed");
+        tokio::time::timeout(Duration::from_secs(60), async {
+            loop {
+                if let Ok(response) = grpc_client
+                    .ledger_client()
+                    .get_service_info(
+                        sui_rpc::proto::sui::rpc::v2::GetServiceInfoRequest::default(),
+                    )
+                    .await
+                    && response.into_inner().checkpoint_height >= target_height
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+        })
+        .await
+        .expect("gRPC-only fullnode must catch up within 60 seconds");
+        Some(rpc_url)
     }
 }
 

--- a/crates/walrus-sui/src/test_utils.rs
+++ b/crates/walrus-sui/src/test_utils.rs
@@ -151,9 +151,46 @@ pub struct TestClusterHandle {
     wallet_path: Mutex<PathBuf>,
     cluster: LocalOrExternalTestCluster,
     additional_fullnodes: Vec<FullNodeHandle>,
+    grpc_only_rpc_url: Option<String>,
 
     #[cfg(msim)]
     node_handle: NodeHandle,
+}
+
+/// Spawns an additional fullnode with JSON-RPC disabled and returns its RPC URL once its gRPC
+/// service is reachable. Panics on failure.
+///
+/// Only used by `test_store_and_read_with_grpc_only_sui_fullnode`. Spawned through the swarm
+/// because the cluster's primary fullnode cannot run without JSON-RPC (the Sui test harness
+/// handshakes with it over JSON-RPC during construction).
+async fn spawn_grpc_only_fullnode(test_cluster: &mut TestCluster) -> String {
+    let config = test_cluster
+        .fullnode_config_builder()
+        .with_disable_json_rpc(true)
+        .build(&mut rand::rngs::OsRng, test_cluster.swarm.config());
+    let rpc_url = format!("http://{}", config.json_rpc_address);
+    test_cluster.swarm.spawn_new_node(config).await;
+
+    // Poll with the raw gRPC client (not walrus's) so this does not depend on the
+    // `WALRUS_GRPC_MIGRATION_LEVEL` environment variable.
+    let mut grpc_client =
+        sui_rpc::Client::new(rpc_url.clone()).expect("creating gRPC client must succeed");
+    tokio::time::timeout(Duration::from_secs(60), async {
+        loop {
+            if grpc_client
+                .ledger_client()
+                .get_service_info(sui_rpc::proto::sui::rpc::v2::GetServiceInfoRequest::default())
+                .await
+                .is_ok()
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+    })
+    .await
+    .expect("gRPC-only fullnode must become ready within 60 seconds");
+    rpc_url
 }
 
 impl Debug for TestClusterHandle {
@@ -186,17 +223,25 @@ impl TestClusterHandle {
                 }
             }
 
-            tx.send((test_cluster, wallet_path, full_node_handles))
-                .expect("can send test cluster");
+            let grpc_only_rpc_url = Some(spawn_grpc_only_fullnode(&mut test_cluster).await);
+
+            tx.send((
+                test_cluster,
+                wallet_path,
+                full_node_handles,
+                grpc_only_rpc_url,
+            ))
+            .expect("can send test cluster");
         });
 
-        let (cluster, wallet_path, full_node_handles) =
+        let (cluster, wallet_path, full_node_handles, grpc_only_rpc_url) =
             rx.recv().expect("should receive test_cluster");
 
         Self {
             wallet_path: Mutex::new(wallet_path),
             cluster: LocalOrExternalTestCluster::Local { cluster },
             additional_fullnodes: full_node_handles,
+            grpc_only_rpc_url,
         }
     }
 
@@ -218,6 +263,7 @@ impl TestClusterHandle {
             cluster: LocalOrExternalTestCluster::External { rpc_url },
             wallet_path,
             additional_fullnodes: Vec::new(),
+            grpc_only_rpc_url: None,
         })
     }
 
@@ -274,13 +320,20 @@ impl TestClusterHandle {
                             full_node_handles.push(full_node_handle);
                         }
                     }
-                    tx.send((test_cluster, wallet_path, full_node_handles))
-                        .await
-                        .expect("Notifying cluster creation must succeed");
+                    let grpc_only_rpc_url = Some(spawn_grpc_only_fullnode(&mut test_cluster).await);
+                    tx.send((
+                        test_cluster,
+                        wallet_path,
+                        full_node_handles,
+                        grpc_only_rpc_url,
+                    ))
+                    .await
+                    .expect("Notifying cluster creation must succeed");
                 }
             })
             .build();
-        let Some((cluster, wallet_path, full_node_handles)) = rx.recv().await else {
+        let Some((cluster, wallet_path, full_node_handles, grpc_only_rpc_url)) = rx.recv().await
+        else {
             panic!("Unexpected end of channel");
         };
         Self {
@@ -288,6 +341,7 @@ impl TestClusterHandle {
             cluster: LocalOrExternalTestCluster::Local { cluster },
             node_handle,
             additional_fullnodes: full_node_handles,
+            grpc_only_rpc_url,
         }
     }
 
@@ -327,6 +381,12 @@ impl TestClusterHandle {
     /// Returns the additional fullnodes.
     pub fn additional_fullnodes(&self) -> &[FullNodeHandle] {
         &self.additional_fullnodes
+    }
+
+    /// Returns the RPC URL of the fullnode that has JSON-RPC disabled; `None` on an external
+    /// Sui cluster.
+    pub fn grpc_only_rpc_url(&self) -> Option<&str> {
+        self.grpc_only_rpc_url.as_deref()
     }
 }
 


### PR DESCRIPTION
## Description

Add an e2e test that runs the client against a Sui fullnode with JSON-RPC disabled, matching public fullnodes. The client under test reaches Sui only through the gRPC-only fullnode's URL; the node is spawned on demand so other tests' cluster topology is unchanged.

Remove the test once Sui drops JSON-RPC from fullnodes entirely and test clusters are gRPC-only by themselves.
