### PR TITLE
docs: update homepage cards, navbar, and walrus-memory routing

### DIFF
--- a/docs/site/docusaurus.config.js
+++ b/docs/site/docusaurus.config.js
@@ -143,7 +143,10 @@ const config = {
       "@docusaurus/plugin-client-redirects",
       {
         fromExtensions: ["html", "htm"],
-        redirects: [{ from: "/index.html", to: "/" }],
+        redirects: [
+          { from: "/index.html", to: "/" },
+          { from: "/walrus-memory/getting-started/what-is-walrus-memory", to: "/walrus-memory" },
+        ],
         createRedirects(existingPath) {
           if (existingPath === "/" || existingPath === "") return undefined;
 
@@ -335,10 +338,10 @@ const config = {
             type: "docSidebar",
             sidebarId: "docsSidebar",
             position: "left",
-            label: "Walrus Platform",
+            label: "Walrus",
           },
           {
-            to: "/walrus-memory/getting-started/what-is-walrus-memory",
+            to: "/walrus-memory",
             label: "Walrus Memory",
             position: "left",
           },

--- a/docs/site/src/components/LandingPage.tsx
+++ b/docs/site/src/components/LandingPage.tsx
@@ -173,20 +173,20 @@ html, body { background: var(--l-bg) !important; }
 
 const HOME_CARDS = [
   {
+    image: '/img/home/walrus-protocol.webp',
+    title: 'Walrus',
+    description:
+      'Open-source decentralized storage infrastructure for '
+      + 'building your own data layer.',
+    href: '/docs/getting-started',
+  },
+  {
     image: '/img/home/walrus-memory.webp',
     title: 'Walrus Memory',
     description:
       'Portable memory layer for AI agents that persists context '
       + 'across apps and sessions.',
-    href: '/walrus-memory/getting-started/what-is-walrus-memory',
-  },
-  {
-    image: '/img/home/walrus-protocol.webp',
-    title: 'Walrus Protocol',
-    description:
-      'Open-source decentralized storage infrastructure for '
-      + 'building your own data layer.',
-    href: '/docs/getting-started',
+    href: '/walrus-memory',
   },
   {
     image: '/img/home/walrus-skills.webp',

--- a/docs/site/src/scripts/transform-walrus-memory-docs.js
+++ b/docs/site/src/scripts/transform-walrus-memory-docs.js
@@ -856,49 +856,13 @@ function main() {
     count++;
   }
 
-  // Write landing page (not in upstream repo, maintained here)
-  const landingPage = `---
-title: Walrus Memory
-description: "Portable, verifiable memory for AI agents built on Walrus and Sui."
-slug: /
----
-
-Walrus Memory gives AI agents persistent, portable memory that works across apps, sessions, and
-workflows. Ownership and access are enforced onchain through Sui smart contracts, and all content is
-encrypted through Seal before reaching Walrus.
-
-<Cards>
-  <Card title="Get Started" href="/walrus-memory/getting-started/what-is-walrus-memory">
-    Learn what Walrus Memory is and get up and running quickly
-  </Card>
-  <Card title="Concepts" href="/walrus-memory/fundamentals/concepts/memory-space">
-    Memory spaces, ownership, delegates, and access control
-  </Card>
-  <Card title="Architecture" href="/walrus-memory/fundamentals/architecture/core-components">
-    Core components, data flow, storage model, and security
-  </Card>
-  <Card title="TypeScript SDK" href="/walrus-memory/sdk/overview">
-    Integrate memory into TypeScript apps with the SDK
-  </Card>
-  <Card title="Python SDK" href="/walrus-memory/python-sdk/quick-start">
-    Use Walrus Memory from Python
-  </Card>
-  <Card title="Relayer" href="/walrus-memory/relayer/overview">
-    Managed relayer, self-hosting, and API reference
-  </Card>
-  <Card title="MCP" href="/walrus-memory/mcp/overview">
-    Model Context Protocol integration for AI tools
-  </Card>
-  <Card title="Smart Contract" href="/walrus-memory/contract/overview">
-    Onchain ownership model, delegate keys, and permissions
-  </Card>
-  <Card title="Indexer" href="/walrus-memory/indexer/purpose">
-    Event indexing, onchain events, and database sync
-  </Card>
-</Cards>
-`;
-  fs.writeFileSync(path.join(OUTPUT_DIR, "index.md"), landingPage);
-  count++;
+  // Add slug: / to what-is-walrus-memory so it serves at /walrus-memory
+  const wmPath = path.join(OUTPUT_DIR, "getting-started/what-is-walrus-memory.md");
+  if (fs.existsSync(wmPath)) {
+    let wmContent = fs.readFileSync(wmPath, "utf8");
+    wmContent = wmContent.replace(/^---\n/, "---\nslug: /\n");
+    fs.writeFileSync(wmPath, wmContent);
+  }
 
   console.log(
     `✅ walrus-memory: transformed ${count} files → walrus-memory-content/`,


### PR DESCRIPTION
## Summary
- Rename "Walrus Platform" → "Walrus" in the navbar
- Reorder homepage cards: Walrus first (renamed from "Walrus Protocol"), Walrus Memory second
- Serve the "What is Walrus Memory?" page at `/walrus-memory` instead of the card-hub landing page
- Add redirect from `/walrus-memory/getting-started/what-is-walrus-memory` → `/walrus-memory`

## Test plan
- [ ] Homepage shows Walrus as the first card, Walrus Memory as the second
- [ ] Navbar shows "Walrus" instead of "Walrus Platform"
- [ ] `/walrus-memory` shows the "What is Walrus Memory?" content
- [ ] `/walrus-memory/getting-started/what-is-walrus-memory` redirects to `/walrus-memory`
- [ ] Sidebar "Get Started" category still links correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)