### PR TITLE
chore: replace MSIM_TEST_NUM with a for loop in simtest-run.sh

### DIFF
--- a/scripts/simtest/simtest-run.sh
+++ b/scripts/simtest/simtest-run.sh
@@ -89,7 +89,6 @@ if [ "$TEST_FILTER" != "simtest" ] && [ "$TEST_NUM" -gt 1 ]; then
 
     TMPDIR="$WALRUS_TMP_DIR" \
     MSIM_TEST_SEED="$ITER_SEED" \
-    MSIM_TEST_NUM=1 \
     MSIM_WATCHDOG_TIMEOUT_MS="$WATCHDOG_TIMEOUT_MS" \
     scripts/simtest/cargo-simtest simtest "$TEST_FILTER" \
       --color never \
@@ -97,18 +96,21 @@ if [ "$TEST_FILTER" != "simtest" ] && [ "$TEST_NUM" -gt 1 ]; then
       --profile simtestnightly > "$ITER_LOG_FILE" 2>&1 &
   done
 else
-  # This command runs many different tests, so it already uses all CPUs fairly efficiently, and
-  # don't need to be done inside of the for loop below.
-  # TODO: this logs directly to stdout since it is not being run in parallel. is that ok?
+  # This command runs many different tests, so each iteration already uses all CPUs fairly
+  # efficiently. Run the iterations sequentially rather than in parallel, each with a distinct seed.
 
-  TMPDIR="$WALRUS_TMP_DIR" \
-  MSIM_TEST_SEED="$SEED" \
-  MSIM_TEST_NUM=${TEST_NUM} \
-  MSIM_WATCHDOG_TIMEOUT_MS="$WATCHDOG_TIMEOUT_MS" \
-  scripts/simtest/cargo-simtest simtest "$TEST_FILTER" \
-    --color never \
-    --test-threads "$NUM_CPUS" \
-    --profile simtestnightly 2>&1 | tee "$LOG_FILE"
+  for ((ITER = 0; ITER < TEST_NUM; ITER++)); do
+    ITER_SEED=$((SEED + ITER))
+    echo "Starting iteration $ITER with seed $ITER_SEED"
+
+    TMPDIR="$WALRUS_TMP_DIR" \
+    MSIM_TEST_SEED="$ITER_SEED" \
+    MSIM_WATCHDOG_TIMEOUT_MS="$WATCHDOG_TIMEOUT_MS" \
+    scripts/simtest/cargo-simtest simtest "$TEST_FILTER" \
+      --color never \
+      --test-threads "$NUM_CPUS" \
+      --profile simtestnightly 2>&1 | tee -a "$LOG_FILE"
+  done
 fi
 
 # wait for all the jobs to end


### PR DESCRIPTION
## Summary

Replaces the use of the `MSIM_TEST_NUM` environment variable in `scripts/simtest/simtest-run.sh` with an explicit `for` loop that repeats the simtest command the requested number of times.

- The `else` branch now loops `TEST_NUM` times, running the simtest command once per iteration with a distinct seed (`SEED + ITER`), instead of relying on `MSIM_TEST_NUM` to run iterations inside a single execution.
- Removed the now-redundant `MSIM_TEST_NUM=1` from the parallel branch (that loop already runs each iteration exactly once).
- Switched `tee` to `tee -a` so sequential iterations append to the log rather than clobbering it.
- Updated a stale comment that referenced a "for loop below" and stdout-only logging.

`MSIM_TEST_NUM` no longer appears anywhere in the script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)