### PR TITLE
feat: derive client config from wallet network and print aggregator download URLs

### DIFF
--- a/crates/walrus-sdk/src/config.rs
+++ b/crates/walrus-sdk/src/config.rs
@@ -101,6 +101,25 @@ pub fn load_configuration(
     Ok(config)
 }
 
+/// Returns the embedded default client configuration for the Sui network of the given RPC URL.
+///
+/// Detects Sui Testnet if the URL contains `testnet.sui.io` and Sui Mainnet if it contains
+/// `mainnet.sui.io`. Returns the parsed configuration together with the network name, or `None`
+/// if the network cannot be determined from the URL.
+pub fn default_configuration_for_rpc_url(rpc_url: &str) -> Option<(ClientConfig, &'static str)> {
+    let (network, yaml) = if rpc_url.contains("testnet.sui.io") {
+        ("testnet", TESTNET_CLIENT_CONFIG_YAML)
+    } else if rpc_url.contains("mainnet.sui.io") {
+        ("mainnet", MAINNET_CLIENT_CONFIG_YAML)
+    } else {
+        return None;
+    };
+    let mut config: ClientConfig =
+        load_from_yaml_str(network, yaml, "embedded default client config")?;
+    config.apply_upload_mode_preset();
+    Some((config, network))
+}
+
 /// Config for the client.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct ClientConfig {
@@ -553,6 +572,37 @@ mod tests {
     ) -> TestResult {
         let (_config, context) = ClientConfig::load_from_multi_config(path, input_context)?;
         assert_eq!(context.as_deref(), expected_context);
+        Ok(())
+    }
+
+    param_test! {
+        check_default_configuration_for_rpc_url -> TestResult: [
+            testnet: ("https://fullnode.testnet.sui.io:443", Some("testnet")),
+            mainnet: ("https://fullnode.mainnet.sui.io:443", Some("mainnet")),
+            localnet: ("http://127.0.0.1:9000", None),
+            devnet: ("https://fullnode.devnet.sui.io:443", None),
+        ]
+    }
+    /// This test ensures that the embedded default configurations can be derived from known Sui
+    /// RPC URLs.
+    fn check_default_configuration_for_rpc_url(
+        rpc_url: &str,
+        expected_network: Option<&str>,
+    ) -> TestResult {
+        let derived = default_configuration_for_rpc_url(rpc_url);
+        assert_eq!(
+            derived.as_ref().map(|(_, network)| *network),
+            expected_network
+        );
+        if let Some((config, network)) = derived {
+            let expected_yaml = match network {
+                "testnet" => TESTNET_CLIENT_CONFIG_YAML,
+                "mainnet" => MAINNET_CLIENT_CONFIG_YAML,
+                other => panic!("unexpected network: {other}"),
+            };
+            let expected: ClientConfig = serde_yaml::from_str(expected_yaml)?;
+            assert_eq!(config.contract_config, expected.contract_config);
+        }
         Ok(())
     }
 

--- a/crates/walrus-service/src/client/cli/args.rs
+++ b/crates/walrus-service/src/client/cli/args.rs
@@ -55,6 +55,10 @@ pub struct App {
     /// 2. If the environment variable `XDG_CONFIG_HOME` is set, in `$XDG_CONFIG_HOME/walrus/`.
     /// 3. In `~/.config/walrus/`.
     /// 4. In `~/.walrus/`.
+    ///
+    /// If no configuration file is found in any of these locations and no context is specified,
+    /// but the Sui wallet points to a known network (`testnet.sui.io` or `mainnet.sui.io`), the
+    /// built-in default configuration for that network is used.
     // NB: Keep this in sync with `crate::cli`.
     #[arg(long, verbatim_doc_comment, global = true)]
     #[serde(

--- a/crates/walrus-service/src/client/cli/cli_output.rs
+++ b/crates/walrus-service/src/client/cli/cli_output.rs
@@ -24,7 +24,7 @@ use walrus_sdk::{
     node_client::{
         client_types::{self, StoredQuiltPatch},
         resource::RegisterBlobOp,
-        responses::{BlobStoreResult, BlobStoreResultWithPath, QuiltStoreResult},
+        responses::{BlobStoreResult, BlobStoreResultWithPath, EventOrObjectId, QuiltStoreResult},
     },
 };
 use walrus_storage_node_client::api::{BlobStatus, DeletableCounts, EventProgress};
@@ -336,6 +336,101 @@ impl CliOutput for StoreQuiltDryRunOutput {
             self.quilt_blob_output.blob_id,
         ))
         .printstd();
+    }
+}
+
+/// Prints download URLs, through the given public aggregator, for the successfully stored blobs.
+pub(crate) fn print_download_urls_for_blobs(
+    results: &[BlobStoreResultWithPath],
+    aggregator_url: &str,
+) {
+    print_download_url_entries(&blob_download_url_entries(results, aggregator_url));
+}
+
+/// Prints download URLs, through the given public aggregator, for the files stored in the quilt.
+pub(crate) fn print_download_urls_for_quilt(result: &QuiltStoreResult, aggregator_url: &str) {
+    print_download_url_entries(&quilt_download_url_entries(result, aggregator_url));
+}
+
+/// Returns `(name, download URL)` pairs, through the given public aggregator, for the
+/// successfully stored blobs.
+pub(crate) fn blob_download_url_entries(
+    results: &[BlobStoreResultWithPath],
+    aggregator_url: &str,
+) -> Vec<(String, String)> {
+    results
+        .iter()
+        .filter_map(|result| {
+            let url_path = blob_download_url_path(&result.blob_store_result)?;
+            Some((
+                result.path.display().to_string(),
+                format!("{aggregator_url}{url_path}"),
+            ))
+        })
+        .collect()
+}
+
+/// Returns `(name, download URL)` pairs, through the given public aggregator, for the files
+/// stored in the quilt.
+pub(crate) fn quilt_download_url_entries(
+    result: &QuiltStoreResult,
+    aggregator_url: &str,
+) -> Vec<(String, String)> {
+    if blob_download_url_path(&result.blob_store_result).is_none() {
+        return Vec::new();
+    }
+    result
+        .stored_quilt_blobs
+        .iter()
+        .map(|patch| {
+            (
+                patch.identifier.clone(),
+                format!(
+                    "{aggregator_url}/v1/blobs/by-quilt-patch-id/{}",
+                    patch.quilt_patch_id
+                ),
+            )
+        })
+        .collect()
+}
+
+/// Returns the aggregator URL path for the stored blob, if it is available on Walrus.
+///
+/// Prefers the object-ID-based path, so that response headers (such as `content-disposition`)
+/// configured through blob attributes are served by the aggregator; falls back to the
+/// blob-ID-based path if no blob object is known.
+fn blob_download_url_path(result: &BlobStoreResult) -> Option<String> {
+    match result {
+        BlobStoreResult::NewlyCreated { blob_object, .. } => {
+            Some(format!("/v1/blobs/by-object-id/{}", blob_object.id))
+        }
+        BlobStoreResult::AlreadyCertified {
+            blob_id,
+            event_or_object,
+            ..
+        } => match event_or_object {
+            EventOrObjectId::Object(object_id) => {
+                Some(format!("/v1/blobs/by-object-id/{object_id}"))
+            }
+            EventOrObjectId::Event(_) => Some(format!("/v1/blobs/{blob_id}")),
+        },
+        BlobStoreResult::MarkedInvalid { .. } | BlobStoreResult::Error { .. } => None,
+    }
+}
+
+/// Prints the given `(name, download URL)` pairs, if any, under a common header.
+pub(crate) fn print_download_url_entries(entries: &[(String, String)]) {
+    if entries.is_empty() {
+        return;
+    }
+    println!(
+        "{}",
+        "Download the stored files via the public aggregator:"
+            .bold()
+            .walrus_purple()
+    );
+    for (name, url) in entries {
+        println!("  {name}: {url}");
     }
 }
 

--- a/crates/walrus-service/src/client/cli/cli_output.rs
+++ b/crates/walrus-service/src/client/cli/cli_output.rs
@@ -401,8 +401,15 @@ pub(crate) fn quilt_download_url_entries(
 /// blob-ID-based path if no blob object is known.
 fn blob_download_url_path(result: &BlobStoreResult) -> Option<String> {
     match result {
-        BlobStoreResult::NewlyCreated { blob_object, .. } => {
-            Some(format!("/v1/blobs/by-object-id/{}", blob_object.id))
+        BlobStoreResult::NewlyCreated {
+            blob_object,
+            shared_blob_object,
+            ..
+        } => {
+            // After sharing, the blob object is wrapped in the shared blob object and is no
+            // longer accessible by its own ID.
+            let object_id = shared_blob_object.unwrap_or(blob_object.id);
+            Some(format!("/v1/blobs/by-object-id/{object_id}"))
         }
         BlobStoreResult::AlreadyCertified {
             blob_id,

--- a/crates/walrus-service/src/client/cli/internal_run.rs
+++ b/crates/walrus-service/src/client/cli/internal_run.rs
@@ -35,6 +35,7 @@ use walrus_sdk::{
     utils::{styled_progress_bar_with_disabled_steady_tick, styled_spinner},
 };
 
+use super::cli_output::print_download_url_entries;
 use crate::client::cli::{
     HumanReadableBytes,
     HumanReadableFrost,
@@ -121,6 +122,9 @@ pub(crate) enum ChildUploaderEvent {
         blob_id: String,
         end_epoch: u64,
         event_or_object: String,
+    },
+    DownloadUrls {
+        entries: Vec<(String, String)>,
     },
     Done {
         #[allow(dead_code)]
@@ -263,6 +267,7 @@ where
     let mut lines = reader.lines();
     let mut certified_count = 0;
     let mut command_output: Option<serde_json::Value> = None;
+    let mut download_urls: Vec<(String, String)> = Vec::new();
     let multi = MultiProgress::new();
     let mut per_blob_bars: HashMap<String, ProgressBar> = HashMap::new();
     let mut encoding_spinner: Option<ProgressBar> = None;
@@ -419,6 +424,9 @@ where
                         event_or_object,
                     );
                 }
+                ChildUploaderEvent::DownloadUrls { entries } => {
+                    download_urls = entries;
+                }
                 ChildUploaderEvent::Done {
                     ok,
                     error,
@@ -457,6 +465,8 @@ where
                                 "No blobs were modified or created".bold().walrus_purple()
                             );
                         }
+
+                        print_download_url_entries(&download_urls);
                     }
 
                     return command_output;
@@ -1011,6 +1021,22 @@ mod tests {
         assert_eq!(observed_blob, &BlobId::from_str(blob_id)?);
         assert_eq!(*extra_ms, 10);
 
+        Ok(())
+    }
+
+    #[test]
+    fn download_urls_event_round_trips() -> Result<()> {
+        let event = ChildUploaderEvent::DownloadUrls {
+            entries: vec![(
+                "file.bin".to_string(),
+                "https://aggregator.example/v1/blobs/by-object-id/0x123".to_string(),
+            )],
+        };
+        let json = serde_json::to_string(&event)?;
+        let parsed: ChildUploaderEvent = serde_json::from_str(&json)?;
+        assert!(
+            matches!(parsed, ChildUploaderEvent::DownloadUrls { entries } if entries.len() == 1)
+        );
         Ok(())
     }
 

--- a/crates/walrus-service/src/client/cli/runner.rs
+++ b/crates/walrus-service/src/client/cli/runner.rs
@@ -42,7 +42,7 @@ use walrus_core::{
 };
 use walrus_sdk::{
     SuiReadClient,
-    config::load_configuration,
+    config::{default_configuration_for_rpc_url, load_configuration},
     error::ClientErrorKind,
     node_client::{
         NodeCommunicationFactory,
@@ -81,7 +81,7 @@ use walrus_sdk::{
 };
 use walrus_storage_node_client::api::BlobStatus;
 use walrus_sui::{client::rpc_client, wallet::Wallet};
-use walrus_utils::{load_from_yaml_str, metrics::Registry, read_blob_from_file};
+use walrus_utils::{is_internal_run, load_from_yaml_str, metrics::Registry, read_blob_from_file};
 
 use super::{
     args::{
@@ -104,6 +104,12 @@ use super::{
         UserConfirmation,
     },
     backfill::{pull_archive_blobs, run_blob_backfill},
+    cli_output::{
+        blob_download_url_entries,
+        print_download_urls_for_blobs,
+        print_download_urls_for_quilt,
+        quilt_download_url_entries,
+    },
 };
 use crate::{
     client::{
@@ -221,6 +227,25 @@ fn default_child_process_uploads(config: &ClientConfig) -> bool {
     known.testnet.as_ref() == Some(&config_ids)
 }
 
+const MAINNET_PUBLIC_AGGREGATOR_URL: &str = "https://aggregator.walrus-mainnet.walrus.space";
+const TESTNET_PUBLIC_AGGREGATOR_URL: &str = "https://aggregator.walrus-testnet.walrus.space";
+
+/// Returns the public aggregator URL if the config corresponds to a known network.
+fn public_aggregator_url(config: &ClientConfig) -> Option<&'static str> {
+    let config_ids = ContractIds {
+        system_object: config.contract_config.system_object,
+        staking_object: config.contract_config.staking_object,
+    };
+    let known = known_network_ids();
+    if known.mainnet.as_ref() == Some(&config_ids) {
+        return Some(MAINNET_PUBLIC_AGGREGATOR_URL);
+    }
+    if known.testnet.as_ref() == Some(&config_ids) {
+        return Some(TESTNET_PUBLIC_AGGREGATOR_URL);
+    }
+    None
+}
+
 /// A helper struct to run commands for the Walrus client.
 #[allow(missing_debug_implementations)]
 pub struct ClientCommandRunner {
@@ -243,7 +268,7 @@ impl ClientCommandRunner {
         gas_budget: Option<u64>,
         json: bool,
     ) -> Self {
-        let config = load_configuration(config_path.as_ref(), context);
+        let mut config = load_configuration(config_path.as_ref(), context);
         let wallet_config = wallet_override
             .as_ref()
             .map(WalletConfig::from_path)
@@ -258,6 +283,25 @@ impl ClientCommandRunner {
                 .ok()
                 .and_then(|config| config.communication_config.sui_client_request_timeout),
         );
+
+        // If no configuration file was found and none was specified explicitly, fall back to the
+        // built-in configuration for the network (Mainnet or Testnet) the wallet's RPC URL
+        // points to.
+        if config.is_err()
+            && config_path.is_none()
+            && context.is_none()
+            && let Ok(wallet) = &wallet
+            && let Some((derived_config, network)) =
+                default_configuration_for_rpc_url(wallet.get_rpc_url())
+        {
+            if !is_internal_run() {
+                tracing::info!(
+                    "no Walrus configuration file found; using the built-in {network} \
+                    configuration derived from the wallet's RPC URL"
+                );
+            }
+            config = Ok(derived_config);
+        }
 
         Self {
             wallet,
@@ -1057,6 +1101,16 @@ impl ClientCommandRunner {
                 }
             }
 
+            if let Some(aggregator_url) = public_aggregator_url(&config) {
+                let entries = blob_download_url_entries(&results, aggregator_url);
+                if !entries.is_empty()
+                    && let Err(err) =
+                        emit_child_event(&ChildUploaderEvent::DownloadUrls { entries })
+                {
+                    tracing::warn!(%err, "failed to emit download urls");
+                }
+            }
+
             if let Err(err) = emit_child_event(&ChildUploaderEvent::Done {
                 ok: true,
                 error: None,
@@ -1077,7 +1131,14 @@ impl ClientCommandRunner {
             );
         }
 
-        results.print_output(self.json)
+        results.print_output(self.json)?;
+        if !self.json
+            && !internal_run
+            && let Some(aggregator_url) = public_aggregator_url(&config)
+        {
+            print_download_urls_for_blobs(&results, aggregator_url);
+        }
+        Ok(())
     }
 
     #[tracing::instrument(skip_all)]
@@ -1411,6 +1472,16 @@ impl ClientCommandRunner {
                     _ => (0, 0, 0, 0),
                 };
 
+            if let Some(aggregator_url) = public_aggregator_url(&config) {
+                let entries = quilt_download_url_entries(&result, aggregator_url);
+                if !entries.is_empty()
+                    && let Err(err) =
+                        emit_child_event(&ChildUploaderEvent::DownloadUrls { entries })
+                {
+                    tracing::warn!(%err, "failed to emit download urls");
+                }
+            }
+
             if let Err(err) = emit_child_event(&ChildUploaderEvent::Done {
                 ok: true,
                 error: None,
@@ -1425,7 +1496,14 @@ impl ClientCommandRunner {
             internal_run_ctx.await_tail_handles().await;
         }
 
-        result.print_output(self.json)
+        result.print_output(self.json)?;
+        if !self.json
+            && !internal_run
+            && let Some(aggregator_url) = public_aggregator_url(&config)
+        {
+            print_download_urls_for_quilt(&result, aggregator_url);
+        }
+        Ok(())
     }
 
     fn load_blobs_for_quilt(

--- a/crates/walrus-service/src/client/cli/runner.rs
+++ b/crates/walrus-service/src/client/cli/runner.rs
@@ -42,7 +42,7 @@ use walrus_core::{
 };
 use walrus_sdk::{
     SuiReadClient,
-    config::{default_configuration_for_rpc_url, load_configuration},
+    config::{default_configuration_for_rpc_url, default_configuration_paths, load_configuration},
     error::ClientErrorKind,
     node_client::{
         NodeCommunicationFactory,
@@ -284,12 +284,16 @@ impl ClientCommandRunner {
                 .and_then(|config| config.communication_config.sui_client_request_timeout),
         );
 
-        // If no configuration file was found and none was specified explicitly, fall back to the
-        // built-in configuration for the network (Mainnet or Testnet) the wallet's RPC URL
-        // points to.
+        // If no configuration file exists in the default locations and none was specified
+        // explicitly, fall back to the built-in configuration for the network (Mainnet or
+        // Testnet) the wallet's RPC URL points to. Errors from an existing configuration file
+        // (for example, a malformed file) are preserved.
         if config.is_err()
             && config_path.is_none()
             && context.is_none()
+            && !default_configuration_paths()
+                .iter()
+                .any(|path| path.exists())
             && let Ok(wallet) = &wallet
             && let Some((derived_config, network)) =
                 default_configuration_for_rpc_url(wallet.get_rpc_url())


### PR DESCRIPTION
## Description

Two CLI usability improvements:

### Derive the client config from the wallet's network

If no client config file is found (no `--config`, no `client_config.yaml` in the default locations) and no `--context` is given, the CLI now derives the configuration from the Sui wallet's RPC URL:

- URL contains `testnet.sui.io` → built-in `setup/client_config_testnet.yaml`
- URL contains `mainnet.sui.io` → built-in `setup/client_config_mainnet.yaml`

This means the `walrus` binary works with only a Sui wallet, no config file needed. An explicit `--config` or a discovered config file always takes precedence, and unknown networks (localnet, devnet) keep the existing "could not find a valid Walrus configuration file" error.

### Print public-aggregator download URLs after store / store-quilt

After a successful `store` or `store-quilt`, the CLI prints download URLs through the well-known public aggregator of the network (detected by matching the config's system/staking object IDs, same mechanism as `default_child_process_uploads`):

- `store`: `<aggregator>/v1/blobs/by-object-id/<object_id>` per file (falls back to the blob-ID URL when only a certification event is known). The object-ID route lets response headers configured through blob attributes (such as `content-disposition`) take effect.
- `store-quilt`: `<aggregator>/v1/blobs/by-quilt-patch-id/<patch_id>` per file.

URLs are printed in human-readable mode only (JSON output schema is unchanged). In the child-process upload flow (testnet default), the child emits the URLs through a new `ChildUploaderEvent::DownloadUrls` event and the parent prints them after the summary, so both the single-process and child-process paths behave the same. Nothing is printed for unknown networks (such as a local testbed) that have no public aggregator.

## Test plan

- New param tests `check_default_configuration_for_rpc_url` (testnet/mainnet/localnet/devnet) in `walrus-sdk`.
- New serde round-trip test for the `DownloadUrls` child event.
- `cargo nextest run` (full suite), `cargo clippy --all-features --tests -D warnings`, and `cargo fmt` all pass.