### PR TITLE
docs: add a gRPC and JSON-RPC migration troubleshooting page

### DIFF
--- a/docs/content/troubleshooting/grpc-migration.mdx
+++ b/docs/content/troubleshooting/grpc-migration.mdx
@@ -36,16 +36,16 @@ questions:
   - Which Walrus setting selects gRPC instead of JSON-RPC?
 answer: >-
   Sui has deprecated JSON-RPC, and current Walrus clients already read and write Sui state over
-  gRPC at the same full node URL. There is no gRPC endpoint setting to change, so a deployment
-  that fails against a full node which stopped serving JSON-RPC is fixed by upgrading to a
-  current release rather than by reconfiguring.
+  gRPC at the same full node URL. There is no gRPC endpoint setting to change, so upgrading to a
+  current release fixes a deployment that fails against a full node which stopped serving
+  JSON-RPC, and reconfiguring does not.
 ---
 
-Sui has deprecated JSON-RPC. The following sections cover the failures that deprecation causes across the Walrus CLI, the TypeScript SDK, `site-builder`, and self-hosted full nodes, with the cause and fix for each.
+Sui has deprecated JSON-RPC. For the Sui API surface itself, see the [Sui API reference](https://docs.sui.io/references/sui-api).
 
-Start here, because it answers most reports in one line: **the fix is almost always an upgrade, not a configuration change.** Current Walrus clients already reach Sui over gRPC, and they do it at the same full node URL your configuration already lists. Walrus has no separate gRPC endpoint setting to point somewhere new.
+**The fix is almost always an upgrade, not a configuration change.** Current Walrus clients already reach Sui over gRPC at the same full node URL the configuration already lists, and Walrus has no separate gRPC endpoint setting.
 
-For the canonical explanation of the transport and what it means for configuration, see [Transport: JSON-RPC deprecation](/docs/network-reference#transport-json-rpc-deprecation).
+The sections below cover the failures the deprecation causes in the Walrus CLI, `site-builder`, and self-hosted full nodes, with the cause and fix for each. For the transport itself and what it means for configuration, see [Transport: JSON-RPC deprecation](/docs/network-reference#transport-json-rpc-deprecation).
 
 ## Walrus client errors
 
@@ -76,7 +76,7 @@ $ curl --create-dirs https://docs.wal.app/setup/client_config.yaml -o ~/.config/
 
 #### `rpc.discover` returns `404` against a working full node
 
-**Cause:** The public full nodes serve Sui client and SDK traffic rather than JSON-RPC method discovery. A `404` from `rpc.discover` does not mean the node is down or misconfigured, and normal client calls against the same URL succeed.
+**Cause:** The public full nodes serve Sui client and SDK traffic rather than JSON-RPC method discovery. A `404` from `rpc.discover` does not indicate a down or misconfigured node, and normal client calls against the same URL succeed.
 
 **Solution:** Ignore the discovery call and drive the node through `sui client` and the Walrus configuration file instead of calling JSON-RPC methods against it by hand.
 
@@ -114,10 +114,3 @@ For the full configuration file, see the [Site Builder Reference](/docs/sites/ge
 Do not set `WALRUS_GRPC_MIGRATION_LEVEL` in production. If you set it while debugging, unset it before you deploy.
 
 :::
-
-## See also
-
-- [Transport: JSON-RPC deprecation](/docs/network-reference#transport-json-rpc-deprecation) for the canonical explanation and the full node URLs.
-- [Getting Started](/docs/getting-started) for installing a current client.
-- [Site Builder Reference](/docs/sites/getting-started/using-the-site-builder) for the `site-builder` configuration file.
-- [Troubleshooting Common Errors](/docs/troubleshooting/network-errors) for connectivity and configuration errors unrelated to the transport.

--- a/docs/content/troubleshooting/grpc-migration.mdx
+++ b/docs/content/troubleshooting/grpc-migration.mdx
@@ -1,0 +1,123 @@
+---
+title: Fix gRPC and JSON-RPC Migration Errors
+description: 'Diagnose deployment failures caused by the Sui JSON-RPC deprecation across the Walrus CLI, the TypeScript SDK, and site-builder, with the cause and fix for each.'
+keywords:
+  - walrus
+  - grpc
+  - json-rpc
+  - deprecation
+  - migration
+  - troubleshooting
+  - site-builder
+  - full node
+goal:
+  description: Reader can identify why a Walrus deployment fails against a full node that stopped serving JSON-RPC and apply the fix for their client
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - pattern: Solution|Fix|Cause
+      min: 2
+      label: Has problem-solution pairs
+    - min_words: 300
+      label: Needs more content depth
+    - pattern: '```'
+      min: 2
+      label: Has code examples showing fixes
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+questions:
+  - How do I migrate Walrus from JSON-RPC to gRPC?
+  - Why does my Walrus deployment fail after the Sui JSON-RPC deprecation?
+  - Which Walrus setting selects gRPC instead of JSON-RPC?
+answer: >-
+  Sui has deprecated JSON-RPC, and current Walrus clients already read and write Sui state over
+  gRPC at the same full node URL. There is no gRPC endpoint setting to change, so a deployment
+  that fails against a full node which stopped serving JSON-RPC is fixed by upgrading to a
+  current release rather than by reconfiguring.
+---
+
+Sui has deprecated JSON-RPC. The following sections cover the failures that deprecation causes across the Walrus CLI, the TypeScript SDK, `site-builder`, and self-hosted full nodes, with the cause and fix for each.
+
+Start here, because it answers most reports in one line: **the fix is almost always an upgrade, not a configuration change.** Current Walrus clients already reach Sui over gRPC, and they do it at the same full node URL your configuration already lists. Walrus has no separate gRPC endpoint setting to point somewhere new.
+
+For the canonical explanation of the transport and what it means for configuration, see [Transport: JSON-RPC deprecation](/docs/network-reference#transport-json-rpc-deprecation).
+
+## Walrus client errors
+
+Errors in this section occur when a Walrus client talks to a Sui full node that no longer serves JSON-RPC.
+
+#### A `walrus` command fails against a full node that stopped serving JSON-RPC
+
+**Cause:** The installed release is old enough to still build a JSON-RPC client. Current releases do not, so they keep working against full nodes that have dropped the protocol.
+
+**Solution:** Upgrade the client. The transport moves to gRPC on its own, and your configuration file stays as it is:
+
+```sh
+$ suiup install walrus
+$ walrus --version
+```
+
+Then rerun the command that failed. If it still fails, confirm the full node you point at serves gRPC, covered in [Self-hosted full nodes](#self-hosted-full-nodes) below.
+
+#### Looking for the setting that selects gRPC
+
+**Cause:** There is no such setting. One URL per network serves both protocols, so `rpc_urls` in the Walrus client configuration keeps the same values it always had.
+
+**Solution:** Leave the configuration alone. Read the current URLs from the [Network Reference](/docs/network-reference#sui-rpc-endpoints), and use the pre-filled configuration file if you want to be sure it matches:
+
+```sh
+$ curl --create-dirs https://docs.wal.app/setup/client_config.yaml -o ~/.config/walrus/client_config.yaml
+```
+
+#### `rpc.discover` returns `404` against a working full node
+
+**Cause:** The public full nodes serve Sui client and SDK traffic rather than JSON-RPC method discovery. A `404` from `rpc.discover` does not mean the node is down or misconfigured, and normal client calls against the same URL succeed.
+
+**Solution:** Ignore the discovery call and drive the node through `sui client` and the Walrus configuration file instead of calling JSON-RPC methods against it by hand.
+
+## Site builder errors
+
+#### `site-builder` fails against a full node that stopped serving JSON-RPC
+
+**Cause:** The same one as the CLI: an older `site-builder` build still constructs a JSON-RPC client.
+
+**Solution:** Upgrade the tooling. The optional `rpc_url` field in `sites-config.yaml` takes a Sui full node URL, and `site-builder` reaches that node over gRPC, so the deprecation needs no change to the file:
+
+```yaml
+contexts:
+  mainnet:
+    general:
+        # rpc_url: https://fullnode.mainnet.sui.io:443
+```
+
+For the full configuration file, see the [Site Builder Reference](/docs/sites/getting-started/using-the-site-builder).
+
+## Self-hosted full nodes
+
+#### A custom full node rejects Walrus client traffic
+
+**Cause:** The node does not serve the gRPC API. The public endpoints in the [Network Reference](/docs/network-reference#sui-rpc-endpoints) do, but a self-hosted node has to enable it.
+
+**Solution:** Enable the gRPC API on the node, then point the client at it as before. No Walrus-side configuration changes.
+
+## Do not force the old code paths
+
+`WALRUS_GRPC_MIGRATION_LEVEL` exists as a temporary escape hatch for debugging the migration. If you set it below the client's default, the client falls back to the older JSON-RPC code paths that Sui full nodes are removing, which reintroduces the failures above.
+
+:::caution
+
+Do not set `WALRUS_GRPC_MIGRATION_LEVEL` in production. If you set it while debugging, unset it before you deploy.
+
+:::
+
+## See also
+
+- [Transport: JSON-RPC deprecation](/docs/network-reference#transport-json-rpc-deprecation) for the canonical explanation and the full node URLs.
+- [Getting Started](/docs/getting-started) for installing a current client.
+- [Site Builder Reference](/docs/sites/getting-started/using-the-site-builder) for the `site-builder` configuration file.
+- [Troubleshooting Common Errors](/docs/troubleshooting/network-errors) for connectivity and configuration errors unrelated to the transport.

--- a/docs/content/troubleshooting/grpc-migration.mdx
+++ b/docs/content/troubleshooting/grpc-migration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Fix gRPC and JSON-RPC Migration Errors
-description: 'Diagnose deployment failures caused by the Sui JSON-RPC deprecation across the Walrus CLI, the TypeScript SDK, and site-builder, with the cause and fix for each.'
+description: Diagnose deployment failures caused by the Sui JSON-RPC deprecation across the Walrus CLI, the TypeScript SDK, and site-builder, with the cause and fix for each.
 keywords:
   - walrus
   - grpc
@@ -43,7 +43,7 @@ answer: >-
 
 Sui has deprecated JSON-RPC. For the Sui API surface itself, see the [Sui API reference](https://docs.sui.io/references/sui-api).
 
-When a Walrus tool fails against a full node that has stopped serving JSON-RPC, the fix is almost always an upgrade rather than a configuration change. Current Walrus clients already reach Sui over gRPC at the same full node URL the configuration already lists, and Walrus has no separate gRPC endpoint setting to point at.
+When a Walrus tool fails against a full node that has stopped serving JSON-RPC, upgrading the client almost always fixes it, rather than changing configuration. Current Walrus clients already reach Sui over gRPC at the same full node URL the configuration already lists, and Walrus has no separate gRPC endpoint setting to point at.
 
 The deprecation causes distinct failures in the Walrus CLI, in `site-builder`, and on self-hosted full nodes, each with its own cause and fix. For the transport itself and what it means for configuration, see [Transport: JSON-RPC deprecation](/docs/network-reference#transport-json-rpc-deprecation).
 
@@ -82,6 +82,8 @@ $ curl --create-dirs https://docs.wal.app/setup/client_config.yaml -o ~/.config/
 
 ## Site builder errors
 
+These errors come from the `site-builder` binary rather than from the Walrus client.
+
 #### `site-builder` fails against a full node that stopped serving JSON-RPC
 
 **Cause:** The installed `site-builder` build is old enough to still construct a JSON-RPC client. Current builds do not, so they keep working against full nodes that have dropped the protocol.
@@ -98,6 +100,8 @@ contexts:
 For the full configuration file, see the [Site Builder Reference](/docs/sites/getting-started/using-the-site-builder).
 
 ## Self-hosted full nodes
+
+These errors appear when you point the client at a node you operate rather than at a public endpoint.
 
 #### A custom full node rejects Walrus client traffic
 

--- a/docs/content/troubleshooting/grpc-migration.mdx
+++ b/docs/content/troubleshooting/grpc-migration.mdx
@@ -57,60 +57,43 @@ No setting selects gRPC. One URL per network serves both protocols, which is why
 
 ## Migrate
 
-Steps 1 and 2 cover most deployments. Step 4 applies only if you run your own Sui full node.
+Upgrading your tooling is the migration. To move to another form of data access instead, see [Transport: JSON-RPC deprecation](/docs/network-reference#transport-json-rpc-deprecation).
 
-### Step 1: Upgrade the Walrus CLI
-
-Older releases still build a JSON-RPC client, so they break against a full node that dropped the protocol. Current releases do not:
+Older releases still build a JSON-RPC client, so they break against a full node that no longer serves JSON-RPC. Upgrade to the current release:
 
 ```sh
 $ suiup install walrus
+$ suiup install site-builder   # only if you publish Walrus Sites
 $ walrus --version
+$ site-builder --version
 ```
 
-### Step 2: Upgrade site-builder
-
-`site-builder` has the same split, so upgrade it alongside the CLI if you publish Walrus Sites.
-
-### Step 3: Leave your configuration alone
-
-Read the current URLs from the [Network Reference](/docs/network-reference#sui-rpc-endpoints), and pull the pre-filled file if you want to be certain yours matches:
+Your configuration needs no changes. If you want to be certain yours matches, pull the pre-filled file:
 
 ```sh
 $ curl --create-dirs https://docs.wal.app/setup/client_config.yaml -o ~/.config/walrus/client_config.yaml
 ```
 
-The optional `rpc_url` field in `sites-config.yaml` also stays as it is, because `site-builder` reaches that same node over gRPC:
+The optional `rpc_url` field in `sites-config.yaml` needs no change either, because `site-builder` reaches that same node over gRPC. For the full file, see the [Site Builder Reference](/docs/sites/getting-started/using-the-site-builder).
 
-```yaml
-contexts:
-  mainnet:
-    general:
-        # rpc_url: https://fullnode.mainnet.sui.io:443
-```
+Then rerun whatever failed. If it still fails against a public endpoint, you are running an older binary than `walrus --version` reports, so check your `PATH`.
 
-For the full file, see the [Site Builder Reference](/docs/sites/getting-started/using-the-site-builder).
+## Migration for full node operators
 
-### Step 4: Enable gRPC on a full node you operate
+A full node you operate has to enable the gRPC API. The public endpoints in the [Network Reference](/docs/network-reference#sui-rpc-endpoints) already serve it. Nothing changes on the Walrus side once yours does.
 
-The public endpoints in the [Network Reference](/docs/network-reference#sui-rpc-endpoints) already serve the gRPC API. A node you run has to enable it. Nothing changes on the Walrus side once it does.
+## Migration troubleshooting
 
-### Step 5: Rerun what failed
+Each of these means the same thing: a client that still speaks JSON-RPC, or a node that does not serve gRPC.
 
-Run the command that failed before. If it still fails against a public endpoint, you are running an older binary than `walrus --version` reports, so check your `PATH`.
+| **What you see** | **What it means** |
+| --- | --- |
+| A `walrus` command fails against a full node that stopped serving JSON-RPC | The installed release still builds a JSON-RPC client |
+| `site-builder` fails the same way | The installed build still builds a JSON-RPC client |
+| You cannot find the setting that selects gRPC | No such setting exists |
+| A full node you operate rejects Walrus client traffic | The node does not serve the gRPC API |
 
-## Recognize an incomplete migration
-
-These failures all mean the same thing: a client that still speaks JSON-RPC, or a node that does not serve gRPC.
-
-| **What you see** | **What it means** | **Where to go** |
-| --- | --- | --- |
-| A `walrus` command fails against a full node that stopped serving JSON-RPC | The installed release still builds a JSON-RPC client | Step 1 |
-| `site-builder` fails the same way | The installed build still builds a JSON-RPC client | Step 2 |
-| You cannot find the setting that selects gRPC | No such setting exists | Step 3 |
-| A full node you operate rejects Walrus client traffic | The node does not serve the gRPC API | Step 4 |
-
-One failure means nothing is wrong: `rpc.discover` returns `404` against a working full node. The public nodes serve Sui client and SDK traffic rather than JSON-RPC method discovery, and normal calls against the same URL succeed. Drive the node through `sui client` and the Walrus configuration file instead of calling JSON-RPC methods by hand.
+One symptom means nothing is wrong. The public nodes serve Sui client and SDK traffic rather than JSON-RPC method discovery, so normal calls against the same URL succeed. If `rpc.discover` returns `404` against a working full node, drive the node through `sui client` and the Walrus configuration file instead of calling JSON-RPC methods by hand.
 
 ## Do not force the old code paths
 

--- a/docs/content/troubleshooting/grpc-migration.mdx
+++ b/docs/content/troubleshooting/grpc-migration.mdx
@@ -1,6 +1,6 @@
 ---
-title: Fix gRPC and JSON-RPC Migration Errors
-description: Diagnose deployment failures caused by the Sui JSON-RPC deprecation across the Walrus CLI, the TypeScript SDK, and site-builder, with the cause and fix for each.
+title: Migrate from JSON-RPC to gRPC
+description: Upgrade the Walrus CLI and site-builder so they reach Sui over gRPC after the JSON-RPC deprecation, confirm your existing configuration still applies, and recognize the failures that mean you have not migrated yet.
 keywords:
   - walrus
   - grpc
@@ -11,21 +11,21 @@ keywords:
   - site-builder
   - full node
 goal:
-  description: Reader can identify why a Walrus deployment fails against a full node that stopped serving JSON-RPC and apply the fix for their client
+  description: Reader can migrate a Walrus deployment off Sui JSON-RPC by upgrading their tooling, and can recognize the failures that mean the migration is incomplete
   requires:
     - has_frontmatter:
         - title
         - description
         - keywords
       label: Has required frontmatter fields
-    - pattern: Solution|Fix|Cause
+    - pattern: Solution|Fix|Cause|Step
       min: 2
-      label: Has problem-solution pairs
+      label: Has actionable migration steps
     - min_words: 300
       label: Needs more content depth
     - pattern: '```'
       min: 2
-      label: Has code examples showing fixes
+      label: Has code examples showing the migration
     - has_questions: true
       label: Needs questions for AI search visibility
     - has_answer: true
@@ -36,59 +36,51 @@ questions:
   - Which Walrus setting selects gRPC instead of JSON-RPC?
 answer: >-
   Sui has deprecated JSON-RPC, and current Walrus clients already read and write Sui state over
-  gRPC at the same full node URL. There is no gRPC endpoint setting to change, so upgrading to a
-  current release fixes a deployment that fails against a full node which stopped serving
-  JSON-RPC, and reconfiguring does not.
+  gRPC at the same full node URL. Migrating means upgrading the Walrus CLI and site-builder to a
+  current release. There is no gRPC endpoint setting to change, so your existing `rpc_urls` values
+  stay as they are, and only a self-hosted full node needs work: enable its gRPC API.
 ---
 
-Sui has deprecated JSON-RPC. For the Sui API surface itself, see the [Sui API reference](https://docs.sui.io/references/sui-api).
+Sui has deprecated JSON-RPC. Current Walrus clients already reach Sui over gRPC at the same full node URL your configuration lists, so migrating means upgrading your tooling rather than rewriting your configuration. For the Sui API surface itself, see the [Sui API reference](https://docs.sui.io/references/sui-api).
 
-When a Walrus tool fails against a full node that has stopped serving JSON-RPC, upgrading the client almost always fixes it, rather than changing configuration. Current Walrus clients already reach Sui over gRPC at the same full node URL the configuration already lists, and Walrus has no separate gRPC endpoint setting to point at.
+## What changes, and what stays
 
-The deprecation causes distinct failures in the Walrus CLI, in `site-builder`, and on self-hosted full nodes, each with its own cause and fix. For the transport itself and what it means for configuration, see [Transport: JSON-RPC deprecation](/docs/network-reference#transport-json-rpc-deprecation).
+| **Component** | **What you do** |
+| --- | --- |
+| Walrus CLI | Upgrade to a current release |
+| `site-builder` | Upgrade to a current build |
+| Client configuration (`rpc_urls`) | Nothing, the values stay as they are |
+| `sites-config.yaml` (`rpc_url`) | Nothing, the value stays as it is |
+| A full node you operate | Enable its gRPC API |
 
-## Walrus client errors
+No setting selects gRPC. One URL per network serves both protocols, which is why upgrading fixes a broken deployment and reconfiguring does not. For the transport itself, see [Transport: JSON-RPC deprecation](/docs/network-reference#transport-json-rpc-deprecation).
 
-Errors in this section occur when a Walrus client talks to a Sui full node that no longer serves JSON-RPC.
+## Migrate
 
-#### A `walrus` command fails against a full node that stopped serving JSON-RPC
+Steps 1 and 2 cover most deployments. Step 4 applies only if you run your own Sui full node.
 
-**Cause:** The installed release is old enough to still build a JSON-RPC client. Current releases do not, so they keep working against full nodes that have dropped the protocol.
+### Step 1: Upgrade the Walrus CLI
 
-**Solution:** Upgrade the client. The transport moves to gRPC on its own, and your configuration file stays as it is:
+Older releases still build a JSON-RPC client, so they break against a full node that dropped the protocol. Current releases do not:
 
 ```sh
 $ suiup install walrus
 $ walrus --version
 ```
 
-Then rerun the command that failed. If it still fails, confirm the full node you point at serves gRPC, covered in [Self-hosted full nodes](#self-hosted-full-nodes) below.
+### Step 2: Upgrade site-builder
 
-#### Looking for the setting that selects gRPC
+`site-builder` has the same split, so upgrade it alongside the CLI if you publish Walrus Sites.
 
-**Cause:** There is no such setting. One URL per network serves both protocols, so `rpc_urls` in the Walrus client configuration keeps the same values it always had.
+### Step 3: Leave your configuration alone
 
-**Solution:** Leave the configuration alone. Read the current URLs from the [Network Reference](/docs/network-reference#sui-rpc-endpoints), and use the pre-filled configuration file if you want to be sure it matches:
+Read the current URLs from the [Network Reference](/docs/network-reference#sui-rpc-endpoints), and pull the pre-filled file if you want to be certain yours matches:
 
 ```sh
 $ curl --create-dirs https://docs.wal.app/setup/client_config.yaml -o ~/.config/walrus/client_config.yaml
 ```
 
-#### `rpc.discover` returns `404` against a working full node
-
-**Cause:** The public full nodes serve Sui client and SDK traffic rather than JSON-RPC method discovery. A `404` from `rpc.discover` does not indicate a down or misconfigured node, and normal client calls against the same URL succeed.
-
-**Solution:** Ignore the discovery call and drive the node through `sui client` and the Walrus configuration file instead of calling JSON-RPC methods against it by hand.
-
-## Site builder errors
-
-These errors come from the `site-builder` binary rather than from the Walrus client.
-
-#### `site-builder` fails against a full node that stopped serving JSON-RPC
-
-**Cause:** The installed `site-builder` build is old enough to still construct a JSON-RPC client. Current builds do not, so they keep working against full nodes that have dropped the protocol.
-
-**Solution:** Upgrade the tooling. The optional `rpc_url` field in `sites-config.yaml` takes a Sui full node URL, and `site-builder` reaches that node over gRPC, so the deprecation needs no change to the file:
+The optional `rpc_url` field in `sites-config.yaml` also stays as it is, because `site-builder` reaches that same node over gRPC:
 
 ```yaml
 contexts:
@@ -97,21 +89,32 @@ contexts:
         # rpc_url: https://fullnode.mainnet.sui.io:443
 ```
 
-For the full configuration file, see the [Site Builder Reference](/docs/sites/getting-started/using-the-site-builder).
+For the full file, see the [Site Builder Reference](/docs/sites/getting-started/using-the-site-builder).
 
-## Self-hosted full nodes
+### Step 4: Enable gRPC on a full node you operate
 
-These errors appear when you point the client at a node you operate rather than at a public endpoint.
+The public endpoints in the [Network Reference](/docs/network-reference#sui-rpc-endpoints) already serve the gRPC API. A node you run has to enable it. Nothing changes on the Walrus side once it does.
 
-#### A custom full node rejects Walrus client traffic
+### Step 5: Rerun what failed
 
-**Cause:** The node does not serve the gRPC API. The public endpoints in the [Network Reference](/docs/network-reference#sui-rpc-endpoints) do, but a self-hosted node has to enable it.
+Run the command that failed before. If it still fails against a public endpoint, you are running an older binary than `walrus --version` reports, so check your `PATH`.
 
-**Solution:** Enable the gRPC API on the node, then point the client at it as before. No Walrus-side configuration changes.
+## Recognize an incomplete migration
+
+These failures all mean the same thing: a client that still speaks JSON-RPC, or a node that does not serve gRPC.
+
+| **What you see** | **What it means** | **Where to go** |
+| --- | --- | --- |
+| A `walrus` command fails against a full node that stopped serving JSON-RPC | The installed release still builds a JSON-RPC client | Step 1 |
+| `site-builder` fails the same way | The installed build still builds a JSON-RPC client | Step 2 |
+| You cannot find the setting that selects gRPC | No such setting exists | Step 3 |
+| A full node you operate rejects Walrus client traffic | The node does not serve the gRPC API | Step 4 |
+
+One failure means nothing is wrong: `rpc.discover` returns `404` against a working full node. The public nodes serve Sui client and SDK traffic rather than JSON-RPC method discovery, and normal calls against the same URL succeed. Drive the node through `sui client` and the Walrus configuration file instead of calling JSON-RPC methods by hand.
 
 ## Do not force the old code paths
 
-`WALRUS_GRPC_MIGRATION_LEVEL` exists as a temporary escape hatch for debugging the migration. If you set it below the client's default, the client falls back to the older JSON-RPC code paths that Sui full nodes are removing, which reintroduces the failures above.
+`WALRUS_GRPC_MIGRATION_LEVEL` exists as a temporary escape hatch for debugging the migration. If you set it below the client's default, the client falls back to the older JSON-RPC code paths that Sui full nodes are removing, which reintroduces every failure above.
 
 :::caution
 

--- a/docs/content/troubleshooting/grpc-migration.mdx
+++ b/docs/content/troubleshooting/grpc-migration.mdx
@@ -43,9 +43,9 @@ answer: >-
 
 Sui has deprecated JSON-RPC. For the Sui API surface itself, see the [Sui API reference](https://docs.sui.io/references/sui-api).
 
-**The fix is almost always an upgrade, not a configuration change.** Current Walrus clients already reach Sui over gRPC at the same full node URL the configuration already lists, and Walrus has no separate gRPC endpoint setting.
+When a Walrus tool fails against a full node that has stopped serving JSON-RPC, the fix is almost always an upgrade rather than a configuration change. Current Walrus clients already reach Sui over gRPC at the same full node URL the configuration already lists, and Walrus has no separate gRPC endpoint setting to point at.
 
-The sections below cover the failures the deprecation causes in the Walrus CLI, `site-builder`, and self-hosted full nodes, with the cause and fix for each. For the transport itself and what it means for configuration, see [Transport: JSON-RPC deprecation](/docs/network-reference#transport-json-rpc-deprecation).
+The deprecation causes distinct failures in the Walrus CLI, in `site-builder`, and on self-hosted full nodes, each with its own cause and fix. For the transport itself and what it means for configuration, see [Transport: JSON-RPC deprecation](/docs/network-reference#transport-json-rpc-deprecation).
 
 ## Walrus client errors
 
@@ -84,7 +84,7 @@ $ curl --create-dirs https://docs.wal.app/setup/client_config.yaml -o ~/.config/
 
 #### `site-builder` fails against a full node that stopped serving JSON-RPC
 
-**Cause:** The same one as the CLI: an older `site-builder` build still constructs a JSON-RPC client.
+**Cause:** The installed `site-builder` build is old enough to still construct a JSON-RPC client. Current builds do not, so they keep working against full nodes that have dropped the protocol.
 
 **Solution:** Upgrade the tooling. The optional `rpc_url` field in `sites-config.yaml` takes a Sui full node URL, and `site-builder` reaches that node over gRPC, so the deprecation needs no change to the file:
 

--- a/docs/content/troubleshooting/index.mdx
+++ b/docs/content/troubleshooting/index.mdx
@@ -70,7 +70,7 @@ $ RUST_LOG=walrus=debug walrus store file.txt --epochs 5
 ```
 If a freshly uploaded blob returns `404 Not Found` from a CDN-fronted aggregator, you are likely hitting a cached `404` response from before the blob propagated. See [Reading Blobs Right After Upload](/docs/troubleshooting/reading-blobs-after-upload) for when to retry and when not to.
 
-If a deployment fails against a Sui full node that stopped serving JSON-RPC, upgrade the client rather than reconfiguring it. See [Fix gRPC and JSON-RPC Migration Errors](/docs/troubleshooting/grpc-migration) for the CLI, `site-builder`, and self-hosted full node cases.
+If a deployment fails against a Sui full node that stopped serving JSON-RPC, upgrade the client rather than reconfiguring it. See [Migrate from JSON-RPC to gRPC](/docs/troubleshooting/grpc-migration) for the upgrade steps covering the CLI, `site-builder`, and self-hosted full nodes.
 
 import DocCardList from '@theme/DocCardList';
 import AskAiCta from '@site/src/shared/components/AskAiCta';

--- a/docs/content/troubleshooting/index.mdx
+++ b/docs/content/troubleshooting/index.mdx
@@ -37,8 +37,7 @@ answer: >-
   connectivity.
 ---
 
-<AgentPrompt
-  prompt="My walrus store call on Testnet fails with could not retrieve enough confirmations to certify the blob, and which walrus shows two different binaries on my PATH. Diagnose both, fix them, and show me how to turn on debug logging to confirm which config file the client actually loaded."
+<AgentPrompt prompt="My walrus store call on Testnet fails with could not retrieve enough confirmations to certify the blob, and which walrus shows two different binaries on my PATH. Diagnose both, fix them, and show me how to turn on debug logging to confirm which config file the client actually loaded."
 />
 
 Resolve common issues with the Walrus CLI, configuration, and network connectivity.
@@ -71,7 +70,7 @@ $ RUST_LOG=walrus=debug walrus store file.txt --epochs 5
 ```
 If a freshly uploaded blob returns `404 Not Found` from a CDN-fronted aggregator, you are likely hitting a cached `404` response from before the blob propagated. See [Reading Blobs Right After Upload](/docs/troubleshooting/reading-blobs-after-upload) for when to retry and when not to.
 
-If a deployment started failing against a Sui full node that stopped serving JSON-RPC, upgrade the client rather than reconfiguring it. See [Fix gRPC and JSON-RPC Migration Errors](/docs/troubleshooting/grpc-migration) for the CLI, `site-builder`, and self-hosted full node cases.
+If a deployment fails against a Sui full node that stopped serving JSON-RPC, upgrade the client rather than reconfiguring it. See [Fix gRPC and JSON-RPC Migration Errors](/docs/troubleshooting/grpc-migration) for the CLI, `site-builder`, and self-hosted full node cases.
 
 import DocCardList from '@theme/DocCardList';
 import AskAiCta from '@site/src/shared/components/AskAiCta';

--- a/docs/content/troubleshooting/index.mdx
+++ b/docs/content/troubleshooting/index.mdx
@@ -71,6 +71,8 @@ $ RUST_LOG=walrus=debug walrus store file.txt --epochs 5
 ```
 If a freshly uploaded blob returns `404 Not Found` from a CDN-fronted aggregator, you are likely hitting a cached `404` response from before the blob propagated. See [Reading Blobs Right After Upload](/docs/troubleshooting/reading-blobs-after-upload) for when to retry and when not to.
 
+If a deployment started failing against a Sui full node that stopped serving JSON-RPC, upgrade the client rather than reconfiguring it. See [Fix gRPC and JSON-RPC Migration Errors](/docs/troubleshooting/grpc-migration) for the CLI, `site-builder`, and self-hosted full node cases.
+
 import DocCardList from '@theme/DocCardList';
 import AskAiCta from '@site/src/shared/components/AskAiCta';
 

--- a/docs/site/sidebars.js
+++ b/docs/site/sidebars.js
@@ -156,6 +156,7 @@ const sidebars = {
       items: [
         "troubleshooting/network-errors",
         "troubleshooting/error-handling",
+        "troubleshooting/grpc-migration",
         "troubleshooting/reading-blobs-after-upload",
       ],
     },


### PR DESCRIPTION
Addresses BEDU-1088, which reported 10 questions in one week about gRPC migration across different contexts.

_Generated by [Claude Code](https://claude.ai/code)._

## Description

#3624 established the canonical explanation of the transport in the Network Reference and linked it from the two setup pages. What was still missing is a symptom-first entry point: a reader whose deployment just broke looks in Troubleshooting, not in a network reference.

New `troubleshooting/grpc-migration` collects every failure the deprecation causes, in the order a reader meets them:

- **Walrus client errors** — a `walrus` command failing against a full node that dropped JSON-RPC, the search for a gRPC endpoint setting that does not exist, and `rpc.discover` returning `404` against a node that otherwise works.
- **Site builder errors** — the same upgrade path for `site-builder`, and why the optional `rpc_url` in `sites-config.yaml` needs no change.
- **Self-hosted full nodes** — a custom node has to enable the gRPC API; the public endpoints already do.
- **`WALRUS_GRPC_MIGRATION_LEVEL`** — why setting it below the default reintroduces exactly these failures.

The page leads with the answer that resolves most reports in one line: the fix is an upgrade, not a configuration change. It links the Network Reference for the canonical explanation rather than restating it, so there is still one source of truth.

Also added an entry point from the Troubleshooting index and the sidebar.

## Sources

| Claim | Source |
| --- | --- |
| Current clients no longer build a JSON-RPC client, so upgrading is the fix | `GRPC_MIGRATION_LEVEL_DEFAULT_U32 = 100` vs `GRPC_MIGRATION_LEVEL_SKIP_JSON_RPC_CLIENT = 11` in `crates/walrus-sui/src/client/retry_client/retriable_sui_client.rs` |
| One URL serves both protocols; no separate gRPC endpoint setting | `GrpcClient::new(rpc_url)` alongside the JSON-RPC client in `crates/walrus-sui/src/client/dual_client.rs` |
| `WALRUS_GRPC_MIGRATION_LEVEL` is the only knob, and a debugging escape hatch | the env var read in the same `retriable_sui_client.rs` |
| Config field names `rpc_urls` / `rpc_url` | `crates/walrus-sdk/src/config.rs`; `docs/content/sites/getting-started/using-the-site-builder.mdx` |
| `rpc.discover` returning `404` is expected, not a fault | existing `testnet-reference.mdx`, carried over rather than restated from scratch |
| Full node URLs and the transport explanation | the generated tables and the Transport section in `network-reference.mdx` (#3624) |

Prose written fresh for this page. No new facts were introduced beyond what the sources above already establish.

## Test plan

- `editorconfig-checker` clean; mechanical and voice style gates passed on push.
- The two cross-page anchors resolve against the current headings in `network-reference.mdx` (`## Sui RPC endpoints`, `### Transport: JSON-RPC deprecation`).
- Sidebar entry added under Troubleshooting; page ID matches the file path.

## Release notes

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI: