### PR TITLE
docs: surface Quilt where small-file cost decisions get made

### DIFF
--- a/docs/content/system-overview/storage-costs.mdx
+++ b/docs/content/system-overview/storage-costs.mdx
@@ -52,6 +52,12 @@ When choosing a platform to store and verify data, you should consider reliabili
 
 ## Estimate storage costs
 
+:::tip Storing many small files?
+
+Every blob pays a fixed metadata overhead whatever its size, so a batch of small files stored separately costs far more than the bytes suggest. [Walrus Quilt](/docs/system-overview/quilt) spreads that overhead across one stored unit. Read [Reducing costs for small blobs](#reducing-costs-for-small-blobs-with-quilt) before you model the cost of many small blobs.
+
+:::
+
 Use the embedded Walrus Cost Calculator to estimate storage costs before you upload. The calculator models storage size, duration, encoding overhead, WAL storage costs, and SUI transaction costs together.
 
 <iframe

--- a/docs/content/walrus-client/storing-blobs.mdx
+++ b/docs/content/walrus-client/storing-blobs.mdx
@@ -58,6 +58,12 @@ $ walrus store *.png --epochs <EPOCHS>
 
 This example stores all PNG files in the current directory.
 
+:::tip Storing many small files?
+
+Every blob pays a fixed metadata overhead whatever its size, so storing many small files as separate blobs costs far more than the files themselves. [Walrus Quilt](/docs/system-overview/quilt) batches them into one stored unit and spreads that overhead across the batch. See [Reducing costs for small blobs](/docs/system-overview/storage-costs#reducing-costs-for-small-blobs-with-quilt) for when the tradeoff pays off.
+
+:::
+
 ## Blob lifetimes
 
 You must set a mandatory CLI argument to specify the lifetime for the blob. There are currently 3 methods for setting a blob's lifetime:


### PR DESCRIPTION
Addresses BEDU-1087, filed after a developer considered leaving Walrus over small-file costs.

_Generated by [Claude Code](https://claude.ai/code)._

## Description

Both pages already linked Quilt, so the gap was discoverability rather than coverage:

- **`system-overview/storage-costs`** is 263 lines, and the first Quilt mention sat at line 126 with no callout above it. A reader worried about small-file costs met the pricing model, the calculator, and the encoding overhead before learning the remedy exists. Adds a tip at the top of "Estimate storage costs" pointing at the existing "Reducing costs for small blobs" section.
- **`walrus-client/storing-blobs`** mentioned Quilt only once, in passing, about the unrelated `--upload-relay` flag. The natural decision point is the glob example (`walrus store *.png`), which is exactly the moment a reader is about to store many files as separate blobs. Adds the callout there.

Deliberately kept small. **BEDU-961 separately owns restructuring the storage costs page** with an upfront 64 MB overhead callout and a small-file decision tree, so this does not rewrite that page or preempt that work.

## Sources

| Claim | Source |
| --- | --- |
| Every blob pays a fixed per-blob metadata overhead, which dominates for small blobs | existing prose in `storage-costs.mdx`: "a fixed 64 MB of per-blob metadata. For blobs smaller than 10 MB, the fixed metadata cost dominates" |
| Quilt batches small files and amortizes that overhead | the existing "Reducing costs for small blobs with Quilt" section on the same page |
| Quilt suits many small files such as JSON metadata, thumbnails, and config files | same section |

No new technical claims. Both callouts restate what the pages already establish and link to the existing section rather than duplicating it.

## Test plan

- `editorconfig-checker` clean on both files; style gates passed on push.
- The in-page anchor `#reducing-costs-for-small-blobs-with-quilt` resolves against the existing heading at line 237.

## Release notes

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI: