### PR TITLE
docs: explain the Sui gRPC transport and JSON-RPC deprecation

### DIFF
--- a/docs/content/getting-started/index.mdx
+++ b/docs/content/getting-started/index.mdx
@@ -140,6 +140,8 @@ $ curl --create-dirs https://docs.wal.app/setup/client_config.yaml -o ~/.config/
 
 This pre-filled file includes both the Mainnet and Testnet contexts. For the canonical endpoints, RPC URLs, object IDs, and configuration snippets, see the [Network Reference](/docs/network-reference).
 
+The client reaches the full node over gRPC at the same URL this file already lists, so Sui's JSON-RPC deprecation needs no change on your side. If an older installation fails against a full node that stopped serving JSON-RPC, upgrade Walrus. See [Transport: gRPC and the Sui JSON-RPC deprecation](/docs/network-reference#transport-grpc-and-the-sui-json-rpc-deprecation).
+
 Configure the Sui client to connect to Testnet.
 
 The Sui client configuration is separate from the Walrus client configuration. [Learn more about the Sui client configuration.](https://docs.sui.io/guides/developer/getting-started/configure-sui-client)

--- a/docs/content/getting-started/index.mdx
+++ b/docs/content/getting-started/index.mdx
@@ -140,7 +140,7 @@ $ curl --create-dirs https://docs.wal.app/setup/client_config.yaml -o ~/.config/
 
 This pre-filled file includes both the Mainnet and Testnet contexts. For the canonical endpoints, RPC URLs, object IDs, and configuration snippets, see the [Network Reference](/docs/network-reference).
 
-The client reaches the full node over gRPC at the same URL this file already lists, so Sui's JSON-RPC deprecation needs no change on your side. If an older installation fails against a full node that stopped serving JSON-RPC, upgrade Walrus. See [Transport: gRPC and the Sui JSON-RPC deprecation](/docs/network-reference#transport-grpc-and-the-sui-json-rpc-deprecation).
+The client reaches the full node over gRPC at the same URL this file already lists, so Sui's JSON-RPC deprecation needs no change on your side. If an older installation fails against a full node that stopped serving JSON-RPC, upgrade Walrus. See [Transport: JSON-RPC deprecation](/docs/network-reference#transport-json-rpc-deprecation).
 
 Configure the Sui client to connect to Testnet.
 

--- a/docs/content/network-reference.mdx
+++ b/docs/content/network-reference.mdx
@@ -87,13 +87,13 @@ The Walrus client and SDKs read Walrus state from a Sui full node. The default R
 | Testnet | `https://fullnode.testnet.sui.io:443` |
 {/* GENERATED:END id=rpc-endpoints */}
 
-### Transport: gRPC and the Sui JSON-RPC deprecation
+### Transport: JSON-RPC deprecation
 
-Sui is deprecating JSON-RPC in favor of gRPC. Current Walrus clients already read and write Sui state over gRPC, and they reach it at the same full node URL the table above lists. Three consequences follow:
+Sui has deprecated JSON-RPC. Current Walrus clients already read and write Sui state over gRPC, and they reach it at the same full node URL the table above lists. Three consequences follow:
 
 1. **No configuration change.** One URL per network serves both protocols, so `rpc_urls` in the Walrus client configuration and `rpc_url` in the Walrus Sites configuration keep the values above. Walrus has no separate gRPC endpoint setting.
 2. **Upgrade rather than reconfigure.** If a deployment fails against a full node that stopped serving JSON-RPC, upgrade to a current Walrus release, which no longer builds a JSON-RPC client at all. See [Getting Started](/docs/getting-started).
-3. **Custom full nodes must serve gRPC.** The public endpoints above do. A self-hosted full node needs the gRPC API enabled.
+3. **Custom full nodes must serve gRPC.** The public endpoints above do. A self-hosted full node must enable the gRPC API.
 
 :::caution
 

--- a/docs/content/network-reference.mdx
+++ b/docs/content/network-reference.mdx
@@ -87,6 +87,20 @@ The Walrus client and SDKs read Walrus state from a Sui full node. The default R
 | Testnet | `https://fullnode.testnet.sui.io:443` |
 {/* GENERATED:END id=rpc-endpoints */}
 
+### Transport: gRPC and the Sui JSON-RPC deprecation
+
+Sui is deprecating JSON-RPC in favor of gRPC. Current Walrus clients already read and write Sui state over gRPC, and they reach it at the same full node URL the table above lists. Three consequences follow:
+
+1. **No configuration change.** One URL per network serves both protocols, so `rpc_urls` in the Walrus client configuration and `rpc_url` in the Walrus Sites configuration keep the values above. Walrus has no separate gRPC endpoint setting.
+2. **Upgrade rather than reconfigure.** If a deployment fails against a full node that stopped serving JSON-RPC, upgrade to a current Walrus release, which no longer builds a JSON-RPC client at all. See [Getting Started](/docs/getting-started).
+3. **Custom full nodes must serve gRPC.** The public endpoints above do. A self-hosted full node needs the gRPC API enabled.
+
+:::caution
+
+`WALRUS_GRPC_MIGRATION_LEVEL` exists as a temporary escape hatch for debugging the migration. Setting it below the client's default forces older JSON-RPC code paths that Sui full nodes are removing, so do not set it in production.
+
+:::
+
 ## Package IDs
 
 The Walrus client and the TypeScript SDK infer package IDs automatically from the system and staking objects, so you do not need to set them manually in most configurations. The values below are provided for contract exploration and for advanced setups that pin a specific deployment.

--- a/docs/content/sites/getting-started/using-the-site-builder.mdx
+++ b/docs/content/sites/getting-started/using-the-site-builder.mdx
@@ -89,7 +89,7 @@ contexts:
 default_context: mainnet
 ```
 
-The optional `rpc_url` takes a Sui full node URL, and `site-builder` reaches that node over gRPC. Sui's JSON-RPC deprecation therefore needs no change to this file. If an older installation fails against a full node that stopped serving JSON-RPC, upgrade the tooling. See [Transport: gRPC and the Sui JSON-RPC deprecation](/docs/network-reference#transport-grpc-and-the-sui-json-rpc-deprecation).
+The optional `rpc_url` takes a Sui full node URL, and `site-builder` reaches that node over gRPC. Sui's JSON-RPC deprecation therefore needs no change to this file. If an older installation fails against a full node that stopped serving JSON-RPC, upgrade the tooling. See [Transport: JSON-RPC deprecation](/docs/network-reference#transport-json-rpc-deprecation).
 
 ## `site-builder` CLI commands
 

--- a/docs/content/sites/getting-started/using-the-site-builder.mdx
+++ b/docs/content/sites/getting-started/using-the-site-builder.mdx
@@ -89,6 +89,8 @@ contexts:
 default_context: mainnet
 ```
 
+The optional `rpc_url` takes a Sui full node URL, and `site-builder` reaches that node over gRPC. Sui's JSON-RPC deprecation therefore needs no change to this file. If an older installation fails against a full node that stopped serving JSON-RPC, upgrade the tooling. See [Transport: gRPC and the Sui JSON-RPC deprecation](/docs/network-reference#transport-grpc-and-the-sui-json-rpc-deprecation).
+
 ## `site-builder` CLI commands
 
 :::info


### PR DESCRIPTION
## Description

Addresses BEDU-1019, which reported that Sui's JSON-RPC deprecation is breaking deployments for users following the current docs.

**A note on the ticket's premise.** The ticket asks for "gRPC-first configuration examples" in the getting-started guides. There are none to write: the Walrus client reaches the Sui full node over gRPC at **the same URL** already in the configuration, and there is no separate gRPC endpoint setting. Writing gRPC config examples would document a setting that does not exist. This PR instead documents what is actually true and actually unblocks the reported failures.

What the code says (see Sources):

- `DualClient::new` passes one `rpc_url` to both the JSON-RPC and gRPC clients, so a single URL serves both protocols.
- `GrpcMigrationLevel` defaults to `100`, far above `GRPC_MIGRATION_LEVEL_SKIP_JSON_RPC_CLIENT` (`11`), the level at which the client stops constructing a JSON-RPC client at all. Current clients are therefore already fully gRPC, "allowing running against Sui endpoints that no longer serve JSON-RPC" (source comment).
- The only knob is the `WALRUS_GRPC_MIGRATION_LEVEL` environment variable, a debugging escape hatch that *re-enables* the deprecated paths.

So the real remedy for a broken deployment is to **upgrade**, not reconfigure. The docs never said so.

### Changes

- **`network-reference.mdx`**: new "Transport: gRPC and the Sui JSON-RPC deprecation" section under the RPC endpoints table, covering the three consequences (no configuration change; upgrade rather than reconfigure; custom full nodes must serve gRPC) and warning against setting `WALRUS_GRPC_MIGRATION_LEVEL` in production.
- **`getting-started/index.mdx`**: a line at the client-configuration step pointing at that section.
- **`sites/getting-started/using-the-site-builder.mdx`**: the same for the `rpc_url` field in the `site-builder` configuration file, the second path the ticket names.

### Sources

| Claim | Source |
| --- | --- |
| One URL serves both protocols; no separate gRPC endpoint | `crates/walrus-sui/src/client/dual_client.rs` (`GrpcClient::new(rpc_url)` alongside the JSON-RPC client) |
| Current clients skip the JSON-RPC client entirely | `crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs` (`GRPC_MIGRATION_LEVEL_DEFAULT_U32 = 100` vs `GRPC_MIGRATION_LEVEL_SKIP_JSON_RPC_CLIENT = 11`, and `requires_json_rpc_client`) |
| `WALRUS_GRPC_MIGRATION_LEVEL` is the only knob | `impl Default for GrpcMigrationLevel` in the same file |
| Config field names `rpc_urls` / `rpc_url` | `crates/walrus-sdk/src/config.rs`; `docs/content/sites/getting-started/using-the-site-builder.mdx` |
| Public endpoint values | Existing generated table in `network-reference.mdx` |

Prose written fresh for this PR; no examples copied from elsewhere.

## Test plan

- `editorconfig-checker` clean on all three files; mechanical and voice style gates passed on push.
- `python3 scripts/generate_network_reference.py --check` reports the page up to date, so the new prose sits outside the generated blocks.
- Style-audit findings on these files (a "this page" preamble, stacked headings, an unbolded table header) were verified to pre-date this change and are left alone to keep the diff scoped.

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
