### PR TITLE
fix(sdk): fail fast when reading quilts of nonexistent blobs

### DIFF
--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -1411,6 +1411,43 @@ async fn test_read_empty_blob_as_quilt_returns_error() -> TestResult {
     Ok(())
 }
 
+/// Tests that reading a quilt that does not exist on Walrus fails with `BlobIdDoesNotExist`
+/// instead of a generic retrieval error after exhausting sliver requests to the committee.
+#[ignore = "ignore E2E tests by default"]
+#[walrus_simtest]
+async fn test_read_nonexistent_quilt_returns_blob_id_does_not_exist() -> TestResult {
+    walrus_test_utils::init_tracing();
+
+    let (_sui_cluster_handle, _cluster, client, _, _) =
+        test_cluster::E2eTestSetupBuilder::new().build().await?;
+    let quilt_client = client.as_ref().quilt_client();
+
+    let nonexistent_quilt_id = BlobId(random());
+
+    let result = quilt_client.get_quilt_metadata(&nonexistent_quilt_id).await;
+    assert!(matches!(
+        result.unwrap_err().kind(),
+        ClientErrorKind::BlobIdDoesNotExist
+    ));
+
+    // A syntactically valid QuiltPatchIdV1 (version byte followed by start and end indices)
+    // pointing into the nonexistent quilt.
+    let patch_id = QuiltPatchId::new(nonexistent_quilt_id, vec![0x01, 1, 0, 2, 0]);
+    let result = quilt_client.get_blobs_by_ids(&[patch_id]).await;
+    assert!(matches!(
+        result.unwrap_err().kind(),
+        ClientErrorKind::BlobIdDoesNotExist
+    ));
+
+    let result = quilt_client.get_all_blobs(&nonexistent_quilt_id).await;
+    assert!(matches!(
+        result.unwrap_err().kind(),
+        ClientErrorKind::BlobIdDoesNotExist
+    ));
+
+    Ok(())
+}
+
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_blocklist() -> TestResult {

--- a/crates/walrus-sdk/src/node_client.rs
+++ b/crates/walrus-sdk/src/node_client.rs
@@ -562,21 +562,37 @@ impl<T: ReadClient> WalrusNodeClient<T> {
             .get_blob_status_and_certified_epoch(blob_id, blob_status)
             .await?;
 
-        // Execute the status request and the metadata/sliver request concurrently.
-        //
-        // If the status request fails, the metadata/sliver request will be cancelled. If the status
-        // request succeeds, the metadata/sliver request will be executed to completion. If we
-        // already have a blob status, the `get_status_fn` immediately returns Ok.
-        //
-        // In the unlikely event that the status request takes longer than reading the
-        // metadata/slivers, the status request will be dropped.
-        match select(
-            pin!(self.try_get_blob_status(blob_id, blob_status)),
-            pin!(self.read_metadata_and_slivers_and_reconstruct_blob::<U>(
+        // The read future is boxed to keep the enclosing futures small; unboxed, the large read
+        // futures can overflow the stack.
+        self.race_read_with_status_check(
+            blob_id,
+            blob_status,
+            Box::pin(self.read_metadata_and_slivers_and_reconstruct_blob::<U>(
                 certified_epoch,
                 blob_id,
-                consistency_check
+                consistency_check,
             )),
+        )
+        .await
+    }
+
+    /// Executes the status request and the given read future concurrently.
+    ///
+    /// If the status request fails (in particular, if the blob does not exist), the read future
+    /// will be cancelled. If the status request succeeds, the read future will be executed to
+    /// completion. If we already have a blob status, the status check immediately returns Ok.
+    ///
+    /// In the unlikely event that the status request takes longer than the read future, the
+    /// status request will be dropped.
+    async fn race_read_with_status_check<R>(
+        &self,
+        blob_id: &BlobId,
+        known_status: Option<BlobStatus>,
+        read_future: impl Future<Output = ClientResult<R>>,
+    ) -> ClientResult<R> {
+        match select(
+            pin!(self.try_get_blob_status(blob_id, known_status)),
+            pin!(read_future),
         )
         .await
         {
@@ -584,7 +600,7 @@ impl<T: ReadClient> WalrusNodeClient<T> {
                 Self::continue_on_no_valid_status_received(
                     status_result,
                     self.get_committees().await?.as_ref(),
-                    blob_status,
+                    known_status,
                 )?;
                 read_future.await
             }

--- a/crates/walrus-sdk/src/node_client/quilt_client.rs
+++ b/crates/walrus-sdk/src/node_client/quilt_client.rs
@@ -409,31 +409,44 @@ impl<T: ReadClient> QuiltClient<'_, WalrusNodeClient<T>> {
     /// If not enough slivers can be retrieved for the quilt index, the entire blob will be read.
     pub async fn get_quilt_metadata(&self, quilt_id: &BlobId) -> ClientResult<QuiltMetadata> {
         self.client.check_blob_is_blocked(quilt_id)?;
-        let (certified_epoch, _) = self
+        let (certified_epoch, blob_status) = self
             .client
             .get_blob_status_and_certified_epoch(quilt_id, None)
             .await?;
-        let metadata = self
+        // The read future is boxed to keep the enclosing futures small; unboxed, the nested quilt
+        // read futures can overflow the stack.
+        let (metadata, quilt_index) = self
             .client
-            .retrieve_metadata(certified_epoch, quilt_id)
-            .await?;
+            .race_read_with_status_check(
+                quilt_id,
+                blob_status,
+                Box::pin(async {
+                    let metadata = self
+                        .client
+                        .retrieve_metadata(certified_epoch, quilt_id)
+                        .await?;
 
-        // Try to retrieve the quilt index from the slivers.
-        let quilt_index =
-            if let Ok(quilt_index) = self.retrieve_quilt_index(&metadata, certified_epoch).await {
-                quilt_index
-            } else {
-                // If the quilt index cannot be retrieved from the slivers, try to retrieve the
-                // quilt.
-                tracing::debug!(
-                    "failed to retrieve index slivers, trying to get quilt instead {}",
-                    quilt_id
-                );
-                // TODO(WAL-879): Cache the quilt.
-                self.get_full_quilt(&metadata, certified_epoch)
-                    .await?
-                    .get_quilt_index()?
-            };
+                    // Try to retrieve the quilt index from the slivers.
+                    let quilt_index = if let Ok(quilt_index) =
+                        self.retrieve_quilt_index(&metadata, certified_epoch).await
+                    {
+                        quilt_index
+                    } else {
+                        // If the quilt index cannot be retrieved from the slivers, try to
+                        // retrieve the quilt.
+                        tracing::debug!(
+                            "failed to retrieve index slivers, trying to get quilt instead {}",
+                            quilt_id
+                        );
+                        // TODO(WAL-879): Cache the quilt.
+                        self.get_full_quilt(&metadata, certified_epoch)
+                            .await?
+                            .get_quilt_index()?
+                    };
+                    Ok((metadata, quilt_index))
+                }),
+            )
+            .await?;
 
         let quilt_metadata = match quilt_index {
             QuiltIndex::V1(quilt_index) => QuiltMetadata::V1(QuiltMetadataV1 {
@@ -639,25 +652,35 @@ impl<T: ReadClient> QuiltClient<'_, WalrusNodeClient<T>> {
                 .all(|quilt_patch_id| quilt_patch_id.quilt_id == quilt_id)
         );
 
-        let (certified_epoch, _) = self
+        let (certified_epoch, blob_status) = self
             .client
             .get_blob_status_and_certified_epoch(&quilt_id, None)
             .await?;
-        let metadata = self
-            .client
-            .retrieve_metadata(certified_epoch, &quilt_id)
-            .await?;
+        self.client
+            .race_read_with_status_check(
+                &quilt_id,
+                blob_status,
+                // The read future is boxed to keep the enclosing futures small; unboxed, the
+                // nested quilt read futures can overflow the stack.
+                Box::pin(async {
+                    let metadata = self
+                        .client
+                        .retrieve_metadata(certified_epoch, &quilt_id)
+                        .await?;
 
-        match version_enum {
-            QuiltVersionEnum::V1 => {
-                self.get_blobs_from_quilt_by_internal_ids_impl::<QuiltVersionV1>(
-                    &metadata,
-                    certified_epoch,
-                    quilt_patch_ids,
-                )
-                .await
-            }
-        }
+                    match version_enum {
+                        QuiltVersionEnum::V1 => {
+                            self.get_blobs_from_quilt_by_internal_ids_impl::<QuiltVersionV1>(
+                                &metadata,
+                                certified_epoch,
+                                quilt_patch_ids,
+                            )
+                            .await
+                        }
+                    }
+                }),
+            )
+            .await
     }
 
     async fn get_blobs_from_quilt_by_internal_ids_impl<V: QuiltVersion>(
@@ -689,18 +712,28 @@ impl<T: ReadClient> QuiltClient<'_, WalrusNodeClient<T>> {
         &self,
         quilt_id: &BlobId,
     ) -> ClientResult<Vec<QuiltStoreBlob<'static>>> {
-        let (certified_epoch, _) = self
+        let (certified_epoch, blob_status) = self
             .client
             .get_blob_status_and_certified_epoch(quilt_id, None)
             .await?;
-        let metadata = self
-            .client
-            .retrieve_metadata(certified_epoch, quilt_id)
-            .await?;
+        self.client
+            .race_read_with_status_check(
+                quilt_id,
+                blob_status,
+                // The read future is boxed to keep the enclosing futures small; unboxed, the
+                // nested quilt read futures can overflow the stack.
+                Box::pin(async {
+                    let metadata = self
+                        .client
+                        .retrieve_metadata(certified_epoch, quilt_id)
+                        .await?;
 
-        let mut quilt_reader =
-            QuiltReader::<'_, QuiltVersionV1, _>::new(self, self.config.clone(), None);
-        quilt_reader.get_all_blobs(&metadata, certified_epoch).await
+                    let mut quilt_reader =
+                        QuiltReader::<'_, QuiltVersionV1, _>::new(self, self.config.clone(), None);
+                    quilt_reader.get_all_blobs(&metadata, certified_epoch).await
+                }),
+            )
+            .await
     }
 
     /// Retrieves the quilt from Walrus.


### PR DESCRIPTION
## Description

Reading a quilt patch of an expired or never-certified quilt spends 10-20 seconds fanning out to the whole committee before failing with a retryable-looking error (503 `BLOB_UNAVAILABLE` through the aggregator). The quilt read paths never check the blob status up front, so a nonexistent quilt is only discovered if a quorum of nodes returns 404 during metadata/sliver retrieval — slow or never on a large committee with unresponsive nodes.

The plain blob read path already solves this: it races the read against a blob status check and cancels the read if the blob does not exist. This PR extracts that pattern into a `race_read_with_status_check` helper and applies it to the quilt entry points (`get_quilt_metadata`, `get_blobs_from_quilt_by_internal_ids`, `get_all_blobs`). A nonexistent quilt now fails with `BlobIdDoesNotExist` in a single status round-trip, which the aggregator maps to a fast 404 `BLOB_NOT_FOUND`.

The read futures are boxed because the quilt futures are large enough to overflow the stack when nested inline.

## Test plan

- New e2e test: `test_read_nonexistent_quilt_returns_blob_id_does_not_exist` covers all three entry points.
- Existing quilt e2e tests pass (`test_store_quilt`, `test_read_empty_blob_as_quilt_returns_error`, both aggregator quilt tests), plus `test_delete_blob::one_delete` for the refactored plain read path.

---

## Release notes

- [ ] Storage node:
- [x] Aggregator: Requests for quilt patches of expired or nonexistent quilts now return 404 `BLOB_NOT_FOUND` within about a second, instead of 503 `BLOB_UNAVAILABLE` after a 10-20 second fan-out.
- [ ] Publisher:
- [x] CLI: `walrus read-quilt` fails immediately with "the blob ID does not exist" for expired or never-certified quilts, instead of timing out against the storage nodes.