### PR TITLE
docs: add a worked cost example for many small files

### DIFF
--- a/docs/content/system-overview/storage-costs.mdx
+++ b/docs/content/system-overview/storage-costs.mdx
@@ -99,6 +99,31 @@ For example, to keep a 50 GB file for 1 year:
 
 The result is USD-denominated. Storage is paid in WAL, so the WAL amount changes with the WAL price. Use `walrus info` or the [Walrus Cost Calculator](https://costcalculator.wal.app/) to convert to a current WAL figure, and `walrus store --dry-run ...` to confirm the exact encoded size before you spend anything.
 
+#### Estimate cost for many small files
+
+The same formula explains why a batch of small files costs far more than its contents suggest. Take 600 files of 10 KiB each, roughly 6 MB of data altogether.
+
+If you store them as individual blobs, every file pays the fixed metadata overhead in full:
+
+```text
+per_blob_GB      = 4.5 * 0.00001 + 0.064, roughly 0.064
+six_hundred_GB   = 0.064 * 600, roughly 38.4
+monthly_cost_USD = 38.4 * 0.023, roughly $0.88
+```
+
+You hold 6 MB and pay for 38.4 GB, about 6,000 times the data you actually store, because the fixed overhead applies once per blob and dwarfs 10 KiB of content. The file size barely enters the arithmetic.
+
+If you store them as a single quilt, the batch pays that overhead once instead of 600 times:
+
+```text
+encoded_GB       = 4.5 * 0.006 + 0.064, roughly 0.09
+monthly_cost_USD = 0.09 * 0.023, roughly $0.002
+```
+
+Measured runs agree with the shape of that estimate. The [cost comparison table](/docs/system-overview/quilt#lower-cost) recorded a 409x saving for exactly this case, 600 files of 10 KiB stored for one epoch on Testnet. Treat the measured table as the expected saving and this arithmetic as the reason behind it.
+
+The advantage narrows as files grow, because the per-blob overhead stops dominating: the same table shows 13x at 1 MiB per file. To decide whether to batch a specific workload, work through the [decision guide](/docs/system-overview/quilt#decision-guide).
+
 ## What you get for $0.023/GB/month
 
 At $0.023 per GB per month, Walrus is in line with centralized storage providers but includes additional capabilities and lower configuration requirements.


### PR DESCRIPTION
Addresses BEDU-961, and the gap a previous review (BEDU-223) left open: "I didn't find a step-by-step real-number example on Storage Costs."

_Generated by [Claude Code](https://claude.ai/code)._

## A note on the ticket's premise

BEDU-961 asks to restructure the storage costs page with a 64 MB overhead callout and a small-file decision tree. Most of that already exists:

- The 64 MB overhead has a `:::tip` under "How pricing works", and #3632 added a Quilt callout at the top of "Estimate storage costs".
- The small-file decision tree lives on the Quilt page as "Decision guide", with file-count and size thresholds, a cost-impact summary, and common pitfalls. **BEDU-855 delivered it and is marked Done.**

Two sibling tickets asking for the same guide, BEDU-1013 and BEDU-1021, are closed as duplicates of BEDU-855.

What genuinely remained is the worked example, which is what this PR adds.

## Description

The page worked one example: a single 50 GB file. That is the case where per-blob overhead is negligible. The readers hitting cost surprises are in the opposite case, and nothing walked them through it.

New "Estimate cost for many small files" section, using the same formula the page already gives:

- 600 files of 10 KiB hold roughly 6 MB, and bill as **38.4 GB**, about 6,000 times the data actually stored, because the fixed overhead applies once per blob and dwarfs 10 KiB of content.
- The same batch as one quilt encodes to roughly 0.09 GB.

It then reconciles the arithmetic with the measured comparison rather than competing with it: the Quilt page's table recorded a 409x saving for exactly this case (600 files of 10 KiB, one epoch, Testnet), and the text says to treat the measured table as the expected saving and the arithmetic as the reason behind it. It closes by noting the advantage narrows to 13x at 1 MiB and pointing at the decision guide.

## Sources

| Claim | Source |
| --- | --- |
| `encoded_size_GB = 4.5 * original_size_GB + 0.064` and the $0.023/GB/month rate | the existing "Estimate cost by hand" section on the same page |
| Fixed 64 MB per-blob metadata, dominating below 10 MB | existing prose in `storage-costs.mdx` |
| 409x saving at 10 KiB, 13x at 1 MiB, for 600 files over one epoch on Testnet | the measured cost comparison table in `system-overview/quilt.mdx` |
| Decision guide with file-count and size thresholds | the existing "Decision guide" section in `quilt.mdx` (BEDU-855) |

The arithmetic is computed from the page's own formula; no new measurements are introduced, and no figure competes with the measured table.

## Test plan

- `editorconfig-checker` clean; style gates passed on push.
- Both cross-page anchors (`#lower-cost`, `#decision-guide`) resolve against current headings in `quilt.mdx`.
- Worked figures recomputed from the documented formula: `4.5 * (10 KiB) + 0.064 GB` per blob, times 600, gives 38.4 GB and $0.88/month at the documented rate.

## Release notes

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI: