### PR TITLE
docs(site): MemWal discoverability on the Memory docs (BEDU-951, BEDU-956)

### DIFF
--- a/docs/site/sidebarsWalrusMemory.js
+++ b/docs/site/sidebarsWalrusMemory.js
@@ -21,7 +21,12 @@ const sidebars = {
       "items": [
         "getting-started/quick-start",
         "getting-started/choose-your-path",
-        "examples/example-apps"
+        "examples/example-apps",
+        {
+          "type": "link",
+          "label": "GitHub",
+          "href": "https://github.com/MystenLabs/MemWal"
+        }
       ]
     },
     {

--- a/docs/site/src/scripts/generate-walrus-memory-sidebar.js
+++ b/docs/site/src/scripts/generate-walrus-memory-sidebar.js
@@ -71,6 +71,11 @@ const STRUCTURE = [
       "getting-started/quick-start",
       "getting-started/choose-your-path",
       "examples/example-apps",
+      {
+        type: "link",
+        label: "GitHub",
+        href: "https://github.com/MystenLabs/MemWal",
+      },
     ],
     autoDirs: ["getting-started", "examples"],
   },
@@ -279,6 +284,9 @@ function buildCategory(def, availableSlugs, placedSlugs) {
       } else {
         console.warn(`  \u26a0\ufe0f  Page listed but not found on disk: ${item}`);
       }
+    } else if (item.type === "link") {
+      // External link item (e.g. the MemWal GitHub repo) — pass through as-is
+      items.push(item);
     } else if (item.items) {
       // Subcategory — recurse
       const sub = buildCategory(item, availableSlugs, placedSlugs);

--- a/docs/site/src/scripts/transform-walrus-memory-docs.js
+++ b/docs/site/src/scripts/transform-walrus-memory-docs.js
@@ -687,6 +687,12 @@ function fixNumberedHeadingCase(content) {
 const AGENT_PROMPTS = {
   "getting-started/quick-start.md":
     "Run `curl -sL https://memory.walrus.xyz/skills/setup` and use the returned instructions to set up Walrus Memory in this AI client.",
+  "sdk/quick-start.md":
+    "Install @mysten-incubation/memwal in this project, create a MemWal client from the MEMWAL_PRIVATE_KEY, MEMWAL_ACCOUNT_ID, and MEMWAL_SERVER_URL environment variables, then store and recall a test memory to verify the setup.",
+  "sdk/headless-setup.md":
+    "Set up the Walrus Memory SDK headlessly in this server codebase: load the delegate key, account ID, and relayer URL from the environment, create the client at startup, and add a health check that calls memwal.health() on boot.",
+  "mcp/overview.md":
+    "Add the Walrus Memory MCP server to this client. On Claude Code run `claude mcp add --scope user memwal -- npx -y @mysten-incubation/memwal-mcp`; on other clients add the equivalent mcp.json entry. Then ask the agent to run memwal_login to sign in.",
 };
 
 function injectAgentPrompt(content, relPath) {

--- a/docs/site/src/scripts/transform-walrus-memory-docs.js
+++ b/docs/site/src/scripts/transform-walrus-memory-docs.js
@@ -688,11 +688,17 @@ const AGENT_PROMPTS = {
   "getting-started/quick-start.md":
     "Run `curl -sL https://memory.walrus.xyz/skills/setup` and use the returned instructions to set up Walrus Memory in this AI client.",
   "sdk/quick-start.md":
-    "Install @mysten-incubation/memwal in this project, create a MemWal client from the MEMWAL_PRIVATE_KEY, MEMWAL_ACCOUNT_ID, and MEMWAL_SERVER_URL environment variables, then store and recall a test memory to verify the setup.",
+    "Install @mysten-incubation/memwal in this project, create a MemWal client from the " +
+    "MEMWAL_PRIVATE_KEY, MEMWAL_ACCOUNT_ID, and MEMWAL_SERVER_URL environment variables, " +
+    "then store and recall a test memory to verify the setup.",
   "sdk/headless-setup.md":
-    "Set up the Walrus Memory SDK headlessly in this server codebase: load the delegate key, account ID, and relayer URL from the environment, create the client at startup, and add a health check that calls memwal.health() on boot.",
+    "Set up the Walrus Memory SDK headlessly in this server codebase: load the delegate key, " +
+    "account ID, and relayer URL from the environment, create the client at startup, and add " +
+    "a health check that calls memwal.health() on boot.",
   "mcp/overview.md":
-    "Add the Walrus Memory MCP server to this client. On Claude Code run `claude mcp add --scope user memwal -- npx -y @mysten-incubation/memwal-mcp`; on other clients add the equivalent mcp.json entry. Then ask the agent to run memwal_login to sign in.",
+    "Add the Walrus Memory MCP server to this client. On Claude Code run " +
+    "`claude mcp add --scope user memwal -- npx -y @mysten-incubation/memwal-mcp`; on other " +
+    "clients add the equivalent mcp.json entry. Then ask the agent to run memwal_login to sign in.",
 };
 
 function injectAgentPrompt(content, relPath) {


### PR DESCRIPTION
## Description

GitHub Stars Initiative, walrus-repo half (companion to MystenLabs/MemWal#498, which carries the content-side CTAs and example pages that flow through the fetch pipeline).

- **BEDU-951 — scoped GitHub link:** adds a GitHub link to `MystenLabs/MemWal` inside the Memory docs sidebar (Get Started group), so the repo link lives exactly where Memory readers are, without touching the global navbar. Implemented as a small link-item passthrough in `generate-walrus-memory-sidebar.js` plus a STRUCTURE entry; `sidebarsWalrusMemory.js` regenerated through the real pipeline.
- **BEDU-956 — AgentPrompt coverage:** extends the existing `AGENT_PROMPTS` injection map in `transform-walrus-memory-docs.js` to three more Memory task pages (SDK quick start, headless setup, MCP overview), each with a concrete builder prompt. llms.txt coverage for the Memory section was audited and is already complete (74 entries; generator handles the `/walrus-memory/` prefix) — no change needed.

## Verification

Ran the full pipeline locally (`fetch-walrus-memory-docs.js --force` → `transform-walrus-memory-docs.js` → `generate-walrus-memory-sidebar.js`): 74 files transformed, sidebar regenerated with the link item, and all four AgentPrompt injections present in the output content.

## Deliberately deferred (visual changes needing design review)

- The optional live star-count component and the LandingPage Memory-card repo link (the card is a single anchor; adding a second link means restructuring the card markup). Happy to follow up with design input.
- After MemWal#498 merges, a sidebar regen picks up the three new example pages automatically via `autoDirs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoBWxqLzd9hAxrhoqv3iSv

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoBWxqLzd9hAxrhoqv3iSv)_