### PR TITLE
test: add a blob info snapshot determinism simtest covering storage pools and pooled blobs

### DIFF
--- a/crates/walrus-service/src/node/blob_info_snapshot_writer.rs
+++ b/crates/walrus-service/src/node/blob_info_snapshot_writer.rs
@@ -8,6 +8,8 @@
 //! The size and content digest are reported through metrics and a log line for cross-node
 //! comparison.
 
+#[cfg(msim)]
+use std::{collections::HashMap, sync::Mutex};
 use std::{
     fs,
     hash::Hasher as _,
@@ -19,6 +21,8 @@ use std::{
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+#[cfg(msim)]
+use sui_types::base_types::ObjectID;
 use twox_hash::XxHash64;
 use walrus_core::{DEFAULT_ENCODING, Epoch, encoding::EncodingFactory as _};
 
@@ -221,6 +225,19 @@ async fn write_snapshot_file(
         digest = %digest_hex,
         path = %final_path.display(),
         "serialized blob info snapshot in-process"
+    );
+
+    // No-op outside of simtest.
+    sui_macros::fail_point_arg!(
+        "storage_node_blob_info_snapshot_digest",
+        |digest_map: Arc<Mutex<HashMap<Epoch, HashMap<ObjectID, u64>>>>| {
+            digest_map
+                .lock()
+                .expect("failed to lock the digest map")
+                .entry(epoch)
+                .or_default()
+                .insert(node.node_capability, digest);
+        }
     );
     Ok(())
 }

--- a/crates/walrus-simtest/src/test_utils.rs
+++ b/crates/walrus-simtest/src/test_utils.rs
@@ -310,7 +310,13 @@ pub mod simtest_utils {
         }
     }
 
-    /// Starts a background workload that writes and reads random blobs.
+    /// Capacity of the storage pool backing the pooled half of the background workload.
+    const WORKLOAD_POOL_CAPACITY_BYTES: u64 = 64 * 1024 * 1024;
+    /// Lifetime of that pool. The pooled store does not extend it, so it is provisioned to
+    /// outlive the workload.
+    const WORKLOAD_POOL_EPOCHS: EpochCount = 50;
+
+    /// Starts a background workload that writes and reads random owned and pooled blobs.
     pub fn start_background_workload(
         client_clone: Arc<WithTempDir<WalrusNodeClient<SuiContractClient>>>,
         write_only: bool,
@@ -318,6 +324,18 @@ pub mod simtest_utils {
         epochs_max: Option<EpochCount>,
     ) -> JoinHandle<()> {
         tokio::spawn(async move {
+            // The pooled half needs a pool. Without one the workload still runs, covering owned
+            // blobs only, so a cluster that rejects the pool does not fail the test.
+            let storage_pool_id = client_clone
+                .inner
+                .sui_client()
+                .create_storage_pool(WORKLOAD_POOL_CAPACITY_BYTES, WORKLOAD_POOL_EPOCHS)
+                .await
+                .inspect_err(
+                    |error| tracing::warn!(%error, "no storage pool; writing owned blobs only"),
+                )
+                .ok();
+
             let mut data_length = 64;
             let mut blobs_written = HashSet::new();
             loop {
@@ -338,6 +356,23 @@ pub mod simtest_utils {
                 .await
                 .expect("workload should not fail");
 
+                // Pooled blobs populate the pooled column families, which owned blobs never
+                // touch. Failures only warn: an epoch change during the upload fails the store
+                // but leaves the blob registered in the pool, so the traffic still lands, and
+                // the next iteration uses a new blob id anyway.
+                if let Some(storage_pool_id) = storage_pool_id
+                    && let Err(error) = write_read_and_check_random_pooled_blob(
+                        client_clone.as_ref(),
+                        storage_pool_id,
+                        data_length,
+                        write_only,
+                        deletable,
+                    )
+                    .await
+                {
+                    tracing::warn!(%error, "pooled blob workload iteration failed");
+                }
+
                 maybe_extend_blob(client_clone.as_ref(), &blobs_written).await;
                 if deletable {
                     maybe_delete_blob(client_clone.as_ref(), &blobs_written).await;
@@ -352,17 +387,17 @@ pub mod simtest_utils {
 
     /// Stores a random blob into the given storage pool and reads it back.
     ///
-    /// The pooled store does not extend the pool, so the pool must already outlive
-    /// `epochs_ahead`.
+    /// The blob lives as long as the pool does, so it asks for the shortest lifetime the pool is
+    /// guaranteed to cover; the pooled store neither extends nor grows the pool.
     pub async fn write_read_and_check_random_pooled_blob(
         client: &WithTempDir<WalrusNodeClient<SuiContractClient>>,
         storage_pool_id: ObjectID,
         data_length: usize,
+        write_only: bool,
         deletable: bool,
-        epochs_ahead: EpochCount,
     ) -> anyhow::Result<()> {
         let blob = walrus_test_utils::random_data(data_length);
-        let store_args = StoreArgs::default_with_epochs(epochs_ahead)
+        let store_args = StoreArgs::default_with_epochs(1)
             .no_store_optimizations()
             .with_persistence(BlobPersistence::from_deletable(deletable));
 
@@ -382,9 +417,14 @@ pub mod simtest_utils {
             anyhow::bail!("storing the pooled blob failed: {result:?}");
         };
 
+        let blob_id = pooled_blob_object.blob_id;
+        if write_only {
+            tracing::info!(%blob_id, %storage_pool_id, "stored a pooled blob");
+            return Ok(());
+        }
+
         // Absorb the transient unavailability that can follow an upload.
         const READ_ATTEMPTS: usize = 10;
-        let blob_id = pooled_blob_object.blob_id;
         let mut read = client.as_ref().read_blob::<Primary>(&blob_id).await;
         for attempt in 1..=READ_ATTEMPTS {
             if read.is_ok() {
@@ -400,35 +440,6 @@ pub mod simtest_utils {
         );
         tracing::info!(%blob_id, %storage_pool_id, "stored and read back a pooled blob");
         Ok(())
-    }
-
-    /// Starts a background workload that writes and reads random blobs in a storage pool.
-    ///
-    /// Errors are logged and the next iteration continues: the pooled store does not retry
-    /// across epoch changes.
-    pub fn start_pooled_background_workload(
-        client: Arc<WithTempDir<WalrusNodeClient<SuiContractClient>>>,
-        storage_pool_id: ObjectID,
-        epochs_ahead: EpochCount,
-    ) -> JoinHandle<()> {
-        tokio::spawn(async move {
-            let mut data_length = 64;
-            loop {
-                let deletable = rand::thread_rng().gen_bool(0.5);
-                if let Err(error) = write_read_and_check_random_pooled_blob(
-                    client.as_ref(),
-                    storage_pool_id,
-                    data_length,
-                    deletable,
-                    epochs_ahead,
-                )
-                .await
-                {
-                    tracing::warn!(%error, "pooled workload iteration failed; continuing");
-                }
-                data_length += 1;
-            }
-        })
     }
 
     /// BlobInfoConsistencyCheck is a helper struct to check the consistency of the blob info.

--- a/crates/walrus-simtest/src/test_utils.rs
+++ b/crates/walrus-simtest/src/test_utils.rs
@@ -134,7 +134,8 @@ pub mod simtest_utils {
         let max_retry_count = max_retry_count.unwrap_or(DEFAULT_MAX_RETRY_COUNT);
 
         // Get a random epoch length for the blob to be stored.
-        let epoch_ahead = rand::thread_rng().gen_range(1..=epochs_max.unwrap_or(5));
+        let epoch_ahead =
+            rand::thread_rng().gen_range(1..=epochs_max.unwrap_or(DEFAULT_EPOCHS_MAX));
 
         tracing::info!(
             "generating random blobs of length {data_length} and store them for {epoch_ahead} \
@@ -310,11 +311,11 @@ pub mod simtest_utils {
         }
     }
 
+    /// Epochs a workload blob is stored for when the caller does not cap it.
+    const DEFAULT_EPOCHS_MAX: EpochCount = 5;
+
     /// Capacity of the storage pool backing the pooled half of the background workload.
     const WORKLOAD_POOL_CAPACITY_BYTES: u64 = 64 * 1024 * 1024;
-    /// Lifetime of that pool. The pooled store does not extend it, so it is provisioned to
-    /// outlive the workload.
-    const WORKLOAD_POOL_EPOCHS: EpochCount = 50;
 
     /// Starts a background workload that writes and reads random owned and pooled blobs.
     pub fn start_background_workload(
@@ -324,17 +325,11 @@ pub mod simtest_utils {
         epochs_max: Option<EpochCount>,
     ) -> JoinHandle<()> {
         tokio::spawn(async move {
-            // The pooled half needs a pool. Without one the workload still runs, covering owned
-            // blobs only, so a cluster that rejects the pool does not fail the test.
-            let storage_pool_id = client_clone
-                .inner
-                .sui_client()
-                .create_storage_pool(WORKLOAD_POOL_CAPACITY_BYTES, WORKLOAD_POOL_EPOCHS)
-                .await
-                .inspect_err(
-                    |error| tracing::warn!(%error, "no storage pool; writing owned blobs only"),
-                )
-                .ok();
+            // The pool is requested for the same span the owned blobs use, so a system that
+            // caps `max_epochs_ahead` accepts it. It is recreated below when missing, which
+            // covers both a rejected request and a pool that has since expired.
+            let pool_epochs = epochs_max.unwrap_or(DEFAULT_EPOCHS_MAX);
+            let mut storage_pool_id = None;
 
             let mut data_length = 64;
             let mut blobs_written = HashSet::new();
@@ -360,10 +355,21 @@ pub mod simtest_utils {
                 // touch. Failures only warn: an epoch change during the upload fails the store
                 // but leaves the blob registered in the pool, so the traffic still lands, and
                 // the next iteration uses a new blob id anyway.
-                if let Some(storage_pool_id) = storage_pool_id
+                if storage_pool_id.is_none() {
+                    storage_pool_id = client_clone
+                        .inner
+                        .sui_client()
+                        .create_storage_pool(WORKLOAD_POOL_CAPACITY_BYTES, pool_epochs)
+                        .await
+                        .inspect_err(|error| {
+                            tracing::warn!(%error, "no storage pool; writing owned blobs only")
+                        })
+                        .ok();
+                }
+                if let Some(pool_id) = storage_pool_id
                     && let Err(error) = write_read_and_check_random_pooled_blob(
                         client_clone.as_ref(),
-                        storage_pool_id,
+                        pool_id,
                         data_length,
                         write_only,
                         deletable,
@@ -371,6 +377,8 @@ pub mod simtest_utils {
                     .await
                 {
                     tracing::warn!(%error, "pooled blob workload iteration failed");
+                    // The pool may have expired or filled up; a fresh one is made next round.
+                    storage_pool_id = None;
                 }
 
                 maybe_extend_blob(client_clone.as_ref(), &blobs_written).await;

--- a/crates/walrus-simtest/src/test_utils.rs
+++ b/crates/walrus-simtest/src/test_utils.rs
@@ -25,8 +25,9 @@ pub mod simtest_utils {
         node_client::{
             StoreArgs,
             StoreBlobsApi as _,
+            StoreBlobsInStoragePoolApi as _,
             WalrusNodeClient,
-            responses::BlobStoreResult,
+            responses::{BlobStoreResult, PooledBlobStoreResult},
         },
         uploader::TailHandling,
     };
@@ -349,6 +350,87 @@ pub mod simtest_utils {
         })
     }
 
+    /// Stores a random blob into the given storage pool and reads it back.
+    ///
+    /// The pooled store does not extend the pool, so the pool must already outlive
+    /// `epochs_ahead`.
+    pub async fn write_read_and_check_random_pooled_blob(
+        client: &WithTempDir<WalrusNodeClient<SuiContractClient>>,
+        storage_pool_id: ObjectID,
+        data_length: usize,
+        deletable: bool,
+        epochs_ahead: EpochCount,
+    ) -> anyhow::Result<()> {
+        let blob = walrus_test_utils::random_data(data_length);
+        let store_args = StoreArgs::default_with_epochs(epochs_ahead)
+            .no_store_optimizations()
+            .with_persistence(BlobPersistence::from_deletable(deletable));
+
+        let results = client
+            .as_ref()
+            .reserve_and_store_blobs_in_storage_pool(
+                vec![blob.clone()],
+                storage_pool_id,
+                &store_args,
+            )
+            .await?;
+        let result = results
+            .into_iter()
+            .next()
+            .context("the pooled store returned no result")?;
+        let PooledBlobStoreResult::NewlyCreated { pooled_blob_object } = result else {
+            anyhow::bail!("storing the pooled blob failed: {result:?}");
+        };
+
+        // Absorb the transient unavailability that can follow an upload.
+        const READ_ATTEMPTS: usize = 10;
+        let blob_id = pooled_blob_object.blob_id;
+        let mut read = client.as_ref().read_blob::<Primary>(&blob_id).await;
+        for attempt in 1..=READ_ATTEMPTS {
+            if read.is_ok() {
+                break;
+            }
+            tracing::info!(attempt, %blob_id, "retrying the pooled blob read");
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            read = client.as_ref().read_blob::<Primary>(&blob_id).await;
+        }
+        anyhow::ensure!(
+            read? == blob,
+            "the pooled blob read back does not match what was stored"
+        );
+        tracing::info!(%blob_id, %storage_pool_id, "stored and read back a pooled blob");
+        Ok(())
+    }
+
+    /// Starts a background workload that writes and reads random blobs in a storage pool.
+    ///
+    /// Errors are logged and the next iteration continues: the pooled store does not retry
+    /// across epoch changes.
+    pub fn start_pooled_background_workload(
+        client: Arc<WithTempDir<WalrusNodeClient<SuiContractClient>>>,
+        storage_pool_id: ObjectID,
+        epochs_ahead: EpochCount,
+    ) -> JoinHandle<()> {
+        tokio::spawn(async move {
+            let mut data_length = 64;
+            loop {
+                let deletable = rand::thread_rng().gen_bool(0.5);
+                if let Err(error) = write_read_and_check_random_pooled_blob(
+                    client.as_ref(),
+                    storage_pool_id,
+                    data_length,
+                    deletable,
+                    epochs_ahead,
+                )
+                .await
+                {
+                    tracing::warn!(%error, "pooled workload iteration failed; continuing");
+                }
+                data_length += 1;
+            }
+        })
+    }
+
     /// BlobInfoConsistencyCheck is a helper struct to check the consistency of the blob info.
     #[derive(Debug)]
     pub struct BlobInfoConsistencyCheck {
@@ -362,6 +444,9 @@ pub mod simtest_utils {
         per_object_pooled_blob_digest_map: Arc<Mutex<HashMap<Epoch, HashMap<ObjectID, u64>>>>,
         // Per epoch, the existence check of all nodes.
         blob_existence_check_map: Arc<Mutex<HashMap<Epoch, HashMap<ObjectID, f64>>>>,
+        // Per epoch, the blob info snapshot digest of all nodes, paired with the number of
+        // entries the snapshot holds in its two pool sections.
+        blob_info_snapshot_digest_map: Arc<Mutex<HashMap<Epoch, HashMap<ObjectID, u64>>>>,
         checked: Arc<AtomicBool>,
     }
 
@@ -378,6 +463,8 @@ pub mod simtest_utils {
             let per_object_pooled_blob_digest_map_clone = per_object_pooled_blob_digest_map.clone();
             let blob_existence_check_map = Arc::new(Mutex::new(HashMap::new()));
             let blob_existence_check_map_clone = blob_existence_check_map.clone();
+            let blob_info_snapshot_digest_map = Arc::new(Mutex::new(HashMap::new()));
+            let blob_info_snapshot_digest_map_clone = blob_info_snapshot_digest_map.clone();
 
             sui_macros::register_fail_point_arg(
                 "storage_node_event_index_source",
@@ -414,12 +501,20 @@ pub mod simtest_utils {
                 },
             );
 
+            sui_macros::register_fail_point_arg(
+                "storage_node_blob_info_snapshot_digest",
+                move || -> Option<Arc<Mutex<HashMap<Epoch, HashMap<ObjectID, u64>>>>> {
+                    Some(blob_info_snapshot_digest_map_clone.clone())
+                },
+            );
+
             Self {
                 event_source_map,
                 certified_blob_digest_map,
                 per_object_blob_digest_map,
                 per_object_pooled_blob_digest_map,
                 blob_existence_check_map,
+                blob_info_snapshot_digest_map,
                 checked: Arc::new(AtomicBool::new(false)),
             }
         }
@@ -457,6 +552,27 @@ pub mod simtest_utils {
             self.check_per_object_blob_digest(min_epoch);
             self.check_per_object_pooled_blob_digest(min_epoch);
             self.check_blob_existence(min_epoch);
+            self.check_blob_info_snapshot_digest(min_epoch);
+        }
+
+        /// Ensures that for all epochs, all nodes have the same blob info snapshot digest.
+        ///
+        /// This is a no-op unless the blob info snapshot writer is enabled in the node config.
+        #[tracing::instrument(skip(self))]
+        pub fn check_blob_info_snapshot_digest(&self, min_epoch: Epoch) {
+            tracing::info!(
+                "checking blob info snapshot digest consistency starting with epoch {min_epoch}"
+            );
+            let digest_map = self.blob_info_snapshot_digest_map.lock().unwrap();
+            for (epoch, node_digest_map) in digest_map.iter().sorted_by_key(|(epoch, _)| *epoch) {
+                if *epoch < min_epoch {
+                    tracing::info!(
+                        "skipping epoch {epoch} because it is before the minimum epoch {min_epoch}"
+                    );
+                    continue;
+                }
+                Self::check_digests_are_equal(*epoch, node_digest_map);
+            }
         }
 
         /// Ensures that for all epochs, all nodes have the same certified blob digest.
@@ -566,6 +682,7 @@ pub mod simtest_utils {
             sui_macros::clear_fail_point("storage_node_certified_blob_object_digest");
             sui_macros::clear_fail_point("storage_node_certified_pooled_blob_object_digest");
             sui_macros::clear_fail_point("storage_node_certified_blob_existence_check");
+            sui_macros::clear_fail_point("storage_node_blob_info_snapshot_digest");
         }
     }
 

--- a/crates/walrus-simtest/tests/simtest_blob_info_snapshot.rs
+++ b/crates/walrus-simtest/tests/simtest_blob_info_snapshot.rs
@@ -9,18 +9,11 @@
 mod tests {
     use std::{sync::Arc, time::Duration};
 
-    use walrus_core::EpochCount;
     use walrus_proc_macros::walrus_simtest;
     use walrus_service::test_utils::{SimStorageNodeHandle, TestNodesConfig, test_cluster};
     use walrus_simtest::test_utils::simtest_utils::{self, BlobInfoConsistencyCheck};
 
-    /// Lifetime of the storage pool backing the pooled workload.
-    const POOL_EPOCHS: EpochCount = 30;
-    /// Lifetime requested for each pooled blob. The pooled store does not extend the pool.
-    const POOLED_BLOB_EPOCHS: EpochCount = 1;
-
-    /// Checks that all nodes serialize identical blob info snapshots at each epoch boundary,
-    /// with both owned and pooled blobs in them.
+    /// Checks that all nodes serialize identical blob info snapshots at each epoch boundary.
     #[ignore = "ignore integration simtests by default"]
     #[walrus_simtest]
     async fn test_blob_info_snapshot_digests_match_across_nodes() {
@@ -38,27 +31,13 @@ mod tests {
                 .await
                 .unwrap();
 
-        let client_arc = Arc::new(client);
-        let pool_id = client_arc
-            .inner
-            .sui_client()
-            .create_storage_pool(64 * 1024 * 1024, POOL_EPOCHS)
-            .await
-            .expect("creating the storage pool should succeed");
-
         let workload_handle =
-            simtest_utils::start_background_workload(client_arc.clone(), false, None, None);
-        let pooled_workload_handle = simtest_utils::start_pooled_background_workload(
-            client_arc.clone(),
-            pool_id,
-            POOLED_BLOB_EPOCHS,
-        );
+            simtest_utils::start_background_workload(Arc::new(client), false, None, None);
 
         // Let several epoch boundaries pass so that multiple snapshots are produced.
         tokio::time::sleep(Duration::from_mins(3)).await;
 
         workload_handle.abort();
-        pooled_workload_handle.abort();
 
         blob_info_consistency_check.check_storage_node_consistency();
     }

--- a/crates/walrus-simtest/tests/simtest_blob_info_snapshot.rs
+++ b/crates/walrus-simtest/tests/simtest_blob_info_snapshot.rs
@@ -1,0 +1,65 @@
+// Copyright (c) Walrus Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Contains simtests for the cross-node determinism of blob info snapshots.
+
+#![recursion_limit = "256"]
+
+#[cfg(msim)]
+mod tests {
+    use std::{sync::Arc, time::Duration};
+
+    use walrus_core::EpochCount;
+    use walrus_proc_macros::walrus_simtest;
+    use walrus_service::test_utils::{SimStorageNodeHandle, TestNodesConfig, test_cluster};
+    use walrus_simtest::test_utils::simtest_utils::{self, BlobInfoConsistencyCheck};
+
+    /// Lifetime of the storage pool backing the pooled workload.
+    const POOL_EPOCHS: EpochCount = 30;
+    /// Lifetime requested for each pooled blob. The pooled store does not extend the pool.
+    const POOLED_BLOB_EPOCHS: EpochCount = 1;
+
+    /// Checks that all nodes serialize identical blob info snapshots at each epoch boundary,
+    /// with both owned and pooled blobs in them.
+    #[ignore = "ignore integration simtests by default"]
+    #[walrus_simtest]
+    async fn test_blob_info_snapshot_digests_match_across_nodes() {
+        let blob_info_consistency_check = BlobInfoConsistencyCheck::new();
+
+        let (_sui_cluster, _walrus_cluster, client, _, _) =
+            test_cluster::E2eTestSetupBuilder::new()
+                .with_epoch_duration(Duration::from_secs(30))
+                .with_test_nodes_config(
+                    TestNodesConfig::builder()
+                        .with_node_weights(&[1, 2, 3, 3, 4])
+                        .build(),
+                )
+                .build_generic::<SimStorageNodeHandle>()
+                .await
+                .unwrap();
+
+        let client_arc = Arc::new(client);
+        let pool_id = client_arc
+            .inner
+            .sui_client()
+            .create_storage_pool(64 * 1024 * 1024, POOL_EPOCHS)
+            .await
+            .expect("creating the storage pool should succeed");
+
+        let workload_handle =
+            simtest_utils::start_background_workload(client_arc.clone(), false, None, None);
+        let pooled_workload_handle = simtest_utils::start_pooled_background_workload(
+            client_arc.clone(),
+            pool_id,
+            POOLED_BLOB_EPOCHS,
+        );
+
+        // Let several epoch boundaries pass so that multiple snapshots are produced.
+        tokio::time::sleep(Duration::from_mins(3)).await;
+
+        workload_handle.abort();
+        pooled_workload_handle.abort();
+
+        blob_info_consistency_check.check_storage_node_consistency();
+    }
+}


### PR DESCRIPTION
## Description

Adds a simtest asserting that every storage node serializes a bit-identical blob info snapshot at each epoch boundary, with pooled blobs present so the pooled column families carry entries instead of being empty.

## Test plan

Added simtest passes.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
