### PR TITLE
fix: keep unpublished Memory contributing pages out of llms.txt

### DIFF
--- a/docs/site/src/scripts/copy-markdown-files.js
+++ b/docs/site/src/scripts/copy-markdown-files.js
@@ -313,6 +313,14 @@ if (fs.existsSync(walrusMemoryDir)) {
     files.forEach(file => {
       const filePath = path.join(dir, file);
       const stat = fs.statSync(filePath);
+      // The site's walrus-memory docs plugin excludes contributing/** from
+      // rendering (docusaurus.config.js), so those pages have no HTML route.
+      // Keep them out of the markdown export too, or they leak into llms.txt
+      // and the .md routes as links to pages that 404.
+      const relFromBase = path.relative(baseDir, filePath).replace(/\\/g, "/");
+      if (relFromBase === "contributing" || relFromBase.startsWith("contributing/")) {
+        return;
+      }
       if (stat.isDirectory()) {
         copyWalrusMemoryFiles(filePath, baseDir);
       } else if (file.endsWith('.md') || file.endsWith('.mdx')) {

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -593,21 +593,6 @@ Sui smart contract as the on-chain index.
     unauthenticated and unsigned. They do not require a valid Ed25519 signature in headers like the
     rest of the API.
 
-## Walrus Memory: Contributing
-
-- [Docs Workflow](https://docs.wal.app/walrus-memory/contributing/docs-workflow.md):
-    Walrus Memory is still in beta, so documentation is an active part of product hardening. If you
-    see unclear guidance, outdated flows, or missing examples, contributions are welcome. The docs
-    source of truth is the markdown content under docs/ in this repository.
-- [Run Docs Locally](https://docs.wal.app/walrus-memory/contributing/run-docs-locally.md):
-    Run these commands from the repository root: Source: contributing/run-docs-locally.md This
-    starts the Mintlify site using the docs in this repository. Use Node 20 LTS for Mintlify local
-    preview. Mintlify fails on Node 25+.
-- [Docs site (Mintlify)](https://docs.wal.app/walrus-memory/contributing/run-repo-locally.md):
-    | Tool | Version | Check | |------|---------|-------| | Node.js | ≥ 20 | node -v | | pnpm | ≥
-    9.12 | pnpm -v | | Rust | latest stable (only for backend services) | rustc --version | > Tip >
-    > If you only work on TypeScript apps or docs, you don't need Rust.
-
 ## Walrus Memory: Examples
 
 - [Chatbot](https://docs.wal.app/walrus-memory/examples/chatbot.md):

--- a/docs/site/static/llms.txt
+++ b/docs/site/static/llms.txt
@@ -595,21 +595,6 @@ Sui smart contract as the on-chain index.
     unauthenticated and unsigned. They do not require a valid Ed25519 signature in headers like the
     rest of the API.
 
-## Walrus Memory: Contributing
-
-- [Docs Workflow](https://docs.wal.app/walrus-memory/contributing/docs-workflow.md):
-    Walrus Memory is still in beta, so documentation is an active part of product hardening. If you
-    see unclear guidance, outdated flows, or missing examples, contributions are welcome. The docs
-    source of truth is the markdown content under docs/ in this repository.
-- [Run Docs Locally](https://docs.wal.app/walrus-memory/contributing/run-docs-locally.md):
-    Run these commands from the repository root: Source: contributing/run-docs-locally.md This
-    starts the Mintlify site using the docs in this repository. Use Node 20 LTS for Mintlify local
-    preview. Mintlify fails on Node 25+.
-- [Docs site (Mintlify)](https://docs.wal.app/walrus-memory/contributing/run-repo-locally.md):
-    | Tool | Version | Check | |------|---------|-------| | Node.js | ≥ 20 | node -v | | pnpm | ≥
-    9.12 | pnpm -v | | Rust | latest stable (only for backend services) | rustc --version | > Tip >
-    > If you only work on TypeScript apps or docs, you don't need Rust.
-
 ## Walrus Memory: Examples
 
 - [Chatbot](https://docs.wal.app/walrus-memory/examples/chatbot.md):

--- a/docs/site/static/walrus-memory/llms-full.txt
+++ b/docs/site/static/walrus-memory/llms-full.txt
@@ -198,21 +198,6 @@
     unauthenticated and unsigned. They do not require a valid Ed25519 signature in headers like the
     rest of the API.
 
-## Walrus Memory: Contributing
-
-- [Docs Workflow](https://docs.wal.app/walrus-memory/contributing/docs-workflow.md):
-    Walrus Memory is still in beta, so documentation is an active part of product hardening. If you
-    see unclear guidance, outdated flows, or missing examples, contributions are welcome. The docs
-    source of truth is the markdown content under docs/ in this repository.
-- [Run Docs Locally](https://docs.wal.app/walrus-memory/contributing/run-docs-locally.md):
-    Run these commands from the repository root: Source: contributing/run-docs-locally.md This
-    starts the Mintlify site using the docs in this repository. Use Node 20 LTS for Mintlify local
-    preview. Mintlify fails on Node 25+.
-- [Docs site (Mintlify)](https://docs.wal.app/walrus-memory/contributing/run-repo-locally.md):
-    | Tool | Version | Check | |------|---------|-------| | Node.js | ≥ 20 | node -v | | pnpm | ≥
-    9.12 | pnpm -v | | Rust | latest stable (only for backend services) | rustc --version | > Tip >
-    > If you only work on TypeScript apps or docs, you don't need Rust.
-
 ## Walrus Memory: Examples
 
 - [Chatbot](https://docs.wal.app/walrus-memory/examples/chatbot.md):

--- a/docs/site/static/walrus-memory/llms.txt
+++ b/docs/site/static/walrus-memory/llms.txt
@@ -201,21 +201,6 @@
     unauthenticated and unsigned. They do not require a valid Ed25519 signature in headers like the
     rest of the API.
 
-## Walrus Memory: Contributing
-
-- [Docs Workflow](https://docs.wal.app/walrus-memory/contributing/docs-workflow.md):
-    Walrus Memory is still in beta, so documentation is an active part of product hardening. If you
-    see unclear guidance, outdated flows, or missing examples, contributions are welcome. The docs
-    source of truth is the markdown content under docs/ in this repository.
-- [Run Docs Locally](https://docs.wal.app/walrus-memory/contributing/run-docs-locally.md):
-    Run these commands from the repository root: Source: contributing/run-docs-locally.md This
-    starts the Mintlify site using the docs in this repository. Use Node 20 LTS for Mintlify local
-    preview. Mintlify fails on Node 25+.
-- [Docs site (Mintlify)](https://docs.wal.app/walrus-memory/contributing/run-repo-locally.md):
-    | Tool | Version | Check | |------|---------|-------| | Node.js | ≥ 20 | node -v | | pnpm | ≥
-    9.12 | pnpm -v | | Rust | latest stable (only for backend services) | rustc --version | > Tip >
-    > If you only work on TypeScript apps or docs, you don't need Rust.
-
 ## Walrus Memory: Examples
 
 - [Chatbot](https://docs.wal.app/walrus-memory/examples/chatbot.md):


### PR DESCRIPTION
## Description

An external audit flagged that AI search tools keep citing "Walrus Memory is still in beta" from `https://docs.wal.app/walrus-memory/contributing/docs-workflow.md` — a page whose rendered route returns 404.

Root cause: the walrus-memory docs plugin excludes `contributing/**` from rendering (`docusaurus.config.js`), so those pages have no HTML route by design — but the markdown-export pipeline that feeds `llms.txt` and the `.md` routes did not know about that exclusion, so the unpublished pages leaked into the AI-facing indexes anyway, stale description included.

The Walrus Memory export in `copy-markdown-files.js` now skips `contributing/`, matching the site config, and the committed llms files are regenerated: the three unpublished contributing pages drop out of the site-wide index (183 → 180 pages) and the Memory-scoped index (77 → 74).

This handles the stale-index half of the audit only. The live "beta" wording on the What is Walrus Memory page and the relayer pages is upstream MemWal content and a product-positioning decision, tracked separately.

## Test plan

- Ran the export and both llms generations locally: `contributing/` absent from `static/markdown/walrus-memory/`, zero `contributing` references in all four llms files.
- `node --check` and `editorconfig-checker==2.7.3` (the CI version) clean on the changed script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoBWxqLzd9hAxrhoqv3iSv

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoBWxqLzd9hAxrhoqv3iSv)_

---

## Release notes

Docs-tooling-only change; release notes aren't required.

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI: