### PR TITLE
fix: Memory-docs transform rewrote identifiers inside indented code samples

### DIFF
--- a/docs/site/src/scripts/transform-walrus-memory-docs.js
+++ b/docs/site/src/scripts/transform-walrus-memory-docs.js
@@ -310,7 +310,9 @@ function renameMemwal(content) {
   const result = [];
 
   for (const line of lines) {
-    if (/^```/.test(line)) {
+    // Fences can be indented (content nested in <Steps>/<Tabs> keeps its
+    // source indentation), so match them anywhere after leading whitespace.
+    if (/^\s*```/.test(line)) {
       inCodeBlock = !inCodeBlock;
       result.push(line);
       continue;
@@ -386,20 +388,26 @@ function enforceStyleGuide(content, relPath) {
       continue;
     }
 
-    if (/^```/.test(line)) {
+    // Fences can be indented (content nested in <Steps>/<Tabs> keeps its
+    // source indentation), so match them anywhere after leading whitespace.
+    if (/^\s*```/.test(line)) {
+      const indented = /^\s/.test(line);
       if (!inCodeBlock) {
         inCodeBlock = true;
-        inBashBlock = /^```(bash|shell|sh)\b/.test(line);
+        inBashBlock = /^\s*```(bash|shell|sh)\b/.test(line);
         // Convert Mintlify filename convention (```lang filename.ext)
         // to Docusaurus title attribute (```lang title="filename.ext")
-        const fenceMatch = line.match(/^```(\w+)\s+(\S+.+)$/);
+        const fenceMatch = line.match(/^(\s*)```(\w+)\s+(\S+.+)$/);
         if (fenceMatch && !line.includes('title=')) {
-          const lang = fenceMatch[1];
-          const filename = fenceMatch[2].trim();
-          line = `\`\`\`${lang} title="${filename}"`;
+          const indent = fenceMatch[1];
+          const lang = fenceMatch[2];
+          const filename = fenceMatch[3].trim();
+          line = `${indent}\`\`\`${lang} title="${filename}"`;
         }
-        // Add source link before every code block
-        if (sourceUrl) {
+        // Add source link before every top-level code block (indented
+        // fences sit inside <Steps>/<Tabs>, where the link would repeat
+        // once per tab)
+        if (sourceUrl && !indented) {
           result.push(`<a href="${sourceUrl}" target="_blank" className="code-source-link">Source: ${relPath}</a>\n`);
         }
       } else {


### PR DESCRIPTION
## Description

The Walrus Memory docs import pipeline (`transform-walrus-memory-docs.js`) applies a "MemWal → Walrus Memory" rename plus style-guide prose rules, both of which are supposed to skip code. Their code-fence detection only matched fences at column 0, but pages that nest fences inside `<Steps>`/`<Tabs>` keep their source indentation — so those code samples were treated as prose and rewritten. Live breakage on docs.wal.app:

- [Quick Start](https://docs.wal.app/walrus-memory/getting-started/quick-start), Configure the SDK: `import { Walrus Memory } from "@mysten-incubation/memwal"` and `const memwal = Walrus Memory.create({` — invalid TypeScript.
- MCP Antigravity page: `npx degit MystenLabs/Walrus Memory/packages/mcp/plugin ...` — broken install command.
- OpenClaw quick start: `etc.` rewritten to `and so on.` inside a shell comment.

The fix makes fence detection tolerate leading whitespace in both `renameMemwal` and `enforceStyleGuide`. Source-link injection stays limited to top-level fences, so tabbed one-line install commands don't each gain a repeated Source link; correct fence pairing also restores two missing source links on the Claude Code MCP page.

The upstream MemWal pages are correct — no changes needed there. The fix reaches the live site on the next docs publish.

## Test plan

- Ran the transform over the full 77-page cache before and after the fix and diffed the outputs: only the three broken spots above change (plus the two restored source links on `mcp/claude-code.md`); all other 72 pages are byte-identical.
- `node --check` and `editorconfig-checker==2.7.3` (the CI version) clean on the changed script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoBWxqLzd9hAxrhoqv3iSv

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoBWxqLzd9hAxrhoqv3iSv)_

---

## Release notes

Docs-tooling-only change; release notes aren't required.

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI: