### PR TITLE
docs: fix invisible changelog github link in dark mode

### DIFF
--- a/docs/site/src/pages/changelog.module.css
+++ b/docs/site/src/pages/changelog.module.css
@@ -402,6 +402,10 @@
   color: var(--color-walrus-midnight);
 }
 
+[data-theme="dark"] .githubLink {
+  color: var(--color-walrus-tusk);
+}
+
 .githubLink:hover {
   text-decoration: none;
 }


### PR DESCRIPTION
The "View on GitHub" link had no dark-mode color override, so it rendered in the light-mode midnight color against the black background and was effectively invisible.