### PR TITLE
ci: remove legacy JSON-RPC test runs, test with gRPC only

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -106,18 +106,14 @@ jobs:
         run: cargo build --workspace --features "walrus-service/backup" --verbose
 
   test:
-    name: Test Rust code (gRPC level ${{ matrix.grpc_migration_level }})
+    name: Test Rust code
     needs: diff
     if: ${{ needs.diff.outputs.isRelevantForRustTests == 'true' }}
     runs-on: ubuntu-ghcloud
-    strategy:
-      matrix:
-        grpc_migration_level: [0, 100]
     env:
       RUST_LOG: walrus=info,error,sui_=off,consensus_core=off
       OPENSSL_STATIC: "1"
       OPENSSL_NO_VENDOR: "0"
-      WALRUS_GRPC_MIGRATION_LEVEL: "${{ matrix.grpc_migration_level }}"
     steps:
       - uses: taiki-e/install-action@a2352fc6ce487f030a3aa709482d57823eadfb37 # pin@v2.75.16
         with:
@@ -186,7 +182,7 @@ jobs:
       # Turn off Sui logging since it can be very distractive in CI
       RUST_LOG: simtest=info,error,sui_=off,consensus_core=off
       # Default: all 5 seeds. PRs with the `ci:less-simtest-seeds` label run only
-      # 2 seeds (1 without gRPC, 1 with gRPC).
+      # 2 seeds.
       SIMTEST_REDUCED: ${{ github.event_name != 'push' && contains(github.event.pull_request.labels.*.name, 'ci:less-simtest-seeds')
         }}
     steps:
@@ -199,13 +195,13 @@ jobs:
           gcp_credentials_json: ${{ secrets.GCP_WALRUS_RELEASE_BUCKET_SVCUSER_CREDENTIALS }}
 
       - run: ./scripts/simtest/install.sh
-      - name: Run tests (seed=1, legacy json-rpc)
-        run: MSIM_TEST_SEED=1 WALRUS_GRPC_MIGRATION_LEVEL=0 cargo simtest simtest --profile simtest
+      - name: Run tests (seed=1)
+        run: MSIM_TEST_SEED=1 cargo simtest simtest --profile simtest
       - name: Run tests (seed=2)
         run: MSIM_TEST_SEED=2 cargo simtest simtest --profile simtest
-      - name: Run tests (seed=3, legacy json-rpc)
+      - name: Run tests (seed=3)
         if: env.SIMTEST_REDUCED != 'true'
-        run: MSIM_TEST_SEED=3 WALRUS_GRPC_MIGRATION_LEVEL=0 cargo simtest simtest --profile simtest
+        run: MSIM_TEST_SEED=3 cargo simtest simtest --profile simtest
       - name: Run tests (seed=4)
         if: env.SIMTEST_REDUCED != 'true'
         run: MSIM_TEST_SEED=4 cargo simtest simtest --profile simtest


### PR DESCRIPTION
## Description

JSON PRC is decrepated in both testnet and mainnet. We have been running in gRPC only for few weeks now.

CI still exercised the legacy JSON-RPC path in two places in `code.yml`:

- The `test` job ran a matrix over `grpc_migration_level: [0, 100]`.
- The `simtests` job ran seeds 1 and 3 with `WALRUS_GRPC_MIGRATION_LEVEL=0`.

This removes both: the `test` job now runs once with the default migration level (100, gRPC only), and all simtest seeds run against gRPC. Step names and the `ci:less-simtest-seeds` comment are updated accordingly.

The `check-all` aggregate job references jobs by ID, which is unchanged, so required status checks are unaffected.

Note that this only changes CI coverage; the `WALRUS_GRPC_MIGRATION_LEVEL=0` code path itself still exists.

## Test plan

CI on this PR.