### PR TITLE
feat: expose the blob info snapshot digest as a metric

### DIFF
--- a/crates/walrus-service/src/node/blob_info_snapshot_writer.rs
+++ b/crates/walrus-service/src/node/blob_info_snapshot_writer.rs
@@ -175,7 +175,7 @@ pub(super) async fn serialize_snapshot_at_epoch_boundary(
     // bucketed like the consistency-check hashes to keep Prometheus cardinality bounded.
     #[allow(clippy::cast_possible_wrap)] // reinterpreting the hash bits as i64 is fine
     walrus_utils::with_label!(
-        node.metrics.blob_info_snapshot_digest,
+        node.metrics.per_object_blob_info_snapshot_digest,
         super::consistency_check::get_epoch_bucket(epoch)
     )
     .set(digest as i64);

--- a/crates/walrus-service/src/node/blob_info_snapshot_writer.rs
+++ b/crates/walrus-service/src/node/blob_info_snapshot_writer.rs
@@ -171,6 +171,14 @@ pub(super) async fn serialize_snapshot_at_epoch_boundary(
     node.metrics
         .blob_info_snapshot_size_bytes
         .set(saturating_i64(size_bytes));
+    // Expose the digest per epoch so an off-node observer can compare it across nodes; the label is
+    // bucketed like the consistency-check hashes to keep Prometheus cardinality bounded.
+    #[allow(clippy::cast_possible_wrap)] // reinterpreting the hash bits as i64 is fine
+    walrus_utils::with_label!(
+        node.metrics.blob_info_snapshot_digest,
+        super::consistency_check::get_epoch_bucket(epoch)
+    )
+    .set(digest as i64);
     let digest_hex = format!("{digest:016x}");
     tracing::info!(
         walrus.epoch = epoch,

--- a/crates/walrus-service/src/node/consistency_check.rs
+++ b/crates/walrus-service/src/node/consistency_check.rs
@@ -213,7 +213,7 @@ fn epoch_bucket_count() -> u32 {
     })
 }
 
-fn get_epoch_bucket(epoch: Epoch) -> String {
+pub(super) fn get_epoch_bucket(epoch: Epoch) -> String {
     (epoch % epoch_bucket_count()).to_string()
 }
 

--- a/crates/walrus-service/src/node/metrics.rs
+++ b/crates/walrus-service/src/node/metrics.rs
@@ -209,7 +209,7 @@ walrus_utils::metrics::define_metric_set! {
 
         #[help = "The xxhash64 digest of the in-process blob info snapshot, for cross-node \
         comparison. Note that the label is epoch % EPOCH_BUCKET_COUNT (see consistency_check.rs)."]
-        blob_info_snapshot_digest: IntGaugeVec["epoch"],
+        per_object_blob_info_snapshot_digest: IntGaugeVec["epoch"],
 
         #[help = "The number of certified per-object blobs scanned during the per-object blob info \
         consistency check."]

--- a/crates/walrus-service/src/node/metrics.rs
+++ b/crates/walrus-service/src/node/metrics.rs
@@ -207,6 +207,10 @@ walrus_utils::metrics::define_metric_set! {
         #[help = "The size in bytes of the in-process blob info snapshot."]
         blob_info_snapshot_size_bytes: IntGauge[],
 
+        #[help = "The xxhash64 digest of the in-process blob info snapshot, for cross-node \
+        comparison. Note that the label is epoch % EPOCH_BUCKET_COUNT (see consistency_check.rs)."]
+        blob_info_snapshot_digest: IntGaugeVec["epoch"],
+
         #[help = "The number of certified per-object blobs scanned during the per-object blob info \
         consistency check."]
         per_object_blob_info_consistency_check_certified_scanned: IntCounterVec["epoch"],


### PR DESCRIPTION
## Description

Add `walrus_blob_info_snapshot_digest`, an epoch-labelled gauge carrying the xxhash64 digest of the snapshot.
Later in Antithesis tests,  an observer can compare digests across nodes from metrics alone. 

The epoch label is bucketed via `get_epoch_bucket` exactly like the consistency-check hashes to keep Prometheus cardinality bounded.

## Test plan

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
