### PR TITLE
fix: avoid printing TIMEOUT in cargo-simtest output

### DIFF
--- a/scripts/simtest/cargo-simtest
+++ b/scripts/simtest/cargo-simtest
@@ -57,7 +57,9 @@ fi
 if [[ -z "$MSIM_WATCHDOG_TIMEOUT_MS" ]]; then
   export MSIM_WATCHDOG_TIMEOUT_MS=30000
 else
-  echo "Using MSIM_WATCHDOG_TIMEOUT_MS=$MSIM_WATCHDOG_TIMEOUT_MS from the environment"
+  # Avoid printing the variable name: scripts/simtest/simtest-run.sh greps the test logs for
+  # "TIMEOUT" to detect failures, and the literal name would trip that check.
+  echo "Using msim watchdog timeout of ${MSIM_WATCHDOG_TIMEOUT_MS}ms from the environment"
 fi
 
 rust_flags=( '"--cfg"' '"msim"' )


### PR DESCRIPTION
## Description

#3590 added a message to `cargo-simtest` that prints the literal variable name `MSIM_WATCHDOG_TIMEOUT_MS` when the timeout is set in the environment. `simtest-run.sh` always sets this variable and detects test failures by grepping the captured logs for `TIMEOUT|FAIL|STDERR|SIGABRT|error:|...`, so the `TIMEOUT` substring in the variable name caused every simtest CI run to be reported as failed.

Reword the message to "Using msim watchdog timeout of ...ms from the environment" so it keeps the same information without tripping the failure grep, and add a comment explaining the constraint.

## Test plan

- `bash -n scripts/simtest/cargo-simtest` passes.
- Verified the script no longer prints any string matching the failure grep pattern in `simtest-run.sh`.