### PR TITLE
docs: builder-feedback batch — browser guide, Sites production, ecosystem, crosslinks

### DIFF
--- a/docs/content/examples/awesome-walrus.mdx
+++ b/docs/content/examples/awesome-walrus.mdx
@@ -1,22 +1,73 @@
 ---
-draft: true
+title: Ecosystem
+sidebar_label: Ecosystem
+description: >-
+  Projects and tools built on Walrus, including Walrus Memory for AI agents, first-party
+  tooling, and the community-maintained Awesome Walrus directory.
+keywords:
+  - walrus ecosystem
+  - built on walrus
+  - awesome walrus
+  - walrus memory
+  - memwal
+  - community projects
 goal:
-  description: Reader can find community-built Walrus projects and examples to learn from
+  description: Reader can find projects and tools built on Walrus to use or learn from
   requires:
-    - pattern: '```'
-      min: 3
-      label: 'Has code blocks for setup, source, and output'
     - has_frontmatter:
         - title
         - description
         - keywords
       label: Has required frontmatter fields
     - min_words: 100
-      label: Has enough content to describe the example
+      label: Has enough content to describe the ecosystem
     - has_questions: true
       label: Needs questions for AI search visibility
     - has_answer: true
       label: Needs answer summary for AI citation
+questions:
+  - What is built on Walrus?
+  - Where do I find projects in the Walrus ecosystem?
+  - What is Walrus Memory?
+answer: >-
+  The Walrus ecosystem includes first-party products such as Walrus Memory (portable,
+  encrypted memory for AI agents), Walrus Sites for decentralized web hosting, and a
+  growing set of community projects cataloged in the Awesome Walrus directory on GitHub.
 ---
 
-https://github.com/MystenLabs/awesome-walrus
+Walrus is a storage layer, and the products in this section show what teams build on top of it.
+Use them directly, or read their source as reference implementations for your own project.
+
+## Built on Walrus
+
+First-party products with Walrus as their storage layer.
+
+### Walrus Memory
+
+[Walrus Memory](https://docs.wal.app/walrus-memory/) gives AI agents portable, verifiable
+long-term memory. It stores encrypted memories on Walrus as durable blobs and retrieves them
+with semantic search; Sui smart contracts enforce ownership onchain. It ships a TypeScript SDK,
+a Python SDK, an MCP server for agent clients, and a hosted playground.
+
+- App: [memory.walrus.xyz](https://memory.walrus.xyz)
+- Source: [github.com/MystenLabs/MemWal](https://github.com/MystenLabs/MemWal)
+- Docs: [docs.wal.app/walrus-memory](https://docs.wal.app/walrus-memory/)
+
+### Walrus Sites
+
+[Walrus Sites](/docs/sites) hosts static web sites entirely onchain: Sui stores the ownership
+and resource index, Walrus stores the files, and portals serve the result over standard HTTP.
+The documentation site you are reading is itself a Walrus Site.
+
+## Community directory
+
+The community maintains [Awesome Walrus](https://github.com/MystenLabs/awesome-walrus), a
+categorized directory of ecosystem projects: SDKs and client libraries, infrastructure and
+tooling, and applications built on Walrus. Open a pull request there to add your project.
+
+## Reference implementations
+
+- [Walrus Relay example](/docs/examples/walrus-relay): a deployed browser app storing blobs
+  through the public upload relay, with annotated source.
+- [SDK examples](https://github.com/MystenLabs/ts-sdks/tree/main/packages/walrus/examples):
+  runnable TypeScript SDK snippets maintained alongside the SDK.

--- a/docs/content/examples/awesome-walrus.mdx
+++ b/docs/content/examples/awesome-walrus.mdx
@@ -35,8 +35,7 @@ answer: >-
   growing set of community projects cataloged in the Awesome Walrus directory on GitHub.
 ---
 
-Walrus is a storage layer, and the products in this section show what teams build on top of it.
-Use them directly, or read their source as reference implementations for your own project.
+Walrus is a storage layer, and the products in this section show what teams build on top of it. Use them directly, or read their source as reference implementations for your own project.
 
 ## Built on Walrus
 
@@ -44,10 +43,7 @@ First-party products with Walrus as their storage layer.
 
 ### Walrus Memory
 
-[Walrus Memory](https://docs.wal.app/walrus-memory/) gives AI agents portable, verifiable
-long-term memory. It stores encrypted memories on Walrus as durable blobs and retrieves them
-with semantic search; Sui smart contracts enforce ownership onchain. It ships a TypeScript SDK,
-a Python SDK, an MCP server for agent clients, and a hosted playground.
+[Walrus Memory](https://docs.wal.app/walrus-memory/) gives AI agents portable, verifiable long-term memory. It stores encrypted memories on Walrus as durable blobs and retrieves them with semantic search; Sui smart contracts enforce ownership onchain. It ships a TypeScript SDK, a Python SDK, an MCP server for agent clients, and a hosted playground.
 
 - App: [memory.walrus.xyz](https://memory.walrus.xyz)
 - Source: [github.com/MystenLabs/MemWal](https://github.com/MystenLabs/MemWal)
@@ -55,19 +51,13 @@ a Python SDK, an MCP server for agent clients, and a hosted playground.
 
 ### Walrus Sites
 
-[Walrus Sites](/docs/sites) hosts static web sites entirely onchain: Sui stores the ownership
-and resource index, Walrus stores the files, and portals serve the result over standard HTTP.
-The documentation site you are reading is itself a Walrus Site.
+[Walrus Sites](/docs/sites) hosts static web sites entirely onchain: Sui stores the ownership and resource index, Walrus stores the files, and portals serve the result over standard HTTP. The documentation site you are reading is itself a Walrus Site.
 
 ## Community directory
 
-The community maintains [Awesome Walrus](https://github.com/MystenLabs/awesome-walrus), a
-categorized directory of ecosystem projects: SDKs and client libraries, infrastructure and
-tooling, and applications built on Walrus. Open a pull request there to add your project.
+The community maintains [Awesome Walrus](https://github.com/MystenLabs/awesome-walrus), a categorized directory of ecosystem projects: SDKs and client libraries, infrastructure and tooling, and applications built on Walrus. Open a pull request there to add your project.
 
 ## Reference implementations
 
-- [Walrus Relay example](/docs/examples/walrus-relay): a deployed browser app storing blobs
-  through the public upload relay, with annotated source.
-- [SDK examples](https://github.com/MystenLabs/ts-sdks/tree/main/packages/walrus/examples):
-  runnable TypeScript SDK snippets maintained alongside the SDK.
+- [Walrus Relay example](/docs/examples/walrus-relay): A deployed browser app storing blobs through the public upload relay, with annotated source.
+- [SDK examples](https://github.com/MystenLabs/ts-sdks/tree/main/packages/walrus/examples): Runnable TypeScript SDK snippets maintained alongside the SDK.

--- a/docs/content/examples/browser-and-mobile.mdx
+++ b/docs/content/examples/browser-and-mobile.mdx
@@ -14,6 +14,11 @@ keywords:
   - client app
   - typescript sdk
   - react native
+  - cors
+  - wasm
+  - signer
+  - quilt patch
+  - range reads
 goal:
   description: Reader can store and read blobs from a browser or mobile client using an upload relay and a CDN-backed aggregator
   requires:
@@ -32,20 +37,23 @@ goal:
     - has_answer: true
       label: Needs answer summary for AI citation
 questions:
-  - How do I build a browser and mobile apps on Walrus?
-  - Why client apps use a relay?
-  - How do I configure the client?
+  - How do I build a browser or mobile app on Walrus?
+  - How do I fix CORS errors when reading Walrus blobs in the browser?
+  - What signer does the Walrus TypeScript SDK expect?
+  - How do I read a quilt patch from the browser?
 answer: >-
-  Store blobs from a browser or mobile client through a Walrus upload relay,
-  then read them back through a CDN-backed aggregator.
+  Store blobs from a browser or mobile client through a Walrus upload relay and read
+  them back through a CDN-backed aggregator. The SDK encodes blobs locally with
+  WebAssembly, onchain steps run through any signer that returns a transaction digest,
+  and reads are plain HTTP requests subject to the aggregator's CORS policy.
 ---
 
 Client apps that run in a browser or on a mobile device cannot open the many connections a direct
 store needs. A blob is split into slivers that go to every storage node, so an unprivileged client
 would have to manage dozens of parallel uploads and collect a confirmation from each node. The two
 building blocks that make client-side storage practical are an upload relay for writes and a
-CDN-backed aggregator for reads. This page shows the full round trip with the Walrus TypeScript SDK,
-and the points where a mobile app differs from a browser app.
+CDN-backed aggregator for reads. The sections below show the full round trip with the Walrus
+TypeScript SDK, and the points where a mobile app differs from a browser app.
 
 For the upload path tradeoffs, see [Choose your upload path](/docs/getting-started#choose-your-upload-path).
 For a deployed reference app, open [relay.wal.app](https://relay.wal.app) or read the full
@@ -173,6 +181,82 @@ Blobs stored on Walrus are public and readable by anyone. Encrypt sensitive data
 it, for example with [Seal](/docs/data-security). This applies equally to browser and mobile clients.
 
 :::
+
+## Browser requests and CORS
+
+A browser app talks to two Walrus services, and each has its own cross-origin story.
+
+- **Reads** go to an aggregator. The reference aggregator daemon answers with permissive CORS
+  headers, allowing any origin, method, and header. Public aggregators often sit behind a CDN,
+  and the CDN configuration decides the effective policy, so one public endpoint can allow a
+  cross-origin `fetch` while another blocks it.
+- **Writes** go through an upload relay. The public relays accept browser-origin uploads; the
+  deployed [relay example app](https://relay.wal.app) stores from the browser through the public
+  Testnet relay.
+
+If a cross-origin `fetch` to an aggregator fails, you have three options: load the blob through
+an element `src` attribute (media and image elements load cross-origin without a preflight),
+switch to a different public aggregator from the
+[Network Reference](/docs/network-reference#aggregators-and-publishers), or read through an
+[aggregator you run yourself](/docs/operator-guide/aggregators/operating-aggregator), which gives
+you full control of the CORS policy.
+
+## The WebAssembly module and bundlers
+
+The SDK encodes blobs locally before upload using a WebAssembly module, in the browser and on the
+server alike. Most modern bundlers load it without configuration. If your bundler fails on the
+`.wasm` asset, configure it to serve the module as a static asset; the
+[Walrus TypeScript SDK documentation](https://sdk.mystenlabs.com/walrus) covers the supported
+setups.
+
+## The signer contract
+
+`flow.register` and `flow.certify` return Sui `Transaction` objects; the flow never signs
+anything itself. The `signAndExecuteTransaction` in the example stands for any function with this
+shape: it accepts `{ transaction }`, executes the transaction on Sui, and resolves with an object
+that includes the transaction `digest`.
+
+- In a browser app, the `useSignAndExecuteTransaction` hook from `@mysten/dapp-kit` matches the
+  contract directly, and the connected wallet signs.
+- In a server or script context, sign with a keypair instead:
+  `suiClient.signAndExecuteTransaction({ signer: keypair, transaction })`.
+
+Either way, pass the digest of the **register** transaction to `flow.upload({ digest })`; the
+relay uses it to verify the registration before accepting sliver data.
+
+## Reading files stored in a quilt
+
+A [quilt](/docs/system-overview/quilt) addresses each batched file by `QuiltPatchId`, not
+`BlobId`. A `QuiltPatchId` derives from the composition of the whole quilt, so you cannot
+compute it from the file contents, and it changes if the file moves to a different quilt. Capture
+patch IDs at store time, or list them later with
+[`walrus list-patches-in-quilt`](/docs/walrus-client/quilts). A browser reads a patch the same
+way it reads a blob:
+
+```ts
+const res = await fetch(`${AGGREGATOR}/v1/blobs/by-quilt-patch-id/${patchId}`);
+```
+
+The patch's identifier and tags come back in response headers. See
+[Quilt HTTP APIs](/docs/http-api/quilt-http-apis) for the full endpoint set.
+
+## Range reads
+
+Aggregators support the HTTP `Range` header and return `206 Partial Content`, so a browser can
+seek within large media or fetch just a slice of a blob without downloading all of it. See
+[streaming media](/docs/http-api/streaming-media) for the header and query-parameter forms.
+
+## Browser and server compatibility
+
+The same SDK package runs in both environments. What changes is the surrounding plumbing:
+
+| **Concern** | **Browser** | **Server (Node.js)** |
+| --- | --- | --- |
+| Encoding | Local, through the SDK's WebAssembly module | Same |
+| Store path | Upload relay (browsers cannot hold the direct-store fan-out) | Direct store or relay |
+| Signing | Wallet connector, for example `@mysten/dapp-kit` | Keypair signer |
+| Reading bytes | `File` → `arrayBuffer` → `Uint8Array` | `fs.readFile` returns a usable buffer |
+| Reads | `fetch` against an aggregator, subject to CORS | Any HTTP client, no CORS |
 
 ## Read through a CDN-backed aggregator
 

--- a/docs/content/examples/browser-and-mobile.mdx
+++ b/docs/content/examples/browser-and-mobile.mdx
@@ -48,27 +48,13 @@ answer: >-
   and reads are plain HTTP requests subject to the aggregator's CORS policy.
 ---
 
-Client apps that run in a browser or on a mobile device cannot open the many connections a direct
-store needs. A blob is split into slivers that go to every storage node, so an unprivileged client
-would have to manage dozens of parallel uploads and collect a confirmation from each node. The two
-building blocks that make client-side storage practical are an upload relay for writes and a
-CDN-backed aggregator for reads. The sections below show the full round trip with the Walrus
-TypeScript SDK, and the points where a mobile app differs from a browser app.
+Client apps that run in a browser or on a mobile device cannot open the many connections a direct store needs. A blob is split into slivers that go to every storage node, so an unprivileged client would have to manage dozens of parallel uploads and collect a confirmation from each node. The two building blocks that make client-side storage practical are an upload relay for writes and a CDN-backed aggregator for reads. The sections below show the full round trip with the Walrus TypeScript SDK, and the points where a mobile app differs from a browser app.
 
-For the upload path tradeoffs, see [Choose your upload path](/docs/getting-started#choose-your-upload-path).
-For a deployed reference app, open [relay.wal.app](https://relay.wal.app) or read the full
-[source code](https://github.com/MystenLabs/walrus-sdk-relay-example-app). For an annotated
-walkthrough of that app, see [Walrus Relay](/docs/examples/walrus-relay).
+For the upload path tradeoffs, see [Choose your upload path](/docs/getting-started#choose-your-upload-path). For a deployed reference app, open [relay.wal.app](https://relay.wal.app) or read the full [source code](https://github.com/MystenLabs/walrus-sdk-relay-example-app). For an annotated walkthrough of that app, see [Walrus Relay](/docs/examples/walrus-relay).
 
 ## Why client apps use a relay
 
-An upload relay accepts a single request, encodes the blob, distributes the slivers to the storage
-nodes, and returns one certificate. Asset management onchain still happens on the client, so the
-client keeps control of registration, payment, and certification while the relay absorbs the
-network fan-out. Browsers and mobile devices benefit the most, since both have limited bandwidth and
-cannot hold many outbound connections open. See the [upload relay](/docs/system-overview/relay)
-overview for the design, and [Operate an Upload Relay](/docs/operator-guide/upload-relay) for the
-endpoints and tip mechanism.
+An upload relay accepts a single request, encodes the blob, distributes the slivers to the storage nodes, and returns one certificate. Asset management onchain still happens on the client, so the client keeps control of registration, payment, and certification while the relay absorbs the network fan-out. Browsers and mobile devices benefit the most, since both have limited bandwidth and cannot hold many outbound connections open. See the [upload relay](/docs/system-overview/relay) overview for the design, and [Operate an Upload Relay](/docs/operator-guide/upload-relay) for the endpoints and tip mechanism.
 
 :::tip
 
@@ -83,9 +69,7 @@ These are also listed in the [Network Reference](/docs/network-reference#upload-
 
 ## Configure the client
 
-Create a `WalrusClient` with an `uploadRelay` configuration. The `host` points at the relay, and
-`sendTip` sets the maximum tip your client is willing to pay a paid relay. A free relay reports
-`no_tip` and the client pays only the onchain storage fee.
+Create a `WalrusClient` with an `uploadRelay` configuration. The `host` points at the relay, and `sendTip` sets the maximum tip your client is willing to pay a paid relay. A free relay reports `no_tip` and the client pays only the onchain storage fee.
 
 ```ts
 import { getFullnodeUrl, SuiClient } from "@mysten/sui/client";
@@ -110,9 +94,7 @@ export const walrusClient = new WalrusClient({
 
 ## Store a file through the relay
 
-The SDK exposes the relay store as a `writeFilesFlow` with four steps. Each onchain step returns a
-transaction for the connected wallet to sign, so the user keeps custody of the keys and pays the
-fees. The flow is the same in a browser and in a mobile app.
+The SDK exposes the relay store as a `writeFilesFlow` with four steps. Each onchain step returns a transaction for the connected wallet to sign, so the user keeps custody of the keys and pays the fees. The flow is the same in a browser and in a mobile app.
 
 ```ts
 import { WalrusFile } from "@mysten/walrus";
@@ -150,35 +132,24 @@ const storedFiles = await flow.listFiles();
 // storedFiles[0] carries the blob ID and the Sui object ID you read back later.
 ```
 
-After `listFiles` returns, confirm the blob is durable before you depend on it. See
-[Verify blob availability before acting](/docs/walrus-client/verifying-availability).
+After `listFiles` returns, confirm the blob is durable before you depend on it. See [Verify blob availability before acting](/docs/walrus-client/verifying-availability).
 
 ## Browser and mobile differences
 
-The flow above runs unchanged in any JavaScript runtime. Two parts of the surrounding app differ by
-platform.
+The flow above runs unchanged in any JavaScript runtime. Two parts of the surrounding app differ by platform.
 
-- **Reading file bytes.** A browser reads bytes from a `File` with `arrayBuffer`. A React Native app
-  reads them from the device file system or image picker and converts the result to a `Uint8Array`
-  before calling `WalrusFile.from`.
-- **Signing transactions.** A browser app signs the `register` and `certify` transactions through a
-  wallet connector. A mobile app signs through its wallet integration, such as a deep-linked wallet
-  or an embedded signer. The transactions the flow produces are identical either way.
+- **Reading file bytes.** A browser reads bytes from a `File` with `arrayBuffer`. A React Native app reads them from the device file system or image picker and converts the result to a `Uint8Array` before calling `WalrusFile.from`.
+- **Signing transactions.** A browser app signs the `register` and `certify` transactions through a wallet connector. A mobile app signs through its wallet integration, such as a deep-linked wallet or an embedded signer. The transactions the flow produces are identical either way.
 
 :::caution `WalrusFile` buffer error
 
-If `WalrusFile.from` throws `Cannot read properties of undefined (reading 'buffer')`, it
-received something other than a typed array for `contents`. The SDK expects a `Uint8Array`, not a
-`File`, `Blob`, or raw `ArrayBuffer`. Read the bytes first and wrap them, as in the example above:
-`new Uint8Array(await file.arrayBuffer())`. In a React Native app, convert the bytes you read from
-the file system or image picker to a `Uint8Array` before you call `WalrusFile.from`.
+If `WalrusFile.from` throws `Cannot read properties of undefined (reading 'buffer')`, it received something other than a typed array for `contents`. The SDK expects a `Uint8Array`, not a `File`, `Blob`, or raw `ArrayBuffer`. Read the bytes first and wrap them, as in the example above: `new Uint8Array(await file.arrayBuffer())`. In a React Native app, convert the bytes you read from the file system or image picker to a `Uint8Array` before you call `WalrusFile.from`.
 
 :::
 
 :::caution
 
-Blobs stored on Walrus are public and readable by anyone. Encrypt sensitive data before you store
-it, for example with [Seal](/docs/data-security). This applies equally to browser and mobile clients.
+Blobs stored on Walrus are public and readable by anyone. Encrypt sensitive data before you store it, for example with [Seal](/docs/data-security). This applies equally to browser and mobile clients.
 
 :::
 
@@ -186,69 +157,58 @@ it, for example with [Seal](/docs/data-security). This applies equally to browse
 
 A browser app talks to two Walrus services, and each has its own cross-origin story.
 
-- **Reads** go to an aggregator. The reference aggregator daemon answers with permissive CORS
-  headers, allowing any origin, method, and header. Public aggregators often sit behind a CDN,
-  and the CDN configuration decides the effective policy, so one public endpoint can allow a
-  cross-origin `fetch` while another blocks it.
-- **Writes** go through an upload relay. The public relays accept browser-origin uploads; the
-  deployed [relay example app](https://relay.wal.app) stores from the browser through the public
-  Testnet relay.
+1. **Reads** go to an aggregator. The reference aggregator daemon itself sends permissive CORS headers, but public aggregators often sit behind a CDN, and the CDN configuration decides the policy your browser actually sees: one public endpoint can allow a cross-origin `fetch` while another blocks it.
+2. **Writes** go through an upload relay. The public relays accept browser-origin uploads; the deployed [relay example app](https://relay.wal.app) stores from the browser through the public Testnet relay.
 
-If a cross-origin `fetch` to an aggregator fails, you have three options: load the blob through
-an element `src` attribute (media and image elements load cross-origin without a preflight),
-switch to a different public aggregator from the
-[Network Reference](/docs/network-reference#aggregators-and-publishers), or read through an
-[aggregator you run yourself](/docs/operator-guide/aggregators/operating-aggregator), which gives
-you full control of the CORS policy.
+If a cross-origin `fetch` to an aggregator fails, work around it in one of three ways:
+
+1. Load the blob through an element's `src` attribute instead of `fetch`. Media and image elements load cross-origin resources without a CORS preflight:
+
+   ```html
+   <img src="https://aggregator.walrus-testnet.walrus.space/v1/blobs/<BLOB_ID>" alt="Stored image" />
+   ```
+
+2. Switch to a different public aggregator from the [Network Reference](/docs/network-reference#aggregators-and-publishers). CDN policies differ between endpoints, so another endpoint might allow your origin.
+3. Read through an [aggregator you run yourself](/docs/operator-guide/aggregators/operating-aggregator), which gives you full control of the CORS policy.
 
 ## The WebAssembly module and bundlers
 
-The SDK encodes blobs locally before upload using a WebAssembly module, in the browser and on the
-server alike. Most modern bundlers load it without configuration. If your bundler fails on the
-`.wasm` asset, configure it to serve the module as a static asset; the
-[Walrus TypeScript SDK documentation](https://sdk.mystenlabs.com/walrus) covers the supported
-setups.
+The Walrus TypeScript SDK encodes blobs locally before upload using a WebAssembly module, in the browser and on the server alike. Most modern bundlers load it without configuration. If your bundler fails on the `.wasm` asset, exclude the WASM package from dependency pre-bundling or serve it as a static asset. For example, the [relay example app](https://github.com/MystenLabs/walrus-sdk-relay-example-app) configures Vite in `vite.config.ts` as follows:
+
+```ts
+optimizeDeps: {
+  exclude: ["@mysten/walrus-wasm"],
+},
+```
+
+The [Walrus TypeScript SDK documentation](https://sdk.mystenlabs.com/walrus) covers the supported bundler setups.
 
 ## The signer contract
 
-`flow.register` and `flow.certify` return Sui `Transaction` objects; the flow never signs
-anything itself. The `signAndExecuteTransaction` in the example stands for any function with this
-shape: it accepts `{ transaction }`, executes the transaction on Sui, and resolves with an object
-that includes the transaction `digest`.
+`flow.register` and `flow.certify` return Sui `Transaction` objects; the flow never signs anything itself. The `signAndExecuteTransaction` in the example stands for any function with this shape: it accepts `{ transaction }`, executes the transaction on Sui, and resolves with an object that includes the transaction `digest`.
 
-- In a browser app, the `useSignAndExecuteTransaction` hook from `@mysten/dapp-kit` matches the
-  contract directly, and the connected wallet signs.
-- In a server or script context, sign with a keypair instead:
-  `suiClient.signAndExecuteTransaction({ signer: keypair, transaction })`.
+- In a browser app, the `useSignAndExecuteTransaction` hook from `@mysten/dapp-kit` matches the contract directly, and the connected wallet signs.
+- In a server or script context, sign with a keypair instead: `suiClient.signAndExecuteTransaction({ signer: keypair, transaction })`.
 
-Either way, pass the digest of the **register** transaction to `flow.upload({ digest })`; the
-relay uses it to verify the registration before accepting sliver data.
+Either way, pass the digest of the **register** transaction to `flow.upload({ digest })`; the relay uses it to verify the registration before accepting sliver data.
 
 ## Reading files stored in a quilt
 
-A [quilt](/docs/system-overview/quilt) addresses each batched file by `QuiltPatchId`, not
-`BlobId`. A `QuiltPatchId` derives from the composition of the whole quilt, so you cannot
-compute it from the file contents, and it changes if the file moves to a different quilt. Capture
-patch IDs at store time, or list them later with
-[`walrus list-patches-in-quilt`](/docs/walrus-client/quilts). A browser reads a patch the same
-way it reads a blob:
+A [quilt](/docs/system-overview/quilt) addresses each batched file by `QuiltPatchId`, not `BlobId`. A `QuiltPatchId` derives from the composition of the whole quilt, so you cannot compute it from the file contents, and it changes if the file moves to a different quilt. Capture patch IDs at store time, or list them later with [`walrus list-patches-in-quilt`](/docs/walrus-client/quilts). A browser reads a patch the same way it reads a blob:
 
 ```ts
 const res = await fetch(`${AGGREGATOR}/v1/blobs/by-quilt-patch-id/${patchId}`);
 ```
 
-The patch's identifier and tags come back in response headers. See
-[Quilt HTTP APIs](/docs/http-api/quilt-http-apis) for the full endpoint set.
+The patch's identifier and tags come back in response headers. See [Quilt HTTP APIs](/docs/http-api/quilt-http-apis) for the full endpoint set.
 
 ## Range reads
 
-Aggregators support the HTTP `Range` header and return `206 Partial Content`, so a browser can
-seek within large media or fetch just a slice of a blob without downloading all of it. See
-[streaming media](/docs/http-api/streaming-media) for the header and query-parameter forms.
+Aggregators support the HTTP `Range` header and return `206 Partial Content`, so a browser can seek within large media or fetch just a slice of a blob without downloading all of it. See [streaming media](/docs/http-api/streaming-media) for the header and query-parameter forms.
 
 ## Browser and server compatibility
 
-The same SDK package runs in both environments. What changes is the surrounding plumbing:
+The Walrus TypeScript SDK (`@mysten/walrus`) runs both in the browser and in server-side Node.js. What changes between the two runtimes is the surrounding plumbing:
 
 | **Concern** | **Browser** | **Server (Node.js)** |
 | --- | --- | --- |
@@ -260,10 +220,7 @@ The same SDK package runs in both environments. What changes is the surrounding 
 
 ## Read through a CDN-backed aggregator
 
-Reads are plain HTTPS GET requests, so a browser or mobile client reads a blob with `fetch` and no
-SDK. Put a CDN in front of an aggregator so repeated reads of popular blobs are served from a nearby
-edge cache, which matters most for mobile clients on slow or metered networks. Set the aggregator
-base URL from an endpoint in the [Network Reference](/docs/network-reference#aggregators-and-publishers).
+Reads are plain HTTPS GET requests, so a browser or mobile client reads a blob with `fetch` and no SDK. Put a CDN in front of an aggregator so repeated reads of popular blobs are served from a nearby edge cache, which matters most for mobile clients on slow or metered networks. Set the aggregator base URL from an endpoint in the [Network Reference](/docs/network-reference#aggregators-and-publishers).
 
 Read by blob ID:
 
@@ -280,9 +237,7 @@ const res = await fetch(`${AGGREGATOR}/v1/blobs/by-object-id/${objectId}`);
 
 :::caution Reading right after upload
 
-A CDN-fronted aggregator might briefly serve a cached `404` from before the blob propagated to the
-edge. If your app just certified the blob, retry the read with backoff rather than treating the
-first `404` as missing. See [Reading blobs right after upload](/docs/troubleshooting/reading-blobs-after-upload).
+A CDN-fronted aggregator might briefly serve a cached `404` from before the blob propagated to the edge. If your app just certified the blob, retry the read with backoff rather than treating the first `404` as missing. See [Reading blobs right after upload](/docs/troubleshooting/reading-blobs-after-upload).
 
 :::
 
@@ -291,5 +246,4 @@ first `404` as missing. See [Reading blobs right after upload](/docs/troubleshoo
 - [Walrus Relay](/docs/examples/walrus-relay): annotated source for the deployed browser example.
 - [Upload relay](/docs/system-overview/relay): how the relay batches, retries, and certifies.
 - [Reading blobs over HTTP](/docs/http-api/reading-blobs): the full aggregator read API.
-- [Verify blob availability before acting](/docs/walrus-client/verifying-availability): confirm
-  durability before depending on a blob.
+- [Verify blob availability before acting](/docs/walrus-client/verifying-availability): confirm durability before depending on a blob.

--- a/docs/content/sites/production.mdx
+++ b/docs/content/sites/production.mdx
@@ -70,9 +70,10 @@ long-lived:
 - **Use content-hashed filenames** for scripts, styles, and other assets (the default in most
   bundlers). A stale cache then serves a consistent old version instead of mixing old HTML with
   new assets.
-- **Pin a version by keeping the old site object.** Each deploy updates your site object in
-  place; when you need a guaranteed rollback target or a frozen release, publish the release as
-  its own site object and point your name at the object you want to serve.
+- **Pin a version by keeping the old site object.** When `ws-resources.json` carries your
+  site's object ID, each deploy updates that site in place; when you need a guaranteed rollback
+  target or a frozen release, publish the release as its own site object and point your name at
+  the object you want to serve.
 - **Expect propagation delay after an update.** Caches refresh on their own schedule; verify a
   fresh deploy from a private browser window or with cache-busting query parameters before
   concluding an update failed. See [troubleshooting](/docs/sites/troubleshooting) if an update
@@ -92,8 +93,14 @@ There is no built-in watch mode; the supported path to update-on-push is running
 `site-builder deploy` from your CI pipeline on every push to your production branch. The
 [GitHub Actions workflow guide](/docs/sites/ci-cd/github-actions-workflow) walks through the
 setup, including [preparing deployment credentials](/docs/sites/ci-cd/preparing-deployment-credentials)
-so the pipeline signs with a dedicated wallet. Rerunning deploy updates the existing site object
-in place, so CI redeploys never create duplicate sites.
+so the pipeline signs with a dedicated wallet.
+
+One trap decides whether redeploys update your site or duplicate it: `site-builder` records
+your site's object ID in `ws-resources.json` inside the deploy directory, and CI recreates that
+directory on every run. Commit `ws-resources.json` to your framework's `public/` directory so
+builds carry it into the output, or pass `--object-id` explicitly; otherwise every pipeline run
+creates a new site object and pays for it. See
+[`ws-resources.json` in pipelines](/docs/sites/ci-cd/other-ci-cd-platforms#understanding-ws-resourcesjson-in-pipelines).
 
 ## Keep the toolchain small
 
@@ -114,10 +121,12 @@ const nextConfig = {
 };
 ```
 
-`next build` then writes plain HTML and assets to `out/`, which you deploy directly:
+`next build` then writes plain HTML and assets to `out/`, which you deploy directly
+(`--epochs` is required; place `ws-resources.json` in `public/` so redeploys update the same
+site):
 
 ```sh
-$ site-builder deploy ./out
+$ site-builder deploy --epochs <NUMBER> ./out
 ```
 
 Features that need a server at request time, such as API routes, server actions, and on-demand

--- a/docs/content/sites/production.mdx
+++ b/docs/content/sites/production.mdx
@@ -28,27 +28,18 @@ answer: >-
   every push, and port Next.js apps by building with static export.
 ---
 
-A working deploy and a production site differ in a handful of predictable ways: which portal
-serves it, how client-side routes resolve, how caches behave across updates, and how new versions
-ship. Work through each section below before you share a production URL.
+A working deploy and a production site differ in a handful of predictable ways: which portal serves it, how client-side routes resolve, how caches behave across updates, and how new versions ship. Work through each section below before you share a production URL.
 
 ## Pick the network and portal
 
-The public portal at [wal.app](https://wal.app) serves only Mainnet sites that have a
-[SuiNS name](/docs/sites/custom-domains/setting-a-suins-name) configured. It does not serve
-Testnet sites, and it does not serve Mainnet sites by object ID alone.
+The public portal at [wal.app](https://wal.app) serves only Mainnet sites that have a [SuiNS name](/docs/sites/custom-domains/setting-a-suins-name) configured. It does not serve Testnet sites, and it does not serve Mainnet sites by object ID alone.
 
-- **Production:** deploy to Mainnet and attach a SuiNS name, or serve the site under
-  [your own domain](/docs/sites/custom-domains/bringing-your-own-domain).
-- **Testnet or previews:** run a [local portal](/docs/sites/portals/deploy-locally) for
-  development, or self-host a Testnet portal when others need to open the site. See
-  [Mainnet and Testnet portals](/docs/sites/portals/mainnet-testnet).
+- **Production:** deploy to Mainnet and attach a SuiNS name, or serve the site under [your own domain](/docs/sites/custom-domains/bringing-your-own-domain).
+- **Testnet or previews:** run a [local portal](/docs/sites/portals/deploy-locally) for development, or self-host a Testnet portal when others need to open the site. See [Mainnet and Testnet portals](/docs/sites/portals/mainnet-testnet).
 
 ## Configure SPA routing
 
-A single-page app serves one `index.html` and routes in the client, so deep links like
-`/dashboard/settings` return `404` unless the site falls back to the index resource. Walrus Sites
-support this natively with the `routes` section of `ws-resources.json`:
+A single-page app serves one `index.html` and routes in the client, so deep links like `/dashboard/settings` return `404` unless the site falls back to the index resource. Walrus Sites support this natively with the `routes` section of `ws-resources.json`:
 
 ```json
 {
@@ -58,61 +49,33 @@ support this natively with the `routes` section of `ws-resources.json`:
 }
 ```
 
-More specific patterns win over the wildcard, so you can mix real files with client routes. See
-[site configuration](/docs/sites/configuration/site-configuration) for the full route syntax and
-[redirects](/docs/sites/linking/redirects) for sending old paths to new ones.
+More specific patterns win over the wildcard, so you can mix real files with client routes. See [site configuration](/docs/sites/configuration/site-configuration) for the full route syntax and [redirects](/docs/sites/linking/redirects) for sending old paths to new ones.
 
 ## Control caching and pin versions
 
-Portals and any CDN in front of them cache aggressively, so treat every deployed resource as
-long-lived:
+Portals and any CDN in front of them cache aggressively, so treat every deployed resource as long-lived:
 
-- **Use content-hashed filenames** for scripts, styles, and other assets (the default in most
-  bundlers). A stale cache then serves a consistent old version instead of mixing old HTML with
-  new assets.
-- **Pin a version by keeping the old site object.** When `ws-resources.json` carries your
-  site's object ID, each deploy updates that site in place; when you need a guaranteed rollback
-  target or a frozen release, publish the release as its own site object and point your name at
-  the object you want to serve.
-- **Expect propagation delay after an update.** Caches refresh on their own schedule; verify a
-  fresh deploy from a private browser window or with cache-busting query parameters before
-  concluding an update failed. See [troubleshooting](/docs/sites/troubleshooting) if an update
-  never appears.
+- **Use content-hashed filenames** for scripts, styles, and other assets (the default in most bundlers). A stale cache then serves a consistent old version instead of mixing old HTML with new assets.
+- **Pin a version by keeping the old site object.** When `ws-resources.json` carries your site's object ID, each deploy updates that site in place; when you need a guaranteed rollback target or a frozen release, publish the release as its own site object and point your name at the object you want to serve.
+- **Expect propagation delay after an update.** Caches refresh on their own schedule; verify a fresh deploy from a private browser window or with cache-busting query parameters before concluding an update failed. See [troubleshooting](/docs/sites/troubleshooting) if an update never appears.
 
 ## Name the site with SuiNS
 
-The public portal resolves sites at `<name>.wal.app` from the SuiNS name that points at your site
-object. Nested subnames, such as `app.myname.wal.app`, do not resolve on the public portal; use a
-separate SuiNS name per site, or serve nested structures under
-[your own domain](/docs/sites/custom-domains/bringing-your-own-domain) where your DNS controls
-the hostname.
+The public portal resolves sites at `<name>.wal.app` from the SuiNS name that points at your site object. Nested subnames, such as `app.myname.wal.app`, do not resolve on the public portal; use a separate SuiNS name per site, or serve nested structures under [your own domain](/docs/sites/custom-domains/bringing-your-own-domain) where your DNS controls the hostname.
 
 ## Automate updates from CI
 
-There is no built-in watch mode; the supported path to update-on-push is running
-`site-builder deploy` from your CI pipeline on every push to your production branch. The
-[GitHub Actions workflow guide](/docs/sites/ci-cd/github-actions-workflow) walks through the
-setup, including [preparing deployment credentials](/docs/sites/ci-cd/preparing-deployment-credentials)
-so the pipeline signs with a dedicated wallet.
+There is no built-in watch mode; the supported path to update-on-push is running `site-builder deploy` from your CI pipeline on every push to your production branch. The [GitHub Actions workflow guide](/docs/sites/ci-cd/github-actions-workflow) walks through the setup, including [preparing deployment credentials](/docs/sites/ci-cd/preparing-deployment-credentials) so the pipeline signs with a dedicated wallet.
 
-One trap decides whether redeploys update your site or duplicate it: `site-builder` records
-your site's object ID in `ws-resources.json` inside the deploy directory, and CI recreates that
-directory on every run. Commit `ws-resources.json` to your framework's `public/` directory so
-builds carry it into the output, or pass `--object-id` explicitly; otherwise every pipeline run
-creates a new site object and pays for it. See
-[`ws-resources.json` in pipelines](/docs/sites/ci-cd/other-ci-cd-platforms#understanding-ws-resourcesjson-in-pipelines).
+One trap decides whether redeploys update your site or duplicate it: `site-builder` records your site's object ID in `ws-resources.json` inside the deploy directory, and CI recreates that directory on every run. Commit `ws-resources.json` to your framework's `public/` directory so builds carry it into the output, or pass `--object-id` explicitly; otherwise every pipeline run creates a new site object and pays for it. See [`ws-resources.json` in pipelines](/docs/sites/ci-cd/other-ci-cd-platforms#understanding-ws-resourcesjson-in-pipelines).
 
 ## Keep the toolchain small
 
-One installer manages the whole toolchain: [`suiup`](https://github.com/MystenLabs/suiup)
-installs and pins `sui`, `walrus`, and `site-builder` together, replacing separate per-tool
-installs. See [Install the Site Builder](/docs/sites/getting-started/installing-the-site-builder).
-Day-to-day deploys then come down to one command against your build directory.
+One installer manages the whole toolchain: [`suiup`](https://github.com/MystenLabs/suiup) installs and pins `sui`, `walrus`, and `site-builder` together, replacing separate per-tool installs. See [Install the Site Builder](/docs/sites/getting-started/installing-the-site-builder). Day-to-day deploys then come down to one command against your build directory.
 
 ## Port a Next.js app
 
-Walrus Sites serve static files, so a Next.js app must build with
-[static export](https://nextjs.org/docs/app/building-your-application/deploying/static-exports):
+Walrus Sites serve static files, so a Next.js app must build with [static export](https://nextjs.org/docs/app/building-your-application/deploying/static-exports):
 
 ```js title="next.config.js"
 const nextConfig = {
@@ -121,14 +84,10 @@ const nextConfig = {
 };
 ```
 
-`next build` then writes plain HTML and assets to `out/`, which you deploy directly
-(`--epochs` is required; place `ws-resources.json` in `public/` so redeploys update the same
-site):
+`next build` then writes plain HTML and assets to `out/`, which you deploy directly (`--epochs` is required; place `ws-resources.json` in `public/` so redeploys update the same site):
 
 ```sh
 $ site-builder deploy --epochs <NUMBER> ./out
 ```
 
-Features that need a server at request time, such as API routes, server actions, and on-demand
-rendering, do not run on a static host; move that logic to external services or client-side
-calls. Client-side navigation works with the SPA routing configuration above.
+Features that need a server at request time, such as API routes, server actions, and on-demand rendering, do not run on a static host; move that logic to external services or client-side calls. Client-side navigation works with the SPA routing configuration above.

--- a/docs/content/sites/production.mdx
+++ b/docs/content/sites/production.mdx
@@ -1,0 +1,125 @@
+---
+title: Production Checklist
+description: >-
+  Take a Walrus Site from a local deploy to production, covering portal and network
+  choice, SPA routing, caching and version pinning, SuiNS naming, and automated
+  updates from CI.
+keywords:
+  - walrus sites
+  - production
+  - testnet portal
+  - spa routing
+  - cache invalidation
+  - version pinning
+  - suins
+  - ci deployment
+  - next.js export
+questions:
+  - How do I put a Walrus Site into production?
+  - Why does my Testnet Walrus Site not load on wal.app?
+  - How do I set up SPA routing on a Walrus Site?
+  - How do I update a Walrus Site automatically on every push?
+  - How do I port a Next.js app to Walrus Sites?
+answer: >-
+  The public wal.app portal serves only Mainnet sites with a SuiNS name, so Testnet
+  sites need a self-hosted or local portal. Configure SPA routing with a wildcard
+  route to index.html in ws-resources.json, use content-hashed asset filenames so
+  caches stay consistent, automate updates by running site-builder deploy from CI on
+  every push, and port Next.js apps by building with static export.
+---
+
+A working deploy and a production site differ in a handful of predictable ways: which portal
+serves it, how client-side routes resolve, how caches behave across updates, and how new versions
+ship. Work through each section below before you share a production URL.
+
+## Pick the network and portal
+
+The public portal at [wal.app](https://wal.app) serves only Mainnet sites that have a
+[SuiNS name](/docs/sites/custom-domains/setting-a-suins-name) configured. It does not serve
+Testnet sites, and it does not serve Mainnet sites by object ID alone.
+
+- **Production:** deploy to Mainnet and attach a SuiNS name, or serve the site under
+  [your own domain](/docs/sites/custom-domains/bringing-your-own-domain).
+- **Testnet or previews:** run a [local portal](/docs/sites/portals/deploy-locally) for
+  development, or self-host a Testnet portal when others need to open the site. See
+  [Mainnet and Testnet portals](/docs/sites/portals/mainnet-testnet).
+
+## Configure SPA routing
+
+A single-page app serves one `index.html` and routes in the client, so deep links like
+`/dashboard/settings` return `404` unless the site falls back to the index resource. Walrus Sites
+support this natively with the `routes` section of `ws-resources.json`:
+
+```json
+{
+  "routes": {
+    "/*": "/index.html"
+  }
+}
+```
+
+More specific patterns win over the wildcard, so you can mix real files with client routes. See
+[site configuration](/docs/sites/configuration/site-configuration) for the full route syntax and
+[redirects](/docs/sites/linking/redirects) for sending old paths to new ones.
+
+## Control caching and pin versions
+
+Portals and any CDN in front of them cache aggressively, so treat every deployed resource as
+long-lived:
+
+- **Use content-hashed filenames** for scripts, styles, and other assets (the default in most
+  bundlers). A stale cache then serves a consistent old version instead of mixing old HTML with
+  new assets.
+- **Pin a version by keeping the old site object.** Each deploy updates your site object in
+  place; when you need a guaranteed rollback target or a frozen release, publish the release as
+  its own site object and point your name at the object you want to serve.
+- **Expect propagation delay after an update.** Caches refresh on their own schedule; verify a
+  fresh deploy from a private browser window or with cache-busting query parameters before
+  concluding an update failed. See [troubleshooting](/docs/sites/troubleshooting) if an update
+  never appears.
+
+## Name the site with SuiNS
+
+The public portal resolves sites at `<name>.wal.app` from the SuiNS name that points at your site
+object. Nested subnames, such as `app.myname.wal.app`, do not resolve on the public portal; use a
+separate SuiNS name per site, or serve nested structures under
+[your own domain](/docs/sites/custom-domains/bringing-your-own-domain) where your DNS controls
+the hostname.
+
+## Automate updates from CI
+
+There is no built-in watch mode; the supported path to update-on-push is running
+`site-builder deploy` from your CI pipeline on every push to your production branch. The
+[GitHub Actions workflow guide](/docs/sites/ci-cd/github-actions-workflow) walks through the
+setup, including [preparing deployment credentials](/docs/sites/ci-cd/preparing-deployment-credentials)
+so the pipeline signs with a dedicated wallet. Rerunning deploy updates the existing site object
+in place, so CI redeploys never create duplicate sites.
+
+## Keep the toolchain small
+
+One installer manages the whole toolchain: [`suiup`](https://github.com/MystenLabs/suiup)
+installs and pins `sui`, `walrus`, and `site-builder` together, replacing separate per-tool
+installs. See [Install the Site Builder](/docs/sites/getting-started/installing-the-site-builder).
+Day-to-day deploys then come down to one command against your build directory.
+
+## Port a Next.js app
+
+Walrus Sites serve static files, so a Next.js app must build with
+[static export](https://nextjs.org/docs/app/building-your-application/deploying/static-exports):
+
+```js title="next.config.js"
+const nextConfig = {
+  output: "export",
+  images: { unoptimized: true },
+};
+```
+
+`next build` then writes plain HTML and assets to `out/`, which you deploy directly:
+
+```sh
+$ site-builder deploy ./out
+```
+
+Features that need a server at request time, such as API routes, server actions, and on-demand
+rendering, do not run on a static host; move that logic to external services or client-side
+calls. Client-side navigation works with the SPA routing configuration above.

--- a/docs/site/docusaurus.config.js
+++ b/docs/site/docusaurus.config.js
@@ -367,6 +367,26 @@ const config = {
       },
       footer: {
         style: "dark",
+        links: [
+          {
+            title: "Walrus",
+            items: [
+              { label: "walrus.xyz", href: "https://www.walrus.xyz" },
+              { label: "Walrus Memory", href: "https://memory.walrus.xyz" },
+              { label: "GitHub", href: "https://github.com/MystenLabs/walrus" },
+              { label: "Discord", href: "https://discord.gg/walrusprotocol" },
+            ],
+          },
+          {
+            title: "Documentation",
+            items: [
+              { label: "Get started", to: "/docs/getting-started" },
+              { label: "Walrus Sites", to: "/docs/sites" },
+              { label: "Walrus Memory docs", to: "/walrus-memory/" },
+              { label: "Ecosystem", to: "/docs/examples/awesome-walrus" },
+            ],
+          },
+        ],
         copyright: `Copyright © ${new Date().getFullYear()}
                     Walrus Foundation. All rights reserved.`,
       },

--- a/docs/site/sidebars.js
+++ b/docs/site/sidebars.js
@@ -65,6 +65,8 @@ const sidebars = {
         "examples/move",
         "examples/python",
         "examples/walrus-relay",
+        "examples/browser-and-mobile",
+        "examples/awesome-walrus",
       ],
     },
     {
@@ -242,6 +244,7 @@ const sidebars = {
         "sites/security/access-control-options",
       ],
     },
+    "sites/production",
     "sites/known-restrictions",
     "sites/troubleshooting",
   ],


### PR DESCRIPTION
## Description

The high-priority Cycle 7 builder-feedback documentation (BEDU-1047), four tickets in one PR:

**BEDU-284 — Browser/CORS + SDK gaps.** Extends `examples/browser-and-mobile.mdx` with the topics builder feedback flagged as missing: CORS behavior for aggregator reads and relay writes (sourced from the reference daemon's actual CORS layer), the SDK's WebAssembly module and bundler handling, the signer contract `flow.register`/`flow.certify` expect (accepts `{ transaction }`, resolves with a `digest`), reading quilt patches by `QuiltPatchId` with the `by-quilt-patch-id` endpoint, range reads, and a browser-vs-server compatibility table. Also adds the page to the Examples sidebar — it was orphaned. The 7 SDK follow-up tickets the Linear issue lists are being filed in Linear separately.

**BEDU-286 — Sites discoverability + production.** New `sites/production.mdx` production checklist: Testnet portal reality (wal.app serves only Mainnet + SuiNS), SPA routing via the documented `ws-resources.json` routes wildcard, cache behavior and version pinning, SuiNS name/subname status, CI on push as the supported update flow, `suiup` as the single-installer answer to the "three CLIs" complaint, and a Next.js `output: 'export'` porting section.

**BEDU-955 — Ecosystem page.** The draft `awesome-walrus.mdx` stub becomes a full Ecosystem page: Built on Walrus section featuring Walrus Memory (app, repo, docs links — phrased per the Memory security-wording conventions), Walrus Sites, the community Awesome Walrus directory, and reference implementations. Added to the sidebar and un-drafted.

**BEDU-630 — Crosslinking.** Site-wide footer now links walrus.xyz, the Walrus Memory app, GitHub, and Discord alongside docs entry points (Get started, Sites, Memory docs, Ecosystem). Note: the walrus.xyz → docs direction lives on the marketing site and needs that team; this PR covers the docs side.

## Test plan

- `editorconfig-checker==2.7.3` (the CI version) clean on all changed files; `git diff --check` clean.
- `sidebars.js` and `docusaurus.config.js` pass `node --check`; all internal links target existing pages.
- Technical claims verified in-repo: daemon CORS layer (`daemon_cors_layer`), quilt patch ID semantics (`system-overview/quilt`), routes syntax (`site-configuration`), portal constraints (`portals/mainnet-testnet`), `suiup` install path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoBWxqLzd9hAxrhoqv3iSv

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoBWxqLzd9hAxrhoqv3iSv)_

---

## Release notes

Docs-only change; release notes aren't required.

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI: