### PR TITLE
test: fix flaky storage pool simtests racing epoch changes

### DIFF
--- a/crates/walrus-simtest/tests/simtest_storage_pool.rs
+++ b/crates/walrus-simtest/tests/simtest_storage_pool.rs
@@ -148,6 +148,12 @@ mod tests {
 
         // An epoch change concurrent with the upload can invalidate the confirmations or
         // the certificate; refresh the committees and retry in that case.
+        //
+        // The retry must wait before the next attempt: the client refreshes its committees
+        // from the chain as soon as the new epoch starts, but the storage nodes only switch
+        // epochs once they process the epoch-change event, which takes several (simulated)
+        // seconds. Retrying immediately makes the nodes sign confirmations with the old
+        // epoch, which the client rejects, exhausting all attempts within milliseconds.
         let mut attempt = 1;
         loop {
             let result: anyhow::Result<()> = async {
@@ -176,7 +182,7 @@ mod tests {
             match result {
                 Ok(()) => break,
                 Err(error)
-                    if attempt < 3
+                    if attempt < 5
                         && (error
                             .downcast_ref::<ClientError>()
                             .is_some_and(|error| error.may_be_caused_by_epoch_change())
@@ -187,6 +193,7 @@ mod tests {
                         attempt,
                         "storing pooled blob failed, possibly due to an epoch change; retrying"
                     );
+                    tokio::time::sleep(Duration::from_secs(5)).await;
                     client.as_ref().force_refresh_committees().await?;
                     attempt += 1;
                 }
@@ -503,7 +510,9 @@ mod tests {
         let ctx = setup_cluster(epoch_dur, Some(3)).await;
         let sui = ctx.sui();
 
-        let bucket = sui.create_storage_pool(10 * 1024 * 1024, 1).await.unwrap();
+        // Two epochs so that a store racing the next epoch change cannot hit the pool's
+        // expiry boundary (see `test_storage_pool_same_blob_two_pools`).
+        let bucket = sui.create_storage_pool(10 * 1024 * 1024, 2).await.unwrap();
         let end_epoch = sui.storage_pool_status(bucket).await.unwrap().end_epoch;
 
         let d = walrus_test_utils::random_data(1024);
@@ -526,7 +535,10 @@ mod tests {
         let sui = ctx.sui();
         let cap: u64 = 10 * 1024 * 1024;
 
-        let short = sui.create_storage_pool(cap, 1).await.unwrap();
+        // Use two epochs for the short pool: with a single epoch, the pool expires at the
+        // first epoch change after creation, and a store racing that boundary fails
+        // unrecoverably (the registration is garbage collected on all nodes).
+        let short = sui.create_storage_pool(cap, 2).await.unwrap();
         let long = sui.create_storage_pool(cap, 5).await.unwrap();
         let short_end = sui.storage_pool_status(short).await.unwrap().end_epoch;
 
@@ -738,7 +750,9 @@ mod tests {
         let ctx = setup_cluster(epoch_dur, Some(3)).await;
         let sui = ctx.sui();
 
-        let bucket = sui.create_storage_pool(10 * 1024 * 1024, 1).await.unwrap();
+        // Two epochs so that a store racing the next epoch change cannot hit the pool's
+        // expiry boundary (see `test_storage_pool_same_blob_two_pools`).
+        let bucket = sui.create_storage_pool(10 * 1024 * 1024, 2).await.unwrap();
         let end_epoch = sui.storage_pool_status(bucket).await.unwrap().end_epoch;
 
         let original = walrus_test_utils::random_data(1024);


### PR DESCRIPTION
## Description

`simtest_test_storage_pool_same_blob_two_pools` fails in CI with:

```
thread '<unnamed>' panicked at crates/walrus-simtest/tests/simtest_storage_pool.rs:210:14:
store_blob should succeed: could not retrieve enough confirmations to certify the blob: 0 / 9 required;
```

Reproduced deterministically with `MSIM_TEST_SEED=11` (10 out of 60 seeds fail on `main`). The failing seed's logs show two distinct races between the test's pooled-blob store and an epoch change:

1. **Retry loop burns out during the epoch transition.** On the failing seed, the store's certify transaction lands just after the on-chain epoch change and fails with `EIncorrectEpoch`. The `store_blob` helper then refreshed the client committees and retried immediately, but the storage nodes only switch epochs once they process the epoch-change event, which takes several simulated seconds. The nodes keep signing confirmations with the old epoch, the client (already on the new epoch) rejects all of them, and all retry attempts complete within ~200 ms — each failing with 0/9 confirmations. The fix waits 5 seconds before each retry (and allows up to 5 attempts) so the nodes can finish the transition.

2. **Single-epoch pools expire at the first epoch boundary.** Pools created with `epochs_ahead=1` expire at the first epoch change after creation. A store racing that boundary fails unrecoverably: garbage collection deletes the pooled registration on all nodes at the epoch start (so no node signs a confirmation), and the on-chain `certify` asserts `current_epoch < end_epoch`. The short-lived pools in `test_storage_pool_same_blob_two_pools`, `test_storage_pool_expiration`, and `test_storage_pool_expired_pool_rejects_mutations` now use two epochs instead; the expiry assertions are unchanged since they read the pool's `end_epoch` from chain state.

## Test plan

- Before the fix: seeds 9, 11, 12, 17, 20, 22, 32, 42, 46, 49 (of 1–60) fail with the exact CI panic; `MSIM_TEST_SEED=11` fails deterministically.
- After the fix: `simtest_test_storage_pool_same_blob_two_pools` passes on all 60 seeds, including seed 11.
- `simtest_test_storage_pool_expiration` and `simtest_test_storage_pool_expired_pool_rejects_mutations` pass on seeds 1–5.