### PR TITLE
feat: encode blob info snapshots to report their blob ID

### DIFF
--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -1858,7 +1858,7 @@ async fn test_repeated_shard_move() -> TestResult {
             .with_epoch_duration(Duration::from_secs(20))
             .with_test_nodes_config(
                 TestNodesConfig::builder()
-                    .with_node_weights(&[1, 1])
+                    .with_node_weights(&[2, 2])
                     .build(),
             )
             .build()
@@ -2640,7 +2640,7 @@ async fn test_shard_move_out_and_back_in_immediately() -> TestResult {
             .with_epoch_duration(Duration::from_secs(20))
             .with_test_nodes_config(
                 TestNodesConfig::builder()
-                    .with_node_weights(&[1, 1])
+                    .with_node_weights(&[2, 2])
                     .build(),
             )
             .build()

--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -1891,7 +1891,7 @@ async fn test_repeated_shard_move() -> TestResult {
             .existing_shards()
             .await
             .len(),
-        2
+        4
     );
 
     client
@@ -1913,7 +1913,7 @@ async fn test_repeated_shard_move() -> TestResult {
             .existing_shards()
             .await
             .len(),
-        2
+        4
     );
     assert_eq!(
         walrus_cluster.nodes[1]
@@ -2657,7 +2657,7 @@ async fn test_shard_move_out_and_back_in_immediately() -> TestResult {
                 .as_ref()
                 .unwrap()
                 .node_id,
-            FROST_PER_NODE_WEIGHT * 5,
+            FROST_PER_NODE_WEIGHT * 10,
         )
         .await?;
 
@@ -2672,7 +2672,7 @@ async fn test_shard_move_out_and_back_in_immediately() -> TestResult {
                 .as_ref()
                 .unwrap()
                 .node_id,
-            FROST_PER_NODE_WEIGHT * 30,
+            FROST_PER_NODE_WEIGHT * 60,
         )
         .await?;
 
@@ -2687,7 +2687,7 @@ async fn test_shard_move_out_and_back_in_immediately() -> TestResult {
             .existing_shards()
             .await
             .len(),
-        2
+        4
     );
     assert_eq!(
         walrus_cluster.nodes[0]
@@ -2695,7 +2695,7 @@ async fn test_shard_move_out_and_back_in_immediately() -> TestResult {
             .existing_shards()
             .await
             .len(),
-        2
+        4
     );
     assert_unordered_eq!(
         walrus_cluster.nodes[1]
@@ -2709,7 +2709,7 @@ async fn test_shard_move_out_and_back_in_immediately() -> TestResult {
             .storage_node()
             .existing_shards_live()
             .await,
-        vec![ShardIndex(0), ShardIndex(1)]
+        vec![ShardIndex(0), ShardIndex(1), ShardIndex(2), ShardIndex(3)]
     );
 
     walrus_cluster.wait_for_nodes_to_reach_epoch(6).await;
@@ -2729,7 +2729,7 @@ async fn test_shard_move_out_and_back_in_immediately() -> TestResult {
             .existing_shards()
             .await
             .len(),
-        2
+        4
     );
 
     Ok(())

--- a/crates/walrus-e2e-tests/tests/test_event_blobs.rs
+++ b/crates/walrus-e2e-tests/tests/test_event_blobs.rs
@@ -83,7 +83,7 @@ async fn test_disabled_event_blob_writer() -> anyhow::Result<()> {
     let (_sui_cluster, _cluster, client, _, _) = test_cluster::E2eTestSetupBuilder::new()
         .with_test_nodes_config(
             TestNodesConfig::builder()
-                .with_node_weights(&[1, 1])
+                .with_node_weights(&[2, 2])
                 .with_disable_event_blob_writer()
                 .build(),
         )

--- a/crates/walrus-service/src/node/blob_info_snapshot_writer.rs
+++ b/crates/walrus-service/src/node/blob_info_snapshot_writer.rs
@@ -48,6 +48,23 @@ impl Default for BlobInfoSnapshotWriterConfig {
     }
 }
 
+/// Number of epoch buckets used as the label of `blob_info_snapshot_blob_id`.
+///
+/// The label is `epoch % SNAPSHOT_EPOCH_BUCKET_COUNT`, which bounds the distinct series a node
+/// ever creates. Bucketing per se is not safe: it is safe here only because the metric is reset
+/// before each write, so a node exports exactly one bucket, the one of its latest snapshot.
+///
+/// Two nodes therefore share a bucket only when their epochs are congruent modulo this count,
+/// which means either the same epoch, a correct comparison, or a divergence of exactly a
+/// multiple of it, a false mismatch. That takes a node running for this many epochs without
+/// writing a snapshot, and it heals as soon as the node writes one again.
+///
+/// Without the reset, a node would keep every bucket it has ever written, every shared bucket
+/// would compare values from epochs a multiple apart, and recovering the node would not clear
+/// them until it had run for a further `SNAPSHOT_EPOCH_BUCKET_COUNT` epochs. Do not export more
+/// than the current bucket without raising this count accordingly.
+const SNAPSHOT_EPOCH_BUCKET_COUNT: Epoch = 100;
+
 /// Returns the directory under which the writer keeps its snapshots.
 pub fn snapshot_base_dir(storage_path: &Path) -> PathBuf {
     storage_path.join("blob_info_snapshots")
@@ -257,16 +274,20 @@ async fn try_encode_snapshot(
         .set(encode_elapsed.as_secs_f64());
 
     let blob_id = *verified_metadata.blob_id();
-    // Export only the current epoch's series, so that a node whose snapshots stalled is never
-    // compared against another epoch's blob ID. Alerts recover earlier epochs from the metric
-    // store with a lookback window, which retains them regardless of what a node still exports.
-    node.metrics.blob_info_snapshot_info.reset();
+    let blob_id_prefix = u64::from_be_bytes(
+        blob_id.as_ref()[..8]
+            .try_into()
+            .expect("blob id has at least 8 bytes"),
+    );
+    // Reset before setting, so that only the bucket of the latest snapshot is exported. The
+    // bucket bound depends on this; see `SNAPSHOT_EPOCH_BUCKET_COUNT`.
+    node.metrics.blob_info_snapshot_blob_id.reset();
+    #[allow(clippy::cast_possible_wrap)] // reinterpreting the bits as i64 is fine
     walrus_utils::with_label!(
-        node.metrics.blob_info_snapshot_info,
-        epoch.to_string(),
-        blob_id.to_string()
+        node.metrics.blob_info_snapshot_blob_id,
+        (epoch % SNAPSHOT_EPOCH_BUCKET_COUNT).to_string()
     )
-    .set(1);
+    .set(blob_id_prefix as i64);
     tracing::info!(
         walrus.epoch = epoch,
         walrus.blob_id = %blob_id,

--- a/crates/walrus-service/src/node/blob_info_snapshot_writer.rs
+++ b/crates/walrus-service/src/node/blob_info_snapshot_writer.rs
@@ -234,7 +234,7 @@ async fn try_encode_snapshot(
     // recovery symbols, and encoding panics.
     // TODO(WAL-1270): reject such committees where the system is defined, and drop this.
     debug_assert!(
-        encoding_config.n_shards() > encoding_config.n_secondary_source_symbols(),
+        encoding_config.n_shards().get() >= 4,
         "the system must be able to encode"
     );
 
@@ -242,6 +242,8 @@ async fn try_encode_snapshot(
     let path = snapshot_path.to_path_buf();
     let verified_metadata = tokio::task::spawn_blocking(move || {
         let content = fs::read(path)?;
+        // TODO(WAL-1250): certifying the snapshot needs its slivers, so this becomes a full
+        // encode rather than only the metadata.
         encoding_config
             .compute_metadata(&content)
             .map_err(anyhow::Error::from)

--- a/crates/walrus-service/src/node/blob_info_snapshot_writer.rs
+++ b/crates/walrus-service/src/node/blob_info_snapshot_writer.rs
@@ -20,7 +20,7 @@ use std::{
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use twox_hash::XxHash64;
-use walrus_core::Epoch;
+use walrus_core::{DEFAULT_ENCODING, Epoch, encoding::EncodingFactory as _};
 
 use super::{
     StorageNodeInner,
@@ -36,9 +36,9 @@ pub struct BlobInfoSnapshotWriterConfig {
     /// Defaults to `true`; set it explicitly to `false` to disable.
     ///
     /// When enabled, the node serializes the three blob-info column families in-process at the
-    /// post-GC-phase-1 boundary and reports the serialization duration, size, and digest. Note
-    /// that disabling this flag leaves the last snapshot file on disk until it is removed
-    /// manually.
+    /// post-GC-phase-1 boundary and reports the serialization duration, size, and digest, then
+    /// encodes the snapshot to report its blob ID. Note that disabling this flag leaves the
+    /// last snapshot file on disk until it is removed manually.
     pub enabled: bool,
 }
 
@@ -97,7 +97,8 @@ fn hash_file(path: &Path) -> std::io::Result<u64> {
 }
 
 /// Serializes the three blob info column families in-process at the epoch boundary, reports the
-/// duration, size, and digest, and removes older snapshot files.
+/// duration, size, and digest, and removes older snapshot files. Then encodes the durable
+/// snapshot to report its blob ID.
 ///
 /// Must be called at the post-GC-phase-1 point while event processing is blocked. `event_cursor`
 /// is the position of the `EpochChangeStart` being processed.
@@ -113,14 +114,27 @@ pub(super) async fn serialize_snapshot_at_epoch_boundary(
     if final_path.exists() {
         // Already created, e.g., because the epoch change event is being reprocessed after a
         // restart. Still drop any older snapshots so that at most one remains.
-        //
-        // TODO(WAL-1252): once snapshots are published and certified, a present file no longer
-        // means the work is done. This early return should consider both the on-disk write and the
-        // publish/certify state, and resume publishing rather than returning early.
         tracing::debug!(walrus.epoch = epoch, "blob info snapshot already exists");
         remove_snapshot_files_matching(&base_dir, |snapshot_epoch| snapshot_epoch != epoch);
-        return Ok(());
+    } else {
+        write_snapshot_file(&node, epoch, event_cursor, &base_dir, &final_path).await?;
     }
+
+    // TODO(WAL-1252): resume an interrupted publication here once snapshots are published and
+    // certified.
+    encode_snapshot(&node, epoch, &final_path).await;
+    Ok(())
+}
+
+/// Serializes the snapshot to `final_path` durably (write, fsync, rename, fsync dir), removes
+/// older snapshot files, and reports the duration, size, and digest.
+async fn write_snapshot_file(
+    node: &Arc<StorageNodeInner>,
+    epoch: Epoch,
+    event_cursor: EventStreamCursor,
+    base_dir: &Path,
+    final_path: &Path,
+) -> Result<()> {
     let tmp_path = base_dir.join(format!("snapshot_epoch_{epoch}.bin.tmp"));
     if tmp_path.exists() {
         fs::remove_file(&tmp_path)?;
@@ -154,15 +168,15 @@ pub(super) async fn serialize_snapshot_at_epoch_boundary(
         })
         .await
         .context("snapshot serialization task panicked")??;
-    fs::rename(&tmp_path, &final_path)?;
+    fs::rename(&tmp_path, final_path)?;
     // Fsync the directory so the rename is durable: the `sync_all` above flushes the file
     // contents, but not the parent directory entry that the rename created.
-    sync_dir(&base_dir)?;
+    sync_dir(base_dir)?;
     // Only now that the new snapshot is durably in place, remove older epochs' snapshots so that
     // at most one remains. Deleting them after the rename (rather than before writing) means a
     // write or rename failure leaves the previous snapshot intact instead of dropping it
     // prematurely.
-    remove_snapshot_files_matching(&base_dir, |snapshot_epoch| snapshot_epoch != epoch);
+    remove_snapshot_files_matching(base_dir, |snapshot_epoch| snapshot_epoch != epoch);
     let elapsed = start.elapsed();
 
     node.metrics
@@ -190,6 +204,72 @@ pub(super) async fn serialize_snapshot_at_epoch_boundary(
         digest = %digest_hex,
         path = %final_path.display(),
         "serialized blob info snapshot in-process"
+    );
+    Ok(())
+}
+
+/// Encodes the snapshot into a Walrus blob to report its blob ID, logging errors and counting
+/// them in metrics without failing the epoch change.
+async fn encode_snapshot(node: &Arc<StorageNodeInner>, epoch: Epoch, snapshot_path: &Path) {
+    if let Err(error) = try_encode_snapshot(node, epoch, snapshot_path).await {
+        node.metrics.blob_info_snapshot_encode_error_total.inc();
+        tracing::warn!(
+            ?error,
+            walrus.epoch = epoch,
+            "failed to encode the blob info snapshot"
+        );
+    }
+}
+
+/// Computes the blob ID of the snapshot file and reports it for cross-node comparison; nothing
+/// is stored.
+async fn try_encode_snapshot(
+    node: &Arc<StorageNodeInner>,
+    epoch: Epoch,
+    snapshot_path: &Path,
+) -> Result<()> {
+    let encoding_config = node.encoding_config().get_for_type(DEFAULT_ENCODING);
+    // Encoding is inherent to the protocol, so every valid system can encode. Committees of
+    // fewer than four shards cannot: no shard may be faulty, so the encoding is left without
+    // recovery symbols, and encoding panics.
+    // TODO(WAL-1270): reject such committees where the system is defined, and drop this.
+    debug_assert!(
+        encoding_config.n_shards() > encoding_config.n_secondary_source_symbols(),
+        "the system must be able to encode"
+    );
+
+    let encode_start = Instant::now();
+    let path = snapshot_path.to_path_buf();
+    let verified_metadata = tokio::task::spawn_blocking(move || {
+        let content = fs::read(path)?;
+        encoding_config
+            .compute_metadata(&content)
+            .map_err(anyhow::Error::from)
+    })
+    .await
+    .context("snapshot encoding task panicked")?
+    .context("failed to encode the blob info snapshot")?;
+    let encode_elapsed = encode_start.elapsed();
+    node.metrics
+        .blob_info_snapshot_encode_duration_seconds
+        .set(encode_elapsed.as_secs_f64());
+
+    let blob_id = *verified_metadata.blob_id();
+    // Export only the current epoch's series, so that a node whose snapshots stalled is never
+    // compared against another epoch's blob ID. Alerts recover earlier epochs from the metric
+    // store with a lookback window, which retains them regardless of what a node still exports.
+    node.metrics.blob_info_snapshot_info.reset();
+    walrus_utils::with_label!(
+        node.metrics.blob_info_snapshot_info,
+        epoch.to_string(),
+        blob_id.to_string()
+    )
+    .set(1);
+    tracing::info!(
+        walrus.epoch = epoch,
+        walrus.blob_id = %blob_id,
+        ?encode_elapsed,
+        "encoded blob info snapshot"
     );
     Ok(())
 }

--- a/crates/walrus-service/src/node/metrics.rs
+++ b/crates/walrus-service/src/node/metrics.rs
@@ -218,10 +218,10 @@ walrus_utils::metrics::define_metric_set! {
         #[help = "The number of errors while encoding blob info snapshots."]
         blob_info_snapshot_encode_error_total: IntCounter[],
 
-        #[help = "The blob ID of the blob info snapshot of the labeled epoch, for cross-node \
-        comparison and mismatch alerting. The value is always 1; only the current epoch is \
-        exported."]
-        blob_info_snapshot_info: IntGaugeVec["epoch", "blob_id"],
+        #[help = "The first 8 bytes of the blob ID of the blob info snapshot, for cross-node \
+        comparison and mismatch alerting. Only the latest snapshot is exported, and the label \
+        is epoch % SNAPSHOT_EPOCH_BUCKET_COUNT (see blob_info_snapshot_writer.rs)."]
+        blob_info_snapshot_blob_id: IntGaugeVec["epoch"],
 
         #[help = "The number of certified per-object blobs scanned during the per-object blob info \
         consistency check."]

--- a/crates/walrus-service/src/node/metrics.rs
+++ b/crates/walrus-service/src/node/metrics.rs
@@ -211,6 +211,18 @@ walrus_utils::metrics::define_metric_set! {
         comparison. Note that the label is epoch % EPOCH_BUCKET_COUNT (see consistency_check.rs)."]
         per_object_blob_info_snapshot_digest: IntGaugeVec["epoch"],
 
+        #[help = "The duration of encoding the blob info snapshot into a Walrus blob, in \
+        seconds."]
+        blob_info_snapshot_encode_duration_seconds: Gauge[],
+
+        #[help = "The number of errors while encoding blob info snapshots."]
+        blob_info_snapshot_encode_error_total: IntCounter[],
+
+        #[help = "The blob ID of the blob info snapshot of the labeled epoch, for cross-node \
+        comparison and mismatch alerting. The value is always 1; only the current epoch is \
+        exported."]
+        blob_info_snapshot_info: IntGaugeVec["epoch", "blob_id"],
+
         #[help = "The number of certified per-object blobs scanned during the per-object blob info \
         consistency check."]
         per_object_blob_info_consistency_check_certified_scanned: IntCounterVec["epoch"],

--- a/crates/walrus-service/tests/epoch_change.rs
+++ b/crates/walrus-service/tests/epoch_change.rs
@@ -19,7 +19,7 @@ async fn nodes_drive_epoch_change() -> walrus_test_utils::Result {
         .with_epoch_duration(epoch_duration)
         .with_test_nodes_config(
             TestNodesConfig::builder()
-                .with_node_weights(&[1, 1])
+                .with_node_weights(&[2, 2])
                 .build(),
         )
         .with_default_num_checkpoints_per_blob()

--- a/crates/walrus-simtest/tests/simtest_core.rs
+++ b/crates/walrus-simtest/tests/simtest_core.rs
@@ -1523,7 +1523,7 @@ mod tests {
                 .with_epoch_duration(epoch_duration)
                 .with_test_nodes_config(
                     TestNodesConfig::builder()
-                        .with_node_weights(&[1, 1])
+                        .with_node_weights(&[2, 2])
                         .build(),
                 )
                 .with_default_num_checkpoints_per_blob()


### PR DESCRIPTION
## Description
After writing the snapshot file at the epoch boundary, encode it to derive its Walrus blob ID and report the ID prefix per epoch bucket, the encoding duration, and errors as metrics, so cross-node blob-ID agreement can be verified before any on-chain certification exists.

## Test change
Five test clusters used with_node_weights(&[1, 1]), that is two shards. With n_shards <= 3, encoding panics. Nothing had ever encoded in those clusters because no client stores blobs there, so this stage was the first to try. They now use [2, 2], keeping the two-node topology with four shards.