### PR TITLE
docs: content-audit improvements across 13 pages

### DIFF
--- a/docs/content/examples/checkpoint-data.mdx
+++ b/docs/content/examples/checkpoint-data.mdx
@@ -42,57 +42,34 @@ answer: >-
   service yourself with Cargo.
 ---
 
-The Sui Archival application demonstrates how you can archive blockchain data on Walrus in a
-reliable, deterministic, and resilient manner. The service continuously downloads Sui checkpoints,
-the sequential batches of finalized transactions that the Sui network produces, bundles them into
-compressed blobs, and uploads the blobs to Walrus. Because Walrus erasure-codes every blob across a
-large committee of storage nodes, the archive stays readable even when individual nodes fail.
+The Sui Archival application demonstrates how you can archive blockchain data on Walrus in a reliable, deterministic, and resilient manner. The service continuously downloads Sui checkpoints, the sequential batches of finalized transactions that the Sui network produces, bundles them into compressed blobs, and uploads the blobs to Walrus. Because Walrus erasure-codes every blob across a large committee of storage nodes, the archive stays readable even when individual nodes fail.
 
 See also:
 
-- [Deployed archive](https://walrus-sui-archival.wal.app/): browse the live instance, its archival
-  statistics, and its [technical documentation](https://walrus-sui-archival.wal.app/tech/).
-- [walrus-sui-archival on GitHub](https://github.com/MystenLabs/walrus-sui-archival): the full
-  source code for the service, the frontend, and the Docker configurations.
-- [Core Concepts](/docs/system-overview/core-concepts): how blobs, epochs, and certification work
-  in Walrus.
-- [Getting Started](/docs/getting-started): install and configure the Walrus client that the
-  service uses to store blobs.
+- [Deployed archive](https://walrus-sui-archival.wal.app/): browse the live instance, its archival statistics, and its [technical documentation](https://walrus-sui-archival.wal.app/tech/).
+- [walrus-sui-archival on GitHub](https://github.com/MystenLabs/walrus-sui-archival): the full source code for the service, the frontend, and the Docker configurations.
+- [Core Concepts](/docs/system-overview/core-concepts): how blobs, epochs, and certification work in Walrus.
+- [Getting Started](/docs/getting-started): install and configure the Walrus client that the service uses to store blobs.
 
 ## How it works
 
-Walrus stores data as blobs, immutable units of data that storage nodes keep available for a paid
-number of epochs (fixed-length periods: 2 weeks on Mainnet, 1 day on Testnet). The archival
-service runs the following components concurrently:
+Walrus stores data as blobs, immutable units of data that storage nodes keep available for a paid number of epochs (fixed-length periods: 2 weeks on Mainnet, 1 day on Testnet). The archival service runs the following components concurrently:
 
-1. **Checkpoint downloader:** Downloads checkpoints from a configurable checkpoint source, such as
-   the Sui data ingestion service, using multiple parallel workers.
-2. **Checkpoint monitor:** Tracks downloaded checkpoints, handles out-of-order delivery, and
-   triggers blob building when the pending checkpoints hit a configured threshold: total size,
-   elapsed time, or the end of a Sui epoch. A backpressure mechanism pauses the downloader when too
-   many checkpoints await bundling.
-3. **Checkpoint blob publisher:** Bundles a contiguous range of checkpoints into a single
-   compressed blob and uploads it to Walrus. The bundling follows a deterministic algorithm: a
-   given checkpoint range, cut at the configured size, time, or end-of-epoch boundaries, always
-   produces the same blob.
-4. **Checkpoint blob extender:** Watches the expiration epoch of every archived blob and extends
-   it automatically, so the archive stays available without manual renewals.
-5. **Archival state snapshot creator:** Uploads snapshots of the archive's metadata and maintains
-   an onchain pointer to the latest snapshot, so a fresh instance can rebuild its database for
-   disaster recovery.
+1. **Checkpoint downloader:** Downloads checkpoints from a configurable checkpoint source, such as the Sui data ingestion service, using multiple parallel workers.
+2. **Checkpoint monitor:** Tracks downloaded checkpoints, handles out-of-order delivery, and triggers blob building when the pending checkpoints hit a configured threshold: total size, elapsed time, or the end of a Sui epoch. A backpressure mechanism pauses the downloader when too many checkpoints await bundling.
+3. **Checkpoint blob publisher:** Bundles a contiguous range of checkpoints into a single compressed blob and uploads it to Walrus. The bundling follows a deterministic algorithm: a given checkpoint range, cut at the configured size, time, or end-of-epoch boundaries, always produces the same blob.
+4. **Checkpoint blob extender:** Watches the expiration epoch of every archived blob and extends it automatically, so the archive stays available without manual renewals.
+5. **Archival state snapshot creator:** Uploads snapshots of the archive's metadata and maintains an onchain pointer to the latest snapshot, so a fresh instance can rebuild its database for disaster recovery.
 6. **REST API server:** Serves the web interface and the JSON endpoints described below.
 
-The service records blob metadata, that is, the Walrus blob ID, the Sui object ID, the checkpoint
-range, and the size of each archived blob, in a local RocksDB database, and can optionally mirror
-it to PostgreSQL for fast indexed queries.
+The service records blob metadata, that is, the Walrus blob ID, the Sui object ID, the checkpoint range, and the size of each archived blob, in a local RocksDB database, and can optionally mirror it to PostgreSQL for fast indexed queries.
 
 ## Build and run the service
 
 Before you start, you need:
 
 - A recent Rust toolchain, because the service builds with Cargo.
-- A Walrus client configuration and a wallet funded with SUI and WAL, because the service pays for
-  the storage it uses. See [Getting Started](/docs/getting-started).
+- A Walrus client configuration and a wallet funded with SUI and WAL, because the service pays for the storage it uses. See [Getting Started](/docs/getting-started).
 - Optional: a PostgreSQL database if you want indexed queries alongside the local RocksDB store.
 
 Then build and run the service:
@@ -105,10 +82,7 @@ Then build and run the service:
    cargo build --release
    ```
 
-2. Review the example configuration in `config/testnet_local_config.yaml`. The configuration file
-   selects the checkpoint source, the blob building thresholds, the path to your Walrus client
-   configuration, the local database path, the REST API bind address (default `0.0.0.0:9185`), and
-   the optional PostgreSQL connection URL.
+2. Review the example configuration in `config/testnet_local_config.yaml`. The configuration file selects the checkpoint source, the blob building thresholds, the path to your Walrus client configuration, the local database path, the REST API bind address (default `0.0.0.0:9185`), and the optional PostgreSQL connection URL.
 
 3. Run the archival service with your configuration:
 
@@ -116,8 +90,7 @@ Then build and run the service:
    cargo run --release -p walrus-sui-archival -- run --config config/testnet_local_config.yaml
    ```
 
-4. Open the web interface at `http://localhost:9185` to view archival statistics, browse archived
-   blobs, and look up checkpoints.
+4. Open the web interface at `http://localhost:9185` to view archival statistics, browse archived blobs, and look up checkpoints.
 
 ## Query the API
 
@@ -150,8 +123,7 @@ cargo run --release -p walrus-sui-archival -- inspect-blob \
 
 ## Main archival code
 
-The following code drives the main archival functionality. It wires together the downloader,
-monitor, publisher, extender, snapshot creator, and REST API server described above:
+The following code drives the main archival functionality. It wires together the downloader, monitor, publisher, extender, snapshot creator, and REST API server described above:
 
 <ImportContent source="crates/walrus-sui-archival/src/archival.rs" mode="code" org="MystenLabs" repo="walrus-sui-archival" />
 

--- a/docs/content/examples/checkpoint-data.mdx
+++ b/docs/content/examples/checkpoint-data.mdx
@@ -1,8 +1,8 @@
 ---
 title: Sui Archival System
 description: >-
-  An example application that demonstrates archiving Sui blockchain checkpoint
-  data on Walrus.
+  An example application that archives Sui blockchain checkpoint data on
+  Walrus, with instructions to build, run, and query the service.
 keywords:
   - sui
   - archival
@@ -10,7 +10,8 @@ keywords:
   - checkpoint data
   - archive data
   - archive checkpoints
-hide_table_of_contents: true
+  - walrus
+  - rust
 goal:
   description: Reader can understand and run the Sui archival example that stores blockchain checkpoint data on Walrus
   requires:
@@ -33,23 +34,124 @@ questions:
   - How does the Sui archival system work with Walrus?
   - What is Sui Archival System?
 answer: >-
-  The Sui Archival application demonstrates how you can archive checkpoint data
-  on Walrus in a reliable, deterministic, and resilient manner.
+  The Sui Archival application archives Sui checkpoint data on Walrus. The
+  service downloads checkpoints from Sui, bundles contiguous ranges of them
+  into compressed blobs, uploads the blobs to Walrus, and automatically
+  extends their storage lifetime. You can browse the deployed archive at
+  https://walrus-sui-archival.wal.app/ or build and run the open source
+  service yourself with Cargo.
 ---
 
-The Sui Archival application demonstrates how you can archive checkpoint data on Walrus in a reliable, deterministic, and resilient manner.
+The Sui Archival application demonstrates how you can archive blockchain data on Walrus in a
+reliable, deterministic, and resilient manner. The service continuously downloads Sui checkpoints,
+the sequential batches of finalized transactions that the Sui network produces, bundles them into
+compressed blobs, and uploads the blobs to Walrus. Because Walrus erasure-codes every blob across a
+large committee of storage nodes, the archive stays readable even when individual nodes fail.
 
-The application is accessible at https://walrus-sui-archival.wal.app/
+See also:
 
-The application's code is [open source and available on GitHub](https://github.com/MystenLabs/walrus-sui-archival).
+- [Deployed archive](https://walrus-sui-archival.wal.app/): browse the live instance, its archival
+  statistics, and its [technical documentation](https://walrus-sui-archival.wal.app/tech/).
+- [walrus-sui-archival on GitHub](https://github.com/MystenLabs/walrus-sui-archival): the full
+  source code for the service, the frontend, and the Docker configurations.
+- [Core Concepts](/docs/system-overview/core-concepts): how blobs, epochs, and certification work
+  in Walrus.
+- [Getting Started](/docs/getting-started): install and configure the Walrus client that the
+  service uses to store blobs.
 
 ## How it works
 
-The application polls data from Sui by subscribing to checkpoint sources such as the ingestion framework. It continuously receives live checkpoints as they are created. Once the application obtains a checkpoint, it creates a checkpoint blob based on a deterministic algorithm. The application then uploads blobs to Walrus. The application stores blob metadata in its local database. When blobs are close to expiration, the system automatically extends their lifetime to ensure continuous availability.
+Walrus stores data as blobs, immutable units of data that storage nodes keep available for a paid
+number of epochs (fixed-length periods: 2 weeks on Mainnet, 1 day on Testnet). The archival
+service runs the following components concurrently:
 
-Additional technical details can be found in the [application's documentation](https://walrus-sui-archival.wal.app/tech/).
+1. **Checkpoint downloader:** Downloads checkpoints from a configurable checkpoint source, such as
+   the Sui data ingestion service, using multiple parallel workers.
+2. **Checkpoint monitor:** Tracks downloaded checkpoints, handles out-of-order delivery, and
+   triggers blob building when the pending checkpoints hit a configured threshold: total size,
+   elapsed time, or the end of a Sui epoch. A backpressure mechanism pauses the downloader when too
+   many checkpoints await bundling.
+3. **Checkpoint blob publisher:** Bundles a contiguous range of checkpoints into a single
+   compressed blob and uploads it to Walrus. The bundling follows a deterministic algorithm: a
+   given checkpoint range, cut at the configured size, time, or end-of-epoch boundaries, always
+   produces the same blob.
+4. **Checkpoint blob extender:** Watches the expiration epoch of every archived blob and extends
+   it automatically, so the archive stays available without manual renewals.
+5. **Archival state snapshot creator:** Uploads snapshots of the archive's metadata and maintains
+   an onchain pointer to the latest snapshot, so a fresh instance can rebuild its database for
+   disaster recovery.
+6. **REST API server:** Serves the web interface and the JSON endpoints described below.
 
-The application uses the following code for the main archival functionality:
+The service records blob metadata, that is, the Walrus blob ID, the Sui object ID, the checkpoint
+range, and the size of each archived blob, in a local RocksDB database, and can optionally mirror
+it to PostgreSQL for fast indexed queries.
+
+## Build and run the service
+
+Before you start, you need:
+
+- A recent Rust toolchain, because the service builds with Cargo.
+- A Walrus client configuration and a wallet funded with SUI and WAL, because the service pays for
+  the storage it uses. See [Getting Started](/docs/getting-started).
+- Optional: a PostgreSQL database if you want indexed queries alongside the local RocksDB store.
+
+Then build and run the service:
+
+1. Clone the repository and build all crates:
+
+   ```sh
+   git clone https://github.com/MystenLabs/walrus-sui-archival.git
+   cd walrus-sui-archival
+   cargo build --release
+   ```
+
+2. Review the example configuration in `config/testnet_local_config.yaml`. The configuration file
+   selects the checkpoint source, the blob building thresholds, the path to your Walrus client
+   configuration, the local database path, the REST API bind address (default `0.0.0.0:9185`), and
+   the optional PostgreSQL connection URL.
+
+3. Run the archival service with your configuration:
+
+   ```sh
+   cargo run --release -p walrus-sui-archival -- run --config config/testnet_local_config.yaml
+   ```
+
+4. Open the web interface at `http://localhost:9185` to view archival statistics, browse archived
+   blobs, and look up checkpoints.
+
+## Query the API
+
+The REST API server exposes JSON endpoints alongside the web pages:
+
+| **Endpoint** | **Description** |
+|---|---|
+| `GET /v1/health` | Health check that returns `200 OK`. |
+| `GET /v1/checkpoint?checkpoint=<number>` | Returns the metadata of the blob that contains the given checkpoint. Add `show_content=true` to include the full checkpoint data. |
+| `GET /v1/blobs` | Lists all archived blobs with their metadata. |
+
+For example, to find which Walrus blob holds checkpoint `12345` on a local instance:
+
+```sh
+curl "http://localhost:9185/v1/checkpoint?checkpoint=12345"
+```
+
+The service also provides inspection subcommands to examine its local database and archived blobs:
+
+```sh
+# List all archived blobs recorded in the local database
+cargo run --release -p walrus-sui-archival -- inspect-db --db-path archival_db list-blobs
+
+# Fetch a blob from Walrus by blob ID and inspect its bundled checkpoints
+cargo run --release -p walrus-sui-archival -- inspect-blob \
+  --blob-id "<BLOB_ID>" \
+  --client-config config/local_testnet_client_config.yaml \
+  --context testnet
+```
+
+## Main archival code
+
+The following code drives the main archival functionality. It wires together the downloader,
+monitor, publisher, extender, snapshot creator, and REST API server described above:
 
 <ImportContent source="crates/walrus-sui-archival/src/archival.rs" mode="code" org="MystenLabs" repo="walrus-sui-archival" />
 

--- a/docs/content/examples/checkpoint-data.mdx
+++ b/docs/content/examples/checkpoint-data.mdx
@@ -44,13 +44,6 @@ answer: >-
 
 The Sui Archival application demonstrates how you can archive blockchain data on Walrus in a reliable, deterministic, and resilient manner. The service continuously downloads Sui checkpoints, the sequential batches of finalized transactions that the Sui network produces, bundles them into compressed blobs, and uploads the blobs to Walrus. Because Walrus erasure-codes every blob across a large committee of storage nodes, the archive stays readable even when individual nodes fail.
 
-See also:
-
-- [Deployed archive](https://walrus-sui-archival.wal.app/): browse the live instance, its archival statistics, and its [technical documentation](https://walrus-sui-archival.wal.app/tech/).
-- [walrus-sui-archival on GitHub](https://github.com/MystenLabs/walrus-sui-archival): the full source code for the service, the frontend, and the Docker configurations.
-- [Core Concepts](/docs/system-overview/core-concepts): how blobs, epochs, and certification work in Walrus.
-- [Getting Started](/docs/getting-started): install and configure the Walrus client that the service uses to store blobs.
-
 ## How it works
 
 Walrus stores data as blobs, immutable units of data that storage nodes keep available for a paid number of epochs (fixed-length periods: 2 weeks on Mainnet, 1 day on Testnet). The archival service runs the following components concurrently:

--- a/docs/content/examples/data-marketplace.mdx
+++ b/docs/content/examples/data-marketplace.mdx
@@ -1,6 +1,15 @@
 ---
 title: Building a Data Marketplace
-draft: true
+description: >-
+  Build a data marketplace on Walrus by storing datasets as blobs, escrowing and selling the
+  resulting Sui Blob objects from a Move package, and gating paid content with encryption.
+keywords:
+  - data marketplace
+  - blob object
+  - move
+  - sell data
+  - escrow
+  - seal
 goal:
   description: Reader can understand how to build a data marketplace backed by Walrus storage
   requires:
@@ -21,5 +30,203 @@ goal:
 questions:
   - How do I build a data marketplace on Walrus?
   - How do I build a data marketplace?
-  - How do I get started with building a data marketplace?
+  - How do I sell data stored on Walrus?
+answer: >-
+  A data marketplace on Walrus uses three layers: Walrus stores the dataset bytes as blobs, a Move
+  package on Sui escrows and sells the corresponding Blob objects, and client-side encryption with
+  Seal gates access to paid content. Sellers store data through a publisher and list the resulting
+  Blob object at a price; buyers pay through the Move contract and read the data through an
+  aggregator.
 ---
+
+A data marketplace lets sellers publish datasets and buyers pay to acquire them. Walrus provides
+the building blocks for all three layers of such an application: Walrus itself stores and serves
+the dataset bytes, a Move package on Sui handles listings, payments, and ownership, and
+client-side encryption, for example with [Seal](https://seal-docs.wal.app/), keeps paid content
+confidential. Every stored blob has a corresponding `Blob` object on Sui with the `key` and
+`store` abilities, so datasets become assets that smart contracts can escrow, price, and transfer.
+
+See also:
+
+- [Using Walrus with Move](/docs/examples/move): the `Blob` object API and how to depend on the
+  Walrus package.
+- [Storing Blobs](/docs/http-api/storing-blobs) and [Reading Blobs](/docs/http-api/reading-blobs):
+  the HTTP write and read paths.
+- [Data Security](/docs/data-security): what Walrus guarantees and why confidentiality requires
+  client-side encryption.
+- [Managing Blobs](/docs/walrus-client/managing-blobs): extending, sharing, and setting attributes
+  on blobs with the CLI.
+
+:::caution Blob data is public
+
+Anyone who knows a blob ID can read the blob through any aggregator. Owning the `Blob` object does
+not restrict reads; the object controls management rights such as extending, deleting, and setting
+attributes. To sell access to the content itself, encrypt the data before you store it and gate
+decryption onchain, as described in [Gate paid content with
+encryption](#gate-paid-content-with-encryption).
+
+:::
+
+## Architecture
+
+A minimal marketplace consists of four parts:
+
+1. **Seller clients** encrypt (optionally) and upload datasets through a publisher, the CLI, or
+   the TypeScript SDK, and receive the resulting `Blob` objects.
+2. **A marketplace Move package** escrows `Blob` objects in shared listing objects, verifies
+   payment, pays the seller, and transfers the blob to the buyer.
+3. **Buyer clients** purchase a listing, then read the dataset through an aggregator using the
+   blob ID or the object ID.
+4. **Walrus infrastructure** does the heavy lifting: publishers accept uploads, storage nodes hold
+   the encoded slivers, and aggregators serve reads.
+
+## Store the dataset
+
+Sellers first store the dataset on Walrus. The following `curl` command stores a file through a
+publisher for 10 epochs as a permanent blob and sends the created `Blob` object to the seller's
+address:
+
+```sh
+$ curl -X PUT \
+  "$PUBLISHER/v1/blobs?epochs=10&permanent=true&send_object_to=$SELLER_ADDRESS" \
+  --upload-file "dataset.bin"
+```
+
+Three query parameters matter for marketplace listings:
+
+- `epochs` sets the storage duration. The publisher stores the blob for 1 epoch if you omit it.
+- `permanent=true` rules out deletion before expiry. The publisher stores new blobs as deletable
+  by default, and buyers expect that a seller cannot delete data after a sale.
+- `send_object_to` sends the created `Blob` object to the given Sui address, so the seller's
+  wallet holds the object to list.
+
+Set `$PUBLISHER` to an endpoint from the
+[Network Reference](/docs/network-reference#aggregators-and-publishers). Walrus has no public
+unauthenticated publisher on Mainnet, and most public endpoints limit requests to 10 MiB; for
+production stores or larger datasets, run your own publisher or use the
+[CLI](/docs/walrus-client/storing-blobs) or [TypeScript SDK](/docs/typescript-sdk/sdks). The
+response carries the `blobId`, the handle buyers later use to read the data, and, for newly
+created blobs, the Sui object ID of the `Blob` object. See
+[Understanding the response](/docs/http-api/storing-blobs#understanding-the-response).
+
+## Escrow and sell the blob in Move
+
+The marketplace contract escrows the `Blob` object inside a shared `Listing` object so that any
+buyer can purchase it. The following module shows the core pattern:
+
+```move
+module marketplace::listing {
+    use sui::{coin::Coin, sui::SUI};
+    use walrus::blob::Blob;
+
+    const EIncorrectPayment: u64 = 0;
+
+    /// A shared listing that escrows a Walrus `Blob` object until a buyer
+    /// pays the asking price.
+    public struct Listing has key {
+        id: UID,
+        price: u64,
+        seller: address,
+        blob: Blob,
+    }
+
+    /// Escrows the blob in a shared `Listing` that any buyer can purchase.
+    public fun list(blob: Blob, price: u64, ctx: &mut TxContext) {
+        transfer::share_object(Listing {
+            id: object::new(ctx),
+            price,
+            seller: ctx.sender(),
+            blob,
+        })
+    }
+
+    /// Pays the seller and transfers the escrowed `Blob` object to the buyer.
+    public fun buy(listing: Listing, payment: Coin<SUI>, ctx: &mut TxContext) {
+        let Listing { id, price, seller, blob } = listing;
+        assert!(payment.value() == price, EIncorrectPayment);
+        transfer::public_transfer(payment, seller);
+        transfer::public_transfer(blob, ctx.sender());
+        id.delete();
+    }
+}
+```
+
+The module works as follows:
+
+- `list` takes a `Blob` by value, wraps it with a price and the seller's address, and shares the
+  `Listing` so any buyer can call `buy`. While escrowed, not even the seller can extend or delete
+  the blob, unless you add functions for that.
+- `buy` unpacks the `Listing`, checks the payment, pays the seller, and transfers the `Blob`
+  object to the buyer. After the purchase, the buyer owns the object and can extend its lifetime,
+  set attributes, resell it, or wrap it again.
+- The example prices listings in SUI for brevity; change the `Coin` type parameter to price in WAL
+  or any other coin.
+
+Your package needs the Walrus dependency in its `Move.toml`; see
+[Add the Walrus dependency](/docs/examples/move#add-the-walrus-dependency) for the exact
+declaration and build commands.
+
+## Gate paid content with encryption
+
+Because reads are public, a marketplace that sells the content itself, rather than provenance or
+management rights, must encrypt datasets before storing them.
+[Seal](https://seal-docs.wal.app/) provides threshold encryption with onchain access control:
+
+1. The seller encrypts the dataset with Seal under an access policy: a Move function named
+   `seal_approve` in your package decides who can decrypt. Only the ciphertext goes to Walrus.
+2. The marketplace contract records each purchase onchain, for example by adding the buyer to an
+   allowlist that the policy checks.
+3. The buyer downloads the ciphertext from an aggregator and requests key shares from the Seal
+   key servers, which check the onchain policy before answering. The buyer then decrypts locally.
+
+For a runnable end-to-end example that encrypts with Seal and stores the ciphertext on Walrus,
+see the [Seal example code](https://github.com/MystenLabs/walrus/tree/main/docs/examples/seal) in
+the Walrus repository.
+
+## Attach product metadata
+
+Marketplace listings need titles, descriptions, and content types. You can attach this metadata
+directly to the `Blob` object:
+
+- With the CLI, set key-value attributes on a blob you own:
+
+  ```sh
+  $ walrus set-blob-attribute <BLOB_OBJ_ID> --attr "content-type" "text/csv"
+  ```
+
+- From Move, the `walrus::blob` module provides `insert_or_update_metadata_pair` and related
+  functions to manage metadata on a blob your contract holds.
+
+When buyers read a blob by object ID, the aggregator returns recognized attribute keys, such as
+`content-type` and `content-disposition`, in the corresponding HTTP response headers. For many
+small preview files or product cards, [Quilt](/docs/system-overview/quilt) batches them into a
+single stored unit and cuts per-blob overhead.
+
+## Deliver the data to buyers
+
+Buyers read blobs with a GET request to any aggregator:
+
+```sh
+# Read by blob ID
+$ curl "$AGGREGATOR/v1/blobs/<BLOB_ID>" -o dataset.bin
+
+# Read by the Blob object ID, which also returns attribute headers
+$ curl "$AGGREGATOR/v1/blobs/by-object-id/<BLOB_OBJECT_ID>" -o dataset.bin
+```
+
+For encrypted listings, the buyer decrypts locally after Seal releases the key shares. If a read
+right after upload returns a `404` through a CDN-fronted aggregator, retry with backoff; see
+[Reading Blobs Right After Upload](/docs/troubleshooting/reading-blobs-after-upload).
+
+## Keep listings available
+
+Walrus stores each blob for a fixed number of epochs, so a marketplace must plan for expiry:
+
+- The blob owner extends a blob with `walrus extend --blob-obj-id <ID>`, and a contract extends a
+  blob it holds through `walrus::system::extend_blob` with a WAL payment, for example funded from
+  sale proceeds.
+- A [shared blob](/docs/walrus-client/managing-blobs#shared-blobs) wraps a blob in a shared object
+  that anyone can fund and extend, which suits listings the whole marketplace wants to keep alive.
+  Create one with `walrus share --blob-obj-id <SUI_OBJ_ID>`.
+- Storage resources themselves transfer between users, so a marketplace can also acquire and trade
+  storage capacity; see [Storage Costs](/docs/system-overview/storage-costs).

--- a/docs/content/examples/data-marketplace.mdx
+++ b/docs/content/examples/data-marketplace.mdx
@@ -39,31 +39,18 @@ answer: >-
   aggregator.
 ---
 
-A data marketplace lets sellers publish datasets and buyers pay to acquire them. Walrus provides
-the building blocks for all three layers of such an application: Walrus itself stores and serves
-the dataset bytes, a Move package on Sui handles listings, payments, and ownership, and
-client-side encryption, for example with [Seal](https://seal-docs.wal.app/), keeps paid content
-confidential. Every stored blob has a corresponding `Blob` object on Sui with the `key` and
-`store` abilities, so datasets become assets that smart contracts can escrow, price, and transfer.
+A data marketplace lets sellers publish datasets and buyers pay to acquire them. Walrus provides the building blocks for all three layers of such an application: Walrus itself stores and serves the dataset bytes, a Move package on Sui handles listings, payments, and ownership, and client-side encryption, for example with [Seal](https://seal-docs.wal.app/), keeps paid content confidential. Every stored blob has a corresponding `Blob` object on Sui with the `key` and `store` abilities, so datasets become assets that smart contracts can escrow, price, and transfer.
 
 See also:
 
-- [Using Walrus with Move](/docs/examples/move): the `Blob` object API and how to depend on the
-  Walrus package.
-- [Storing Blobs](/docs/http-api/storing-blobs) and [Reading Blobs](/docs/http-api/reading-blobs):
-  the HTTP write and read paths.
-- [Data Security](/docs/data-security): what Walrus guarantees and why confidentiality requires
-  client-side encryption.
-- [Managing Blobs](/docs/walrus-client/managing-blobs): extending, sharing, and setting attributes
-  on blobs with the CLI.
+- [Using Walrus with Move](/docs/examples/move): the `Blob` object API and how to depend on the Walrus package.
+- [Storing Blobs](/docs/http-api/storing-blobs) and [Reading Blobs](/docs/http-api/reading-blobs): the HTTP write and read paths.
+- [Data Security](/docs/data-security): what Walrus guarantees and why confidentiality requires client-side encryption.
+- [Managing Blobs](/docs/walrus-client/managing-blobs): extending, sharing, and setting attributes on blobs with the CLI.
 
 :::caution Blob data is public
 
-Anyone who knows a blob ID can read the blob through any aggregator. Owning the `Blob` object does
-not restrict reads; the object controls management rights such as extending, deleting, and setting
-attributes. To sell access to the content itself, encrypt the data before you store it and gate
-decryption onchain, as described in [Gate paid content with
-encryption](#gate-paid-content-with-encryption).
+Anyone who knows a blob ID can read the blob through any aggregator. Owning the `Blob` object does not restrict reads; the object controls management rights such as extending, deleting, and setting attributes. To sell access to the content itself, encrypt the data before you store it and gate decryption onchain, as described in [Gate paid content with encryption](#gate-paid-content-with-encryption).
 
 :::
 
@@ -71,20 +58,14 @@ encryption](#gate-paid-content-with-encryption).
 
 A minimal marketplace consists of four parts:
 
-1. **Seller clients** encrypt (optionally) and upload datasets through a publisher, the CLI, or
-   the TypeScript SDK, and receive the resulting `Blob` objects.
-2. **A marketplace Move package** escrows `Blob` objects in shared listing objects, verifies
-   payment, pays the seller, and transfers the blob to the buyer.
-3. **Buyer clients** purchase a listing, then read the dataset through an aggregator using the
-   blob ID or the object ID.
-4. **Walrus infrastructure** does the heavy lifting: publishers accept uploads, storage nodes hold
-   the encoded slivers, and aggregators serve reads.
+1. **Seller clients** encrypt (optionally) and upload datasets through a publisher, the CLI, or the TypeScript SDK, and receive the resulting `Blob` objects.
+2. **A marketplace Move package** escrows `Blob` objects in shared listing objects, verifies payment, pays the seller, and transfers the blob to the buyer.
+3. **Buyer clients** purchase a listing, then read the dataset through an aggregator using the blob ID or the object ID.
+4. **Walrus infrastructure** does the heavy lifting: publishers accept uploads, storage nodes hold the encoded slivers, and aggregators serve reads.
 
 ## Store the dataset
 
-Sellers first store the dataset on Walrus. The following `curl` command stores a file through a
-publisher for 10 epochs as a permanent blob and sends the created `Blob` object to the seller's
-address:
+Sellers first store the dataset on Walrus. The following `curl` command stores a file through a publisher for 10 epochs as a permanent blob and sends the created `Blob` object to the seller's address:
 
 ```sh
 $ curl -X PUT \
@@ -95,24 +76,14 @@ $ curl -X PUT \
 Three query parameters matter for marketplace listings:
 
 - `epochs` sets the storage duration. The publisher stores the blob for 1 epoch if you omit it.
-- `permanent=true` rules out deletion before expiry. The publisher stores new blobs as deletable
-  by default, and buyers expect that a seller cannot delete data after a sale.
-- `send_object_to` sends the created `Blob` object to the given Sui address, so the seller's
-  wallet holds the object to list.
+- `permanent=true` rules out deletion before expiry. The publisher stores new blobs as deletable by default, and buyers expect that a seller cannot delete data after a sale.
+- `send_object_to` sends the created `Blob` object to the given Sui address, so the seller's wallet holds the object to list.
 
-Set `$PUBLISHER` to an endpoint from the
-[Network Reference](/docs/network-reference#aggregators-and-publishers). Walrus has no public
-unauthenticated publisher on Mainnet, and most public endpoints limit requests to 10 MiB; for
-production stores or larger datasets, run your own publisher or use the
-[CLI](/docs/walrus-client/storing-blobs) or [TypeScript SDK](/docs/typescript-sdk/sdks). The
-response carries the `blobId`, the handle buyers later use to read the data, and, for newly
-created blobs, the Sui object ID of the `Blob` object. See
-[Understanding the response](/docs/http-api/storing-blobs#understanding-the-response).
+Set `$PUBLISHER` to an endpoint from the [Network Reference](/docs/network-reference#aggregators-and-publishers). Walrus has no public unauthenticated publisher on Mainnet, and most public endpoints limit requests to 10 MiB; for production stores or larger datasets, run your own publisher or use the [CLI](/docs/walrus-client/storing-blobs) or [TypeScript SDK](/docs/typescript-sdk/sdks). The response carries the `blobId`, the handle buyers later use to read the data, and, for newly created blobs, the Sui object ID of the `Blob` object. See [Understanding the response](/docs/http-api/storing-blobs#understanding-the-response).
 
 ## Escrow and sell the blob in Move
 
-The marketplace contract escrows the `Blob` object inside a shared `Listing` object so that any
-buyer can purchase it. The following module shows the core pattern:
+The marketplace contract escrows the `Blob` object inside a shared `Listing` object so that any buyer can purchase it. The following module shows the core pattern:
 
 ```move
 module marketplace::listing {
@@ -153,40 +124,25 @@ module marketplace::listing {
 
 The module works as follows:
 
-- `list` takes a `Blob` by value, wraps it with a price and the seller's address, and shares the
-  `Listing` so any buyer can call `buy`. While escrowed, not even the seller can extend or delete
-  the blob, unless you add functions for that.
-- `buy` unpacks the `Listing`, checks the payment, pays the seller, and transfers the `Blob`
-  object to the buyer. After the purchase, the buyer owns the object and can extend its lifetime,
-  set attributes, resell it, or wrap it again.
-- The example prices listings in SUI for brevity; change the `Coin` type parameter to price in WAL
-  or any other coin.
+- `list` takes a `Blob` by value, wraps it with a price and the seller's address, and shares the `Listing` so any buyer can call `buy`. While escrowed, not even the seller can extend or delete the blob, unless you add functions for that.
+- `buy` unpacks the `Listing`, checks the payment, pays the seller, and transfers the `Blob` object to the buyer. After the purchase, the buyer owns the object and can extend its lifetime, set attributes, resell it, or wrap it again.
+- The example prices listings in SUI for brevity; change the `Coin` type parameter to price in WAL or any other coin.
 
-Your package needs the Walrus dependency in its `Move.toml`; see
-[Add the Walrus dependency](/docs/examples/move#add-the-walrus-dependency) for the exact
-declaration and build commands.
+Your package needs the Walrus dependency in its `Move.toml`; see [Add the Walrus dependency](/docs/examples/move#add-the-walrus-dependency) for the exact declaration and build commands.
 
 ## Gate paid content with encryption
 
-Because reads are public, a marketplace that sells the content itself, rather than provenance or
-management rights, must encrypt datasets before storing them.
-[Seal](https://seal-docs.wal.app/) provides threshold encryption with onchain access control:
+Because reads are public, a marketplace that sells the content itself, rather than provenance or management rights, must encrypt datasets before storing them. [Seal](https://seal-docs.wal.app/) provides threshold encryption with onchain access control:
 
-1. The seller encrypts the dataset with Seal under an access policy: a Move function named
-   `seal_approve` in your package decides who can decrypt. Only the ciphertext goes to Walrus.
-2. The marketplace contract records each purchase onchain, for example by adding the buyer to an
-   allowlist that the policy checks.
-3. The buyer downloads the ciphertext from an aggregator and requests key shares from the Seal
-   key servers, which check the onchain policy before answering. The buyer then decrypts locally.
+1. The seller encrypts the dataset with Seal under an access policy: a Move function named `seal_approve` in your package decides who can decrypt. Only the ciphertext goes to Walrus.
+2. The marketplace contract records each purchase onchain, for example by adding the buyer to an allowlist that the policy checks.
+3. The buyer downloads the ciphertext from an aggregator and requests key shares from the Seal key servers, which check the onchain policy before answering. The buyer then decrypts locally.
 
-For a runnable end-to-end example that encrypts with Seal and stores the ciphertext on Walrus,
-see the [Seal example code](https://github.com/MystenLabs/walrus/tree/main/docs/examples/seal) in
-the Walrus repository.
+For a runnable end-to-end example that encrypts with Seal and stores the ciphertext on Walrus, see the [Seal example code](https://github.com/MystenLabs/walrus/tree/main/docs/examples/seal) in the Walrus repository.
 
 ## Attach product metadata
 
-Marketplace listings need titles, descriptions, and content types. You can attach this metadata
-directly to the `Blob` object:
+Marketplace listings need titles, descriptions, and content types. You can attach this metadata directly to the `Blob` object:
 
 - With the CLI, set key-value attributes on a blob you own:
 
@@ -194,13 +150,9 @@ directly to the `Blob` object:
   $ walrus set-blob-attribute <BLOB_OBJ_ID> --attr "content-type" "text/csv"
   ```
 
-- From Move, the `walrus::blob` module provides `insert_or_update_metadata_pair` and related
-  functions to manage metadata on a blob your contract holds.
+- From Move, the `walrus::blob` module provides `insert_or_update_metadata_pair` and related functions to manage metadata on a blob your contract holds.
 
-When buyers read a blob by object ID, the aggregator returns recognized attribute keys, such as
-`content-type` and `content-disposition`, in the corresponding HTTP response headers. For many
-small preview files or product cards, [Quilt](/docs/system-overview/quilt) batches them into a
-single stored unit and cuts per-blob overhead.
+When buyers read a blob by object ID, the aggregator returns recognized attribute keys, such as `content-type` and `content-disposition`, in the corresponding HTTP response headers. For many small preview files or product cards, [Quilt](/docs/system-overview/quilt) batches them into a single stored unit and cuts per-blob overhead.
 
 ## Deliver the data to buyers
 
@@ -214,19 +166,12 @@ $ curl "$AGGREGATOR/v1/blobs/<BLOB_ID>" -o dataset.bin
 $ curl "$AGGREGATOR/v1/blobs/by-object-id/<BLOB_OBJECT_ID>" -o dataset.bin
 ```
 
-For encrypted listings, the buyer decrypts locally after Seal releases the key shares. If a read
-right after upload returns a `404` through a CDN-fronted aggregator, retry with backoff; see
-[Reading Blobs Right After Upload](/docs/troubleshooting/reading-blobs-after-upload).
+For encrypted listings, the buyer decrypts locally after Seal releases the key shares. If a read right after upload returns a `404` through a CDN-fronted aggregator, retry with backoff; see [Reading Blobs Right After Upload](/docs/troubleshooting/reading-blobs-after-upload).
 
 ## Keep listings available
 
 Walrus stores each blob for a fixed number of epochs, so a marketplace must plan for expiry:
 
-- The blob owner extends a blob with `walrus extend --blob-obj-id <ID>`, and a contract extends a
-  blob it holds through `walrus::system::extend_blob` with a WAL payment, for example funded from
-  sale proceeds.
-- A [shared blob](/docs/walrus-client/managing-blobs#shared-blobs) wraps a blob in a shared object
-  that anyone can fund and extend, which suits listings the whole marketplace wants to keep alive.
-  Create one with `walrus share --blob-obj-id <SUI_OBJ_ID>`.
-- Storage resources themselves transfer between users, so a marketplace can also acquire and trade
-  storage capacity; see [Storage Costs](/docs/system-overview/storage-costs).
+- The blob owner extends a blob with `walrus extend --blob-obj-id <ID>`, and a contract extends a blob it holds through `walrus::system::extend_blob` with a WAL payment, for example funded from sale proceeds.
+- A [shared blob](/docs/walrus-client/managing-blobs#shared-blobs) wraps a blob in a shared object that anyone can fund and extend, which suits listings the whole marketplace wants to keep alive. Create one with `walrus share --blob-obj-id <SUI_OBJ_ID>`.
+- Storage resources themselves transfer between users, so a marketplace can also acquire and trade storage capacity; see [Storage Costs](/docs/system-overview/storage-costs).

--- a/docs/content/examples/data-marketplace.mdx
+++ b/docs/content/examples/data-marketplace.mdx
@@ -76,50 +76,17 @@ Set `$PUBLISHER` to an endpoint from the [Network Reference](/docs/network-refer
 
 ## Escrow and sell the blob in Move
 
-The marketplace contract escrows the `Blob` object inside a shared `Listing` object so that any buyer can purchase it. The following module shows the core pattern:
+A marketplace contract escrows the `Blob` object so that a buyer can purchase it. The primitive that makes this possible is wrapping: because `Blob` has the `store` ability, a Move package can take a blob by value and hold it inside its own object. The Walrus repository ships that primitive as a runnable example:
 
-```move
-module marketplace::listing {
-    use sui::{coin::Coin, sui::SUI};
-    use walrus::blob::Blob;
+<ImportContent source="docs/examples/move/walrus_dep/sources/wrapped_blob.move" mode="code" org="MystenLabs" repo="walrus" />
 
-    const EIncorrectPayment: u64 = 0;
+A marketplace extends this pattern in three ways:
 
-    /// A shared listing that escrows a Walrus `Blob` object until a buyer
-    /// pays the asking price.
-    public struct Listing has key {
-        id: UID,
-        price: u64,
-        seller: address,
-        blob: Blob,
-    }
+- **Add listing terms to the wrapper.** Alongside the escrowed blob, store the price and the seller's address in the same struct.
+- **Share the wrapper instead of holding it.** `transfer::share_object` makes the listing reachable by any buyer, rather than only its owner.
+- **Add a purchase function.** Unpack the listing, verify the payment coin, transfer the payment to the seller, and transfer the `Blob` object to the buyer with `transfer::public_transfer`.
 
-    /// Escrows the blob in a shared `Listing` that any buyer can purchase.
-    public fun list(blob: Blob, price: u64, ctx: &mut TxContext) {
-        transfer::share_object(Listing {
-            id: object::new(ctx),
-            price,
-            seller: ctx.sender(),
-            blob,
-        })
-    }
-
-    /// Pays the seller and transfers the escrowed `Blob` object to the buyer.
-    public fun buy(listing: Listing, payment: Coin<SUI>, ctx: &mut TxContext) {
-        let Listing { id, price, seller, blob } = listing;
-        assert!(payment.value() == price, EIncorrectPayment);
-        transfer::public_transfer(payment, seller);
-        transfer::public_transfer(blob, ctx.sender());
-        id.delete();
-    }
-}
-```
-
-The module works as follows:
-
-- `list` takes a `Blob` by value, wraps it with a price and the seller's address, and shares the `Listing` so any buyer can call `buy`. While escrowed, not even the seller can extend or delete the blob, unless you add functions for that.
-- `buy` unpacks the `Listing`, checks the payment, pays the seller, and transfers the `Blob` object to the buyer. After the purchase, the buyer owns the object and can extend its lifetime, set attributes, resell it, or wrap it again.
-- The example prices listings in SUI for brevity; change the `Coin` type parameter to price in WAL or any other coin.
+After the purchase, the buyer owns the `Blob` object and can extend its lifetime, set attributes, resell it, or wrap it again. While a blob sits escrowed inside a wrapper, only the wrapping module's functions can reach it, so add explicit functions for any management the seller still needs.
 
 Your package needs the Walrus dependency in its `Move.toml`; see [Add the Walrus dependency](/docs/examples/move#add-the-walrus-dependency) for the exact declaration and build commands.
 

--- a/docs/content/examples/data-marketplace.mdx
+++ b/docs/content/examples/data-marketplace.mdx
@@ -41,13 +41,6 @@ answer: >-
 
 A data marketplace lets sellers publish datasets and buyers pay to acquire them. Walrus provides the building blocks for all three layers of such an application: Walrus itself stores and serves the dataset bytes, a Move package on Sui handles listings, payments, and ownership, and client-side encryption, for example with [Seal](https://seal-docs.wal.app/), keeps paid content confidential. Every stored blob has a corresponding `Blob` object on Sui with the `key` and `store` abilities, so datasets become assets that smart contracts can escrow, price, and transfer.
 
-See also:
-
-- [Using Walrus with Move](/docs/examples/move): the `Blob` object API and how to depend on the Walrus package.
-- [Storing Blobs](/docs/http-api/storing-blobs) and [Reading Blobs](/docs/http-api/reading-blobs): the HTTP write and read paths.
-- [Data Security](/docs/data-security): what Walrus guarantees and why confidentiality requires client-side encryption.
-- [Managing Blobs](/docs/walrus-client/managing-blobs): extending, sharing, and setting attributes on blobs with the CLI.
-
 :::caution Blob data is public
 
 Anyone who knows a blob ID can read the blob through any aggregator. Owning the `Blob` object does not restrict reads; the object controls management rights such as extending, deleting, and setting attributes. To sell access to the content itself, encrypt the data before you store it and gate decryption onchain, as described in [Gate paid content with encryption](#gate-paid-content-with-encryption).

--- a/docs/content/examples/javascript.mdx
+++ b/docs/content/examples/javascript.mdx
@@ -42,13 +42,6 @@ answer: >-
 
 You can store and read Walrus blobs from JavaScript with plain HTTP calls: a publisher accepts uploads through PUT requests, and an aggregator serves downloads through GET requests. The built-in `fetch` API covers both, so you need no SDK or other dependencies in the browser, in Node.js, or in any other JavaScript runtime.
 
-See also:
-
-- [Storing Blobs](/docs/http-api/storing-blobs): the full publisher API, including all query parameters and quilts.
-- [Reading Blobs](/docs/http-api/reading-blobs): the full aggregator API, including consistency checks.
-- [Browser and Mobile Apps](/docs/examples/browser-and-mobile): store blobs with the TypeScript SDK and an upload relay when the user's wallet should own the upload.
-- [Network Reference](/docs/network-reference#aggregators-and-publishers): public aggregator and publisher endpoints.
-
 ## Choose your endpoints
 
 The examples on the rest of the page use the public Testnet endpoints:

--- a/docs/content/examples/javascript.mdx
+++ b/docs/content/examples/javascript.mdx
@@ -58,7 +58,7 @@ Two constraints apply when you pick endpoints:
 
 ## Upload a blob
 
-Send the raw bytes as the body of a PUT request to the publisher's `/v1/blobs` endpoint:
+Send the raw bytes as the body of a PUT request to the publisher's `/v1/blobs` endpoint. The following function condenses the store call from the [runnable example](#complete-example-browser-upload-form) below:
 
 ```js
 async function storeBlob(data, epochs = 1) {
@@ -110,7 +110,7 @@ The `blobId` identifies the data on Walrus: pass it to an aggregator to read the
 
 ## Download a blob
 
-Read the blob back with a GET request to an aggregator's `/v1/blobs/<blobId>` endpoint:
+Read the blob back with a GET request to an aggregator's `/v1/blobs/<blobId>` endpoint. The [runnable example](#complete-example-browser-upload-form) builds the same URL to link each stored blob:
 
 ```js
 async function readBlob(blobId) {

--- a/docs/content/examples/javascript.mdx
+++ b/docs/content/examples/javascript.mdx
@@ -1,10 +1,17 @@
 ---
 title: Using Walrus with JavaScript
 description: >-
-  JavaScript code examples to demonstrate how to use Walrus from within a
-  JavaScript application.
+  Upload and download Walrus blobs from JavaScript with plain fetch calls against a publisher and
+  an aggregator, including a complete browser upload form example.
 keywords:
   - javascript
+  - http api
+  - publisher
+  - aggregator
+  - fetch
+  - upload
+  - download
+  - blob
 goal:
   description: Reader can upload and download a blob from a JavaScript application using the Walrus HTTP API
   requires:
@@ -24,17 +31,150 @@ goal:
       label: Needs answer summary for AI citation
 questions:
   - How do I use Walrus with JavaScript?
-  - What is Using Walrus with JavaScript?
-  - How do I get started with using walrus with javascript?
+  - How do I upload a blob to Walrus from JavaScript?
+  - How do I download a Walrus blob in the browser?
 answer: >-
-  The following JavaScript example shows how to upload and download a blob
-  through a web form using the HTTP API.
+  Upload a blob from JavaScript by sending the file bytes in an HTTP PUT request to a publisher's
+  /v1/blobs endpoint, and download it with a GET request to an aggregator's /v1/blobs/<blobId>
+  endpoint. Both are plain HTTP calls, so the built-in fetch API works in any JavaScript runtime
+  without an SDK.
 ---
 
-The following JavaScript example shows how to upload and download a blob through a web form using the HTTP API.
+You can store and read Walrus blobs from JavaScript with plain HTTP calls: a publisher accepts
+uploads through PUT requests, and an aggregator serves downloads through GET requests. The built-in
+`fetch` API covers both, so you need no SDK or other dependencies in the browser, in Node.js, or in
+any other JavaScript runtime.
 
-The following JavaScript example shows how to upload and download a blob through a web form using the HTTP API.
+See also:
 
-The following JavaScript example shows how to upload and download a blob through a web form using the HTTP API.
+- [Storing Blobs](/docs/http-api/storing-blobs): the full publisher API, including all query
+  parameters and quilts.
+- [Reading Blobs](/docs/http-api/reading-blobs): the full aggregator API, including consistency
+  checks.
+- [Browser and Mobile Apps](/docs/examples/browser-and-mobile): store blobs with the TypeScript SDK
+  and an upload relay when the user's wallet should own the upload.
+- [Network Reference](/docs/network-reference#aggregators-and-publishers): public aggregator and
+  publisher endpoints.
+
+## Choose your endpoints
+
+The examples on the rest of the page use the public Testnet endpoints:
+
+```js
+const PUBLISHER = "https://publisher.walrus-testnet.walrus.space";
+const AGGREGATOR = "https://aggregator.walrus-testnet.walrus.space";
+```
+
+Two constraints apply when you pick endpoints:
+
+- Walrus has no public unauthenticated publisher on Mainnet. Use a Testnet publisher for
+  experiments; on Mainnet, run your own publisher, use an upload relay, or use the
+  [TypeScript SDK](/docs/typescript-sdk/sdks).
+- Most public aggregators and publishers limit requests to 10 MiB. To store larger blobs, run your
+  own publisher or use the [CLI](/docs/walrus-client/storing-blobs).
+
+## Upload a blob
+
+Send the raw bytes as the body of a PUT request to the publisher's `/v1/blobs` endpoint:
+
+```js
+async function storeBlob(data, epochs = 1) {
+  const response = await fetch(`${PUBLISHER}/v1/blobs?epochs=${epochs}`, {
+    method: "PUT",
+    body: data, // a File, Blob, ArrayBuffer, Uint8Array, or string
+  });
+  if (!response.ok) {
+    throw new Error(`Store failed with status ${response.status}`);
+  }
+  return response.json();
+}
+```
+
+Control the resulting blob through query parameters:
+
+| **Parameter** | **Effect** |
+| --- | --- |
+| `epochs` | The number of storage epochs. Defaults to 1 if you omit it. |
+| `deletable=true` or `permanent=true` | Whether the owner can delete the blob before it expires. The publisher stores new blobs as deletable by default. |
+| `send_object_to` | A Sui address that receives the created `Blob` object. |
+
+## Handle the store response
+
+A successful store returns JSON in one of two shapes. A `newlyCreated` field describes a blob that
+Walrus stored for the first time, while an `alreadyCertified` field describes a blob that some user
+already stored and certified earlier. The two shapes nest the blob ID differently, so handle both:
+
+```js
+function parseStoreResponse(info) {
+  if ("alreadyCertified" in info) {
+    return {
+      status: "Already certified",
+      blobId: info.alreadyCertified.blobId,
+      endEpoch: info.alreadyCertified.endEpoch,
+    };
+  }
+  if ("newlyCreated" in info) {
+    return {
+      status: "Newly created",
+      blobId: info.newlyCreated.blobObject.blobId,
+      endEpoch: info.newlyCreated.blobObject.storage.endEpoch,
+      suiObjectId: info.newlyCreated.blobObject.id,
+    };
+  }
+  throw new Error("Unexpected store response");
+}
+```
+
+The `blobId` identifies the data on Walrus: pass it to an aggregator to read the blob back. The
+`endEpoch` tells you when the storage period ends. For newly created blobs, the response also
+carries the Sui object ID of the `Blob` object. See
+[Understanding the response](/docs/http-api/storing-blobs#understanding-the-response) for the full
+response format.
+
+## Download a blob
+
+Read the blob back with a GET request to an aggregator's `/v1/blobs/<blobId>` endpoint:
+
+```js
+async function readBlob(blobId) {
+  const response = await fetch(`${AGGREGATOR}/v1/blobs/${blobId}`);
+  if (!response.ok) {
+    throw new Error(`Read failed with status ${response.status}`);
+  }
+  return response.arrayBuffer();
+}
+```
+
+Call `response.text()` or `response.json()` instead of `arrayBuffer()` when you stored text or
+JSON. The aggregator serves blobs read by blob ID as `application/octet-stream`, so specify the
+media type yourself when you embed the blob in a page. To receive stored headers such as
+`content-type`, read by the Sui object ID instead, with
+`/v1/blobs/by-object-id/<objectId>`; the aggregator returns recognized blob attributes in the
+corresponding HTTP headers. See [Reading Blobs](/docs/http-api/reading-blobs) for details.
+
+:::tip Reading a blob right after upload?
+
+A CDN-fronted aggregator might briefly serve a cached `404` from before the blob propagated. If
+your app just stored the blob, retry the read with backoff. See
+[Reading Blobs Right After Upload](/docs/troubleshooting/reading-blobs-after-upload).
+
+:::
+
+## Complete example: browser upload form
+
+The following single-file example combines the upload and download calls into a web form. The form
+lets you set the publisher and aggregator URLs, pick a file and a number of epochs, and optionally
+enter a Sui address that receives the created `Blob` object through the `send_object_to` parameter.
+After a successful upload, the script parses both response shapes and renders each stored blob with
+a download link that points at the aggregator. To try it, save the file locally and open it in a
+browser.
 
 <ImportContent source="docs/examples/javascript/blob_upload_download_webapi.html" mode="code" org="MystenLabs" repo="walrus" />
+
+## Read Walrus system state
+
+The next example reads Walrus system state on Sui instead of blob data. The script calls the
+`sui_getObject` JSON-RPC method on a public Sui full node and renders the per-epoch rewards and
+used storage capacity from the system state into a table.
+
+<ImportContent source="docs/examples/javascript/system_stats.html" mode="code" org="MystenLabs" repo="walrus" />

--- a/docs/content/examples/javascript.mdx
+++ b/docs/content/examples/javascript.mdx
@@ -40,21 +40,14 @@ answer: >-
   without an SDK.
 ---
 
-You can store and read Walrus blobs from JavaScript with plain HTTP calls: a publisher accepts
-uploads through PUT requests, and an aggregator serves downloads through GET requests. The built-in
-`fetch` API covers both, so you need no SDK or other dependencies in the browser, in Node.js, or in
-any other JavaScript runtime.
+You can store and read Walrus blobs from JavaScript with plain HTTP calls: a publisher accepts uploads through PUT requests, and an aggregator serves downloads through GET requests. The built-in `fetch` API covers both, so you need no SDK or other dependencies in the browser, in Node.js, or in any other JavaScript runtime.
 
 See also:
 
-- [Storing Blobs](/docs/http-api/storing-blobs): the full publisher API, including all query
-  parameters and quilts.
-- [Reading Blobs](/docs/http-api/reading-blobs): the full aggregator API, including consistency
-  checks.
-- [Browser and Mobile Apps](/docs/examples/browser-and-mobile): store blobs with the TypeScript SDK
-  and an upload relay when the user's wallet should own the upload.
-- [Network Reference](/docs/network-reference#aggregators-and-publishers): public aggregator and
-  publisher endpoints.
+- [Storing Blobs](/docs/http-api/storing-blobs): the full publisher API, including all query parameters and quilts.
+- [Reading Blobs](/docs/http-api/reading-blobs): the full aggregator API, including consistency checks.
+- [Browser and Mobile Apps](/docs/examples/browser-and-mobile): store blobs with the TypeScript SDK and an upload relay when the user's wallet should own the upload.
+- [Network Reference](/docs/network-reference#aggregators-and-publishers): public aggregator and publisher endpoints.
 
 ## Choose your endpoints
 
@@ -67,11 +60,8 @@ const AGGREGATOR = "https://aggregator.walrus-testnet.walrus.space";
 
 Two constraints apply when you pick endpoints:
 
-- Walrus has no public unauthenticated publisher on Mainnet. Use a Testnet publisher for
-  experiments; on Mainnet, run your own publisher, use an upload relay, or use the
-  [TypeScript SDK](/docs/typescript-sdk/sdks).
-- Most public aggregators and publishers limit requests to 10 MiB. To store larger blobs, run your
-  own publisher or use the [CLI](/docs/walrus-client/storing-blobs).
+- Walrus has no public unauthenticated publisher on Mainnet. Use a Testnet publisher for experiments; on Mainnet, run your own publisher, use an upload relay, or use the [TypeScript SDK](/docs/typescript-sdk/sdks).
+- Most public aggregators and publishers limit requests to 10 MiB. To store larger blobs, run your own publisher or use the [CLI](/docs/walrus-client/storing-blobs).
 
 ## Upload a blob
 
@@ -100,9 +90,7 @@ Control the resulting blob through query parameters:
 
 ## Handle the store response
 
-A successful store returns JSON in one of two shapes. A `newlyCreated` field describes a blob that
-Walrus stored for the first time, while an `alreadyCertified` field describes a blob that some user
-already stored and certified earlier. The two shapes nest the blob ID differently, so handle both:
+A successful store returns JSON in one of two shapes. A `newlyCreated` field describes a blob that Walrus stored for the first time, while an `alreadyCertified` field describes a blob that some user already stored and certified earlier. The two shapes nest the blob ID differently, so handle both:
 
 ```js
 function parseStoreResponse(info) {
@@ -125,11 +113,7 @@ function parseStoreResponse(info) {
 }
 ```
 
-The `blobId` identifies the data on Walrus: pass it to an aggregator to read the blob back. The
-`endEpoch` tells you when the storage period ends. For newly created blobs, the response also
-carries the Sui object ID of the `Blob` object. See
-[Understanding the response](/docs/http-api/storing-blobs#understanding-the-response) for the full
-response format.
+The `blobId` identifies the data on Walrus: pass it to an aggregator to read the blob back. The `endEpoch` tells you when the storage period ends. For newly created blobs, the response also carries the Sui object ID of the `Blob` object. See [Understanding the response](/docs/http-api/storing-blobs#understanding-the-response) for the full response format.
 
 ## Download a blob
 
@@ -145,36 +129,22 @@ async function readBlob(blobId) {
 }
 ```
 
-Call `response.text()` or `response.json()` instead of `arrayBuffer()` when you stored text or
-JSON. The aggregator serves blobs read by blob ID as `application/octet-stream`, so specify the
-media type yourself when you embed the blob in a page. To receive stored headers such as
-`content-type`, read by the Sui object ID instead, with
-`/v1/blobs/by-object-id/<objectId>`; the aggregator returns recognized blob attributes in the
-corresponding HTTP headers. See [Reading Blobs](/docs/http-api/reading-blobs) for details.
+Call `response.text()` or `response.json()` instead of `arrayBuffer()` when you stored text or JSON. The aggregator serves blobs read by blob ID as `application/octet-stream`, so specify the media type yourself when you embed the blob in a page. To receive stored headers such as `content-type`, read by the Sui object ID instead, with `/v1/blobs/by-object-id/<objectId>`; the aggregator returns recognized blob attributes in the corresponding HTTP headers. See [Reading Blobs](/docs/http-api/reading-blobs) for details.
 
 :::tip Reading a blob right after upload?
 
-A CDN-fronted aggregator might briefly serve a cached `404` from before the blob propagated. If
-your app just stored the blob, retry the read with backoff. See
-[Reading Blobs Right After Upload](/docs/troubleshooting/reading-blobs-after-upload).
+A CDN-fronted aggregator might briefly serve a cached `404` from before the blob propagated. If your app just stored the blob, retry the read with backoff. See [Reading Blobs Right After Upload](/docs/troubleshooting/reading-blobs-after-upload).
 
 :::
 
 ## Complete example: browser upload form
 
-The following single-file example combines the upload and download calls into a web form. The form
-lets you set the publisher and aggregator URLs, pick a file and a number of epochs, and optionally
-enter a Sui address that receives the created `Blob` object through the `send_object_to` parameter.
-After a successful upload, the script parses both response shapes and renders each stored blob with
-a download link that points at the aggregator. To try it, save the file locally and open it in a
-browser.
+The following single-file example combines the upload and download calls into a web form. The form lets you set the publisher and aggregator URLs, pick a file and a number of epochs, and optionally enter a Sui address that receives the created `Blob` object through the `send_object_to` parameter. After a successful upload, the script parses both response shapes and renders each stored blob with a download link that points at the aggregator. To try it, save the file locally and open it in a browser.
 
 <ImportContent source="docs/examples/javascript/blob_upload_download_webapi.html" mode="code" org="MystenLabs" repo="walrus" />
 
 ## Read Walrus system state
 
-The next example reads Walrus system state on Sui instead of blob data. The script calls the
-`sui_getObject` JSON-RPC method on a public Sui full node and renders the per-epoch rewards and
-used storage capacity from the system state into a table.
+The next example reads Walrus system state on Sui instead of blob data. The script calls the `sui_getObject` JSON-RPC method on a public Sui full node and renders the per-epoch rewards and used storage capacity from the system state into a table.
 
 <ImportContent source="docs/examples/javascript/system_stats.html" mode="code" org="MystenLabs" repo="walrus" />

--- a/docs/content/examples/move.mdx
+++ b/docs/content/examples/move.mdx
@@ -40,12 +40,6 @@ answer: >-
 
 Every Walrus blob has a corresponding `Blob` object on Sui, defined in the `walrus::blob` module. The `Blob` type has the `key` and `store` abilities, so your own Move packages can hold blobs in custom structs, transfer them between addresses, and manage their lifecycle onchain. Add the Walrus package as a dependency to read blob properties, wrap blobs in your own object types, and call the system functions that extend or delete blobs.
 
-See also:
-
-- [Managing Blobs](/docs/walrus-client/managing-blobs): the CLI equivalents for extending, deleting, sharing, and setting attributes on blobs.
-- [Storage Costs](/docs/system-overview/storage-costs): how registration, certification, and storage resources work onchain.
-- [Building a Data Marketplace](/docs/examples/data-marketplace): a worked example that escrows and sells `Blob` objects from a Move package.
-
 ## Add the Walrus dependency
 
 Declare the Walrus package as a git dependency in your package's `Move.toml`:

--- a/docs/content/examples/move.mdx
+++ b/docs/content/examples/move.mdx
@@ -1,10 +1,15 @@
 ---
 title: Using Walrus with Move
 description: >-
-  Move code examples to demonstrate how to use Walrus from within a Move
-  package.
+  Add the Walrus Move package as a dependency to read blob properties, wrap Blob objects in your
+  own types, and manage the blob lifecycle from your smart contracts.
 keywords:
   - move
+  - sui
+  - blob object
+  - smart contract
+  - move package
+  - shared blob
 goal:
   description: Reader can read and manage Walrus blob objects from a Move package
   requires:
@@ -24,17 +29,135 @@ goal:
       label: Needs answer summary for AI citation
 questions:
   - How do I use Walrus with Move?
-  - What is Using Walrus with Move?
-  - How do I get started with using walrus with move?
+  - How do I add Walrus as a dependency in Move.toml?
+  - How do I read Walrus blob properties from a smart contract?
 answer: >-
-  The following Move example showcases how to import and use Walrus onchain
-  objects.
+  Add the Walrus package as a git dependency in your Move.toml, then import walrus::blob::Blob to
+  hold, wrap, and transfer blob objects from your own package. The Blob type exposes accessors such
+  as blob_id, size, and end_epoch, and the walrus::system module provides functions to extend and
+  delete blobs onchain.
 ---
 
-The following Move example showcases how to import and use Walrus onchain objects.
+Every Walrus blob has a corresponding `Blob` object on Sui, defined in the `walrus::blob` module.
+The `Blob` type has the `key` and `store` abilities, so your own Move packages can hold blobs in
+custom structs, transfer them between addresses, and manage their lifecycle onchain. Add the Walrus
+package as a dependency to read blob properties, wrap blobs in your own object types, and call the
+system functions that extend or delete blobs.
 
-The following Move example showcases how to import and use Walrus onchain objects.
+See also:
 
-The following Move example showcases how to import and use Walrus onchain objects.
+- [Managing Blobs](/docs/walrus-client/managing-blobs): the CLI equivalents for extending,
+  deleting, sharing, and setting attributes on blobs.
+- [Storage Costs](/docs/system-overview/storage-costs): how registration, certification, and
+  storage resources work onchain.
+- [Building a Data Marketplace](/docs/examples/data-marketplace): a worked example that escrows
+  and sells `Blob` objects from a Move package.
+
+## Add the Walrus dependency
+
+Declare the Walrus package as a git dependency in your package's `Move.toml`:
+
+```toml
+[package]
+name = "walrus_dep"
+edition = "2024.beta"
+
+[dependencies]
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "testnet-v1.35.0" }
+Walrus = { git = "https://github.com/MystenLabs/walrus.git", rev = "main", subdir = "contracts/walrus" }
+
+[addresses]
+sui = "0x2"
+walrus_dep = "0x0"
+```
+
+The `contracts/walrus` subdirectory contains the development sources. The Walrus repository also
+tracks the sources deployed on each network in the
+[`mainnet-contracts`](https://github.com/MystenLabs/walrus/tree/main/mainnet-contracts) and
+[`testnet-contracts`](https://github.com/MystenLabs/walrus/tree/main/testnet-contracts)
+directories, and the [Network Reference](/docs/network-reference#package-ids) lists the deployed
+package and object IDs.
+
+## Wrap a blob object
+
+Because `Blob` has the `store` ability, you can embed it in your own object types. The following
+example module accepts a `Blob` by value and escrows it inside a `WrappedBlob`:
 
 <ImportContent source="docs/examples/move/walrus_dep/sources/wrapped_blob.move" mode="code" org="MystenLabs" repo="walrus" />
+
+After wrapping, only the functions of the wrapping module can reach the blob again, which gives
+your package full control over how the blob moves and who can manage it. A marketplace escrow, a
+vault, or an app-specific asset type all follow this pattern.
+
+## Read blob properties
+
+The `walrus::blob` module exposes accessors for every `Blob` field:
+
+| **Accessor** | **Returns** | **Description** |
+| --- | --- | --- |
+| `object_id` | `ID` | The Sui object ID of the `Blob` object. |
+| `blob_id` | `u256` | The blob ID that identifies the data on Walrus. |
+| `size` | `u64` | The unencoded blob size in bytes. |
+| `encoding_type` | `u8` | The blob's erasure encoding. |
+| `registered_epoch` | `u32` | The Walrus epoch of the blob's registration. |
+| `certified_epoch` | `&Option<u32>` | The epoch of first certification, or none for an uncertified blob. |
+| `storage` | `&Storage` | The storage resource that backs the blob. |
+| `end_epoch` | `u32` | The end epoch of the blob's storage resource (exclusive). |
+| `is_deletable` | `bool` | Whether the owner can delete the blob before expiry. |
+| `encoded_size` | `u64` | The encoded size in bytes for a given number of shards. |
+
+For example, the following function checks that a blob is certified and that its storage covers
+the current epoch, which you can read from the shared system object with `system.epoch()`:
+
+```move
+use walrus::blob::Blob;
+
+/// Returns true if `blob` is certified and its storage covers `current_epoch`.
+public fun is_live(blob: &Blob, current_epoch: u32): bool {
+    blob.certified_epoch().is_some() && blob.end_epoch() > current_epoch
+}
+```
+
+## Manage the blob lifecycle
+
+The `walrus::system` module exposes lifecycle functions on the shared `System` object:
+
+- `extend_blob(system, blob, extended_epochs, payment)` extends the blob's storage by
+  `extended_epochs` epochs and draws the storage fee from a `Coin<WAL>`.
+- `extend_blob_with_resource(system, blob, extension)` extends the blob with a `Storage` resource
+  you already own; the resource must match the blob's storage size and last longer.
+- `delete_blob(system, blob)` consumes a deletable blob and returns its `Storage` resource, which
+  you can reuse for another blob.
+
+The `walrus::blob` module additionally provides `burn(blob)`, which destroys the `Blob` object
+without deleting the data from Walrus and without refunding storage, and metadata functions such
+as `insert_or_update_metadata_pair` and `remove_metadata_pair` to manage key-value metadata on a
+blob you hold. The [Managing Blobs](/docs/walrus-client/managing-blobs) page describes the CLI
+equivalents.
+
+## Share a blob
+
+The `walrus::shared_blob` module wraps a `Blob` in a `SharedBlob`, a shared object that acts as a
+tip jar: anyone can add WAL to it, and anyone can spend the stored funds to extend the wrapped
+blob's lifetime.
+
+- `new(blob, ctx)` shares the blob as a `SharedBlob` with zero funds.
+- `new_funded(blob, funds, ctx)` shares the blob together with an initial `Coin<WAL>` balance.
+- `fund(shared_blob, coin)` adds WAL to the stored funds.
+- `extend(shared_blob, system, extended_epochs, ctx)` extends the wrapped blob using the stored
+  funds.
+
+The CLI offers the same capability through `walrus share --blob-obj-id <SUI_OBJ_ID>`; see
+[Shared blobs](/docs/walrus-client/managing-blobs#shared-blobs).
+
+## Build, test, and publish
+
+The complete example package lives in the
+[`docs/examples/move/walrus_dep`](https://github.com/MystenLabs/walrus/tree/main/docs/examples/move/walrus_dep)
+directory of the Walrus repository. From that directory, run:
+
+```sh
+sui move build
+sui move test
+sui client publish --skip-dependency-verification
+```

--- a/docs/content/examples/move.mdx
+++ b/docs/content/examples/move.mdx
@@ -38,20 +38,13 @@ answer: >-
   delete blobs onchain.
 ---
 
-Every Walrus blob has a corresponding `Blob` object on Sui, defined in the `walrus::blob` module.
-The `Blob` type has the `key` and `store` abilities, so your own Move packages can hold blobs in
-custom structs, transfer them between addresses, and manage their lifecycle onchain. Add the Walrus
-package as a dependency to read blob properties, wrap blobs in your own object types, and call the
-system functions that extend or delete blobs.
+Every Walrus blob has a corresponding `Blob` object on Sui, defined in the `walrus::blob` module. The `Blob` type has the `key` and `store` abilities, so your own Move packages can hold blobs in custom structs, transfer them between addresses, and manage their lifecycle onchain. Add the Walrus package as a dependency to read blob properties, wrap blobs in your own object types, and call the system functions that extend or delete blobs.
 
 See also:
 
-- [Managing Blobs](/docs/walrus-client/managing-blobs): the CLI equivalents for extending,
-  deleting, sharing, and setting attributes on blobs.
-- [Storage Costs](/docs/system-overview/storage-costs): how registration, certification, and
-  storage resources work onchain.
-- [Building a Data Marketplace](/docs/examples/data-marketplace): a worked example that escrows
-  and sells `Blob` objects from a Move package.
+- [Managing Blobs](/docs/walrus-client/managing-blobs): the CLI equivalents for extending, deleting, sharing, and setting attributes on blobs.
+- [Storage Costs](/docs/system-overview/storage-costs): how registration, certification, and storage resources work onchain.
+- [Building a Data Marketplace](/docs/examples/data-marketplace): a worked example that escrows and sells `Blob` objects from a Move package.
 
 ## Add the Walrus dependency
 
@@ -71,23 +64,15 @@ sui = "0x2"
 walrus_dep = "0x0"
 ```
 
-The `contracts/walrus` subdirectory contains the development sources. The Walrus repository also
-tracks the sources deployed on each network in the
-[`mainnet-contracts`](https://github.com/MystenLabs/walrus/tree/main/mainnet-contracts) and
-[`testnet-contracts`](https://github.com/MystenLabs/walrus/tree/main/testnet-contracts)
-directories, and the [Network Reference](/docs/network-reference#package-ids) lists the deployed
-package and object IDs.
+The `contracts/walrus` subdirectory contains the development sources. The Walrus repository also tracks the sources deployed on each network in the [`mainnet-contracts`](https://github.com/MystenLabs/walrus/tree/main/mainnet-contracts) and [`testnet-contracts`](https://github.com/MystenLabs/walrus/tree/main/testnet-contracts) directories, and the [Network Reference](/docs/network-reference#package-ids) lists the deployed package and object IDs.
 
 ## Wrap a blob object
 
-Because `Blob` has the `store` ability, you can embed it in your own object types. The following
-example module accepts a `Blob` by value and escrows it inside a `WrappedBlob`:
+Because `Blob` has the `store` ability, you can embed it in your own object types. The following example module accepts a `Blob` by value and escrows it inside a `WrappedBlob`:
 
 <ImportContent source="docs/examples/move/walrus_dep/sources/wrapped_blob.move" mode="code" org="MystenLabs" repo="walrus" />
 
-After wrapping, only the functions of the wrapping module can reach the blob again, which gives
-your package full control over how the blob moves and who can manage it. A marketplace escrow, a
-vault, or an app-specific asset type all follow this pattern.
+After wrapping, only the functions of the wrapping module can reach the blob again, which gives your package full control over how the blob moves and who can manage it. A marketplace escrow, a vault, or an app-specific asset type all follow this pattern.
 
 ## Read blob properties
 
@@ -106,8 +91,7 @@ The `walrus::blob` module exposes accessors for every `Blob` field:
 | `is_deletable` | `bool` | Whether the owner can delete the blob before expiry. |
 | `encoded_size` | `u64` | The encoded size in bytes for a given number of shards. |
 
-For example, the following function checks that a blob is certified and that its storage covers
-the current epoch, which you can read from the shared system object with `system.epoch()`:
+For example, the following function checks that a blob is certified and that its storage covers the current epoch, which you can read from the shared system object with `system.epoch()`:
 
 ```move
 use walrus::blob::Blob;
@@ -122,39 +106,26 @@ public fun is_live(blob: &Blob, current_epoch: u32): bool {
 
 The `walrus::system` module exposes lifecycle functions on the shared `System` object:
 
-- `extend_blob(system, blob, extended_epochs, payment)` extends the blob's storage by
-  `extended_epochs` epochs and draws the storage fee from a `Coin<WAL>`.
-- `extend_blob_with_resource(system, blob, extension)` extends the blob with a `Storage` resource
-  you already own; the resource must match the blob's storage size and last longer.
-- `delete_blob(system, blob)` consumes a deletable blob and returns its `Storage` resource, which
-  you can reuse for another blob.
+- `extend_blob(system, blob, extended_epochs, payment)` extends the blob's storage by `extended_epochs` epochs and draws the storage fee from a `Coin<WAL>`.
+- `extend_blob_with_resource(system, blob, extension)` extends the blob with a `Storage` resource you already own; the resource must match the blob's storage size and last longer.
+- `delete_blob(system, blob)` consumes a deletable blob and returns its `Storage` resource, which you can reuse for another blob.
 
-The `walrus::blob` module additionally provides `burn(blob)`, which destroys the `Blob` object
-without deleting the data from Walrus and without refunding storage, and metadata functions such
-as `insert_or_update_metadata_pair` and `remove_metadata_pair` to manage key-value metadata on a
-blob you hold. The [Managing Blobs](/docs/walrus-client/managing-blobs) page describes the CLI
-equivalents.
+The `walrus::blob` module additionally provides `burn(blob)`, which destroys the `Blob` object without deleting the data from Walrus and without refunding storage, and metadata functions such as `insert_or_update_metadata_pair` and `remove_metadata_pair` to manage key-value metadata on a blob you hold. The [Managing Blobs](/docs/walrus-client/managing-blobs) page describes the CLI equivalents.
 
 ## Share a blob
 
-The `walrus::shared_blob` module wraps a `Blob` in a `SharedBlob`, a shared object that acts as a
-tip jar: anyone can add WAL to it, and anyone can spend the stored funds to extend the wrapped
-blob's lifetime.
+The `walrus::shared_blob` module wraps a `Blob` in a `SharedBlob`, a shared object that acts as a tip jar: anyone can add WAL to it, and anyone can spend the stored funds to extend the wrapped blob's lifetime.
 
 - `new(blob, ctx)` shares the blob as a `SharedBlob` with zero funds.
 - `new_funded(blob, funds, ctx)` shares the blob together with an initial `Coin<WAL>` balance.
 - `fund(shared_blob, coin)` adds WAL to the stored funds.
-- `extend(shared_blob, system, extended_epochs, ctx)` extends the wrapped blob using the stored
-  funds.
+- `extend(shared_blob, system, extended_epochs, ctx)` extends the wrapped blob using the stored funds.
 
-The CLI offers the same capability through `walrus share --blob-obj-id <SUI_OBJ_ID>`; see
-[Shared blobs](/docs/walrus-client/managing-blobs#shared-blobs).
+The CLI offers the same capability through `walrus share --blob-obj-id <SUI_OBJ_ID>`; see [Shared blobs](/docs/walrus-client/managing-blobs#shared-blobs).
 
 ## Build, test, and publish
 
-The complete example package lives in the
-[`docs/examples/move/walrus_dep`](https://github.com/MystenLabs/walrus/tree/main/docs/examples/move/walrus_dep)
-directory of the Walrus repository. From that directory, run:
+The complete example package lives in the [`docs/examples/move/walrus_dep`](https://github.com/MystenLabs/walrus/tree/main/docs/examples/move/walrus_dep) directory of the Walrus repository. From that directory, run:
 
 ```sh
 sui move build

--- a/docs/content/examples/python.mdx
+++ b/docs/content/examples/python.mdx
@@ -40,13 +40,6 @@ answer: >-
 
 Walrus does not ship an official Python SDK, but you can drive every core Walrus operation from Python. The following examples show three integration paths: the HTTP API for storing and reading blobs with plain `requests` calls, the Walrus CLI's JSON mode driven as a subprocess, and Sui JSON-RPC queries for tracking Walrus storage events.
 
-See also:
-
-- [Blob Operations Quickstart](/docs/blob-operations-quickstart): store, read, and check blobs with the CLI, the HTTP API, and Python side by side.
-- [Storing Blobs](/docs/http-api/storing-blobs) and [Reading Blobs](/docs/http-api/reading-blobs): the full HTTP API reference.
-- [JSON Mode](/docs/walrus-client/json-mode): programmatic access to all Walrus CLI commands.
-- [Community SDKs](/docs/typescript-sdk/sdks#community-maintained-sdks): a community-maintained Walrus Python SDK for the HTTP API.
-
 ## Prerequisites
 
 The complete, runnable example files live in the [`docs/examples/python`](https://github.com/MystenLabs/walrus/tree/main/docs/examples/python) directory of the Walrus repository. Before you run them:

--- a/docs/content/examples/python.mdx
+++ b/docs/content/examples/python.mdx
@@ -38,30 +38,20 @@ answer: >-
   over JSON-RPC.
 ---
 
-Walrus does not ship an official Python SDK, but you can drive every core Walrus operation from
-Python. The following examples show three integration paths: the HTTP API for storing and reading
-blobs with plain `requests` calls, the Walrus CLI's JSON mode driven as a subprocess, and Sui
-JSON-RPC queries for tracking Walrus storage events.
+Walrus does not ship an official Python SDK, but you can drive every core Walrus operation from Python. The following examples show three integration paths: the HTTP API for storing and reading blobs with plain `requests` calls, the Walrus CLI's JSON mode driven as a subprocess, and Sui JSON-RPC queries for tracking Walrus storage events.
 
 See also:
 
-- [Blob Operations Quickstart](/docs/blob-operations-quickstart): store, read, and check blobs with
-  the CLI, the HTTP API, and Python side by side.
-- [Storing Blobs](/docs/http-api/storing-blobs) and [Reading Blobs](/docs/http-api/reading-blobs):
-  the full HTTP API reference.
+- [Blob Operations Quickstart](/docs/blob-operations-quickstart): store, read, and check blobs with the CLI, the HTTP API, and Python side by side.
+- [Storing Blobs](/docs/http-api/storing-blobs) and [Reading Blobs](/docs/http-api/reading-blobs): the full HTTP API reference.
 - [JSON Mode](/docs/walrus-client/json-mode): programmatic access to all Walrus CLI commands.
-- [Community SDKs](/docs/typescript-sdk/sdks#community-maintained-sdks): a community-maintained
-  Walrus Python SDK for the HTTP API.
+- [Community SDKs](/docs/typescript-sdk/sdks#community-maintained-sdks): a community-maintained Walrus Python SDK for the HTTP API.
 
 ## Prerequisites
 
-The complete, runnable example files live in the
-[`docs/examples/python`](https://github.com/MystenLabs/walrus/tree/main/docs/examples/python)
-directory of the Walrus repository. Before you run them:
+The complete, runnable example files live in the [`docs/examples/python`](https://github.com/MystenLabs/walrus/tree/main/docs/examples/python) directory of the Walrus repository. Before you run them:
 
-1. Install and configure the `walrus` CLI and a funded Sui wallet, as described in
-   [Getting Started](/docs/getting-started). The JSON API and event tracking examples invoke the
-   CLI binary and read its client configuration file.
+1. Install and configure the `walrus` CLI and a funded Sui wallet, as described in [Getting Started](/docs/getting-started). The JSON API and event tracking examples invoke the CLI binary and read its client configuration file.
 
 2. Optional: create and activate a Python virtual environment:
 
@@ -76,18 +66,11 @@ directory of the Walrus repository. Before you run them:
    pip install requests
    ```
 
-4. Update the constants in [`utils.py`](https://github.com/MystenLabs/walrus/blob/main/docs/examples/python/utils.py)
-   to match your system: `PATH_TO_WALRUS` (the path to your `walrus` binary),
-   `PATH_TO_WALRUS_CONFIG` (the path to your client configuration file), and `FULL_NODE_URL` (a Sui
-   full node RPC URL, for example `https://fullnode.testnet.sui.io:443` for Testnet).
+4. Update the constants in [`utils.py`](https://github.com/MystenLabs/walrus/blob/main/docs/examples/python/utils.py) to match your system: `PATH_TO_WALRUS` (the path to your `walrus` binary), `PATH_TO_WALRUS_CONFIG` (the path to your client configuration file), and `FULL_NODE_URL` (a Sui full node RPC URL, for example `https://fullnode.testnet.sui.io:443` for Testnet).
 
 ## Use the HTTP API
 
-The HTTP API is the lightest integration path: you store blobs with `PUT` requests to a publisher
-and read them with `GET` requests to an aggregator, with no Walrus-specific dependencies in your
-Python code. The example below talks to a local `walrus daemon`, which combines the publisher and
-aggregator roles on a single address. Start the daemon first, pointing it at your client
-configuration and an existing directory for its sub-wallets:
+The HTTP API is the lightest integration path: you store blobs with `PUT` requests to a publisher and read them with `GET` requests to an aggregator, with no Walrus-specific dependencies in your Python code. The example below talks to a local `walrus daemon`, which combines the publisher and aggregator roles on a single address. Start the daemon first, pointing it at your client configuration and an existing directory for its sub-wallets:
 
 ```sh
 walrus --config <PATH_TO_CLIENT_CONFIG> daemon \
@@ -96,11 +79,7 @@ walrus --config <PATH_TO_CLIENT_CONFIG> daemon \
     --n-clients 1
 ```
 
-The script then uploads 1 MiB of random data with `PUT /v1/blobs?epochs=5` and reads it back with
-`GET /v1/blobs/<blob_id>`. A first-time store returns a `newlyCreated` JSON object that carries the
-blob ID; storing data that already exists on Walrus returns an `alreadyCertified` object instead.
-See [Storing Blobs](/docs/http-api/storing-blobs#understanding-the-response) for both response
-shapes.
+The script then uploads 1 MiB of random data with `PUT /v1/blobs?epochs=5` and reads it back with `GET /v1/blobs/<blob_id>`. A first-time store returns a `newlyCreated` JSON object that carries the blob ID; storing data that already exists on Walrus returns an `alreadyCertified` object instead. See [Storing Blobs](/docs/http-api/storing-blobs#understanding-the-response) for both response shapes.
 
 <ImportContent source="docs/examples/python/hello_walrus_webapi.py" mode="code" org="MystenLabs" repo="walrus" />
 
@@ -113,17 +92,11 @@ Upload time: 4.25s
 Download time: 0.51s
 ```
 
-To use public endpoints instead of a local daemon, send `PUT` requests to a Testnet publisher and
-`GET` requests to an aggregator from the
-[Network Reference](/docs/network-reference#aggregators-and-publishers). Note that public
-endpoints limit requests to 10 MiB, and Walrus has no public unauthenticated publisher on Mainnet.
+To use public endpoints instead of a local daemon, send `PUT` requests to a Testnet publisher and `GET` requests to an aggregator from the [Network Reference](/docs/network-reference#aggregators-and-publishers). Note that public endpoints limit requests to 10 MiB, and Walrus has no public unauthenticated publisher on Mainnet.
 
 ## Use the JSON API
 
-The JSON API runs the `walrus` CLI as a subprocess and exchanges JSON on standard input and
-output. JSON mode covers every CLI command, which makes it the right path when you need operations
-the HTTP API does not expose, such as checking a blob's onchain certification. The example passes a
-JSON object that names the client configuration file and the command to run, for example:
+The JSON API runs the `walrus` CLI as a subprocess and exchanges JSON on standard input and output. JSON mode covers every CLI command, which makes it the right path when you need operations the HTTP API does not expose, such as checking a blob's onchain certification. The example passes a JSON object that names the client configuration file and the command to run, for example:
 
 ```json
 {
@@ -137,27 +110,18 @@ JSON object that names the client configuration file and the command to run, for
 }
 ```
 
-The example stores a 1 MiB file, reads it back, and then checks the blob's certification. Every
-stored blob has a corresponding Sui object that records its storage lifetime and certification
-status, so the final part of the script fetches that object through Sui JSON-RPC (`sui_getObject`)
-and verifies that the onchain `blob_id` matches the uploaded blob.
+The example stores a 1 MiB file, reads it back, and then checks the blob's certification. Every stored blob has a corresponding Sui object that records its storage lifetime and certification status, so the final part of the script fetches that object through Sui JSON-RPC (`sui_getObject`) and verifies that the onchain `blob_id` matches the uploaded blob.
 
 <ImportContent source="docs/examples/python/hello_walrus_jsonapi.py" mode="code" org="MystenLabs" repo="walrus" />
 
 ## Track Walrus events
 
-Walrus coordinates storage through smart contracts on Sui, and blob lifecycle operations emit Sui
-events such as `BlobRegistered` and `BlobCertified`. Tracking these events lets you monitor
-activity, for example to confirm certification of your own blobs or to index recent stores. The
-script needs no `walrus` binary at runtime; it only reads the system object ID from your client
-configuration file and queries a Sui full node over JSON-RPC.
+Walrus coordinates storage through smart contracts on Sui, and blob lifecycle operations emit Sui events such as `BlobRegistered` and `BlobCertified`. Tracking these events lets you monitor activity, for example to confirm certification of your own blobs or to index recent stores. The script needs no `walrus` binary at runtime; it only reads the system object ID from your client configuration file and queries a Sui full node over JSON-RPC.
 
 The script proceeds in three steps:
 
 1. Reads the `system_object` ID from your Walrus client configuration.
 2. Fetches that object with `sui_getObject` to discover the Walrus package ID.
-3. Queries the latest 100 events emitted by the package's `blob` module with `suix_queryEvents`,
-   then prints each event's timestamp, type, size (for registrations), blob ID, and transaction
-   digest.
+3. Queries the latest 100 events emitted by the package's `blob` module with `suix_queryEvents`, then prints each event's timestamp, type, size (for registrations), blob ID, and transaction digest.
 
 <ImportContent source="docs/examples/python/track_walrus_events.py" mode="code" org="MystenLabs" repo="walrus" />

--- a/docs/content/examples/python.mdx
+++ b/docs/content/examples/python.mdx
@@ -5,6 +5,10 @@ description: >-
   application.
 keywords:
   - python
+  - http api
+  - json api
+  - walrus events
+  - requests
 goal:
   description: Reader can store, read, and track Walrus blobs from Python using the HTTP and JSON APIs
   requires:
@@ -26,23 +30,134 @@ questions:
   - How do I use Walrus with Python?
   - How do I use the http api?
   - How do I use the json api?
-answer: You can interact with Walrus from within Python code.
+answer: >-
+  Walrus does not ship an official Python SDK, but you can drive every core
+  operation from Python. Store and read blobs through the HTTP API with the
+  requests library, or run the walrus CLI as a subprocess through its JSON
+  mode. You can also track Walrus storage events by querying a Sui full node
+  over JSON-RPC.
 ---
 
-You can interact with Walrus from within Python code. 
+Walrus does not ship an official Python SDK, but you can drive every core Walrus operation from
+Python. The following examples show three integration paths: the HTTP API for storing and reading
+blobs with plain `requests` calls, the Walrus CLI's JSON mode driven as a subprocess, and Sui
+JSON-RPC queries for tracking Walrus storage events.
+
+See also:
+
+- [Blob Operations Quickstart](/docs/blob-operations-quickstart): store, read, and check blobs with
+  the CLI, the HTTP API, and Python side by side.
+- [Storing Blobs](/docs/http-api/storing-blobs) and [Reading Blobs](/docs/http-api/reading-blobs):
+  the full HTTP API reference.
+- [JSON Mode](/docs/walrus-client/json-mode): programmatic access to all Walrus CLI commands.
+- [Community SDKs](/docs/typescript-sdk/sdks#community-maintained-sdks): a community-maintained
+  Walrus Python SDK for the HTTP API.
+
+## Prerequisites
+
+The complete, runnable example files live in the
+[`docs/examples/python`](https://github.com/MystenLabs/walrus/tree/main/docs/examples/python)
+directory of the Walrus repository. Before you run them:
+
+1. Install and configure the `walrus` CLI and a funded Sui wallet, as described in
+   [Getting Started](/docs/getting-started). The JSON API and event tracking examples invoke the
+   CLI binary and read its client configuration file.
+
+2. Optional: create and activate a Python virtual environment:
+
+   ```sh
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+
+3. Install the only third-party dependency, the `requests` HTTP library:
+
+   ```sh
+   pip install requests
+   ```
+
+4. Update the constants in [`utils.py`](https://github.com/MystenLabs/walrus/blob/main/docs/examples/python/utils.py)
+   to match your system: `PATH_TO_WALRUS` (the path to your `walrus` binary),
+   `PATH_TO_WALRUS_CONFIG` (the path to your client configuration file), and `FULL_NODE_URL` (a Sui
+   full node RPC URL, for example `https://fullnode.testnet.sui.io:443` for Testnet).
 
 ## Use the HTTP API
 
-Use the HTTP API to store and read blobs.
+The HTTP API is the lightest integration path: you store blobs with `PUT` requests to a publisher
+and read them with `GET` requests to an aggregator, with no Walrus-specific dependencies in your
+Python code. The example below talks to a local `walrus daemon`, which combines the publisher and
+aggregator roles on a single address. Start the daemon first, pointing it at your client
+configuration and an existing directory for its sub-wallets:
+
+```sh
+walrus --config <PATH_TO_CLIENT_CONFIG> daemon \
+    --bind-address "127.0.0.1:8899" \
+    --sub-wallets-dir <SUB_WALLETS_DIR> \
+    --n-clients 1
+```
+
+The script then uploads 1 MiB of random data with `PUT /v1/blobs?epochs=5` and reads it back with
+`GET /v1/blobs/<blob_id>`. A first-time store returns a `newlyCreated` JSON object that carries the
+blob ID; storing data that already exists on Walrus returns an `alreadyCertified` object instead.
+See [Storing Blobs](/docs/http-api/storing-blobs#understanding-the-response) for both response
+shapes.
 
 <ImportContent source="docs/examples/python/hello_walrus_webapi.py" mode="code" org="MystenLabs" repo="walrus" />
 
-## Use the JSON API 
+The script prints the blob ID, the blob size, and the transfer times, similar to the following:
 
-Use the JSON API to store, read, and check the availability of a blob. Checking the certification of a blob illustrates reading the blob's corresponding Sui object.
+```txt
+Blob ID: iIWkkUTzPZx-d1E_A7LqUynnYFD-ztk39_tP8MLdS2Y
+Size 1048576 bytes
+Upload time: 4.25s
+Download time: 0.51s
+```
+
+To use public endpoints instead of a local daemon, send `PUT` requests to a Testnet publisher and
+`GET` requests to an aggregator from the
+[Network Reference](/docs/network-reference#aggregators-and-publishers). Note that public
+endpoints limit requests to 10 MiB, and Walrus has no public unauthenticated publisher on Mainnet.
+
+## Use the JSON API
+
+The JSON API runs the `walrus` CLI as a subprocess and exchanges JSON on standard input and
+output. JSON mode covers every CLI command, which makes it the right path when you need operations
+the HTTP API does not expose, such as checking a blob's onchain certification. The example passes a
+JSON object that names the client configuration file and the command to run, for example:
+
+```json
+{
+  "config": "path/to/client_config.yaml",
+  "command": {
+    "store": {
+      "files": ["some_file.bin"],
+      "epochs": 2
+    }
+  }
+}
+```
+
+The example stores a 1 MiB file, reads it back, and then checks the blob's certification. Every
+stored blob has a corresponding Sui object that records its storage lifetime and certification
+status, so the final part of the script fetches that object through Sui JSON-RPC (`sui_getObject`)
+and verifies that the onchain `blob_id` matches the uploaded blob.
 
 <ImportContent source="docs/examples/python/hello_walrus_jsonapi.py" mode="code" org="MystenLabs" repo="walrus" />
 
-## Track Walrus events 
+## Track Walrus events
+
+Walrus coordinates storage through smart contracts on Sui, and blob lifecycle operations emit Sui
+events such as `BlobRegistered` and `BlobCertified`. Tracking these events lets you monitor
+activity, for example to confirm certification of your own blobs or to index recent stores. The
+script needs no `walrus` binary at runtime; it only reads the system object ID from your client
+configuration file and queries a Sui full node over JSON-RPC.
+
+The script proceeds in three steps:
+
+1. Reads the `system_object` ID from your Walrus client configuration.
+2. Fetches that object with `sui_getObject` to discover the Walrus package ID.
+3. Queries the latest 100 events emitted by the package's `blob` module with `suix_queryEvents`,
+   then prints each event's timestamp, type, size (for registrations), blob ID, and transaction
+   digest.
 
 <ImportContent source="docs/examples/python/track_walrus_events.py" mode="code" org="MystenLabs" repo="walrus" />

--- a/docs/content/examples/walrus-relay.mdx
+++ b/docs/content/examples/walrus-relay.mdx
@@ -40,14 +40,6 @@ answer: >-
 
 The Walrus upload relay lets browser apps store blobs without opening a connection to every storage node: the client sends a single request to the relay, and the relay encodes the blob, distributes the slivers to the storage node committee, and returns an availability certificate. The following example combines the relay with the Walrus TypeScript SDK into a complete React web application: users connect a Sui wallet, upload files through the public Testnet upload relay, and see each uploaded blob rendered on the page.
 
-See also:
-
-- [Deployed instance](https://relay.wal.app): try the app in your browser.
-- [Source code on GitHub](https://github.com/MystenLabs/walrus-sdk-relay-example-app): the complete application.
-- [Browser and Mobile Apps](/docs/examples/browser-and-mobile): the same store flow as standalone SDK code, with the differences for mobile clients.
-- [Upload Relay](/docs/system-overview/relay): when to use a relay and how it batches, retries, and certifies uploads.
-- [Operate an Upload Relay](/docs/operator-guide/upload-relay): the relay's endpoints, tip mechanism, and configuration.
-
 ## Prerequisites
 
 - Node.js 18 or later and the `pnpm` package manager.

--- a/docs/content/examples/walrus-relay.mdx
+++ b/docs/content/examples/walrus-relay.mdx
@@ -38,33 +38,21 @@ answer: >-
   install and pnpm dev, or open the deployed instance at https://relay.wal.app.
 ---
 
-The Walrus upload relay lets browser apps store blobs without opening a connection to every storage
-node: the client sends a single request to the relay, and the relay encodes the blob, distributes
-the slivers to the storage node committee, and returns an availability certificate. The following
-example combines the relay with the Walrus TypeScript SDK into a complete React web application:
-users connect a Sui wallet, upload files through the public Testnet upload relay, and see each
-uploaded blob rendered on the page.
+The Walrus upload relay lets browser apps store blobs without opening a connection to every storage node: the client sends a single request to the relay, and the relay encodes the blob, distributes the slivers to the storage node committee, and returns an availability certificate. The following example combines the relay with the Walrus TypeScript SDK into a complete React web application: users connect a Sui wallet, upload files through the public Testnet upload relay, and see each uploaded blob rendered on the page.
 
 See also:
 
 - [Deployed instance](https://relay.wal.app): try the app in your browser.
-- [Source code on GitHub](https://github.com/MystenLabs/walrus-sdk-relay-example-app): the complete
-  application.
-- [Browser and Mobile Apps](/docs/examples/browser-and-mobile): the same store flow as standalone
-  SDK code, with the differences for mobile clients.
-- [Upload Relay](/docs/system-overview/relay): when to use a relay and how it batches, retries, and
-  certifies uploads.
-- [Operate an Upload Relay](/docs/operator-guide/upload-relay): the relay's endpoints, tip
-  mechanism, and configuration.
+- [Source code on GitHub](https://github.com/MystenLabs/walrus-sdk-relay-example-app): the complete application.
+- [Browser and Mobile Apps](/docs/examples/browser-and-mobile): the same store flow as standalone SDK code, with the differences for mobile clients.
+- [Upload Relay](/docs/system-overview/relay): when to use a relay and how it batches, retries, and certifies uploads.
+- [Operate an Upload Relay](/docs/operator-guide/upload-relay): the relay's endpoints, tip mechanism, and configuration.
 
 ## Prerequisites
 
 - Node.js 18 or later and the `pnpm` package manager.
-- A Sui browser wallet with Testnet SUI and WAL. The wallet signs the transactions that register
-  and certify each blob and pay for its storage.
-- No API key. The app points at the public Testnet upload relay that Mysten Labs runs at
-  `https://upload-relay.testnet.walrus.space`, listed in the
-  [Network Reference](/docs/network-reference#upload-relays).
+- A Sui browser wallet with Testnet SUI and WAL. The wallet signs the transactions that register and certify each blob and pay for its storage.
+- No API key. The app points at the public Testnet upload relay that Mysten Labs runs at `https://upload-relay.testnet.walrus.space`, listed in the [Network Reference](/docs/network-reference#upload-relays).
 
 ## Run the app locally
 
@@ -86,61 +74,42 @@ See also:
 
 ## Key files
 
-Three files carry the Walrus-specific logic. The rest of the repository is standard React
-scaffolding: components, hooks, and styling.
+Three files carry the Walrus-specific logic. The rest of the repository is standard React scaffolding: components, hooks, and styling.
 
 ### Walrus client
 
-`src/lib/walrus.ts` creates a `SuiClient` for the Testnet full node and a `WalrusClient` with an
-`uploadRelay` configuration. The `host` points at the relay, `sendTip.max` caps the tip (in MIST)
-the client agrees to pay a paid relay, and the generous `timeout` accommodates large uploads. A
-relay advertises its required tip through its `/v1/tip-config` endpoint, and a free relay reports
-`no_tip`.
+`src/lib/walrus.ts` creates a `SuiClient` for the Testnet full node and a `WalrusClient` with an `uploadRelay` configuration. The `host` points at the relay, `sendTip.max` caps the tip (in MIST) the client agrees to pay a paid relay, and the generous `timeout` accommodates large uploads. A relay advertises its required tip through its `/v1/tip-config` endpoint, and a free relay reports `no_tip`.
 
 <ImportContent source="src/lib/walrus.ts" mode="code" org="MystenLabs" repo="walrus-sdk-relay-example-app" />
 
-To target Mainnet instead, set `network: "mainnet"`, create the `SuiClient` for the Mainnet full
-node, and point `uploadRelay.host` at `https://upload-relay.mainnet.walrus.space`.
+To target Mainnet instead, set `network: "mainnet"`, create the `SuiClient` for the Mainnet full node, and point `uploadRelay.host` at `https://upload-relay.mainnet.walrus.space`.
 
 ### Network configuration
 
-`src/networkConfig.ts` registers the Testnet and Mainnet full node URLs with dapp-kit's
-`createNetworkConfig`, which backs the wallet connection UI:
+`src/networkConfig.ts` registers the Testnet and Mainnet full node URLs with dapp-kit's `createNetworkConfig`, which backs the wallet connection UI:
 
 <ImportContent source="src/networkConfig.ts" mode="code" org="MystenLabs" repo="walrus-sdk-relay-example-app" />
 
 ### Application UI
 
-`src/App.tsx` renders the upload page: a `FileUpload` component that drives the store flow and a
-gallery of the blobs uploaded in the current session. The `handleUploadComplete` callback prepends
-each newly stored blob to the list:
+`src/App.tsx` renders the upload page: a `FileUpload` component that drives the store flow and a gallery of the blobs uploaded in the current session. The `handleUploadComplete` callback prepends each newly stored blob to the list:
 
 <ImportContent source="src/App.tsx" mode="code" org="MystenLabs" repo="walrus-sdk-relay-example-app" />
 
 ## Upload flow
 
-The `useWalrusUpload` hook in
-[`src/hooks/useWalrusUpload.ts`](https://github.com/MystenLabs/walrus-sdk-relay-example-app/blob/main/src/hooks/useWalrusUpload.ts)
-orchestrates the store through the SDK's `writeFilesFlow` in four steps:
+The `useWalrusUpload` hook in [`src/hooks/useWalrusUpload.ts`](https://github.com/MystenLabs/walrus-sdk-relay-example-app/blob/main/src/hooks/useWalrusUpload.ts) orchestrates the store through the SDK's `writeFilesFlow` in four steps:
 
-1. **Encode:** Wrap the selected file with `WalrusFile.from` and call `flow.encode()`, which
-   computes the blob metadata locally in the browser.
-2. **Register:** `flow.register()` returns a transaction that registers the blob onchain with its
-   storage parameters and sends the relay tip. The connected wallet signs and executes it.
-3. **Upload:** `flow.upload({ digest })` sends the file data to the relay in a single request. The
-   relay distributes the slivers to the storage nodes and collects a confirmation certificate.
-4. **Certify:** `flow.certify()` returns a transaction that certifies the blob on Sui. After the
-   wallet executes it, `flow.listFiles()` returns the blob ID and Sui object ID of the stored file.
+1. **Encode:** Wrap the selected file with `WalrusFile.from` and call `flow.encode()`, which computes the blob metadata locally in the browser.
+2. **Register:** `flow.register()` returns a transaction that registers the blob onchain with its storage parameters and sends the relay tip. The connected wallet signs and executes it.
+3. **Upload:** `flow.upload({ digest })` sends the file data to the relay in a single request. The relay distributes the slivers to the storage nodes and collects a confirmation certificate.
+4. **Certify:** `flow.certify()` returns a transaction that certifies the blob on Sui. After the wallet executes it, `flow.listFiles()` returns the blob ID and Sui object ID of the stored file.
 
-Because the user's own wallet registers, pays for, and certifies the blob, the user keeps ownership
-of the resulting Sui object; the relay only fans out the data. For the same flow as copy-pasteable
-standalone code, see
-[Browser and Mobile Apps](/docs/examples/browser-and-mobile#store-a-file-through-the-relay).
+Because the user's own wallet registers, pays for, and certifies the blob, the user keeps ownership of the resulting Sui object; the relay only fans out the data. For the same flow as copy-pasteable standalone code, see [Browser and Mobile Apps](/docs/examples/browser-and-mobile#store-a-file-through-the-relay).
 
 ## Troubleshooting
 
-- **The SDK fails to load in your own Vite app:** Exclude the SDK's WASM package from Vite's
-  dependency optimization in `vite.config.ts`:
+- **The SDK fails to load in your own Vite app:** Exclude the SDK's WASM package from Vite's dependency optimization in `vite.config.ts`:
 
   ```ts
   optimizeDeps: {
@@ -148,9 +117,5 @@ standalone code, see
   },
   ```
 
-- **The relay rejects an upload:** A paid relay only accepts uploads whose registration transaction
-  includes the advertised tip. Make sure the client's `sendTip.max` covers the tip that the relay
-  reports through `/v1/tip-config`.
-- **`Cannot read properties of undefined (reading 'buffer')`:** `WalrusFile.from` expects a
-  `Uint8Array` for `contents`, not a `File`, `Blob`, or raw `ArrayBuffer`. Read the bytes first
-  with `new Uint8Array(await file.arrayBuffer())`.
+- **The relay rejects an upload:** A paid relay only accepts uploads whose registration transaction includes the advertised tip. Make sure the client's `sendTip.max` covers the tip that the relay reports through `/v1/tip-config`.
+- **`Cannot read properties of undefined (reading 'buffer')`:** `WalrusFile.from` expects a `Uint8Array` for `contents`, not a `File`, `Blob`, or raw `ArrayBuffer`. Read the bytes first with `new Uint8Array(await file.arrayBuffer())`.

--- a/docs/content/examples/walrus-relay.mdx
+++ b/docs/content/examples/walrus-relay.mdx
@@ -6,6 +6,8 @@ keywords:
   - upload relay
   - file upload application
   - web app example
+  - typescript sdk
+  - react
 goal:
   description: Reader can build a browser file-upload app that stores blobs through the Walrus upload relay
   requires:
@@ -28,23 +30,127 @@ questions:
   - What is Walrus Relay?
   - How do I get started with walrus relay?
 answer: >-
-  Using the Walrus TypeScript SDK and the Walrus Upload Relay, the following
-  example app creates a web application that uploads and manages blobs on
-  Walrus.
+  The Walrus Relay example is a React web application that uploads files to
+  Walrus from the browser using the Walrus TypeScript SDK and a public upload
+  relay. The relay accepts a single request per blob and distributes the
+  encoded slivers to the storage nodes, while the user's wallet registers,
+  pays for, and certifies the blob on Sui. Run the app locally with pnpm
+  install and pnpm dev, or open the deployed instance at https://relay.wal.app.
 ---
 
-Using the Walrus TypeScript SDK and the Walrus Upload Relay, the following example app creates a web application that uploads and manages blobs on Walrus.
+The Walrus upload relay lets browser apps store blobs without opening a connection to every storage
+node: the client sends a single request to the relay, and the relay encodes the blob, distributes
+the slivers to the storage node committee, and returns an availability certificate. The following
+example combines the relay with the Walrus TypeScript SDK into a complete React web application:
+users connect a Sui wallet, upload files through the public Testnet upload relay, and see each
+uploaded blob rendered on the page.
 
-[View a deployed instance of this example in your browser](https://relay.wal.app) or [view the entire source code](https://github.com/MystenLabs/walrus-sdk-relay-example-app).
+See also:
 
-Define and configure the Walrus client:
+- [Deployed instance](https://relay.wal.app): try the app in your browser.
+- [Source code on GitHub](https://github.com/MystenLabs/walrus-sdk-relay-example-app): the complete
+  application.
+- [Browser and Mobile Apps](/docs/examples/browser-and-mobile): the same store flow as standalone
+  SDK code, with the differences for mobile clients.
+- [Upload Relay](/docs/system-overview/relay): when to use a relay and how it batches, retries, and
+  certifies uploads.
+- [Operate an Upload Relay](/docs/operator-guide/upload-relay): the relay's endpoints, tip
+  mechanism, and configuration.
+
+## Prerequisites
+
+- Node.js 18 or later and the `pnpm` package manager.
+- A Sui browser wallet with Testnet SUI and WAL. The wallet signs the transactions that register
+  and certify each blob and pay for its storage.
+- No API key. The app points at the public Testnet upload relay that Mysten Labs runs at
+  `https://upload-relay.testnet.walrus.space`, listed in the
+  [Network Reference](/docs/network-reference#upload-relays).
+
+## Run the app locally
+
+1. Clone the repository and install the dependencies:
+
+   ```sh
+   git clone https://github.com/MystenLabs/walrus-sdk-relay-example-app.git
+   cd walrus-sdk-relay-example-app
+   pnpm install
+   ```
+
+2. Start the development server:
+
+   ```sh
+   pnpm dev
+   ```
+
+3. Open `http://localhost:5173` in your browser, connect your wallet, and upload a file.
+
+## Key files
+
+Three files carry the Walrus-specific logic. The rest of the repository is standard React
+scaffolding: components, hooks, and styling.
+
+### Walrus client
+
+`src/lib/walrus.ts` creates a `SuiClient` for the Testnet full node and a `WalrusClient` with an
+`uploadRelay` configuration. The `host` points at the relay, `sendTip.max` caps the tip (in MIST)
+the client agrees to pay a paid relay, and the generous `timeout` accommodates large uploads. A
+relay advertises its required tip through its `/v1/tip-config` endpoint, and a free relay reports
+`no_tip`.
 
 <ImportContent source="src/lib/walrus.ts" mode="code" org="MystenLabs" repo="walrus-sdk-relay-example-app" />
 
-Define network configuration options:
+To target Mainnet instead, set `network: "mainnet"`, create the `SuiClient` for the Mainnet full
+node, and point `uploadRelay.host` at `https://upload-relay.mainnet.walrus.space`.
+
+### Network configuration
+
+`src/networkConfig.ts` registers the Testnet and Mainnet full node URLs with dapp-kit's
+`createNetworkConfig`, which backs the wallet connection UI:
 
 <ImportContent source="src/networkConfig.ts" mode="code" org="MystenLabs" repo="walrus-sdk-relay-example-app" />
 
-Create the web application's `App.tsx` file:
+### Application UI
+
+`src/App.tsx` renders the upload page: a `FileUpload` component that drives the store flow and a
+gallery of the blobs uploaded in the current session. The `handleUploadComplete` callback prepends
+each newly stored blob to the list:
 
 <ImportContent source="src/App.tsx" mode="code" org="MystenLabs" repo="walrus-sdk-relay-example-app" />
+
+## Upload flow
+
+The `useWalrusUpload` hook in
+[`src/hooks/useWalrusUpload.ts`](https://github.com/MystenLabs/walrus-sdk-relay-example-app/blob/main/src/hooks/useWalrusUpload.ts)
+orchestrates the store through the SDK's `writeFilesFlow` in four steps:
+
+1. **Encode:** Wrap the selected file with `WalrusFile.from` and call `flow.encode()`, which
+   computes the blob metadata locally in the browser.
+2. **Register:** `flow.register()` returns a transaction that registers the blob onchain with its
+   storage parameters and sends the relay tip. The connected wallet signs and executes it.
+3. **Upload:** `flow.upload({ digest })` sends the file data to the relay in a single request. The
+   relay distributes the slivers to the storage nodes and collects a confirmation certificate.
+4. **Certify:** `flow.certify()` returns a transaction that certifies the blob on Sui. After the
+   wallet executes it, `flow.listFiles()` returns the blob ID and Sui object ID of the stored file.
+
+Because the user's own wallet registers, pays for, and certifies the blob, the user keeps ownership
+of the resulting Sui object; the relay only fans out the data. For the same flow as copy-pasteable
+standalone code, see
+[Browser and Mobile Apps](/docs/examples/browser-and-mobile#store-a-file-through-the-relay).
+
+## Troubleshooting
+
+- **The SDK fails to load in your own Vite app:** Exclude the SDK's WASM package from Vite's
+  dependency optimization in `vite.config.ts`:
+
+  ```ts
+  optimizeDeps: {
+    exclude: ["@mysten/walrus-wasm"],
+  },
+  ```
+
+- **The relay rejects an upload:** A paid relay only accepts uploads whose registration transaction
+  includes the advertised tip. Make sure the client's `sendTip.max` covers the tip that the relay
+  reports through `/v1/tip-config`.
+- **`Cannot read properties of undefined (reading 'buffer')`:** `WalrusFile.from` expects a
+  `Uint8Array` for `contents`, not a `File`, `Blob`, or raw `ArrayBuffer`. Read the bytes first
+  with `new Uint8Array(await file.arrayBuffer())`.

--- a/docs/content/sites/configuration/specifying-http-headers.mdx
+++ b/docs/content/sites/configuration/specifying-http-headers.mdx
@@ -1,10 +1,13 @@
 ---
 title: Specifying HTTP Headers
-description: Guide to specifying custom HTTP response headers.
+description: >-
+  Set custom HTTP response headers for Walrus Site resources through the
+  headers section of ws-resources.json.
 keywords:
   - walrus sites
   - headers
   - content-type
+  - cache-control
   - ws-resources
   - configuration
   - site-builder
@@ -27,15 +30,33 @@ goal:
     - has_answer: true
       label: Needs answer summary for AI citation
 questions:
-  - What is Specifying HTTP Headers?
-  - How do I get started with specifying http headers?
-  - What are the requirements for specifying http headers?
-answer: Guide to specifying custom HTTP response headers.
+  - How do I set custom HTTP headers for a Walrus Site?
+  - How do I change the Content-Type of a file on my Walrus Site?
+  - How do I control caching for Walrus Sites assets?
+answer: >-
+  Set custom HTTP response headers in the headers section of ws-resources.json,
+  keyed by the exact resource path starting from the root /. The site-builder
+  writes the headers to your site object on Sui at deploy time, and the portal
+  attaches them to each response. Common uses include Content-Type overrides,
+  Cache-Control policies, Content-Disposition download behavior, and
+  Content-Encoding for pre-compressed assets.
 ---
 
-The `headers` section allows you to specify custom HTTP response headers for specific resources. The keys in the `headers` object are the exact paths of the resources (no wildcards), and the values are lists of key-value pairs corresponding to the headers that the portal attaches to the response.
+The `headers` section of
+[`ws-resources.json`](/docs/sites/configuration/site-configuration) sets custom HTTP response
+headers for individual resources on your Walrus Site. Each key in the `headers` object is the exact
+path of a resource, always starting from the root `/` (no wildcards), and each value is an object
+that maps header names to the values the portal attaches to the response.
 
-This mechanism allows you to control various aspects of the resource delivery, such as caching, encoding, and content types.
+Custom headers let you control how browsers and other clients handle each resource, for example
+caching, encoding, content types, and download behavior.
+
+See also:
+
+- [Site Configuration](/docs/sites/configuration/site-configuration) for the full
+  `ws-resources.json` reference
+- [Using the Site Builder](/docs/sites/getting-started/using-the-site-builder) for the `deploy`,
+  `publish`, and `update` commands that apply your configuration
 
 ```json
 {
@@ -60,17 +81,37 @@ This mechanism allows you to control various aspects of the resource delivery, s
 }
 ```
 
-In the example [`ws-resources.json`](/docs/sites/configuration/site-configuration), the file `index.html` is served with the `Content-Type` header set to `text/html; charset=utf-8` and the `Cache-Control` header set to `max-age=3500`. The resource path is always represented as starting from the root `/`.
+In this example, the portal serves `index.html` with the `Content-Type` header set to
+`text/html; charset=utf-8` and the `Cache-Control` header set to `max-age=3500`.
+
+## How the portal applies headers
+
+Headers live onchain, not in a server configuration file:
+
+1. You define the headers in `ws-resources.json`.
+2. When you run [`site-builder deploy`](/docs/sites/getting-started/using-the-site-builder), the
+   tool writes the headers into your site's resource entries on Sui, alongside each resource path
+   and blob ID.
+3. When a visitor requests a resource, the [portal](/docs/sites/portals/mainnet-testnet) reads the
+   headers from the Sui object and attaches them to the HTTP response.
+
+Because the headers live on Sui, editing `ws-resources.json` alone changes nothing on your live
+site. Run `site-builder deploy` again to apply the new headers.
 
 ## Defaults
 
-By default, you do not need to specify any headers. The `site-builder` automatically tries to infer the `Content-Type` header based on the file extension, and sets the `Content-Encoding` to `identity` (no transformation).
+By default, you do not need to specify any headers. The `site-builder` automatically tries to infer
+the `Content-Type` header based on the file extension, and sets the `Content-Encoding` to
+`identity` (no transformation).
 
-If the content type cannot be inferred, the `Content-Type` is set to `application/octet-stream`. Any headers specified in the `ws-resources.json` file will override these defaults.
+If the `site-builder` cannot infer the content type, it sets the `Content-Type` to
+`application/octet-stream`. Headers you specify in the `ws-resources.json` file override these
+defaults.
 
 ## `Content-Type`
 
-Set the `Content-Type` explicitly when the inferred type is incorrect, when you need to specify a charset, or when serving a file type the portal does not recognise.
+Set the `Content-Type` explicitly when the inferred type is incorrect, when you need to specify a
+charset, or when you serve a file type the `site-builder` does not recognize.
 
 ```json
 "/feed.xml":      { "Content-Type": "application/rss+xml; charset=utf-8" }
@@ -79,11 +120,14 @@ Set the `Content-Type` explicitly when the inferred type is incorrect, when you 
 "/data.csv":      { "Content-Type": "text/csv; charset=utf-8" }
 ```
 
-For [raw markdown files served for LLM ingestion](/docs/sites/configuration/site-configuration#markdown), use lowercase `content-type`.
+For [raw markdown files served for LLM
+ingestion](/docs/sites/configuration/site-configuration#markdown), use lowercase `content-type`.
 
 ## `Cache-Control`
 
-Walrus blobs are immutable, so assets with build-hashed filenames can be cached forever. Entry points should never be cached.
+Walrus blobs are immutable, so browsers can safely cache assets with build-hashed filenames
+forever. Do not let browsers cache entry points such as `/index.html`, because their content
+changes on every deployment while their paths stay the same.
 
 ```json
 "/index.html":              { "Cache-Control": "no-cache" }
@@ -92,7 +136,7 @@ Walrus blobs are immutable, so assets with build-hashed filenames can be cached 
 "/data/prices.json":        { "Cache-Control": "max-age=300" }
 ```
 
-| Value | Meaning |
+| **Value** | **Meaning** |
 |---|---|
 | `no-cache` | Revalidate before each use |
 | `no-store` | Never cache |
@@ -101,7 +145,8 @@ Walrus blobs are immutable, so assets with build-hashed filenames can be cached 
 
 ## `Content-Disposition`
 
-Controls whether the browser renders a resource inline or downloads it.
+The `Content-Disposition` header controls whether the browser renders a resource inline or
+downloads it as a file.
 
 ```json
 "/docs/guide.md":    { "Content-Disposition": "inline" }
@@ -111,7 +156,8 @@ Controls whether the browser renders a resource inline or downloads it.
 
 ## `Content-Encoding`
 
-Use when serving pre-compressed assets from your build pipeline.
+Set `Content-Encoding` when you serve pre-compressed assets from your build pipeline, so browsers
+decompress them correctly.
 
 ```json
 "/assets/app.js.gz": {

--- a/docs/content/sites/configuration/specifying-http-headers.mdx
+++ b/docs/content/sites/configuration/specifying-http-headers.mdx
@@ -46,11 +46,6 @@ The `headers` section of [`ws-resources.json`](/docs/sites/configuration/site-co
 
 Custom headers let you control how browsers and other clients handle each resource, for example caching, encoding, content types, and download behavior.
 
-See also:
-
-- [Site Configuration](/docs/sites/configuration/site-configuration) for the full `ws-resources.json` reference
-- [Using the Site Builder](/docs/sites/getting-started/using-the-site-builder) for the `deploy`, `publish`, and `update` commands that apply your configuration
-
 ```json
 {
   "headers": {

--- a/docs/content/sites/configuration/specifying-http-headers.mdx
+++ b/docs/content/sites/configuration/specifying-http-headers.mdx
@@ -42,21 +42,14 @@ answer: >-
   Content-Encoding for pre-compressed assets.
 ---
 
-The `headers` section of
-[`ws-resources.json`](/docs/sites/configuration/site-configuration) sets custom HTTP response
-headers for individual resources on your Walrus Site. Each key in the `headers` object is the exact
-path of a resource, always starting from the root `/` (no wildcards), and each value is an object
-that maps header names to the values the portal attaches to the response.
+The `headers` section of [`ws-resources.json`](/docs/sites/configuration/site-configuration) sets custom HTTP response headers for individual resources on your Walrus Site. Each key in the `headers` object is the exact path of a resource, always starting from the root `/` (no wildcards), and each value is an object that maps header names to the values the portal attaches to the response.
 
-Custom headers let you control how browsers and other clients handle each resource, for example
-caching, encoding, content types, and download behavior.
+Custom headers let you control how browsers and other clients handle each resource, for example caching, encoding, content types, and download behavior.
 
 See also:
 
-- [Site Configuration](/docs/sites/configuration/site-configuration) for the full
-  `ws-resources.json` reference
-- [Using the Site Builder](/docs/sites/getting-started/using-the-site-builder) for the `deploy`,
-  `publish`, and `update` commands that apply your configuration
+- [Site Configuration](/docs/sites/configuration/site-configuration) for the full `ws-resources.json` reference
+- [Using the Site Builder](/docs/sites/getting-started/using-the-site-builder) for the `deploy`, `publish`, and `update` commands that apply your configuration
 
 ```json
 {
@@ -81,37 +74,27 @@ See also:
 }
 ```
 
-In this example, the portal serves `index.html` with the `Content-Type` header set to
-`text/html; charset=utf-8` and the `Cache-Control` header set to `max-age=3500`.
+In this example, the portal serves `index.html` with the `Content-Type` header set to `text/html; charset=utf-8` and the `Cache-Control` header set to `max-age=3500`.
 
 ## How the portal applies headers
 
 Headers live onchain, not in a server configuration file:
 
 1. You define the headers in `ws-resources.json`.
-2. When you run [`site-builder deploy`](/docs/sites/getting-started/using-the-site-builder), the
-   tool writes the headers into your site's resource entries on Sui, alongside each resource path
-   and blob ID.
-3. When a visitor requests a resource, the [portal](/docs/sites/portals/mainnet-testnet) reads the
-   headers from the Sui object and attaches them to the HTTP response.
+2. When you run [`site-builder deploy`](/docs/sites/getting-started/using-the-site-builder), the tool writes the headers into your site's resource entries on Sui, alongside each resource path and blob ID.
+3. When a visitor requests a resource, the [portal](/docs/sites/portals/mainnet-testnet) reads the headers from the Sui object and attaches them to the HTTP response.
 
-Because the headers live on Sui, editing `ws-resources.json` alone changes nothing on your live
-site. Run `site-builder deploy` again to apply the new headers.
+Because the headers live on Sui, editing `ws-resources.json` alone changes nothing on your live site. Run `site-builder deploy` again to apply the new headers.
 
 ## Defaults
 
-By default, you do not need to specify any headers. The `site-builder` automatically tries to infer
-the `Content-Type` header based on the file extension, and sets the `Content-Encoding` to
-`identity` (no transformation).
+By default, you do not need to specify any headers. The `site-builder` automatically tries to infer the `Content-Type` header based on the file extension, and sets the `Content-Encoding` to `identity` (no transformation).
 
-If the `site-builder` cannot infer the content type, it sets the `Content-Type` to
-`application/octet-stream`. Headers you specify in the `ws-resources.json` file override these
-defaults.
+If the `site-builder` cannot infer the content type, it sets the `Content-Type` to `application/octet-stream`. Headers you specify in the `ws-resources.json` file override these defaults.
 
 ## `Content-Type`
 
-Set the `Content-Type` explicitly when the inferred type is incorrect, when you need to specify a
-charset, or when you serve a file type the `site-builder` does not recognize.
+Set the `Content-Type` explicitly when the inferred type is incorrect, when you need to specify a charset, or when you serve a file type the `site-builder` does not recognize.
 
 ```json
 "/feed.xml":      { "Content-Type": "application/rss+xml; charset=utf-8" }
@@ -120,14 +103,11 @@ charset, or when you serve a file type the `site-builder` does not recognize.
 "/data.csv":      { "Content-Type": "text/csv; charset=utf-8" }
 ```
 
-For [raw markdown files served for LLM
-ingestion](/docs/sites/configuration/site-configuration#markdown), use lowercase `content-type`.
+For [raw markdown files served for LLM ingestion](/docs/sites/configuration/site-configuration#markdown), use lowercase `content-type`.
 
 ## `Cache-Control`
 
-Walrus blobs are immutable, so browsers can safely cache assets with build-hashed filenames
-forever. Do not let browsers cache entry points such as `/index.html`, because their content
-changes on every deployment while their paths stay the same.
+Walrus blobs are immutable, so browsers can safely cache assets with build-hashed filenames forever. Do not let browsers cache entry points such as `/index.html`, because their content changes on every deployment while their paths stay the same.
 
 ```json
 "/index.html":              { "Cache-Control": "no-cache" }
@@ -145,8 +125,7 @@ changes on every deployment while their paths stay the same.
 
 ## `Content-Disposition`
 
-The `Content-Disposition` header controls whether the browser renders a resource inline or
-downloads it as a file.
+The `Content-Disposition` header controls whether the browser renders a resource inline or downloads it as a file.
 
 ```json
 "/docs/guide.md":    { "Content-Disposition": "inline" }
@@ -156,8 +135,7 @@ downloads it as a file.
 
 ## `Content-Encoding`
 
-Set `Content-Encoding` when you serve pre-compressed assets from your build pipeline, so browsers
-decompress them correctly.
+Set `Content-Encoding` when you serve pre-compressed assets from your build pipeline, so browsers decompress them correctly.
 
 ```json
 "/assets/app.js.gz": {

--- a/docs/content/sites/security/access-control-options.mdx
+++ b/docs/content/sites/security/access-control-options.mdx
@@ -1,11 +1,15 @@
 ---
 title: Access Control Options
-description: Overview of access control for Walrus Sites.
+description: >-
+  Choose an approach for handling public and confidential content on Walrus
+  Sites, from the default public model to client-side encryption.
 keywords:
   - walrus sites
   - access control
   - onchain
   - data security
+  - encryption
+  - seal
 goal:
   description: Reader can choose an access-control approach for content served by a Walrus Site
   requires:
@@ -24,36 +28,117 @@ goal:
     - has_answer: true
       label: Needs answer summary for AI citation
 questions:
-  - What is Access Control Options?
-  - How do I get started with access control options?
-  - What are the requirements for access control options?
-answer: Overview of access control for Walrus Sites.
+  - How do I restrict who can view my Walrus Site?
+  - Can I make a Walrus Site private?
+  - How do I keep sensitive data off my Walrus Site?
+answer: >-
+  Walrus Sites serve all published resources publicly. Every blob on Walrus is
+  readable by anyone who knows its blob ID, and portals add no authentication
+  layer. To protect content, keep it out of the deployment with the ignore
+  field in ws-resources.json, encrypt application data on the client (for
+  example with Seal) before storing it on Walrus, or serve it from an
+  authenticated service outside Walrus. Gating a portal does not restrict
+  access, because anyone can fetch the underlying blobs through any aggregator
+  or portal.
 ---
 
 All blobs stored on Walrus are public by default. Anyone who knows a blob ID can fetch its
-contents directly from a Walrus aggregator. Access control for Walrus Sites is not enforced
-at the storage layer.
+contents directly from a Walrus aggregator, and Walrus does not enforce access control at the
+storage layer. Site metadata, including every resource path and blob ID, lives in public objects
+on Sui. Choose an approach based on what each part of your site needs: publish public content
+as-is, keep sensitive files out of the deployment, and encrypt confidential application data
+before it reaches Walrus.
+
+See also:
+
+- [Data Security](/docs/data-security) for the availability, integrity, and confidentiality
+  guarantees of Walrus itself
+- [Known Restrictions](/docs/sites/known-restrictions#no-secret-values) for why site files must
+  not contain secret values
+
+## Choosing an approach
+
+| **Requirement** | **Approach** |
+|---|---|
+| Serve website content to everyone | Publish normally; this is the default model |
+| Keep development files or drafts out of the deployment | Exclude them with the `ignore` field in `ws-resources.json` |
+| Protect confidential data your app reads and writes | Encrypt on the client, for example with Seal, before storing on Walrus |
+| Use secrets such as API keys or credentials | Never place them in site files; keep them in systems outside Walrus |
+| Detect tampering with served content | [Site data authentication](/docs/sites/security/site-data-authentication), active by default |
 
 ## Fully public content (default)
 
 When you publish a Walrus Site using
-[`site-builder`](/docs/sites/getting-started/publishing-your-first-site), all resources are
-stored as publicly readable blobs on Walrus. The portal serves them to any visitor without
+[`site-builder`](/docs/sites/getting-started/publishing-your-first-site), the tool stores all
+resources as publicly readable blobs on Walrus. The portal serves them to any visitor without
 authentication. This is appropriate for most static sites, documentation, open-source
 project pages, and other content that has no confidentiality requirement.
 
 For these use cases, [site data
 authentication](/docs/sites/security/site-data-authentication) already provides integrity
 guarantees: the [portal](/docs/sites/portals/mainnet-testnet) verifies each resource's
-SHA-256 hash against the value stored on Sui before serving it, ensuring the content has
-not been tampered with in transit.
+SHA-256 hash against the value stored on Sui before serving it, ensuring no one tampered
+with the content in transit.
 
 :::info
 Integrity verification and access control are separate concerns. Authentication confirms
-that content has not been modified. It does not restrict who can retrieve it.
+that no one modified the content. It does not restrict who can retrieve it.
 :::
 
-## Restricting access
+## Keeping files out of the deployment
 
-Walrus Sites does not currently document a supported mechanism for restricting who can read
-site content. Treat all published site resources as public.
+The most direct form of access control is not publishing a file at all. The `ignore` field in
+[`ws-resources.json`](/docs/sites/configuration/site-configuration#ignoring-files-from-being-uploaded)
+excludes files and folders from the upload, which keeps development files, drafts, and temporary
+assets out of the published site:
+
+```json
+"ignore": [
+  "/private/*",
+  "/drafts/*",
+  "/notes.txt"
+]
+```
+
+This only controls what `site-builder` uploads. Anything you have already published remains
+readable for its full storage period, so review your build output before you deploy, not after.
+
+:::caution
+Never embed secret values (API keys, tokens, private keys, credentials) anywhere in a site's
+source files. Site files and their metadata are fully public. See
+[Known Restrictions](/docs/sites/known-restrictions#no-secret-values).
+:::
+
+## Encrypting application data
+
+Site resources themselves (the HTML, CSS, and JavaScript that the portal serves) must stay in
+plaintext for browsers to render them. Confidential data that your site's application code reads
+and writes as blobs is a different matter: encrypt it on the client before storing it on Walrus,
+and treat the blob ID as public. Your application then fetches the ciphertext and decrypts it
+locally for users who hold the necessary keys.
+
+[Seal](https://github.com/MystenLabs/seal) supports this pattern. Your application owns key
+management and encryption: Walrus stores and serves whatever bytes you upload. See
+[Data Security](/docs/data-security#data-confidentiality) for the underlying guarantees.
+
+## Serving private content outside Walrus
+
+If content requires per-user authentication and cannot be public even in encrypted form, do not
+store it on Walrus. Serve it from a backend you control, behind your own authentication, and let
+your Walrus Site call that service from client-side code. Privileged operations can also run
+through Sui smart contracts with a
+[Sui-compatible wallet](https://docs.sui.io/guides/developer/wallets/what-is-a-wallet), which
+keeps secrets out of the deployed site assets entirely.
+
+## What does not restrict access
+
+Some approaches look like access control but do not protect the underlying data:
+
+- **Gating a portal:** You can put HTTP authentication, IP restrictions, or rate limits in front
+  of a [self-hosted portal](/docs/sites/portals/deploy-locally), but this only restricts that one
+  portal. Anyone can run their own portal or fetch the site's blobs directly from any aggregator,
+  because the resource paths and blob IDs are public on Sui.
+- **Obscure URLs:** Unlisted paths offer no protection. The site object on Sui publicly maps
+  every resource path to its blob ID.
+- **Blob IDs as secrets:** Blob IDs are content-derived and discoverable. Do not rely on keeping
+  a blob ID private.

--- a/docs/content/sites/security/access-control-options.mdx
+++ b/docs/content/sites/security/access-control-options.mdx
@@ -42,19 +42,12 @@ answer: >-
   or portal.
 ---
 
-All blobs stored on Walrus are public by default. Anyone who knows a blob ID can fetch its
-contents directly from a Walrus aggregator, and Walrus does not enforce access control at the
-storage layer. Site metadata, including every resource path and blob ID, lives in public objects
-on Sui. Choose an approach based on what each part of your site needs: publish public content
-as-is, keep sensitive files out of the deployment, and encrypt confidential application data
-before it reaches Walrus.
+All blobs stored on Walrus are public by default. Anyone who knows a blob ID can fetch its contents directly from a Walrus aggregator, and Walrus does not enforce access control at the storage layer. Site metadata, including every resource path and blob ID, lives in public objects on Sui. Choose an approach based on what each part of your site needs: publish public content as-is, keep sensitive files out of the deployment, and encrypt confidential application data before it reaches Walrus.
 
 See also:
 
-- [Data Security](/docs/data-security) for the availability, integrity, and confidentiality
-  guarantees of Walrus itself
-- [Known Restrictions](/docs/sites/known-restrictions#no-secret-values) for why site files must
-  not contain secret values
+- [Data Security](/docs/data-security) for the availability, integrity, and confidentiality guarantees of Walrus itself
+- [Known Restrictions](/docs/sites/known-restrictions#no-secret-values) for why site files must not contain secret values
 
 ## Choosing an approach
 
@@ -68,29 +61,17 @@ See also:
 
 ## Fully public content (default)
 
-When you publish a Walrus Site using
-[`site-builder`](/docs/sites/getting-started/publishing-your-first-site), the tool stores all
-resources as publicly readable blobs on Walrus. The portal serves them to any visitor without
-authentication. This is appropriate for most static sites, documentation, open-source
-project pages, and other content that has no confidentiality requirement.
+When you publish a Walrus Site using [`site-builder`](/docs/sites/getting-started/publishing-your-first-site), the tool stores all resources as publicly readable blobs on Walrus. The portal serves them to any visitor without authentication. This is appropriate for most static sites, documentation, open-source project pages, and other content that has no confidentiality requirement.
 
-For these use cases, [site data
-authentication](/docs/sites/security/site-data-authentication) already provides integrity
-guarantees: the [portal](/docs/sites/portals/mainnet-testnet) verifies each resource's
-SHA-256 hash against the value stored on Sui before serving it, ensuring no one tampered
-with the content in transit.
+For these use cases, [site data authentication](/docs/sites/security/site-data-authentication) already provides integrity guarantees: the [portal](/docs/sites/portals/mainnet-testnet) verifies each resource's SHA-256 hash against the value stored on Sui before serving it, ensuring no one tampered with the content in transit.
 
 :::info
-Integrity verification and access control are separate concerns. Authentication confirms
-that no one modified the content. It does not restrict who can retrieve it.
+Integrity verification and access control are separate concerns. Authentication confirms that no one modified the content. It does not restrict who can retrieve it.
 :::
 
 ## Keeping files out of the deployment
 
-The most direct form of access control is not publishing a file at all. The `ignore` field in
-[`ws-resources.json`](/docs/sites/configuration/site-configuration#ignoring-files-from-being-uploaded)
-excludes files and folders from the upload, which keeps development files, drafts, and temporary
-assets out of the published site:
+The most direct form of access control is not publishing a file at all. The `ignore` field in [`ws-resources.json`](/docs/sites/configuration/site-configuration#ignoring-files-from-being-uploaded) excludes files and folders from the upload, which keeps development files, drafts, and temporary assets out of the published site:
 
 ```json
 "ignore": [
@@ -100,45 +81,26 @@ assets out of the published site:
 ]
 ```
 
-This only controls what `site-builder` uploads. Anything you have already published remains
-readable for its full storage period, so review your build output before you deploy, not after.
+This only controls what `site-builder` uploads. Anything you have already published remains readable for its full storage period, so review your build output before you deploy, not after.
 
 :::caution
-Never embed secret values (API keys, tokens, private keys, credentials) anywhere in a site's
-source files. Site files and their metadata are fully public. See
-[Known Restrictions](/docs/sites/known-restrictions#no-secret-values).
+Never embed secret values (API keys, tokens, private keys, credentials) anywhere in a site's source files. Site files and their metadata are fully public. See [Known Restrictions](/docs/sites/known-restrictions#no-secret-values).
 :::
 
 ## Encrypting application data
 
-Site resources themselves (the HTML, CSS, and JavaScript that the portal serves) must stay in
-plaintext for browsers to render them. Confidential data that your site's application code reads
-and writes as blobs is a different matter: encrypt it on the client before storing it on Walrus,
-and treat the blob ID as public. Your application then fetches the ciphertext and decrypts it
-locally for users who hold the necessary keys.
+Site resources themselves (the HTML, CSS, and JavaScript that the portal serves) must stay in plaintext for browsers to render them. Confidential data that your site's application code reads and writes as blobs is a different matter: encrypt it on the client before storing it on Walrus, and treat the blob ID as public. Your application then fetches the ciphertext and decrypts it locally for users who hold the necessary keys.
 
-[Seal](https://github.com/MystenLabs/seal) supports this pattern. Your application owns key
-management and encryption: Walrus stores and serves whatever bytes you upload. See
-[Data Security](/docs/data-security#data-confidentiality) for the underlying guarantees.
+[Seal](https://github.com/MystenLabs/seal) supports this pattern. Your application owns key management and encryption: Walrus stores and serves whatever bytes you upload. See [Data Security](/docs/data-security#data-confidentiality) for the underlying guarantees.
 
 ## Serving private content outside Walrus
 
-If content requires per-user authentication and cannot be public even in encrypted form, do not
-store it on Walrus. Serve it from a backend you control, behind your own authentication, and let
-your Walrus Site call that service from client-side code. Privileged operations can also run
-through Sui smart contracts with a
-[Sui-compatible wallet](https://docs.sui.io/guides/developer/wallets/what-is-a-wallet), which
-keeps secrets out of the deployed site assets entirely.
+If content requires per-user authentication and cannot be public even in encrypted form, do not store it on Walrus. Serve it from a backend you control, behind your own authentication, and let your Walrus Site call that service from client-side code. Privileged operations can also run through Sui smart contracts with a [Sui-compatible wallet](https://docs.sui.io/guides/developer/wallets/what-is-a-wallet), which keeps secrets out of the deployed site assets entirely.
 
 ## What does not restrict access
 
 Some approaches look like access control but do not protect the underlying data:
 
-- **Gating a portal:** You can put HTTP authentication, IP restrictions, or rate limits in front
-  of a [self-hosted portal](/docs/sites/portals/deploy-locally), but this only restricts that one
-  portal. Anyone can run their own portal or fetch the site's blobs directly from any aggregator,
-  because the resource paths and blob IDs are public on Sui.
-- **Obscure URLs:** Unlisted paths offer no protection. The site object on Sui publicly maps
-  every resource path to its blob ID.
-- **Blob IDs as secrets:** Blob IDs are content-derived and discoverable. Do not rely on keeping
-  a blob ID private.
+- **Gating a portal:** You can put HTTP authentication, IP restrictions, or rate limits in front of a [self-hosted portal](/docs/sites/portals/deploy-locally), but this only restricts that one portal. Anyone can run their own portal or fetch the site's blobs directly from any aggregator, because the resource paths and blob IDs are public on Sui.
+- **Obscure URLs:** Unlisted paths offer no protection. The site object on Sui publicly maps every resource path to its blob ID.
+- **Blob IDs as secrets:** Blob IDs are content-derived and discoverable. Do not rely on keeping a blob ID private.

--- a/docs/content/sites/security/access-control-options.mdx
+++ b/docs/content/sites/security/access-control-options.mdx
@@ -44,11 +44,6 @@ answer: >-
 
 All blobs stored on Walrus are public by default. Anyone who knows a blob ID can fetch its contents directly from a Walrus aggregator, and Walrus does not enforce access control at the storage layer. Site metadata, including every resource path and blob ID, lives in public objects on Sui. Choose an approach based on what each part of your site needs: publish public content as-is, keep sensitive files out of the deployment, and encrypt confidential application data before it reaches Walrus.
 
-See also:
-
-- [Data Security](/docs/data-security) for the availability, integrity, and confidentiality guarantees of Walrus itself
-- [Known Restrictions](/docs/sites/known-restrictions#no-secret-values) for why site files must not contain secret values
-
 ## Choosing an approach
 
 | **Requirement** | **Approach** |

--- a/docs/content/sites/security/access-control-options.mdx
+++ b/docs/content/sites/security/access-control-options.mdx
@@ -42,7 +42,7 @@ answer: >-
   or portal.
 ---
 
-All blobs stored on Walrus are public by default. Anyone who knows a blob ID can fetch its contents directly from a Walrus aggregator, and Walrus does not enforce access control at the storage layer. Site metadata, including every resource path and blob ID, lives in public objects on Sui. Choose an approach based on what each part of your site needs: publish public content as-is, keep sensitive files out of the deployment, and encrypt confidential application data before it reaches Walrus.
+Walrus stores every blob publicly by default. Anyone who knows a blob ID can fetch its contents directly from a Walrus aggregator, and Walrus does not enforce access control at the storage layer. Site metadata, including every resource path and blob ID, lives in public objects on Sui. Choose an approach based on what each part of your site needs: publish public content as-is, keep sensitive files out of the deployment, and encrypt confidential application data before it reaches Walrus.
 
 ## Choosing an approach
 
@@ -96,6 +96,6 @@ If content requires per-user authentication and cannot be public even in encrypt
 
 Some approaches look like access control but do not protect the underlying data:
 
-- **Gating a portal:** You can put HTTP authentication, IP restrictions, or rate limits in front of a [self-hosted portal](/docs/sites/portals/deploy-locally), but this only restricts that one portal. Anyone can run their own portal or fetch the site's blobs directly from any aggregator, because the resource paths and blob IDs are public on Sui.
+- **Gating a portal:** You can put HTTP authentication, IP restrictions, or rate limits in front of a [self-hosted portal](/docs/sites/portals/deploy-locally), but this only restricts that one portal. Anyone can run their own portal or fetch the site's blobs directly from any aggregator, because Sui exposes the resource paths and blob IDs publicly.
 - **Obscure URLs:** Unlisted paths offer no protection. The site object on Sui publicly maps every resource path to its blob ID.
 - **Blob IDs as secrets:** Blob IDs are content-derived and discoverable. Do not rely on keeping a blob ID private.

--- a/docs/content/system-overview/public-aggregators-and-publishers.mdx
+++ b/docs/content/system-overview/public-aggregators-and-publishers.mdx
@@ -42,12 +42,6 @@ answer: >-
 
 An aggregator serves blob reads over HTTP, and a publisher accepts blob uploads over HTTP. Both roles run through the Walrus client's daemon mode: `walrus aggregator` for reads, `walrus publisher` for stores, or `walrus daemon` for both (see [Operate an Aggregator](/docs/operator-guide/aggregators/operating-aggregator) and [Operate a Publisher](/docs/operator-guide/publishers/operating-publisher)). You do not need to run your own daemon to get started: community operators expose public aggregator and publisher services that you can call directly with any HTTP client.
 
-See also:
-
-- [Network Reference](/docs/network-reference#aggregators-and-publishers) for the Mysten Labs reference endpoints and the stable HTTP API paths
-- [Storing Blobs with the HTTP API](/docs/http-api/storing-blobs) for the full store request and response reference
-- [Reading Blobs with the HTTP API](/docs/http-api/reading-blobs) for reads by blob ID or Sui object ID
-
 ## Using a public aggregator or publisher {#public-services}
 
 To read or store a blob through a public service:

--- a/docs/content/system-overview/public-aggregators-and-publishers.mdx
+++ b/docs/content/system-overview/public-aggregators-and-publishers.mdx
@@ -1,5 +1,15 @@
 ---
 title: Public Aggregators and Publishers
+description: >-
+  Find public Walrus aggregator and publisher endpoints and use them to read and
+  store blobs over HTTP without running your own client.
+keywords:
+  - walrus
+  - aggregator
+  - publisher
+  - public endpoints
+  - HTTP API
+  - blob storage
 goal:
   description: Reader can find and use public Walrus aggregators and publishers
   requires:
@@ -18,24 +28,92 @@ goal:
     - has_answer: true
       label: Needs answer summary for AI citation
 questions:
-  - What is Public Aggregators and Publishers?
-  - How do I get started with public aggregators and publishers?
-  - What are the requirements for public aggregators and publishers?
+  - How do I find a public Walrus aggregator endpoint?
+  - How do I store a blob on Walrus without running my own publisher?
+  - Is there a public Walrus publisher on Mainnet?
+answer: >-
+  Public aggregators serve blob reads and public publishers accept blob uploads
+  over plain HTTP, so you can use Walrus without running a local client.
+  Community operators run public aggregators on Mainnet and Testnet, and public
+  publishers on Testnet only; Walrus has no public unauthenticated publisher on
+  Mainnet. Pick an endpoint from the operator list, then read with GET
+  $AGGREGATOR/v1/blobs/BLOB_ID or store with PUT $PUBLISHER/v1/blobs.
 ---
 
-The Walrus client offers a daemon mode that runs a simple web server that provides HTTP interfaces you can use to store and read blobs in an [aggregator](/docs/operator-guide/aggregators/operating-aggregator) or [publisher](/docs/operator-guide/publishers/operating-publisher) role respectively. Walrus also offers HTTP APIs through [public aggregator and publisher services](#public-services) that you can use without running a local client. 
+An aggregator serves blob reads over HTTP, and a publisher accepts blob uploads over HTTP. Both
+roles run through the Walrus client's daemon mode: `walrus aggregator` for reads, `walrus publisher`
+for stores, or `walrus daemon` for both (see
+[Operate an Aggregator](/docs/operator-guide/aggregators/operating-aggregator) and
+[Operate a Publisher](/docs/operator-guide/publishers/operating-publisher)). You do not need to run
+your own daemon to get started: community operators expose public aggregator and publisher services
+that you can call directly with any HTTP client.
 
-Walrus aggregators and publishers expose their API specifications at the path `/v1/api`. View this path in a browser, for example, at https://aggregator.walrus-testnet.walrus.space/v1/api. The latest version of these specifications is available [on GitHub](https://github.com/MystenLabs/walrus/tree/main/crates/walrus-service) in HTML and YAML format.
+See also:
+
+- [Network Reference](/docs/network-reference#aggregators-and-publishers) for the Mysten Labs
+  reference endpoints and the stable HTTP API paths
+- [Storing Blobs with the HTTP API](/docs/http-api/storing-blobs) for the full store request and
+  response reference
+- [Reading Blobs with the HTTP API](/docs/http-api/reading-blobs) for reads by blob ID or Sui
+  object ID
 
 ## Using a public aggregator or publisher {#public-services}
 
-On Walrus Testnet, many entities run public aggregators and publishers. On Mainnet, there are no public publishers without authentication, as they consume both SUI and WAL. For production upload options, see [Choose your upload path](/docs/getting-started#choose-your-upload-path) and [Mainnet Publisher Production Guide](/docs/operator-guide/publishers/mainnet-production-guide).
+To read or store a blob through a public service:
 
-See the [aggregators and publishers list](#agg-list) for public services on Mainnet and Testnet. Walrus also provides the [operator lists in JSON format](pathname:///operators.json). The [Network Reference](/docs/network-reference#aggregators-and-publishers) lists the Mysten Labs reference endpoints alongside this community list.
+1. Pick an endpoint from the [aggregators and publishers list](#agg-list) below, or use a Mysten
+   Labs reference endpoint from the [Network Reference](/docs/network-reference#aggregators-and-publishers).
+2. Set `$AGGREGATOR` or `$PUBLISHER` to the endpoint URL.
+3. Send a standard HTTP request to the `/v1` API paths, as in the following examples.
 
-The operator list in JSON format includes additional info about aggregators, namely whether they are deployed with caching functionality and whether they are found to be functional. The list is updated once per week.
+Read a blob through an aggregator:
 
-Most aggregators and publishers limit requests to 10 MiB by default. If you want to upload larger files, you need to [run your own publisher](/docs/operator-guide/publishers/operating-publisher#local-daemon) or use the [CLI](/docs/walrus-client/storing-blobs).
+```sh
+$ curl "$AGGREGATOR/v1/blobs/<BLOB_ID>" -o <FILE_NAME>
+```
+
+Store a blob through a Testnet publisher, in this example for 5 storage epochs:
+
+```sh
+$ curl -X PUT "$PUBLISHER/v1/blobs?epochs=5" --upload-file "some/file"
+```
+
+The same services also expose the [quilt endpoints](/docs/http-api/quilt-http-apis) for storing and
+reading batches of small blobs.
+
+Walrus aggregators and publishers expose their full API specifications at the path `/v1/api`. View
+this path in a browser, for example, at https://aggregator.walrus-testnet.walrus.space/v1/api. The
+[Walrus GitHub repository](https://github.com/MystenLabs/walrus/tree/main/crates/walrus-service)
+hosts the latest version of these specifications in HTML and YAML format.
+
+### Network availability
+
+On Walrus Testnet, many entities run public aggregators and publishers. On Mainnet, community
+operators run public aggregators, but no one runs a public publisher without authentication,
+because a publisher consumes both SUI and WAL on the service side. For production upload options,
+see [Choose your upload path](/docs/getting-started#choose-your-upload-path) and the
+[Mainnet Publisher Production Guide](/docs/operator-guide/publishers/mainnet-production-guide).
+
+### Request size limits
+
+Most aggregators and publishers limit requests to 10 MiB by default. If you want to upload larger
+files, [run your own publisher](/docs/operator-guide/publishers/operating-publisher#local-daemon)
+or use the [CLI](/docs/walrus-client/storing-blobs).
+
+:::tip
+
+Do not hardcode a single community endpoint in production code, because community endpoints change
+over time. Use the operator list below, run your own service, or use the Mysten Labs reference
+endpoints.
+
+:::
+
+### Machine-readable operator list
+
+Walrus also provides the [operator lists in JSON format](pathname:///operators.json), grouped by
+network and service type. For each aggregator, the JSON list records whether the operator deploys
+it with [caching functionality](/docs/system-overview/caching) and whether it currently passes a
+functionality check. The list receives updates once per week.
 
 import OperatorsList from '@site/src/components/OperatorsList';
 

--- a/docs/content/system-overview/public-aggregators-and-publishers.mdx
+++ b/docs/content/system-overview/public-aggregators-and-publishers.mdx
@@ -40,29 +40,19 @@ answer: >-
   $AGGREGATOR/v1/blobs/BLOB_ID or store with PUT $PUBLISHER/v1/blobs.
 ---
 
-An aggregator serves blob reads over HTTP, and a publisher accepts blob uploads over HTTP. Both
-roles run through the Walrus client's daemon mode: `walrus aggregator` for reads, `walrus publisher`
-for stores, or `walrus daemon` for both (see
-[Operate an Aggregator](/docs/operator-guide/aggregators/operating-aggregator) and
-[Operate a Publisher](/docs/operator-guide/publishers/operating-publisher)). You do not need to run
-your own daemon to get started: community operators expose public aggregator and publisher services
-that you can call directly with any HTTP client.
+An aggregator serves blob reads over HTTP, and a publisher accepts blob uploads over HTTP. Both roles run through the Walrus client's daemon mode: `walrus aggregator` for reads, `walrus publisher` for stores, or `walrus daemon` for both (see [Operate an Aggregator](/docs/operator-guide/aggregators/operating-aggregator) and [Operate a Publisher](/docs/operator-guide/publishers/operating-publisher)). You do not need to run your own daemon to get started: community operators expose public aggregator and publisher services that you can call directly with any HTTP client.
 
 See also:
 
-- [Network Reference](/docs/network-reference#aggregators-and-publishers) for the Mysten Labs
-  reference endpoints and the stable HTTP API paths
-- [Storing Blobs with the HTTP API](/docs/http-api/storing-blobs) for the full store request and
-  response reference
-- [Reading Blobs with the HTTP API](/docs/http-api/reading-blobs) for reads by blob ID or Sui
-  object ID
+- [Network Reference](/docs/network-reference#aggregators-and-publishers) for the Mysten Labs reference endpoints and the stable HTTP API paths
+- [Storing Blobs with the HTTP API](/docs/http-api/storing-blobs) for the full store request and response reference
+- [Reading Blobs with the HTTP API](/docs/http-api/reading-blobs) for reads by blob ID or Sui object ID
 
 ## Using a public aggregator or publisher {#public-services}
 
 To read or store a blob through a public service:
 
-1. Pick an endpoint from the [aggregators and publishers list](#agg-list) below, or use a Mysten
-   Labs reference endpoint from the [Network Reference](/docs/network-reference#aggregators-and-publishers).
+1. Pick an endpoint from the [aggregators and publishers list](#agg-list) below, or use a Mysten Labs reference endpoint from the [Network Reference](/docs/network-reference#aggregators-and-publishers).
 2. Set `$AGGREGATOR` or `$PUBLISHER` to the endpoint URL.
 3. Send a standard HTTP request to the `/v1` API paths, as in the following examples.
 
@@ -78,42 +68,27 @@ Store a blob through a Testnet publisher, in this example for 5 storage epochs:
 $ curl -X PUT "$PUBLISHER/v1/blobs?epochs=5" --upload-file "some/file"
 ```
 
-The same services also expose the [quilt endpoints](/docs/http-api/quilt-http-apis) for storing and
-reading batches of small blobs.
+The same services also expose the [quilt endpoints](/docs/http-api/quilt-http-apis) for storing and reading batches of small blobs.
 
-Walrus aggregators and publishers expose their full API specifications at the path `/v1/api`. View
-this path in a browser, for example, at https://aggregator.walrus-testnet.walrus.space/v1/api. The
-[Walrus GitHub repository](https://github.com/MystenLabs/walrus/tree/main/crates/walrus-service)
-hosts the latest version of these specifications in HTML and YAML format.
+Walrus aggregators and publishers expose their full API specifications at the path `/v1/api`. View this path in a browser, for example, at https://aggregator.walrus-testnet.walrus.space/v1/api. The [Walrus GitHub repository](https://github.com/MystenLabs/walrus/tree/main/crates/walrus-service) hosts the latest version of these specifications in HTML and YAML format.
 
 ### Network availability
 
-On Walrus Testnet, many entities run public aggregators and publishers. On Mainnet, community
-operators run public aggregators, but no one runs a public publisher without authentication,
-because a publisher consumes both SUI and WAL on the service side. For production upload options,
-see [Choose your upload path](/docs/getting-started#choose-your-upload-path) and the
-[Mainnet Publisher Production Guide](/docs/operator-guide/publishers/mainnet-production-guide).
+On Walrus Testnet, many entities run public aggregators and publishers. On Mainnet, community operators run public aggregators, but no one runs a public publisher without authentication, because a publisher consumes both SUI and WAL on the service side. For production upload options, see [Choose your upload path](/docs/getting-started#choose-your-upload-path) and the [Mainnet Publisher Production Guide](/docs/operator-guide/publishers/mainnet-production-guide).
 
 ### Request size limits
 
-Most aggregators and publishers limit requests to 10 MiB by default. If you want to upload larger
-files, [run your own publisher](/docs/operator-guide/publishers/operating-publisher#local-daemon)
-or use the [CLI](/docs/walrus-client/storing-blobs).
+Most aggregators and publishers limit requests to 10 MiB by default. If you want to upload larger files, [run your own publisher](/docs/operator-guide/publishers/operating-publisher#local-daemon) or use the [CLI](/docs/walrus-client/storing-blobs).
 
 :::tip
 
-Do not hardcode a single community endpoint in production code, because community endpoints change
-over time. Use the operator list below, run your own service, or use the Mysten Labs reference
-endpoints.
+Do not hardcode a single community endpoint in production code, because community endpoints change over time. Use the operator list below, run your own service, or use the Mysten Labs reference endpoints.
 
 :::
 
 ### Machine-readable operator list
 
-Walrus also provides the [operator lists in JSON format](pathname:///operators.json), grouped by
-network and service type. For each aggregator, the JSON list records whether the operator deploys
-it with [caching functionality](/docs/system-overview/caching) and whether it currently passes a
-functionality check. The list receives updates once per week.
+Walrus also provides the [operator lists in JSON format](pathname:///operators.json), grouped by network and service type. For each aggregator, the JSON list records whether the operator deploys it with [caching functionality](/docs/system-overview/caching) and whether it currently passes a functionality check. The list receives updates once per week.
 
 import OperatorsList from '@site/src/components/OperatorsList';
 

--- a/docs/content/troubleshooting/reading-blobs-after-upload.mdx
+++ b/docs/content/troubleshooting/reading-blobs-after-upload.mdx
@@ -42,7 +42,7 @@ answer: >-
   parameter. Treat any other 404 as final.
 ---
 
-Walrus itself is strongly consistent. Once a blob is certified, any aggregator reading directly from storage nodes returns it immediately. If your app reads blobs through a cached aggregator immediately after upload, plan for a short propagation window.
+Walrus itself maintains strong consistency. Once the network certifies a blob, any aggregator reading directly from storage nodes returns it immediately. If your app reads blobs through a cached aggregator immediately after upload, plan for a short propagation window.
 
 ## Cause
 
@@ -62,7 +62,7 @@ The window does not apply in these cases:
 
 ## Solution: retry only when you know the blob should exist
 
-Because Walrus is strongly consistent, a `404` from an uncached aggregator means the blob is not on the network. Retrying every `404` adds latency for missing blobs.
+Because Walrus maintains strong consistency, a `404` from an uncached aggregator means the blob does not exist on the network. Retrying every `404` adds latency for missing blobs.
 
 Retry with backoff only when your app knows the blob has just been certified. Treat other `404` responses as final.
 

--- a/docs/content/troubleshooting/reading-blobs-after-upload.mdx
+++ b/docs/content/troubleshooting/reading-blobs-after-upload.mdx
@@ -12,7 +12,7 @@ keywords:
   - propagation
   - retry
 goal:
-  description: Reader can understand why a blob may return 404 right after upload and handle the propagation window
+  description: Reader can understand why a blob might return 404 right after upload and handle the propagation window
   requires:
     - has_frontmatter:
         - title
@@ -32,47 +32,67 @@ goal:
     - has_answer: true
       label: Needs answer summary for AI citation
 questions:
-  - When this applies?
-  - How do I read blobs right after upload?
-  - How do I get started with reading blobs right after upload?
+  - Why does my blob return 404 right after upload?
+  - When should I retry a 404 from a Walrus aggregator?
+  - How do I bypass a cached 404 from a CDN-fronted aggregator?
 answer: >-
-  Why blobs might return 404 immediately after certification when using a cached
-  aggregator, and how to handle the propagation window.
+  Walrus is strongly consistent, but a CDN in front of a public aggregator can briefly serve a
+  cached 404 from before the blob became visible. When your app knows the blob was just certified,
+  retry the read with exponential backoff for a few seconds or bypass the cache with a unique query
+  parameter. Treat any other 404 as final.
 ---
 
-Walrus itself is strongly consistent. Once a blob is certified, any aggregator reading directly from storage nodes returns it immediately. Public aggregators often sit behind a content delivery network (CDN), which might cache a `404 Not Found` response from before the aggregator sees the blob.
+Walrus itself is strongly consistent. Once a blob is certified, any aggregator reading directly
+from storage nodes returns it immediately. If your app reads blobs through a cached aggregator
+immediately after upload, plan for a short propagation window.
 
-If your app reads blobs through a cached aggregator immediately after upload, plan for this short window.
+See also:
+
+- [Reading blobs over HTTP](/docs/http-api/reading-blobs) for the aggregator read endpoints
+- [Verify Blob Availability Before Acting](/docs/walrus-client/verifying-availability) for
+  confirming certification against Sui state
+
+## Cause
+
+Public aggregators often sit behind a content delivery network (CDN). When a request for a blob
+arrives before the aggregator sees the blob, the CDN might cache the resulting `404 Not Found`
+response and keep serving it for a short time after the blob becomes available.
 
 ## When this applies
 
 This propagation window only affects you when both conditions are true:
 
-- You read through a public aggregator with a CDN in front, such as the Mainnet or Testnet public aggregators.
+- You read through a public aggregator with a CDN in front, such as the Mainnet or Testnet public
+  aggregators.
 - You read a blob within seconds of its certification.
 
 The window does not apply in these cases:
 
 - You read from a self-hosted aggregator with no CDN in front. Reads are strongly consistent.
-- The blob does not exist. A `404` in that case is correct and should not be retried.
+- The blob does not exist. A `404` in that case is correct, so do not retry it.
 
-## Retry only when you know the blob should exist
+## Solution: retry only when you know the blob should exist
 
-Because Walrus is strongly consistent, a `404` from an uncached aggregator means the blob is not on the network. Retrying every `404` adds latency for missing blobs.
+Because Walrus is strongly consistent, a `404` from an uncached aggregator means the blob is not on
+the network. Retrying every `404` adds latency for missing blobs.
 
-Retry with backoff only when your app knows the blob has just been certified. Treat other `404` responses as final.
+Retry with backoff only when your app knows the blob has just been certified. Treat other `404`
+responses as final.
 
-## Example: retry after a known upload
-
-The following helper is for the post-upload path: your app receives a successful certification, then immediately fetches the blob through a cached aggregator. It surfaces non-404 errors immediately and only retries `404`.
+The following helper handles the post-upload path: your app receives a successful certification,
+then immediately fetches the blob through a cached aggregator. It surfaces non-404 errors
+immediately and only retries `404`.
 
 <ImportContent source="examples/typescript/retry_blob_with_backoff.ts" mode="code" />
 
-Tune `maxAttempts` and `baseDelayMs` to your latency budget. A few seconds of total retry time is usually sufficient. Do not use this pattern for general reads. For those reads, treat `404` as final.
+Tune `maxAttempts` and `baseDelayMs` to your latency budget. A few seconds of total retry time is
+usually sufficient. Do not use this pattern for general reads. For those reads, treat `404` as
+final.
 
-#### Bypass the CDN cache if needed
+### Bypass the CDN cache if needed
 
-Some CDNs might ignore cache control headers and cache the `404` response. If retries keep returning the cached `404`, append a unique query parameter:
+Some CDNs might ignore cache control headers and cache the `404` response. If retries keep
+returning the cached `404`, append a unique query parameter:
 
 ```ts
 fetch(`${aggregatorUrl}/v1/blobs/${blobId}?cb=${Date.now()}`);
@@ -80,11 +100,33 @@ fetch(`${aggregatorUrl}/v1/blobs/${blobId}?cb=${Date.now()}`);
 
 Once the blob is reliably reachable, you can remove the query parameter.
 
-#### Use multiple aggregators
+### Use multiple aggregators
 
-If a single aggregator is slow to surface the blob, try another aggregator. If one aggregator returns `404` but another returns the blob, the blob is on the network.
+If a single aggregator is slow to surface the blob, try another aggregator. If one aggregator
+returns `404` but another returns the blob, the blob is on the network and the `404` comes from a
+cache.
 
-#### Pre-warm the read path before demos
+### Pre-warm the read path before demos
 
-Before showing a freshly uploaded blob to an audience, retrieve it once from the aggregator you plan to use. This populates the aggregator and CDN caches before you need them.
+Before showing a freshly uploaded blob to an audience, retrieve it once from the aggregator you
+plan to use. This populates the aggregator and CDN caches before you need them.
 
+## Confirm the blob is on the network
+
+If you are unsure whether a persistent `404` is a cache artifact or a missing blob, check the blob
+directly with the Walrus CLI, which bypasses aggregators and CDNs entirely:
+
+```sh
+$ walrus blob-status --blob-id <BLOB_ID>
+```
+
+The command reports whether the blob is certified and its availability period. See
+[checking blob status](/docs/walrus-client/reading-blobs#check-blob-status). You can also read the
+bytes directly from storage nodes:
+
+```sh
+$ walrus read <BLOB_ID> --out <FILE>
+```
+
+If the CLI confirms the blob is certified but the aggregator still returns `404`, the fix is one of
+the cache workarounds above, or simply waiting out the propagation window.

--- a/docs/content/troubleshooting/reading-blobs-after-upload.mdx
+++ b/docs/content/troubleshooting/reading-blobs-after-upload.mdx
@@ -44,11 +44,6 @@ answer: >-
 
 Walrus itself is strongly consistent. Once a blob is certified, any aggregator reading directly from storage nodes returns it immediately. If your app reads blobs through a cached aggregator immediately after upload, plan for a short propagation window.
 
-See also:
-
-- [Reading blobs over HTTP](/docs/http-api/reading-blobs) for the aggregator read endpoints
-- [Verify Blob Availability Before Acting](/docs/walrus-client/verifying-availability) for confirming certification against Sui state
-
 ## Cause
 
 Public aggregators often sit behind a content delivery network (CDN). When a request for a blob arrives before the aggregator sees the blob, the CDN might cache the resulting `404 Not Found` response and keep serving it for a short time after the blob becomes available.
@@ -109,4 +104,4 @@ The command reports whether the blob is certified and its availability period. S
 $ walrus read <BLOB_ID> --out <FILE>
 ```
 
-If the CLI confirms the blob is certified but the aggregator still returns `404`, the fix is one of the cache workarounds above, or simply waiting out the propagation window.
+If the CLI confirms the blob is certified but the aggregator still returns `404`, the fix is one of the cache workarounds above, or waiting out the propagation window.

--- a/docs/content/troubleshooting/reading-blobs-after-upload.mdx
+++ b/docs/content/troubleshooting/reading-blobs-after-upload.mdx
@@ -42,28 +42,22 @@ answer: >-
   parameter. Treat any other 404 as final.
 ---
 
-Walrus itself is strongly consistent. Once a blob is certified, any aggregator reading directly
-from storage nodes returns it immediately. If your app reads blobs through a cached aggregator
-immediately after upload, plan for a short propagation window.
+Walrus itself is strongly consistent. Once a blob is certified, any aggregator reading directly from storage nodes returns it immediately. If your app reads blobs through a cached aggregator immediately after upload, plan for a short propagation window.
 
 See also:
 
 - [Reading blobs over HTTP](/docs/http-api/reading-blobs) for the aggregator read endpoints
-- [Verify Blob Availability Before Acting](/docs/walrus-client/verifying-availability) for
-  confirming certification against Sui state
+- [Verify Blob Availability Before Acting](/docs/walrus-client/verifying-availability) for confirming certification against Sui state
 
 ## Cause
 
-Public aggregators often sit behind a content delivery network (CDN). When a request for a blob
-arrives before the aggregator sees the blob, the CDN might cache the resulting `404 Not Found`
-response and keep serving it for a short time after the blob becomes available.
+Public aggregators often sit behind a content delivery network (CDN). When a request for a blob arrives before the aggregator sees the blob, the CDN might cache the resulting `404 Not Found` response and keep serving it for a short time after the blob becomes available.
 
 ## When this applies
 
 This propagation window only affects you when both conditions are true:
 
-- You read through a public aggregator with a CDN in front, such as the Mainnet or Testnet public
-  aggregators.
+- You read through a public aggregator with a CDN in front, such as the Mainnet or Testnet public aggregators.
 - You read a blob within seconds of its certification.
 
 The window does not apply in these cases:
@@ -73,26 +67,19 @@ The window does not apply in these cases:
 
 ## Solution: retry only when you know the blob should exist
 
-Because Walrus is strongly consistent, a `404` from an uncached aggregator means the blob is not on
-the network. Retrying every `404` adds latency for missing blobs.
+Because Walrus is strongly consistent, a `404` from an uncached aggregator means the blob is not on the network. Retrying every `404` adds latency for missing blobs.
 
-Retry with backoff only when your app knows the blob has just been certified. Treat other `404`
-responses as final.
+Retry with backoff only when your app knows the blob has just been certified. Treat other `404` responses as final.
 
-The following helper handles the post-upload path: your app receives a successful certification,
-then immediately fetches the blob through a cached aggregator. It surfaces non-404 errors
-immediately and only retries `404`.
+The following helper handles the post-upload path: your app receives a successful certification, then immediately fetches the blob through a cached aggregator. It surfaces non-404 errors immediately and only retries `404`.
 
 <ImportContent source="examples/typescript/retry_blob_with_backoff.ts" mode="code" />
 
-Tune `maxAttempts` and `baseDelayMs` to your latency budget. A few seconds of total retry time is
-usually sufficient. Do not use this pattern for general reads. For those reads, treat `404` as
-final.
+Tune `maxAttempts` and `baseDelayMs` to your latency budget. A few seconds of total retry time is usually sufficient. Do not use this pattern for general reads. For those reads, treat `404` as final.
 
 ### Bypass the CDN cache if needed
 
-Some CDNs might ignore cache control headers and cache the `404` response. If retries keep
-returning the cached `404`, append a unique query parameter:
+Some CDNs might ignore cache control headers and cache the `404` response. If retries keep returning the cached `404`, append a unique query parameter:
 
 ```ts
 fetch(`${aggregatorUrl}/v1/blobs/${blobId}?cb=${Date.now()}`);
@@ -102,31 +89,24 @@ Once the blob is reliably reachable, you can remove the query parameter.
 
 ### Use multiple aggregators
 
-If a single aggregator is slow to surface the blob, try another aggregator. If one aggregator
-returns `404` but another returns the blob, the blob is on the network and the `404` comes from a
-cache.
+If a single aggregator is slow to surface the blob, try another aggregator. If one aggregator returns `404` but another returns the blob, the blob is on the network and the `404` comes from a cache.
 
 ### Pre-warm the read path before demos
 
-Before showing a freshly uploaded blob to an audience, retrieve it once from the aggregator you
-plan to use. This populates the aggregator and CDN caches before you need them.
+Before showing a freshly uploaded blob to an audience, retrieve it once from the aggregator you plan to use. This populates the aggregator and CDN caches before you need them.
 
 ## Confirm the blob is on the network
 
-If you are unsure whether a persistent `404` is a cache artifact or a missing blob, check the blob
-directly with the Walrus CLI, which bypasses aggregators and CDNs entirely:
+If you are unsure whether a persistent `404` is a cache artifact or a missing blob, check the blob directly with the Walrus CLI, which bypasses aggregators and CDNs entirely:
 
 ```sh
 $ walrus blob-status --blob-id <BLOB_ID>
 ```
 
-The command reports whether the blob is certified and its availability period. See
-[checking blob status](/docs/walrus-client/reading-blobs#check-blob-status). You can also read the
-bytes directly from storage nodes:
+The command reports whether the blob is certified and its availability period. See [checking blob status](/docs/walrus-client/reading-blobs#check-blob-status). You can also read the bytes directly from storage nodes:
 
 ```sh
 $ walrus read <BLOB_ID> --out <FILE>
 ```
 
-If the CLI confirms the blob is certified but the aggregator still returns `404`, the fix is one of
-the cache workarounds above, or simply waiting out the propagation window.
+If the CLI confirms the blob is certified but the aggregator still returns `404`, the fix is one of the cache workarounds above, or simply waiting out the propagation window.

--- a/docs/content/typescript-sdk/sdks.mdx
+++ b/docs/content/typescript-sdk/sdks.mdx
@@ -42,15 +42,11 @@ answer: >-
   APIs. The Walruscan explorer and the Awesome Walrus repository list more community tools.
 ---
 
-Official SDKs from Mysten Labs, community-maintained SDKs, and community tools cover the main ways
-to build on Walrus: the TypeScript SDK for full client-side control, HTTP-based SDKs in other
-languages, and explorers for inspecting blobs and operators.
+Official SDKs from Mysten Labs, community-maintained SDKs, and community tools cover the main ways to build on Walrus: the TypeScript SDK for full client-side control, HTTP-based SDKs in other languages, and explorers for inspecting blobs and operators.
 
 ## SDKs maintained by Mysten Labs
 
-Mysten Labs has built and published a [Walrus TypeScript SDK](https://sdk.mystenlabs.com/walrus),
-which supports a wide variety of operations. See also the related
-[examples](https://github.com/MystenLabs/ts-sdks/tree/main/packages/walrus/examples).
+Mysten Labs has built and published a [Walrus TypeScript SDK](https://sdk.mystenlabs.com/walrus), which supports a wide variety of operations. See also the related [examples](https://github.com/MystenLabs/ts-sdks/tree/main/packages/walrus/examples).
 
 Install the SDK together with the Sui TypeScript SDK from npm:
 
@@ -74,43 +70,28 @@ const walrusClient = new WalrusClient({
 });
 ```
 
-The SDK bundles the package and object IDs for each network, so selecting a network applies the
-correct values automatically. To configure a custom or pinned deployment, pass the system and
-staking object IDs from the
-[Network Reference](/docs/network-reference#system-and-staking-object-ids). For a complete browser
-upload flow through an upload relay, see the
-[browser and mobile apps example](/docs/examples/browser-and-mobile), and for SDK error-handling
-patterns, see [error handling](/docs/troubleshooting/error-handling).
+The SDK bundles the package and object IDs for each network, so selecting a network applies the correct values automatically. To configure a custom or pinned deployment, pass the system and staking object IDs from the [Network Reference](/docs/network-reference#system-and-staking-object-ids). For a complete browser upload flow through an upload relay, see the [browser and mobile apps example](/docs/examples/browser-and-mobile), and for SDK error-handling patterns, see [error handling](/docs/troubleshooting/error-handling).
 
-The Walrus repository also contains a Rust SDK (the
-[`walrus-sdk` crate](https://github.com/MystenLabs/walrus/tree/main/crates/walrus-sdk)), which the
-Walrus CLI itself builds on. The Walrus core team continues to develop it.
+The Walrus repository also contains a Rust SDK (the [`walrus-sdk` crate](https://github.com/MystenLabs/walrus/tree/main/crates/walrus-sdk)), which the Walrus CLI itself builds on. The Walrus core team continues to develop it.
 
 ## Community-maintained SDKs
 
-Besides these official SDKs, community teams maintain third-party SDKs that interact with the
-[HTTP API](/docs/http-api/storing-blobs) exposed by Walrus aggregators and
-publishers:
+Besides these official SDKs, community teams maintain third-party SDKs that interact with the [HTTP API](/docs/http-api/storing-blobs) exposed by Walrus aggregators and publishers:
 
 - [Walrus Go SDK](https://github.com/namihq/walrus-go) (maintained by the Nami Cloud team)
 
 - [Walrus PHP SDK](https://github.com/suicore/walrus-sdk-php) (maintained by the Suicore team)
 
-- [Walrus Python SDK](https://github.com/standard-crypto/walrus-python) (maintained by the
-  Standard Crypto team)
+- [Walrus Python SDK](https://github.com/standard-crypto/walrus-python) (maintained by the Standard Crypto team)
 
 Mysten Labs does not maintain these SDKs, so evaluate them before depending on them in production.
 
 ## Explorers
 
-The [Walruscan](https://walruscan.com/) blob explorer, built and maintained by the Staketab team,
-supports exploring blobs, blob events, operators, and more. It also supports staking operations.
+The [Walruscan](https://walruscan.com/) blob explorer, built and maintained by the Staketab team, supports exploring blobs, blob events, operators, and more. It also supports staking operations.
 
-See the
-[Awesome Walrus repository](https://github.com/MystenLabs/awesome-walrus?tab=readme-ov-file#visualization)
-for more visualization tools.
+See the [Awesome Walrus repository](https://github.com/MystenLabs/awesome-walrus?tab=readme-ov-file#visualization) for more visualization tools.
 
 ## Other tools
 
-The community builds many other tools for visualization, monitoring, and more. For a full list,
-see the [Awesome Walrus repository](https://github.com/MystenLabs/awesome-walrus).
+The community builds many other tools for visualization, monitoring, and more. For a full list, see the [Awesome Walrus repository](https://github.com/MystenLabs/awesome-walrus).

--- a/docs/content/typescript-sdk/sdks.mdx
+++ b/docs/content/typescript-sdk/sdks.mdx
@@ -32,41 +32,85 @@ goal:
     - has_answer: true
       label: Needs answer summary for AI citation
 questions:
-  - How do I use the Software Development Kits (SDKs) and Other Tools SDK?
-  - What is Software Development Kits (SDKs) and Other Tools?
-  - How do I get started with software development kits (sdks) and other tools?
+  - Which SDKs can I use to build on Walrus?
+  - How do I get started with the Walrus TypeScript SDK?
+  - Is there a Walrus SDK for Go, Python, or PHP?
 answer: >-
-  Mysten Labs has built and published a [Walrus TypeScript
-  SDK](https://sdk.mystenlabs.com/walrus), which supports a wide variety of
-  operations.
+  Mysten Labs publishes the official Walrus TypeScript SDK as the @mysten/walrus npm package, and
+  the Walrus repository contains a Rust SDK that the Walrus CLI builds on. Community teams maintain
+  Go, PHP, and Python SDKs that interact with Walrus through the aggregator and publisher HTTP
+  APIs. The Walruscan explorer and the Awesome Walrus repository list more community tools.
 ---
+
+Official SDKs from Mysten Labs, community-maintained SDKs, and community tools cover the main ways
+to build on Walrus: the TypeScript SDK for full client-side control, HTTP-based SDKs in other
+languages, and explorers for inspecting blobs and operators.
 
 ## SDKs maintained by Mysten Labs
 
-Mysten Labs has built and published a [Walrus TypeScript SDK](https://sdk.mystenlabs.com/walrus), which supports a wide variety of operations. See also the related [examples](https://github.com/MystenLabs/ts-sdks/tree/main/packages/walrus/examples).
+Mysten Labs has built and published a [Walrus TypeScript SDK](https://sdk.mystenlabs.com/walrus),
+which supports a wide variety of operations. See also the related
+[examples](https://github.com/MystenLabs/ts-sdks/tree/main/packages/walrus/examples).
 
-The SDK bundles the package and object IDs for each network, so selecting a network applies the correct values automatically. To configure a custom or pinned deployment, pass the system and staking object IDs from the [Network Reference](/docs/network-reference#system-and-staking-object-ids).
+Install the SDK together with the Sui TypeScript SDK from npm:
 
-The Walrus core team is actively working on a Rust SDK for Walrus.
+```sh
+$ npm install @mysten/walrus @mysten/sui
+```
 
+Create a `WalrusClient` by selecting a network and passing a `SuiClient`:
+
+```ts
+import { getFullnodeUrl, SuiClient } from '@mysten/sui/client';
+import { WalrusClient } from '@mysten/walrus';
+
+const suiClient = new SuiClient({
+  url: getFullnodeUrl('mainnet'),
+});
+
+const walrusClient = new WalrusClient({
+  network: 'mainnet',
+  suiClient,
+});
+```
+
+The SDK bundles the package and object IDs for each network, so selecting a network applies the
+correct values automatically. To configure a custom or pinned deployment, pass the system and
+staking object IDs from the
+[Network Reference](/docs/network-reference#system-and-staking-object-ids). For a complete browser
+upload flow through an upload relay, see the
+[browser and mobile apps example](/docs/examples/browser-and-mobile), and for SDK error-handling
+patterns, see [error handling](/docs/troubleshooting/error-handling).
+
+The Walrus repository also contains a Rust SDK (the
+[`walrus-sdk` crate](https://github.com/MystenLabs/walrus/tree/main/crates/walrus-sdk)), which the
+Walrus CLI itself builds on. The Walrus core team continues to develop it.
 
 ## Community-maintained SDKs
 
-Besides these official SDKs, there also exist a few unofficial third-party SDKs for interacting with the [HTTP API](/docs/http-api/storing-blobs#http-api-usage) exposed by Walrus aggregators and publishers:
+Besides these official SDKs, community teams maintain third-party SDKs that interact with the
+[HTTP API](/docs/http-api/storing-blobs) exposed by Walrus aggregators and
+publishers:
 
 - [Walrus Go SDK](https://github.com/namihq/walrus-go) (maintained by the Nami Cloud team)
 
 - [Walrus PHP SDK](https://github.com/suicore/walrus-sdk-php) (maintained by the Suicore team)
 
-- [Walrus Python SDK](https://github.com/standard-crypto/walrus-python) (maintained by the Standard Crypto team)
+- [Walrus Python SDK](https://github.com/standard-crypto/walrus-python) (maintained by the
+  Standard Crypto team)
 
+Mysten Labs does not maintain these SDKs, so evaluate them before depending on them in production.
 
 ## Explorers
 
-The [Walruscan](https://walruscan.com/) blob explorer is built and maintained by the Staketab team, which supports exploring blobs, blob events, operators, and more. It also supports staking operations.
+The [Walruscan](https://walruscan.com/) blob explorer, built and maintained by the Staketab team,
+supports exploring blobs, blob events, operators, and more. It also supports staking operations.
 
-See the [Awesome Walrus repository](https://github.com/MystenLabs/awesome-walrus?tab=readme-ov-file#visualization) for more visualization tools.
+See the
+[Awesome Walrus repository](https://github.com/MystenLabs/awesome-walrus?tab=readme-ov-file#visualization)
+for more visualization tools.
 
 ## Other tools
 
-There are many other tools built by the community for visualization, monitoring, and more. For a full list, see the [Awesome Walrus repository](https://github.com/MystenLabs/awesome-walrus).
+The community builds many other tools for visualization, monitoring, and more. For a full list,
+see the [Awesome Walrus repository](https://github.com/MystenLabs/awesome-walrus).

--- a/docs/content/walrus-client/json-mode.mdx
+++ b/docs/content/walrus-client/json-mode.mdx
@@ -44,12 +44,6 @@ answer: >-
 
 JSON mode exposes every Walrus client command and simplifies programmatic access to the [CLI](/docs/walrus-client/walrus-cli). You specify the command and all of its options as a single JSON string, and the CLI prints JSON-formatted results to stdout.
 
-See also:
-
-- [Walrus Client](/docs/walrus-client/walrus-cli) for configuration file locations and global options
-- [Storing Blobs](/docs/walrus-client/storing-blobs) and [Reading Blobs](/docs/walrus-client/reading-blobs) for the underlying commands
-- [HTTP API](/docs/http-api/storing-blobs) for driving a publisher or aggregator over HTTP instead
-
 ## Command structure
 
 Pass a single JSON object to `walrus json`. The object contains the global options (such as `config`, `context`, `wallet`, and `gasBudget`) at the root level, plus a `command` object that holds exactly one command (for example, `store`, `read`, or `blobStatus`) with its options.

--- a/docs/content/walrus-client/json-mode.mdx
+++ b/docs/content/walrus-client/json-mode.mdx
@@ -42,9 +42,7 @@ answer: >-
   the CLI prints a human-readable error to stderr and exits with a non-zero status.
 ---
 
-JSON mode exposes every Walrus client command and simplifies programmatic access to the
-[CLI](/docs/walrus-client/walrus-cli). You specify the command and all of its options as a single
-JSON string, and the CLI prints JSON-formatted results to stdout.
+JSON mode exposes every Walrus client command and simplifies programmatic access to the [CLI](/docs/walrus-client/walrus-cli). You specify the command and all of its options as a single JSON string, and the CLI prints JSON-formatted results to stdout.
 
 See also:
 
@@ -54,16 +52,9 @@ See also:
 
 ## Command structure
 
-Pass a single JSON object to `walrus json`. The object contains the global options (such as
-`config`, `context`, `wallet`, and `gasBudget`) at the root level, plus a `command` object that
-holds exactly one command (for example, `store`, `read`, or `blobStatus`) with its options.
+Pass a single JSON object to `walrus json`. The object contains the global options (such as `config`, `context`, `wallet`, and `gasBudget`) at the root level, plus a `command` object that holds exactly one command (for example, `store`, `read`, or `blobStatus`) with its options.
 
-All commands, options, and default values are the same as those in the standard CLI mode, except
-that the JSON keys use camelCase instead of kebab-case: the `blob-status` command becomes
-`blobStatus`, and the `--strict-consistency-check` flag becomes `strictConsistencyCheck`. Run
-`walrus --help` for the full list of commands, and `walrus <COMMAND> --help` for the options of
-each command. The `json` command ignores any other command-line flags, so specify every option
-inside the JSON string.
+All commands, options, and default values are the same as those in the standard CLI mode, except that the JSON keys use camelCase instead of kebab-case: the `blob-status` command becomes `blobStatus`, and the `--strict-consistency-check` flag becomes `strictConsistencyCheck`. Run `walrus --help` for the full list of commands, and `walrus <COMMAND> --help` for the options of each command. The `json` command ignores any other command-line flags, so specify every option inside the JSON string.
 
 To store two files for 5 epochs, run the following command:
 
@@ -95,17 +86,11 @@ $ walrus json \
     }'
 ```
 
-If you omit `config`, the client searches for `client_config.yaml` (or `client_config.yml`) in the
-[default locations](/docs/walrus-client/walrus-cli#configuration): the current directory,
-`$XDG_CONFIG_HOME/walrus/`, `~/.config/walrus/`, and `~/.walrus/`. If the specified path is
-invalid, the command fails with an error. JSON mode uses no separate authentication: commands that
-create or modify Sui objects sign transactions with the configured Sui wallet, which you can
-override with the `wallet` key.
+If you omit `config`, the client searches for `client_config.yaml` (or `client_config.yml`) in the [default locations](/docs/walrus-client/walrus-cli#configuration): the current directory, `$XDG_CONFIG_HOME/walrus/`, `~/.config/walrus/`, and `~/.walrus/`. If the specified path is invalid, the command fails with an error. JSON mode uses no separate authentication: commands that create or modify Sui objects sign transactions with the configured Sui wallet, which you can override with the `wallet` key.
 
 ## Pass input through stdin
 
-When you run `walrus json` without an argument, the command reads the JSON string from stdin. This
-lets you pipe input from another program or a file:
+When you run `walrus json` without an argument, the command reads the JSON string from stdin. This lets you pipe input from another program or a file:
 
 ```sh
 $ echo '{
@@ -120,11 +105,9 @@ $ echo '{
 
 ## Parse the output
 
-On success, the command prints only JSON to stdout, with keys in camelCase. You can pipe the output
-to `jq` to extract relevant fields.
+On success, the command prints only JSON to stdout, with keys in camelCase. You can pipe the output to `jq` to extract relevant fields.
 
-The `read` command without an `out` file returns the full blob content as a Base64-encoded string
-in the `blob` field:
+The `read` command without an `out` file returns the full blob content as a Base64-encoded string in the `blob` field:
 
 ```json
 {
@@ -133,29 +116,20 @@ in the `blob` field:
 }
 ```
 
-When you set `out`, the CLI writes the bytes to that file and omits the `blob` field from the JSON
-output. For large blobs, always set `out`: this keeps the JSON output small and avoids Base64
-encoding the entire blob into memory.
+When you set `out`, the CLI writes the bytes to that file and omits the `blob` field from the JSON output. For large blobs, always set `out`: this keeps the JSON output small and avoids Base64 encoding the entire blob into memory.
 
-The `store` command returns an array with one result per file. Each entry contains the `path` and a
-`blobStoreResult` object, which holds one of the variants `newlyCreated`, `alreadyCertified`,
-`markedInvalid`, or `error`. The variant contents match the store responses documented for the
-[HTTP API](/docs/http-api/storing-blobs). For example, the following command stores a file and
-extracts the blob ID of a newly created blob:
+The `store` command returns an array with one result per file. Each entry contains the `path` and a `blobStoreResult` object, which holds one of the variants `newlyCreated`, `alreadyCertified`, `markedInvalid`, or `error`. The variant contents match the store responses documented for the [HTTP API](/docs/http-api/storing-blobs). For example, the following command stores a file and extracts the blob ID of a newly created blob:
 
 ```sh
 $ walrus json '{"command": {"store": {"files": ["README.md"], "epochs": 5}}}' \
     | jq -r '.[0].blobStoreResult.newlyCreated.blobObject.blobId'
 ```
 
-To store many files in one batch, list them all in the `files` array. The CLI encodes and uploads
-them in a single run and reports a result for each file.
+To store many files in one batch, list them all in the `files` array. The CLI encodes and uploads them in a single run and reports a result for each file.
 
 ## Handle errors
 
-When a command fails, the CLI prints a human-readable error message to stderr and exits with a
-non-zero status code. JSON mode produces no JSON error object on stdout, so scripts should check
-the exit code first and parse stdout as JSON only when the command succeeds:
+When a command fails, the CLI prints a human-readable error message to stderr and exits with a non-zero status code. JSON mode produces no JSON error object on stdout, so scripts should check the exit code first and parse stdout as JSON only when the command succeeds:
 
 ```sh
 if output=$(walrus json "$request"); then
@@ -167,8 +141,5 @@ fi
 
 Two error cases are worth distinguishing:
 
-- Invalid input, such as malformed JSON or an unknown key, fails before the command runs and
-  reports a parse error on stderr.
-- When storing multiple files, an individual file can fail while others succeed. The JSON output
-  then contains an `error` variant for that file, with an `errorMsg` string and a `failurePhase`
-  field indicating where the store failed.
+- Invalid input, such as malformed JSON or an unknown key, fails before the command runs and reports a parse error on stderr.
+- When storing multiple files, an individual file can fail while others succeed. The JSON output then contains an `error` variant for that file, with an `errorMsg` string and a `failurePhase` field indicating where the store failed.

--- a/docs/content/walrus-client/json-mode.mdx
+++ b/docs/content/walrus-client/json-mode.mdx
@@ -11,6 +11,8 @@ keywords:
   - cli
   - automation
   - scripting
+  - stdin
+  - jq
 goal:
   description: Reader can drive Walrus CLI commands programmatically using JSON input and output
   requires:
@@ -29,19 +31,42 @@ goal:
     - has_answer: true
       label: Needs answer summary for AI citation
 questions:
-  - What is JSON Mode?
-  - >-
-    How do I use json mode for programmatic access to all walrus cli commands
-    with json-formatted input and output?
-  - How do I get started with json mode?
+  - How do I run Walrus CLI commands with JSON input and output?
+  - How do I pipe JSON input to the walrus json command through stdin?
+  - What does the JSON output of a walrus store or read command look like?
+  - How do I handle errors when running the Walrus CLI in JSON mode?
 answer: >-
-  Use JSON mode for programmatic access to all Walrus CLI commands with
-  JSON-formatted input and output.
+  Run walrus json with a JSON string, or pipe the string through stdin, to drive any Walrus CLI
+  command programmatically. The JSON structure mirrors the CLI arguments with camelCase keys
+  instead of kebab-case flags, and the command prints JSON-formatted results to stdout. On failure,
+  the CLI prints a human-readable error to stderr and exits with a non-zero status.
 ---
 
-All Walrus client commands are available in JSON mode, which simplifies programmatic access to the [CLI](/docs/walrus-client/storing-blobs). You can specify all command-line flags of the original CLI command in JSON format.
+JSON mode exposes every Walrus client command and simplifies programmatic access to the
+[CLI](/docs/walrus-client/walrus-cli). You specify the command and all of its options as a single
+JSON string, and the CLI prints JSON-formatted results to stdout.
 
-To store a blob, run the following command:
+See also:
+
+- [Walrus Client](/docs/walrus-client/walrus-cli) for configuration file locations and global options
+- [Storing Blobs](/docs/walrus-client/storing-blobs) and [Reading Blobs](/docs/walrus-client/reading-blobs) for the underlying commands
+- [HTTP API](/docs/http-api/storing-blobs) for driving a publisher or aggregator over HTTP instead
+
+## Command structure
+
+Pass a single JSON object to `walrus json`. The object contains the global options (such as
+`config`, `context`, `wallet`, and `gasBudget`) at the root level, plus a `command` object that
+holds exactly one command (for example, `store`, `read`, or `blobStatus`) with its options.
+
+All commands, options, and default values are the same as those in the standard CLI mode, except
+that the JSON keys use camelCase instead of kebab-case: the `blob-status` command becomes
+`blobStatus`, and the `--strict-consistency-check` flag becomes `strictConsistencyCheck`. Run
+`walrus --help` for the full list of commands, and `walrus <COMMAND> --help` for the options of
+each command. The `json` command ignores any other command-line flags, so specify every option
+inside the JSON string.
+
+To store two files for 5 epochs, run the following command:
+
 ```sh
 $ walrus json \
     '{
@@ -49,27 +74,101 @@ $ walrus json \
         "command": {
             "store": {
                 "files": ["README.md", "LICENSE"],
-                "epochs": 100
+                "epochs": 5
             }
         }
     }'
 ```
 
-To read a blob using the blob ID:
+To read a blob using the blob ID and write it to a file:
+
 ```sh
 $ walrus json \
     '{
         "config": "path/to/client_config.yaml",
         "command": {
             "read": {
-                "blobId": "4BKcDC0Ih5RJ8R0tFMz3MZVNZV8b2goT6_JiEEwNHQo"
+                "blobId": "4BKcDC0Ih5RJ8R0tFMz3MZVNZV8b2goT6_JiEEwNHQo",
+                "out": "blob.bin"
             }
         }
     }'
 ```
 
-All options, default values, and commands are the same as those in the [standard CLI mode](/docs/walrus-client/storing-blobs), except that they use camelCase instead of kebab-case.
+If you omit `config`, the client searches for `client_config.yaml` (or `client_config.yml`) in the
+[default locations](/docs/walrus-client/walrus-cli#configuration): the current directory,
+`$XDG_CONFIG_HOME/walrus/`, `~/.config/walrus/`, and `~/.walrus/`. If the specified path is
+invalid, the command fails with an error. JSON mode uses no separate authentication: commands that
+create or modify Sui objects sign transactions with the configured Sui wallet, which you can
+override with the `wallet` key.
 
-The `json` command also accepts input from `stdin`.
+## Pass input through stdin
 
-The output of a `json` command is JSON-formatted to simplify parsing results programmatically. You can pipe the JSON output to the `jq` command to parse and extract relevant fields.
+When you run `walrus json` without an argument, the command reads the JSON string from stdin. This
+lets you pipe input from another program or a file:
+
+```sh
+$ echo '{
+    "command": {
+        "read": {
+            "blobId": "4BKcDC0Ih5RJ8R0tFMz3MZVNZV8b2goT6_JiEEwNHQo",
+            "out": "blob.bin"
+        }
+    }
+}' | walrus json
+```
+
+## Parse the output
+
+On success, the command prints only JSON to stdout, with keys in camelCase. You can pipe the output
+to `jq` to extract relevant fields.
+
+The `read` command without an `out` file returns the full blob content as a Base64-encoded string
+in the `blob` field:
+
+```json
+{
+  "blobId": "4BKcDC0Ih5RJ8R0tFMz3MZVNZV8b2goT6_JiEEwNHQo",
+  "blob": "SGVsbG8sIFdhbHJ1cyE="
+}
+```
+
+When you set `out`, the CLI writes the bytes to that file and omits the `blob` field from the JSON
+output. For large blobs, always set `out`: this keeps the JSON output small and avoids Base64
+encoding the entire blob into memory.
+
+The `store` command returns an array with one result per file. Each entry contains the `path` and a
+`blobStoreResult` object, which holds one of the variants `newlyCreated`, `alreadyCertified`,
+`markedInvalid`, or `error`. The variant contents match the store responses documented for the
+[HTTP API](/docs/http-api/storing-blobs). For example, the following command stores a file and
+extracts the blob ID of a newly created blob:
+
+```sh
+$ walrus json '{"command": {"store": {"files": ["README.md"], "epochs": 5}}}' \
+    | jq -r '.[0].blobStoreResult.newlyCreated.blobObject.blobId'
+```
+
+To store many files in one batch, list them all in the `files` array. The CLI encodes and uploads
+them in a single run and reports a result for each file.
+
+## Handle errors
+
+When a command fails, the CLI prints a human-readable error message to stderr and exits with a
+non-zero status code. JSON mode produces no JSON error object on stdout, so scripts should check
+the exit code first and parse stdout as JSON only when the command succeeds:
+
+```sh
+if output=$(walrus json "$request"); then
+    echo "$output" | jq .
+else
+    echo "walrus command failed" >&2
+fi
+```
+
+Two error cases are worth distinguishing:
+
+- Invalid input, such as malformed JSON or an unknown key, fails before the command runs and
+  reports a parse error on stderr.
+- When storing multiple files, an individual file can fail while others succeed. The JSON output
+  then contains an `error` variant for that file, with an `errorMsg` string and a `failurePhase`
+  field indicating where the store failed.

--- a/docs/content/walrus-client/reading-blobs.mdx
+++ b/docs/content/walrus-client/reading-blobs.mdx
@@ -42,16 +42,13 @@ answer: >-
   --strict-consistency-check and --skip-consistency-check flags.
 ---
 
-The Walrus client lets you check a blob's storage status and certification, download its data, and
-control the consistency checks that protect reads.
+The Walrus client lets you check a blob's storage status and certification, download its data, and control the consistency checks that protect reads.
 
 See also:
 
 - [Reading blobs over HTTP](/docs/http-api/reading-blobs) to read through an aggregator instead
-- [Verify Blob Availability Before Acting](/docs/walrus-client/verifying-availability) for the
-  onchain checks to run before depending on a blob
-- [Reading Blobs Right After Upload](/docs/troubleshooting/reading-blobs-after-upload) if a
-  freshly stored blob returns `404` from an aggregator
+- [Verify Blob Availability Before Acting](/docs/walrus-client/verifying-availability) for the onchain checks to run before depending on a blob
+- [Reading Blobs Right After Upload](/docs/troubleshooting/reading-blobs-after-upload) if a freshly stored blob returns `404` from an aggregator
 
 ## Check blob status
 
@@ -62,17 +59,11 @@ $ walrus blob-status --blob-id <BLOB_ID>
 $ walrus blob-status --file <FILE>
 ```
 
-Each command returns output that indicates whether Walrus has stored the specified blob, along
-with its availability period. If you specify a file with the `--file` option, the CLI re-encodes the content
-of the file and derives the blob ID before checking the status. For a permanent blob, the output
-also includes an estimated expiry timestamp.
+Each command returns output that indicates whether Walrus has stored the specified blob, along with its availability period. If you specify a file with the `--file` option, the CLI re-encodes the content of the file and derives the blob ID before checking the status. For a permanent blob, the output also includes an estimated expiry timestamp.
 
-For an available blob, the `blob-status` command also returns the `BlobCertified` Sui event ID,
-which consists of a transaction ID and a sequence number in the events emitted by the transaction.
-The existence of this event certifies the availability of the blob.
+For an available blob, the `blob-status` command also returns the `BlobCertified` Sui event ID, which consists of a transaction ID and a sequence number in the events emitted by the transaction. The existence of this event certifies the availability of the blob.
 
-Status requests to storage nodes time out after 1 second by default. Use the
-`--timeout <TIMEOUT>` option (for example, `--timeout 5s`) to adjust this on slow connections.
+Status requests to storage nodes time out after 1 second by default. Use the `--timeout <TIMEOUT>` option (for example, `--timeout 5s`) to adjust this on slow connections.
 
 ## Read blobs
 
@@ -82,47 +73,30 @@ Read blobs from Walrus using the following command:
 $ walrus read <BLOB_ID>
 ```
 
-The client fetches slivers directly from storage nodes and reconstructs the blob locally, so reads
-do not depend on an aggregator or its caches.
+The client fetches slivers directly from storage nodes and reconstructs the blob locally, so reads do not depend on an aggregator or its caches.
 
-By default, the client writes the blob data to the standard output. Use the `--out <OUT>` CLI
-option to specify an output file name:
+By default, the client writes the blob data to the standard output. Use the `--out <OUT>` CLI option to specify an output file name:
 
 ```sh
 $ walrus read <BLOB_ID> --out <FILE>
 ```
 
-Use `--rpc-url <URL>` to specify a Sui RPC node instead of the currently configured RPC node set in
-the CLI configuration file or wallet configuration.
+Use `--rpc-url <URL>` to specify a Sui RPC node instead of the currently configured RPC node set in the CLI configuration file or wallet configuration.
 
-With the `--json` flag, or in [JSON mode](/docs/walrus-client/json-mode), the `read` command prints
-a JSON object containing the blob ID and, when no output file is set, the blob content as a
-Base64-encoded string.
+With the `--json` flag, or in [JSON mode](/docs/walrus-client/json-mode), the `read` command prints a JSON object containing the blob ID and, when no output file is set, the blob content as a Base64-encoded string.
 
-To read individual blobs stored inside a quilt, use the `read-quilt` command instead. See
-[quilts](/docs/walrus-client/quilts#read-blobs-from-a-quilt) for details.
+To read individual blobs stored inside a quilt, use the `read-quilt` command instead. See [quilts](/docs/walrus-client/quilts#read-blobs-from-a-quilt) for details.
 
 ## Check consistency
 
-Walrus performs integrity and consistency checks to ensure that any data read from Walrus is what
-the writer intended, and that the writer encoded the blob correctly. See the
-[data consistency](/docs/system-overview/red-stuff) documentation for further details.
+Walrus performs integrity and consistency checks to ensure that any data read from Walrus is what the writer intended, and that the writer encoded the blob correctly. See the [data consistency](/docs/system-overview/red-stuff) documentation for further details.
 
-Prior to `v1.37`, the Walrus CLI and aggregator always performed the
-[strict consistency check](/docs/system-overview/red-stuff). Starting with `v1.37`, the default is
-a [more performant consistency check](/docs/system-overview/red-stuff), which is sufficient for
-most cases. You can enable the strict consistency check through the `--strict-consistency-check`
-flag:
+Prior to `v1.37`, the Walrus CLI and aggregator always performed the [strict consistency check](/docs/system-overview/red-stuff). Starting with `v1.37`, the default is a [more performant consistency check](/docs/system-overview/red-stuff), which is sufficient for most cases. You can enable the strict consistency check through the `--strict-consistency-check` flag:
 
 ```sh
 $ walrus read <BLOB_ID> --out <FILE> --strict-consistency-check
 ```
 
-You can disable consistency checks completely with the `--skip-consistency-check` flag. Only use
-this if the writer of the blob is known and trusted. Skipping the consistency check does not affect
-the authentication checks for data received from storage nodes, which the client always performs.
-The two flags conflict, so pass at most one of them.
+You can disable consistency checks completely with the `--skip-consistency-check` flag. Only use this if the writer of the blob is known and trusted. Skipping the consistency check does not affect the authentication checks for data received from storage nodes, which the client always performs. The two flags conflict, so pass at most one of them.
 
-When reading through an aggregator instead of the CLI, the equivalent query parameters are
-`strict_consistency_check=true` and `skip_consistency_check=true`. See
-[consistency checks over HTTP](/docs/http-api/reading-blobs#consistency-checks).
+When reading through an aggregator instead of the CLI, the equivalent query parameters are `strict_consistency_check=true` and `skip_consistency_check=true`. See [consistency checks over HTTP](/docs/http-api/reading-blobs#consistency-checks).

--- a/docs/content/walrus-client/reading-blobs.mdx
+++ b/docs/content/walrus-client/reading-blobs.mdx
@@ -44,12 +44,6 @@ answer: >-
 
 The Walrus client lets you check a blob's storage status and certification, download its data, and control the consistency checks that protect reads.
 
-See also:
-
-- [Reading blobs over HTTP](/docs/http-api/reading-blobs) to read through an aggregator instead
-- [Verify Blob Availability Before Acting](/docs/walrus-client/verifying-availability) for the onchain checks to run before depending on a blob
-- [Reading Blobs Right After Upload](/docs/troubleshooting/reading-blobs-after-upload) if a freshly stored blob returns `404` from an aggregator
-
 ## Check blob status
 
 You can query the status of a blob through one of the following commands:

--- a/docs/content/walrus-client/reading-blobs.mdx
+++ b/docs/content/walrus-client/reading-blobs.mdx
@@ -32,37 +32,97 @@ goal:
     - has_answer: true
       label: Needs answer summary for AI citation
 questions:
-  - How do I read blobs?
-  - How do I check consistency?
-  - How do I read blobs?
+  - How do I check the status of a blob with the Walrus CLI?
+  - How do I read a blob with the Walrus CLI?
+  - How do I verify blob consistency when reading?
 answer: >-
-  Use the Walrus client to check blob status, read blob data, and verify
-  consistency.
+  Check a blob's storage status and certification with walrus blob-status, and download its data
+  with walrus read. The client reconstructs the blob from slivers fetched directly from storage nodes
+  and verifies it against the blob ID. Control the consistency check with the
+  --strict-consistency-check and --skip-consistency-check flags.
 ---
 
+The Walrus client lets you check a blob's storage status and certification, download its data, and
+control the consistency checks that protect reads.
+
+See also:
+
+- [Reading blobs over HTTP](/docs/http-api/reading-blobs) to read through an aggregator instead
+- [Verify Blob Availability Before Acting](/docs/walrus-client/verifying-availability) for the
+  onchain checks to run before depending on a blob
+- [Reading Blobs Right After Upload](/docs/troubleshooting/reading-blobs-after-upload) if a
+  freshly stored blob returns `404` from an aggregator
+
+## Check blob status
+
 You can query the status of a blob through one of the following commands:
+
 ```sh
 $ walrus blob-status --blob-id <BLOB_ID>
 $ walrus blob-status --file <FILE>
 ```
 
-Each command returns output that indicates whether the specified blob is stored and its availability period. If you specify a file with the `--file` option, the CLI re-encodes the content of the file and derives the blob ID before checking the status.
+Each command returns output that indicates whether Walrus has stored the specified blob, along
+with its availability period. If you specify a file with the `--file` option, the CLI re-encodes the content
+of the file and derives the blob ID before checking the status. For a permanent blob, the output
+also includes an estimated expiry timestamp.
 
-When a blob is available, the `blob-status` command also returns the `BlobCertified` Sui event ID, which consists of a transaction ID and a sequence number in the events emitted by the transaction. The existence of this event certifies the availability of the blob.
+For an available blob, the `blob-status` command also returns the `BlobCertified` Sui event ID,
+which consists of a transaction ID and a sequence number in the events emitted by the transaction.
+The existence of this event certifies the availability of the blob.
+
+Status requests to storage nodes time out after 1 second by default. Use the
+`--timeout <TIMEOUT>` option (for example, `--timeout 5s`) to adjust this on slow connections.
 
 ## Read blobs
 
 Read blobs from Walrus using the following command:
+
 ```sh
 $ walrus read <BLOB_ID>
 ```
 
-By default, blob data is written to the standard output. Use the `--out <OUT>` CLI option to specify an output file name. Use `--rpc-url <URL>` to specify a Sui RPC node instead of the currently configured RPC node set in the CLI configuration file or wallet configuration.
+The client fetches slivers directly from storage nodes and reconstructs the blob locally, so reads
+do not depend on an aggregator or its caches.
+
+By default, the client writes the blob data to the standard output. Use the `--out <OUT>` CLI
+option to specify an output file name:
+
+```sh
+$ walrus read <BLOB_ID> --out <FILE>
+```
+
+Use `--rpc-url <URL>` to specify a Sui RPC node instead of the currently configured RPC node set in
+the CLI configuration file or wallet configuration.
+
+With the `--json` flag, or in [JSON mode](/docs/walrus-client/json-mode), the `read` command prints
+a JSON object containing the blob ID and, when no output file is set, the blob content as a
+Base64-encoded string.
+
+To read individual blobs stored inside a quilt, use the `read-quilt` command instead. See
+[quilts](/docs/walrus-client/quilts#read-blobs-from-a-quilt) for details.
 
 ## Check consistency
 
-Walrus performs integrity and consistency checks to ensure that any data read from Walrus is what the writer intended, and that the writer encoded the blob correctly. See the [data consistency](/docs/system-overview/red-stuff) documentation for further details.
+Walrus performs integrity and consistency checks to ensure that any data read from Walrus is what
+the writer intended, and that the writer encoded the blob correctly. See the
+[data consistency](/docs/system-overview/red-stuff) documentation for further details.
 
-Prior to `v1.37`, the Walrus CLI and aggregator always performed the [strict consistency check](/docs/system-overview/red-stuff). Starting with `v1.37`, the default is a [more performant consistency check](/docs/system-overview/red-stuff), which is sufficient for most cases. You can enable the strict consistency check through the `--strict-consistency-check` flag.
+Prior to `v1.37`, the Walrus CLI and aggregator always performed the
+[strict consistency check](/docs/system-overview/red-stuff). Starting with `v1.37`, the default is
+a [more performant consistency check](/docs/system-overview/red-stuff), which is sufficient for
+most cases. You can enable the strict consistency check through the `--strict-consistency-check`
+flag:
 
-You can disable consistency checks completely with the `--skip-consistency-check` flag. Only use this if the writer of the blob is known and trusted.
+```sh
+$ walrus read <BLOB_ID> --out <FILE> --strict-consistency-check
+```
+
+You can disable consistency checks completely with the `--skip-consistency-check` flag. Only use
+this if the writer of the blob is known and trusted. Skipping the consistency check does not affect
+the authentication checks for data received from storage nodes, which the client always performs.
+The two flags conflict, so pass at most one of them.
+
+When reading through an aggregator instead of the CLI, the equivalent query parameters are
+`strict_consistency_check=true` and `skip_consistency_check=true`. See
+[consistency checks over HTTP](/docs/http-api/reading-blobs#consistency-checks).

--- a/docs/site/sidebars.js
+++ b/docs/site/sidebars.js
@@ -61,6 +61,7 @@ const sidebars = {
       link: { type: "doc", id: "examples/index" },
       items: [
         "examples/checkpoint-data",
+        "examples/data-marketplace",
         "examples/javascript",
         "examples/move",
         "examples/python",


### PR DESCRIPTION
## Description

Reworks the 13 pages flagged by the content audit (Linear BEDU-969–974, 977, 985–988, 993, 994). Every page gets real frontmatter (description, keywords, reader-phrased questions, citable answer), a "See also" list, and expanded content verified against the repository source rather than paraphrased.

### Examples
- **data-marketplace**: was a `draft: true` stub. Now a full worked example: storing a dataset through a publisher (`epochs`, `permanent`, `send_object_to` verified against the HTTP API docs), a Move `Listing` escrow module, Seal-based gating, blob attributes for product metadata, buyer delivery, and lifetime management. The page is added to the Examples sidebar and un-drafted — see reviewer notes below.
- **javascript**: replaced the thrice-repeated intro with endpoint setup, copy-pasteable `fetch` store/read snippets, both store response shapes (`newlyCreated`/`alreadyCertified`), and framing for the two existing HTML examples.
- **move**: dependency setup with the repo's `Move.toml` verbatim, a `Blob` accessor table (all 10 accessors verified against `contracts/walrus/sources/system/blob.move`), lifecycle functions, and `SharedBlob`.
- **checkpoint-data**: build/run/query instructions verified against the `walrus-sui-archival` repository (subcommands, REST routes, config file; REST port corrected to the actual default `9185`).
- **python**: prerequisites, daemon setup, and per-example explanations verified against `docs/examples/python/`.
- **walrus-relay**: prerequisites, local run steps, key-file walkthrough, and the four-step `writeFilesFlow` verified against the `walrus-sdk-relay-example-app` repository.

### Walrus client
- **json-mode**: command structure, camelCase mapping, stdin input, output parsing (store result variants verified against `BlobStoreResult` in `crates/walrus-sdk`), and error handling.
- **reading-blobs**: status/read/consistency-check sections expanded with verified flags (`--timeout` default 1s, `--strict-consistency-check`/`--skip-consistency-check` conflict) and aggregator query-parameter equivalents.

### Other
- **reading-blobs-after-upload**: restructured into cause/when/solution, plus a section on confirming a blob via the CLI, which bypasses caches.
- **typescript-sdk/sdks**: install and `WalrusClient` setup snippets; Rust SDK claim updated to point at the actual `walrus-sdk` crate.
- **specifying-http-headers**: explains that headers live on Sui and require a redeploy to change.
- **access-control-options**: requirement→approach table, the `ignore` field, encryption for app data, and an honest "what does not restrict access" section (portal gating, obscure URLs, blob-ID secrecy).
- **public-aggregators-and-publishers**: read/store quickstart, network availability, size limits, and the machine-readable operator list.

### Reviewer notes
- `examples/data-marketplace` was previously `draft: true` and unreachable. This PR ships it and adds it to the Examples sidebar. If it should stay hidden, drop the sidebar entry and restore the draft flag.
- The Move `Listing` module on that page is new example code. It uses only verified APIs (`Blob has key, store`, `share_object`, `public_transfer`, shared-object deletion) and Move 2024 idioms, but has not been compiled against the package.
- The audit bodies for three tickets (BEDU-988, 993, 994) returned server errors, so those pages were improved from their page goals rather than specific audit findings. Asks that could not be verified against source (relay rate limits, Seal policy internals, roadmap claims) were deliberately left out.

## Test plan

- `editorconfig-checker` clean on all changed files.
- Every CLI flag, Move signature, REST route, and JSON shape cross-checked against `crates/`, `contracts/`, and the two example repositories; all internal links and anchors verified to resolve.

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
