### PR TITLE
docs: document WAL acquisition and transfer in the CLI reference

### DIFF
--- a/docs/content/operator-guide/publishers/operating-publisher.mdx
+++ b/docs/content/operator-guide/publishers/operating-publisher.mdx
@@ -106,7 +106,7 @@ If you expect the publisher to handle significant traffic, you need substantiall
 <Tabs>
 <TabItem label="Mainnet" value="mainnet">
 
-Acquire WAL tokens through the Walrus token distribution or supported exchanges, and transfer both SUI and WAL to the publisher wallet address.
+Acquire WAL tokens through the Walrus token distribution or supported exchanges, and transfer both SUI and WAL to the publisher wallet address. For the commands, see [Transfer WAL between addresses](/docs/walrus-client/walrus-cli#transfer-wal-between-addresses).
 
 :::caution
 

--- a/docs/content/troubleshooting/network-errors.mdx
+++ b/docs/content/troubleshooting/network-errors.mdx
@@ -1,6 +1,6 @@
 ---
 title: Troubleshooting Common Errors
-description: 'Common errors in the Walrus CLI and network, with causes and solutions.'
+description: Common errors in the Walrus CLI and network, with causes and solutions.
 keywords:
   - walrus
   - troubleshooting
@@ -38,7 +38,7 @@ answer: 'Common errors in the Walrus CLI and network, with causes and solutions.
 
 Common errors in the Walrus CLI and network, with causes and solutions.
 
-This page covers common errors you might encounter when using Walrus. Each entry includes the error message, its cause, and how to troubleshoot it.
+Each entry below gives an error message you might hit when using Walrus, what causes it, and how to troubleshoot it.
 
 ## Configuration errors
 
@@ -73,7 +73,7 @@ Alternatively, download a fresh configuration file:
 $ curl https://docs.wal.app/setup/client_config.yaml -o ~/.config/walrus/client_config.yaml
 ```
 
-If you download a fresh file, be aware that any custom configuration may be overwritten or lost. Take precaution to preserve necessary configuration parameters. 
+If you download a fresh file, be aware that any custom configuration might be overwritten or lost. Take precaution to preserve necessary configuration parameters. 
 
 #### `the specified Walrus system object does not exist`
 
@@ -275,7 +275,7 @@ $ walrus convert-blob-id DECIMAL_VALUE
 ```
 
 :::info
-Some on-chain representations and Sui explorers display blob IDs as large decimal numbers. These are not valid blob IDs for Walrus API calls. Always convert them to URL-safe base64 format before use.
+Some onchain representations and Sui explorers display blob IDs as large decimal numbers. These are not valid blob IDs for Walrus API calls. Always convert them to URL-safe base64 format before use.
 :::
 
 #### `the provided blob ID is invalid`
@@ -293,7 +293,7 @@ Error: Blob not found on Sui
 HTTP 404: Blob ID not registered
 ```
 
-**Cause:** The blob was never uploaded, has expired (past its storage epoch), belongs to a different network, or was marked invalid on-chain.
+**Cause:** The blob was never uploaded, has expired (past its storage epoch), belongs to a different network, or was marked invalid onchain.
 
 **Solution:** Verify the blob ID is correct and that you are querying the correct network. Check the blob status:
 
@@ -312,6 +312,8 @@ If the blob expired, re-upload it. On Mainnet, each storage epoch is approximate
 Retry the upload. If the error persists during high network activity, wait a few minutes and try again. Storage nodes might need time to process recent events.
 
 ## Insufficient funds
+
+These errors mean the wallet lacks the tokens a transaction needs, either SUI for gas or WAL for storage.
 
 #### `Insufficient SUI for gas` or `Insufficient WAL for storage fees`
 
@@ -341,6 +343,8 @@ Add SUI or WAL to your wallet as needed. Use `walrus info` to check current stor
 
 ## Transaction errors
 
+These errors come from the Sui transaction the client submits, rather than from the storage nodes.
+
 #### Transaction timeout
 
 **Error:**
@@ -353,7 +357,7 @@ Error: RPC timeout waiting for transaction
 
 **Cause:** Network congestion on Sui, RPC node issues, or the transaction is stuck in the mempool.
 
-**Solution:** Check whether the transaction succeeded on-chain before retrying:
+**Solution:** Check whether the transaction succeeded onchain before retrying:
 
 ```
 $ sui client tx-block TRANSACTION_ID
@@ -362,7 +366,7 @@ $ sui client tx-block TRANSACTION_ID
 If the transaction succeeded, proceed normally. If it failed or was not found, retry the operation.
 
 :::caution
-Do not assume a timed-out transaction failed. Always check the on-chain state first. Retrying a successful transaction can result in duplicate blob registrations and wasted funds.
+Do not assume a timed-out transaction failed. Always check the onchain state first. Retrying a successful transaction can result in duplicate blob registrations and wasted funds.
 :::
 
 #### Transaction conflict
@@ -412,7 +416,7 @@ Error: Quorum not reached (received 1/2 of signatures)
 
 **Cause:** One or more storage nodes are offline, overloaded, or unreachable due to a network partition.
 
-**Solution:** Retry the upload. The publisher might reach different nodes on subsequent attempts. If 2/3 of storage nodes respond, the upload succeeds. If fewer than 2/3 respond, the upload fails. Check on-chain state to verify whether the blob was registered, then retry if necessary.
+**Solution:** Retry the upload. The publisher might reach different nodes on subsequent attempts. If 2/3 of storage nodes respond, the upload succeeds. If fewer than 2/3 respond, the upload fails. Check onchain state to verify whether the blob was registered, then retry if necessary.
 
 #### Aggregator cannot fetch enough slivers
 
@@ -445,7 +449,7 @@ HTTP 404: Sliver ID not in database
 
 **Cause:** The blob expired or was never stored.
 
-**Solution:** Retry the read. Other nodes hold copies of the slivers through erasure coding. If fewer than 1/3 of nodes lost data, retrieval succeeds normally. If the error persists, check the on-chain blob status with `walrus blob-status`. Re-upload the blob if necessary.
+**Solution:** Retry the read. Other nodes hold copies of the slivers through erasure coding. If fewer than 1/3 of nodes lost data, retrieval succeeds normally. If the error persists, check the onchain blob status with `walrus blob-status`. Re-upload the blob if necessary.
 
 #### Sliver hash mismatch
 
@@ -479,6 +483,8 @@ Error: Certificate verification failed
 
 ## Encoding errors
 
+These errors happen on your own machine while the client encodes a blob, before it reaches the network.
+
 #### Out of memory during encoding
 
 **Error:**
@@ -501,6 +507,6 @@ Error: insufficient balance
 Error: no WAL coins found for storage payment
 ```
 
-**Cause:** Your WAL may be from a different package than the Walrus client expects. Some third-party Testnet faucets distribute WAL from a non-canonical package, and the client rejects it with an `insufficient balance` error even though a balance appears in your wallet.
+**Cause:** Your WAL might be from a different package than the Walrus client expects. Some third-party Testnet faucets distribute WAL from a non-canonical package, and the client rejects it with an `insufficient balance` error even though a balance appears in your wallet.
 
 **Solution:** Acquire WAL through the official path documented in [Getting Started](/docs/getting-started), not third-party faucets. On Testnet, use the WAL exchange (`walrus get-wal`); on Mainnet, swap SUI for WAL through a supported exchange. For both paths, and for moving WAL between addresses, see [Acquire and move WAL](/docs/walrus-client/walrus-cli#acquire-and-move-wal). WAL from an unsupported package cannot be used for storage payments.

--- a/docs/content/troubleshooting/network-errors.mdx
+++ b/docs/content/troubleshooting/network-errors.mdx
@@ -246,11 +246,13 @@ Exactly one query pattern must be specified. Valid query patterns are:
 
 **Cause:** The `get-wal` command requires an exchange object ID, but none was provided. This command is only available on Testnet.
 
-**Solution:** Specify the exchange object ID:
+**Solution:** Confirm you are on Testnet, then specify the exchange object ID:
 
 ```
-$ walrus get-wal --exchange-id EXCHANGE_OBJECT_ID
+$ walrus get-wal --context testnet --exchange-id EXCHANGE_OBJECT_ID
 ```
+
+On Mainnet, the configuration declares no exchange objects, so no flag clears this error. See [Acquire WAL on Mainnet](/docs/walrus-client/walrus-cli#acquire-wal-on-mainnet).
 
 #### `operation cancelled by user`
 
@@ -501,4 +503,4 @@ Error: no WAL coins found for storage payment
 
 **Cause:** Your WAL may be from a different package than the Walrus client expects. Some third-party Testnet faucets distribute WAL from a non-canonical package, and the client rejects it with an `insufficient balance` error even though a balance appears in your wallet.
 
-**Solution:** Acquire WAL through the official path documented in [Getting Started](/docs/getting-started), not third-party faucets. On Testnet, use the WAL exchange (`walrus get-wal`); on Mainnet, swap SUI for WAL through a supported exchange. WAL from an unsupported package cannot be used for storage payments.
+**Solution:** Acquire WAL through the official path documented in [Getting Started](/docs/getting-started), not third-party faucets. On Testnet, use the WAL exchange (`walrus get-wal`); on Mainnet, swap SUI for WAL through a supported exchange. For both paths, and for moving WAL between addresses, see [Acquire and move WAL](/docs/walrus-client/walrus-cli#acquire-and-move-wal). WAL from an unsupported package cannot be used for storage payments.

--- a/docs/content/walrus-client/walrus-cli.mdx
+++ b/docs/content/walrus-client/walrus-cli.mdx
@@ -92,7 +92,7 @@ You can access Testnet and Mainnet through the following configuration. This exa
 
 ## Acquire and move WAL
 
-Storing data costs WAL, and every transaction costs SUI for gas. The `walrus` CLI exchanges SUI for WAL on Testnet. Moving WAL between addresses is a Sui operation, so you run it with `sui client`.
+Storing data costs WAL, and every transaction costs SUI for gas. The `walrus` CLI exchanges SUI for WAL on Testnet. To move WAL between addresses, use `sui client`, because Sui handles the transfer rather than Walrus.
 
 ### Exchange SUI for WAL on Testnet
 
@@ -124,7 +124,7 @@ On Mainnet, acquire WAL on an exchange that lists the token, or receive a transf
 
 ### Transfer WAL between addresses
 
-Walrus has no transfer command. WAL is a Sui coin, so `sui client` moves it. You need this when you fund a publisher wallet, a shared team wallet, or an agent wallet that stores blobs for you.
+Walrus has no transfer command. Sui holds WAL as a coin type, so `sui client` moves it. You need this when you fund a publisher wallet, a shared team wallet, or an agent wallet that stores blobs for you.
 
 1. List the WAL coin objects an address holds. Read the fully qualified coin type, which ends in `::wal::WAL`, from the `coinType` field of `sui client balance --json`:
 

--- a/docs/content/walrus-client/walrus-cli.mdx
+++ b/docs/content/walrus-client/walrus-cli.mdx
@@ -29,6 +29,8 @@ questions:
   - What commands does the Walrus CLI support?
   - How do I configure the Walrus CLI?
   - How do I check the status of a blob?
+  - How do I exchange SUI for WAL?
+  - How do I send WAL to another address?
 answer: Use the Walrus client through the command line to store and retrieve blobs.
 ---
 
@@ -88,6 +90,64 @@ Use the `--json` flag to write a command's output as JSON. This is the default i
 You can access Testnet and Mainnet through the following configuration. This example Walrus CLI configuration refers to the standard location for Sui configuration (`~/.sui/sui_config/client.yaml`).
 
 <ImportContent source="/setup/client_config.yaml" mode="code" />
+
+## Acquire and move WAL
+
+Storing data costs WAL, and every transaction costs SUI for gas. The `walrus` CLI exchanges SUI for WAL on Testnet. Moving WAL between addresses is a Sui operation, so you run it with `sui client`.
+
+### Exchange SUI for WAL on Testnet
+
+Run `walrus get-wal` to exchange Testnet SUI for Testnet WAL at a 1:1 rate:
+
+```sh
+$ walrus get-wal --context testnet
+```
+
+The command exchanges 500,000,000 MIST (0.5 SUI) by default. These options change that behavior:
+
+| **Option** | **What it does** |
+|---|---|
+| `--amount <MIST>` | Exchanges the amount you pass, in MIST. |
+| `--exchange-id <OBJECT_ID>` | Uses the exchange object you name instead of one picked from the configuration file. The option takes precedence over the configuration file. |
+
+For the full walkthrough, including how to confirm the balance afterwards, see [Exchange Testnet SUI for WAL](/docs/system-overview/available-networks#testnet-wal-faucet). The exchange object IDs are listed in the [Network Reference](/docs/network-reference#system-and-staking-object-ids).
+
+### Acquire WAL on Mainnet
+
+`walrus get-wal` runs on Testnet only. The Mainnet context in the client configuration file declares no exchange objects, so the command fails there:
+
+```
+The object ID of an exchange object must be specified either in the config file or as a command-line argument.
+Note that this command is only available on Testnet.
+```
+
+On Mainnet, acquire WAL on an exchange that lists the token, or receive a transfer from an address that already holds WAL. Avoid third-party WAL faucets: they can hand you WAL from a package the Walrus client rejects, and storage payments then fail.
+
+### Transfer WAL between addresses
+
+Walrus has no transfer command. WAL is a Sui coin, so `sui client` moves it. You need this when you fund a publisher wallet, a shared team wallet, or an agent wallet that stores blobs for you.
+
+1. List the WAL coin objects an address holds. Read the fully qualified coin type, which ends in `::wal::WAL`, from the `coinType` field of `sui client balance --json`:
+
+   ```sh
+   $ sui client balance ADDRESS --coin-type WAL_COIN_TYPE --with-coins --json
+   ```
+
+2. Transfer one of those coin objects to the recipient:
+
+   ```sh
+   $ sui client transfer --object-id WAL_COIN_ID --to RECIPIENT_ADDRESS --gas-budget 10000000
+   ```
+
+Sui transfers whole coin objects. To send an exact amount instead, split a coin in a [programmable transaction block](https://docs.sui.io/concepts/transactions/prog-txn-blocks) and transfer the coin object that the split produces. Amounts are in FROST, where 1 WAL = 1,000,000,000 FROST.
+
+If an address holds many small WAL coins, merge them first so that a single coin covers the amount you want to send:
+
+```sh
+$ sui client merge-coin --primary-coin LARGEST_WAL_COIN_ID --coin-to-merge OTHER_WAL_COIN_ID
+```
+
+The recipient needs SUI for gas as well. WAL alone does not pay for transactions.
 
 ## Logging and metrics
 

--- a/docs/content/walrus-client/walrus-cli.mdx
+++ b/docs/content/walrus-client/walrus-cli.mdx
@@ -34,8 +34,7 @@ questions:
 answer: Use the Walrus client through the command line to store and retrieve blobs.
 ---
 
-<AgentPrompt
-  prompt="Install the Walrus CLI on my machine, point it at Testnet, and set up the client config. Then verify it works by printing the current epoch and storage price."
+<AgentPrompt prompt="Install the Walrus CLI on my machine, point it at Testnet, and set up the client config. Then verify it works by printing the current epoch and storage price."
 />
 
 Use the command-line interface (CLI) to interact with the Walrus client. The CLI is available by installing the `walrus` binary. To install Walrus, use the Mysten Labs [`suiup` tool](https://github.com/MystenLabs/suiup?tab=readme-ov-file#installation):


### PR DESCRIPTION
## Description

The CLI reference (`walrus-client/walrus-cli.mdx`) covered installation, contexts, config file location, wallet, gas budget, JSON output, and logging — and nothing about tokens. A reader who hit "no WAL coins found for storage payment" had no page that answered *how do I get WAL on Mainnet* or *how do I send WAL to my publisher wallet*.

Adds an **Acquire and move WAL** section to the CLI reference with three subsections, and links to it from the two places that previously dead-ended.

### What changed

- **`docs/content/walrus-client/walrus-cli.mdx`** — new `## Acquire and move WAL` section:
  - *Exchange SUI for WAL on Testnet*: `walrus get-wal`, the 500,000,000 MIST (0.5 SUI) default, and the `--amount` / `--exchange-id` options. Links to the existing walkthrough rather than duplicating it.
  - *Acquire WAL on Mainnet*: states that `get-wal` is Testnet-only, shows the exact error text, and points to exchanges or an inbound transfer.
  - *Transfer WAL between addresses*: `sui client balance --with-coins` to find WAL coin objects, `sui client transfer` to send one, `sui client merge-coin` to consolidate. Notes that exact amounts require splitting a coin in a PTB.
  - Two new `questions` frontmatter entries for AI search.
- **`docs/content/troubleshooting/network-errors.mdx`** — the `The object ID of an exchange object must be specified` entry previously implied that supplying `--exchange-id` always fixes it; on Mainnet nothing does. Now says so and links to the new section. The `insufficient balance` / `no WAL coins found` entry links there too.
- **`docs/content/operator-guide/publishers/operating-publisher.mdx`** — "transfer both SUI and WAL to the publisher wallet address" now links to the transfer commands.

### Why this is not a duplicate of the existing WAL content

`walrus get-wal` on **Testnet** was already well covered (`system-overview/available-networks.mdx#testnet-wal-faucet`, `getting-started/index.mdx`, `testnet-reference.mdx`), and this PR links to that rather than restating it. The gaps were the other two: **Mainnet acquisition**, which appeared only as scattered half-sentences ("swap SUI for WAL through a supported exchange"), and **WAL transfers**, which had no commands anywhere in the docs.

## Sources

Every command and value is taken from this repository; nothing is written from memory of the Sui CLI.

| Claim | Source |
|---|---|
| `get-wal` is Testnet-only; `--exchange-id` takes precedence over the config file | `crates/walrus-service/src/client/cli/args.rs:563-573` (`CliCommands::GetWal` doc comments) |
| Default exchange amount is 500,000,000 MIST = 0.5 SUI | `crates/walrus-service/src/client/cli/args.rs:1940-1942` (`default::exchange_amount_mist`) |
| Error text quoted verbatim in *Acquire WAL on Mainnet* | `crates/walrus-service/src/client/cli/runner.rs:2137-2141` (`exchange_sui_for_wal` `.context(...)`) |
| Mainnet declares no exchange objects | `setup/client_config.yaml` — `exchange_objects` appears under `contexts.testnet` only |
| `sui client balance ADDRESS --coin-type ... --with-coins --json`; WAL coin type ends in `::wal::WAL` | `scripts/create_multisig_subsidy_tx.sh:43-49` (`all_wal_coins_for_addr`) |
| `sui client merge-coin --primary-coin ... --coin-to-merge ...` | `docs/walrus-memory-content/relayer/runbook-gas-pool.md:100` |
| `sui client transfer --object-id ... --to ... --gas-budget ...` | `docs/content/sites/troubleshooting.mdx:121` |
| Exact amounts need a coin split in a PTB | `scripts/create_multisig_subsidy_tx.sh:145` (`--split-coins "@$PRIMARY_COIN" "[$WAL_AMOUNT_FROST]"`) |
| 1 WAL = 1,000,000,000 FROST | `docs/content/testnet-reference.mdx:23` |
| Third-party WAL faucets can distribute a rejected package | `docs/content/network-reference.mdx:284`, `docs/content/troubleshooting/network-errors.mdx:502` |

The prose is written fresh; the PTB split step deliberately links to [Sui's programmable transaction blocks doc](https://docs.sui.io/concepts/transactions/prog-txn-blocks) instead of showing a `--transfer-objects` invocation, because that flag is not exercised anywhere in this repository and I could not verify it against a `sui` binary in this environment.

## Test plan

- `node src/scripts/audit-docs.mjs` from `docs/site` — all three edited pages report `issues: []`, `brokenLinks: []`, `brokenImports: []`, so the three new in-page anchors (`#acquire-and-move-wal`, `#acquire-wal-on-mainnet`, `#transfer-wal-between-addresses`) resolve.
- Style gate passed on push (one voice fix applied: "On Mainnet no exchange object exists" → "On Mainnet, the configuration declares no exchange objects").
- No `sui` or `walrus` binary is available in this environment, so the commands were verified by provenance against the sources above rather than by execution.

Closes BEDU-1022
