### PR TITLE
docs: legal-page navigation banners and Ask AI entry-point placement

### DIFF
--- a/docs/content/getting-started/index.mdx
+++ b/docs/content/getting-started/index.mdx
@@ -380,5 +380,9 @@ Explore working examples:
 
 ## Need help?
 
+import AskAiCta from '@site/src/shared/components/AskAiCta';
+
+<AskAiCta />
+
 - [Troubleshooting guide](/docs/troubleshooting)
 - [Discord community](https://discord.com/invite/walrusprotocol)

--- a/docs/content/legal/privacy.mdx
+++ b/docs/content/legal/privacy.mdx
@@ -1,5 +1,8 @@
 ---
 title: WALRUS PRIVACY POLICY
+description: >-
+  The Walrus privacy policy, covering what personal information the Walrus Foundation
+  collects, how it uses it, and your privacy rights.
 custom_edit_url: null
 goal:
   description: Reader can find what personal information Walrus collects, how it is used, and their privacy rights
@@ -23,7 +26,7 @@ answer: '**Last Updated:** February 10, 2024.'
 
 :::info Looking for the developer documentation?
 
-You are reading a legal document. To build on Walrus, start with [Get started](/docs/getting-started), [Walrus Sites](/docs/sites), or the [Walrus Memory docs](/walrus-memory/). For technical questions, the Ask Walrus AI assistant is available on every documentation page.
+You are reading a legal document. To build on Walrus, start with [Get started](/docs/getting-started), [Walrus Sites](/docs/sites), or the [Walrus Memory docs](/walrus-memory/), where you can also open the Ask Walrus AI assistant for technical questions.
 
 :::
 

--- a/docs/content/legal/privacy.mdx
+++ b/docs/content/legal/privacy.mdx
@@ -21,6 +21,12 @@ questions:
 answer: '**Last Updated:** February 10, 2024.'
 ---
 
+:::info Looking for the developer documentation?
+
+You are reading a legal document. To build on Walrus, start with [Get started](/docs/getting-started), [Walrus Sites](/docs/sites), or the [Walrus Memory docs](/walrus-memory/). For technical questions, the Ask Walrus AI assistant is available on every documentation page.
+
+:::
+
 **Last Updated:** February 10, 2024
 
 This Privacy Policy is designed to help you understand how Walrus Foundation (collectively called the “**Organization**", "**we**," "**us**," and "**our**") collects, uses, and shares your personal information and to help you understand and exercise your privacy rights in accordance with applicable law. This Policy applies when you use the Website, contact our team members, engage with us on social media or otherwise interact with us. Any capitalized terms that are undefined shall have the meaning as set forth in the [Walrus Airdrop Terms and Conditions](https://claim.walrus.xyz/airdrop/terms-and-conditions)

--- a/docs/content/legal/testnet_tos.mdx
+++ b/docs/content/legal/testnet_tos.mdx
@@ -1,5 +1,6 @@
 ---
 title: TESTNET TERMS OF SERVICE - WALRUS
+description: The terms of service that govern use of the Walrus Testnet.
 custom_edit_url: null
 goal:
   description: Reader can review the terms that govern use of Walrus Testnet
@@ -31,7 +32,7 @@ answer: >-
 
 :::info Looking for the developer documentation?
 
-You are reading a legal document. To build on Walrus, start with [Get started](/docs/getting-started), [Walrus Sites](/docs/sites), or the [Walrus Memory docs](/walrus-memory/). For technical questions, the Ask Walrus AI assistant is available on every documentation page.
+You are reading a legal document. To build on Walrus, start with [Get started](/docs/getting-started), [Walrus Sites](/docs/sites), or the [Walrus Memory docs](/walrus-memory/), where you can also open the Ask Walrus AI assistant for technical questions.
 
 :::
 

--- a/docs/content/legal/testnet_tos.mdx
+++ b/docs/content/legal/testnet_tos.mdx
@@ -29,6 +29,12 @@ answer: >-
   (togethe.
 ---
 
+:::info Looking for the developer documentation?
+
+You are reading a legal document. To build on Walrus, start with [Get started](/docs/getting-started), [Walrus Sites](/docs/sites), or the [Walrus Memory docs](/walrus-memory/). For technical questions, the Ask Walrus AI assistant is available on every documentation page.
+
+:::
+
 Last updated: March 26, 2025
 
 By using Walrus Testnet software, technologies, tools, and other services (collectively

--- a/docs/content/legal/walrus_general_tos.mdx
+++ b/docs/content/legal/walrus_general_tos.mdx
@@ -26,6 +26,12 @@ answer: >-
   located at walrus.
 ---
 
+:::info Looking for the developer documentation?
+
+You are reading a legal document. To build on Walrus, start with [Get started](/docs/getting-started), [Walrus Sites](/docs/sites), or the [Walrus Memory docs](/walrus-memory/). For technical questions, the Ask Walrus AI assistant is available on every documentation page.
+
+:::
+
 Please read these Terms of Service (the “Terms”) and our Privacy Policy carefully because they
 govern your use of the website, the user interface, and other offerings located at walrus.xyz, (the
 “Site”) offered by Walrus Foundation (“Walrus Foundation,” “we,” “our”). To make these Terms easier

--- a/docs/content/legal/walrus_general_tos.mdx
+++ b/docs/content/legal/walrus_general_tos.mdx
@@ -1,5 +1,6 @@
 ---
 title: Walrus General Terms of Service
+description: The general terms of service that govern use of Walrus.
 custom_edit_url: null
 goal:
   description: Reader can review the general terms of service that govern use of Walrus
@@ -28,7 +29,7 @@ answer: >-
 
 :::info Looking for the developer documentation?
 
-You are reading a legal document. To build on Walrus, start with [Get started](/docs/getting-started), [Walrus Sites](/docs/sites), or the [Walrus Memory docs](/walrus-memory/). For technical questions, the Ask Walrus AI assistant is available on every documentation page.
+You are reading a legal document. To build on Walrus, start with [Get started](/docs/getting-started), [Walrus Sites](/docs/sites), or the [Walrus Memory docs](/walrus-memory/), where you can also open the Ask Walrus AI assistant for technical questions.
 
 :::
 

--- a/docs/content/troubleshooting/index.mdx
+++ b/docs/content/troubleshooting/index.mdx
@@ -72,5 +72,8 @@ $ RUST_LOG=walrus=debug walrus store file.txt --epochs 5
 If a freshly uploaded blob returns `404 Not Found` from a CDN-fronted aggregator, you are likely hitting a cached `404` response from before the blob propagated. See [Reading Blobs Right After Upload](/docs/troubleshooting/reading-blobs-after-upload) for when to retry and when not to.
 
 import DocCardList from '@theme/DocCardList';
+import AskAiCta from '@site/src/shared/components/AskAiCta';
+
+<AskAiCta prompt="Error message not covered here? Ask Walrus AI - it answers from this documentation." />
 
 <DocCardList />

--- a/docs/site/src/css/custom.css
+++ b/docs/site/src/css/custom.css
@@ -1794,3 +1794,39 @@ html.kapa-sidebar-open .col[class*="docItemCol"] {
     font-size: 1.25rem;
   }
 }
+
+/* ── Inline Ask Walrus AI entry point (AskAiCta component) ─────────── */
+.askai-cta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin: 1.5rem 0;
+  padding: 0.85rem 1.25rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 10px;
+  background: var(--ifm-background-surface-color);
+}
+
+.askai-cta-text {
+  color: var(--ifm-font-color-base);
+}
+
+.askai-cta-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 1rem;
+  border: 1px solid #37c3b0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--ifm-font-color-base);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.askai-cta-button:hover {
+  background: rgba(55, 195, 176, 0.12);
+}

--- a/docs/site/src/shared/components/AskAiCta/index.tsx
+++ b/docs/site/src/shared/components/AskAiCta/index.tsx
@@ -1,0 +1,31 @@
+// Copyright (c) Walrus Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import React from "react";
+
+/**
+ * Inline entry point for the Ask Walrus AI assistant, for placement on
+ * high-traffic documentation pages. Opens the same Kapa sidebar as the
+ * navbar trigger.
+ */
+export default function AskAiCta({
+    prompt = "Stuck or curious? Ask Walrus AI — it answers from this documentation.",
+}: {
+    prompt?: string;
+}) {
+    const handleClick = () => {
+        if (typeof window !== "undefined" && (window as any).Kapa) {
+            (window as any).Kapa.open();
+        }
+    };
+
+    return (
+        <div className="askai-cta">
+            <span className="askai-cta-text">{prompt}</span>
+            <button type="button" className="askai-cta-button" onClick={handleClick}>
+                <img src="/img/logo.svg" alt="" width="16" height="16" />
+                Ask Walrus AI
+            </button>
+        </div>
+    );
+}

--- a/docs/site/src/theme/Navbar/Content/index.js
+++ b/docs/site/src/theme/Navbar/Content/index.js
@@ -119,7 +119,9 @@ function KapaButton() {
 
   // Legal pages draw consent-flow traffic that produces low-quality AI
   // questions, so the assistant entry point stays off there (BEDU-795).
-  if (pathname.startsWith("/docs/legal/")) {
+  // Substring match rather than startsWith so the check survives a
+  // non-root baseUrl, such as the /walrus/pr-preview/pr-N/ previews.
+  if (pathname.includes("/docs/legal/")) {
     return null;
   }
 

--- a/docs/site/src/theme/Navbar/Content/index.js
+++ b/docs/site/src/theme/Navbar/Content/index.js
@@ -13,6 +13,7 @@ import NavbarMobileSidebarToggle from "@theme/Navbar/MobileSidebar/Toggle";
 import NavbarSearch from "@theme/Navbar/Search";
 import SearchModal from "@site/src/components/Search/SearchModal";
 import Link from "@docusaurus/Link";
+import { useLocation } from "@docusaurus/router";
 import useBaseUrl from "@docusaurus/useBaseUrl";
 import { useThemeConfig as useThemeConfigFull } from "@docusaurus/theme-common";
 import WalrusLogo from "@site/static/img/Walrus_Docs.svg";
@@ -108,11 +109,19 @@ function SearchLauncher() {
 }
 
 function KapaButton() {
+  const { pathname } = useLocation();
+
   const handleClick = () => {
     if (typeof window !== "undefined" && window.Kapa) {
       window.Kapa.open();
     }
   };
+
+  // Legal pages draw consent-flow traffic that produces low-quality AI
+  // questions, so the assistant entry point stays off there (BEDU-795).
+  if (pathname.startsWith("/docs/legal/")) {
+    return null;
+  }
 
   return (
     <button


### PR DESCRIPTION
## Description

The legal + chatbot batch (BEDU-795, BEDU-962, BEDU-1014; closes umbrella BEDU-1041):

- **Suppress the assistant on legal pages (BEDU-795).** The navbar Ask Walrus AI trigger no longer renders on `/docs/legal/*`: consent-flow traffic landing there produces 29% of all assistant questions, mostly low quality. The gate lives in the navbar `KapaButton` via `useLocation`.
- **Prominent entry points on core pages (BEDU-795).** New `AskAiCta` component — an inline card that opens the same Kapa sidebar as the navbar trigger — placed in Getting Started's "Need help?" section and above the troubleshooting index cards, the two natural ask-a-question surfaces.
- **Legal-page banners (BEDU-962 + BEDU-1014).** Each of the three legal pages gains one `:::info` navigation banner after the frontmatter, pointing readers at Get started, Walrus Sites, and the Walrus Memory docs. **The legal text itself is untouched** — that wording belongs to the legal team.

## Test plan

- `editorconfig-checker==2.7.3` (the CI version) clean on all changed files; `git diff --check` clean.
- The `KapaButton` gate only touches render logic; the Kapa script config in `docusaurus.config.js` is unchanged, so the widget still loads site-wide and `AskAiCta` can open it from any page.
- Banner links target existing routes (`/docs/getting-started`, `/docs/sites`, `/walrus-memory/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoBWxqLzd9hAxrhoqv3iSv

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoBWxqLzd9hAxrhoqv3iSv)_

---

## Release notes

Docs-only change; release notes aren't required.

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI: