### PR TITLE
ci: enforce fallback assets for interactive diagrams

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -119,6 +119,21 @@ jobs:
         # scripts/network_reference_data.yaml, and fails if the page is stale.
         run: python3 scripts/generate_network_reference.py --check
 
+  diagram-fallbacks:
+    runs-on: ubuntu-latest
+    name: Check interactive diagram fallback assets
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # pin@v7.0.1
+        with:
+          fetch-depth: 0
+      - name: Check that changed interactive diagrams ship their fallback assets
+        # Asserts that every added or modified interactive_*.html diagram has
+        # its sibling .svg and .png fallback assets in the same directory. See
+        # docs/site/README.md, "Interactive diagram fallback assets".
+        run: |
+          node docs/site/src/scripts/check-diagram-fallbacks.mjs \
+            --base "origin/${{ github.base_ref }}"
+
   check-all:
     name: Check if all lint jobs succeeded
     if: always()
@@ -129,6 +144,7 @@ jobs:
       - typos
       - license-headers
       - network-reference
+      - diagram-fallbacks
     runs-on: ubuntu-latest
     steps:
       - name: Decide whether all needed jobs succeeded

--- a/docs/site/README.md
+++ b/docs/site/README.md
@@ -39,3 +39,27 @@ GIT_USER=<Your GitHub username> yarn deploy
 ```
 
 If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
+
+## Interactive diagram fallback assets
+
+Interactive diagrams live in `static/diagrams/` and follow the interactive diagrams standard: every
+diagram ships as three artifacts in the same directory, sharing one base name.
+
+1. `interactive_<topic>_v<n>.html`: the self-contained interactive HTML.
+2. `interactive_<topic>_v<n>.svg`: the static fallback SVG source.
+3. `interactive_<topic>_v<n>.png`: the fallback PNG export.
+
+The fallback assets carry accessibility: they are what a screen reader, a print export, and a
+reduced-motion reader depend on, so they are required, not optional.
+
+CI enforces this. The `Check interactive diagram fallback assets` job in
+`.github/workflows/lint.yml` runs `src/scripts/check-diagram-fallbacks.mjs` against the files a PR
+adds or changes, and fails when an `interactive_*.html` file lacks its sibling `.svg` and `.png`.
+Diagrams that predate the standard only start failing once a PR touches them; when you modify one,
+add its fallback assets in the same PR.
+
+To audit every diagram in the repository locally, run:
+
+```bash
+node src/scripts/check-diagram-fallbacks.mjs --all
+```

--- a/docs/site/src/scripts/check-diagram-fallbacks.mjs
+++ b/docs/site/src/scripts/check-diagram-fallbacks.mjs
@@ -1,0 +1,115 @@
+// Copyright (c) Walrus Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * CI gate for interactive diagram fallback assets.
+ *
+ * The interactive diagrams standard requires that every interactive diagram
+ * ships as three artifacts in the same directory:
+ *
+ *   1. interactive_<topic>_v<n>.html  - the self-contained interactive HTML
+ *   2. interactive_<topic>_v<n>.svg   - the static fallback SVG source
+ *   3. interactive_<topic>_v<n>.png   - the fallback PNG export
+ *
+ * The fallback carries accessibility: it is what a screen reader, a print
+ * export, and a reduced-motion reader depend on. This script fails when an
+ * interactive diagram HTML file is added or modified without its complete
+ * fallback set.
+ *
+ * The check is diff-scoped so that pre-existing diagrams without fallbacks
+ * only start failing once a PR touches them.
+ *
+ * Usage:
+ *   node check-diagram-fallbacks.mjs --base <git-ref>   # check files changed since <git-ref>
+ *   node check-diagram-fallbacks.mjs [file...]          # check the given files
+ *   node check-diagram-fallbacks.mjs --all              # audit every diagram in the repo
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+const DIAGRAM_PATTERN = /(^|\/)interactive_[^/]+\.html?$/;
+// Build caches contain copies of the diagram files; they are not sources.
+const EXCLUDED_PATH_FRAGMENTS = ["/.cache-walrus-memory/", "/node_modules/", "/build/"];
+const STANDARD_REFERENCE =
+    "See the interactive diagrams standard (docs/site/README.md, " +
+    "\"Interactive diagram fallback assets\").";
+
+function gitLines(args) {
+    return execFileSync("git", args, { encoding: "utf8" })
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean);
+}
+
+function isExcluded(file) {
+    const normalized = `/${file}`;
+    return EXCLUDED_PATH_FRAGMENTS.some((fragment) => normalized.includes(fragment));
+}
+
+function collectTargets(argv) {
+    if (argv.includes("--all")) {
+        return gitLines(["ls-files", "*.html"]).filter(
+            (file) => DIAGRAM_PATTERN.test(file) && !isExcluded(file),
+        );
+    }
+
+    const baseIndex = argv.indexOf("--base");
+    if (baseIndex !== -1) {
+        const base = argv[baseIndex + 1];
+        if (!base) {
+            console.error("--base requires a git ref argument.");
+            process.exit(2);
+        }
+        // Added and modified files only: deleting a diagram must not fail the
+        // check, and renames surface as an addition of the new path.
+        return gitLines([
+            "diff",
+            "--name-only",
+            "--diff-filter=AMR",
+            `${base}...HEAD`,
+        ]).filter((file) => DIAGRAM_PATTERN.test(file) && !isExcluded(file));
+    }
+
+    return argv.filter((file) => DIAGRAM_PATTERN.test(file) && !isExcluded(file));
+}
+
+const targets = collectTargets(process.argv.slice(2));
+
+if (targets.length === 0) {
+    console.log("No added or modified interactive diagram files to check.");
+    process.exit(0);
+}
+
+const failures = [];
+
+for (const file of targets) {
+    const dir = path.dirname(file);
+    const stem = path.basename(file).replace(/\.html?$/, "");
+    const missing = [".svg", ".png"]
+        .map((ext) => path.join(dir, `${stem}${ext}`))
+        .filter((sibling) => !existsSync(sibling));
+    if (missing.length > 0) {
+        failures.push({ file, missing });
+    }
+}
+
+if (failures.length === 0) {
+    console.log(`Checked ${targets.length} interactive diagram file(s); all fallback assets present.`);
+    process.exit(0);
+}
+
+console.error("Interactive diagrams are missing fallback assets:\n");
+for (const { file, missing } of failures) {
+    console.error(`  ${file}`);
+    for (const sibling of missing) {
+        console.error(`    missing: ${sibling}`);
+    }
+}
+console.error(
+    "\nEvery interactive diagram must ship its static fallback SVG source and " +
+        "PNG export next to the HTML file. " +
+        STANDARD_REFERENCE,
+);
+process.exit(1);


### PR DESCRIPTION
## Description

Turns the interactive diagrams standard's fallback requirement into an enforced CI gate (Linear BEDU-858). The standard requires every interactive diagram to ship three artifacts in the same directory — the self-contained `interactive_<topic>_v<n>.html`, the static fallback `.svg` source, and the fallback `.png` export — because the fallbacks are what a screen reader, a print export, and a reduced-motion reader depend on. Until now nothing enforced it, and none of the 11 shipped diagrams have fallbacks.

- **`docs/site/src/scripts/check-diagram-fallbacks.mjs`**: fails when an added or modified `interactive_*.html` under version control lacks its sibling `.svg` and `.png`. Three modes: `--base <ref>` (diff-scoped, used in CI), explicit file arguments, and `--all` (full-repo audit for local use). Build caches (`.cache-walrus-memory`, `node_modules`, `build`) are excluded, and deletions do not fail the check.
- **`.github/workflows/lint.yml`**: new `Check interactive diagram fallback assets` job running the script against `origin/<base branch>`, added to the `check-all` gate.
- **`docs/site/README.md`**: documents the three-artifact rule, the CI job, and the local audit command, so the standard and the gate point at each other.

Deliberately diff-scoped: the 11 pre-existing diagrams without fallbacks only start failing once a PR touches them, so this lands green and ratchets forward. Backfilling the legacy fallbacks can happen incrementally (run `node src/scripts/check-diagram-fallbacks.mjs --all` from `docs/site/` for the worklist).

Decisions on the ticket's open questions: the check asserts file presence only (a `title`/`desc` check inside the HTML is left to review); it folds into the existing lint workflow rather than a standalone one; and it is Walrus-only for now since all interactive diagrams live in this repo.

## Test plan

Verified locally:

- Committed a synthetic `interactive_test-check_v1.html` without siblings → check fails naming both missing files; added the `.svg` and `.png` → check passes.
- `--base origin/main` on this branch (no diagram changes) → passes with "No added or modified interactive diagram files to check."
- `--all` → reports all 11 legacy diagrams, exit 1 (audit mode is for local use, not CI).
- Deleted-file case covered by `--diff-filter=AMR`.
- Workflow YAML validated; `editorconfig-checker` clean on all three files.

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
