### PR TITLE
fix: cancel scheduled epoch change initiation based on its own scheduled epoch

### DIFF
--- a/crates/walrus-service/src/node/epoch_change_driver.rs
+++ b/crates/walrus-service/src/node/epoch_change_driver.rs
@@ -241,7 +241,7 @@ impl EpochChangeDriver {
     pub fn cancel_scheduled_epoch_change_initiation(&self, epoch: Epoch) {
         let mut inner = self.inner.lock().expect("thread did not panic with lock");
 
-        if let Some((ref epoch_of_scheduled_future, _)) = inner.end_voting_future {
+        if let Some((ref epoch_of_scheduled_future, _)) = inner.epoch_change_start_future {
             if epoch == *epoch_of_scheduled_future {
                 inner.epoch_change_start_future = None;
                 tracing::debug!(walrus.epoch = epoch, "cancelled epoch change initiation");


### PR DESCRIPTION
## Description

`EpochChangeDriver::cancel_scheduled_epoch_change_initiation` decides whether to cancel by comparing the requested epoch against the epoch stored in `end_voting_future` — the schedule for a *different* operation — while it clears `epoch_change_start_future`. As a result, the scheduled epoch-change initiation could be cancelled (or kept) based on an unrelated schedule:

- If no voting-end call happens to be scheduled, the cancellation silently does nothing and the node may redundantly attempt `initiate_epoch_change` for an epoch that has already started (harmless on chain, but wasted work and noise).
- If a voting-end call for a matching epoch is scheduled, a scheduled initiation for a *non-matching* epoch could be cleared incorrectly.

This changes the guard to inspect `epoch_change_start_future`, the future it actually clears — mirroring how `cancel_scheduled_voting_end` guards on `end_voting_future`.

## Test plan

Existing unit tests and CI. The `walrus-service` test suite passes locally.