### PR TITLE
docs: replace the duplicated example intros with real content

### DIFF
--- a/docs/content/examples/javascript.mdx
+++ b/docs/content/examples/javascript.mdx
@@ -33,8 +33,8 @@ answer: >-
 
 The following JavaScript example shows how to upload and download a blob through a web form using the HTTP API.
 
-The following JavaScript example shows how to upload and download a blob through a web form using the HTTP API.
+The page takes a publisher URL, an aggregator URL, and a storage duration in epochs. Uploading sends the selected file as the body of a `PUT` request to the publisher's `/v1/blobs` endpoint, and the response reports whether the publisher registered a new blob or found one already certified. Either way the response carries a blob ID, which the page turns into a link to `/v1/blobs/{blobId}` on the aggregator so you can read the blob back.
 
-The following JavaScript example shows how to upload and download a blob through a web form using the HTTP API.
+Two limits shape what the example can do. The default publisher caps uploads at 10 MiB, and the aggregator returns every blob as `application/octet-stream`, so the page infers a media type before it can display an image inline.
 
 <ImportContent source="docs/examples/javascript/blob_upload_download_webapi.html" mode="code" org="MystenLabs" repo="walrus" />

--- a/docs/content/examples/move.mdx
+++ b/docs/content/examples/move.mdx
@@ -33,8 +33,8 @@ answer: >-
 
 The following Move example showcases how to import and use Walrus onchain objects.
 
-The following Move example showcases how to import and use Walrus onchain objects.
+A certified blob exists on Sui as a `Blob` object, so Move code can hold one the same way it holds any other object. The module below imports `walrus::blob::Blob`, defines a `WrappedBlob` struct that owns one, and exposes a `wrap` function that moves a caller's `Blob` into it.
 
-The following Move example showcases how to import and use Walrus onchain objects.
+That pattern is the basis for building on stored data: once your own struct owns the `Blob`, your package controls the blob's lifecycle, and it can attach whatever application state it needs alongside the stored content. The full example package, including the `Move.toml` that declares the Walrus dependency, lives in [`docs/examples/move/walrus_dep`](https://github.com/MystenLabs/walrus/tree/main/docs/examples/move/walrus_dep).
 
 <ImportContent source="docs/examples/move/walrus_dep/sources/wrapped_blob.move" mode="code" org="MystenLabs" repo="walrus" />


### PR DESCRIPTION
## Description

Both example pages currently publish the same sentence three times in a row. It reads as a rendering fault, but it is in the source on `main`:

```
The following Move example showcases how to import and use Walrus onchain objects.

The following Move example showcases how to import and use Walrus onchain objects.

The following Move example showcases how to import and use Walrus onchain objects.
```

## Where it came from

`2effd920f7` (#3547, "add audit pipeline, goal frontmatter, and GEO/AEO metadata") added the `answer:` frontmatter field to both pages and pasted its text into the body twice more. Before that commit each page had exactly one copy:

```
$ git show 2effd920f7^:docs/content/examples/move.mdx | tail -4
The following Move example showcases how to import and use Walrus onchain objects.

<ImportContent source="docs/examples/move/walrus_dep/sources/wrapped_blob.move" ... />
```

## Why deleting the duplicates is not enough

The padding was load-bearing. The same commit gave both pages a `min_words: 100` goal check, and each page is one sentence plus an imported source file, roughly 15 words of prose. Removing the duplicates alone would put them back under that threshold.

So each page now earns the word count with content that describes the example:

- **`examples/javascript.mdx`** — the publisher `PUT` to `/v1/blobs`, the `alreadyCertified` versus `newlyCreated` response shapes, the aggregator read at `/v1/blobs/{blobId}`, and the two constraints the example works around (the 10 MiB default publisher cap, and the aggregator returning `application/octet-stream` so the page infers a media type).
- **`examples/move.mdx`** — that a certified blob is a Sui object, so a Move package can own one; what `WrappedBlob` and `wrap` do; and why that ownership is the basis for building on stored data. Links to the example package for the `Move.toml`.

## Sources

| Claim | Source |
| --- | --- |
| `PUT` to `/v1/blobs?epochs=…` on the publisher | `docs/examples/javascript/blob_upload_download_webapi.html:73-77` |
| `alreadyCertified` and `newlyCreated` both yield a blob ID | same file, lines 104 and 113 |
| Read path is `{aggregator}/v1/blobs/{blobId}` | same file, lines 124-125 |
| Aggregator returns `application/octet-stream`, so the page infers a media type | same file, line 134 comment |
| 10 MiB cap on the default publisher | same file, line 210 |
| `WrappedBlob` owns a `Blob`; `wrap` moves one in | `docs/examples/move/walrus_dep/sources/wrapped_blob.move` |
| Duplication introduced by #3547 | `git log -S` on both pages, and `git show 2effd920f7^` for the pre-commit state |

Prose written fresh from those sources.

## Test plan

`node src/scripts/audit-docs.mjs` from `docs/site`, both pages:

| Page | Before | After |
| --- | --- | --- |
| `examples/javascript.mdx` | duplicated body, padded to length | 146 words, `issues: []`, `brokenLinks: []` |
| `examples/move.mdx` | duplicated body, padded to length | 135 words, `issues: []`, `brokenLinks: []` |

Both now pass `min_words` on real content rather than repetition.

## Unrelated finding, not fixed here

Both pages still fail one goal check: `Has code blocks for setup, source, and output: found 0, need >= 3`. The check counts fenced blocks, and these pages render their code through `<ImportContent>`, so it reads zero on pages that are almost entirely code. Every `ImportContent`-based page will fail it the same way. That is an audit-rule issue rather than a content issue, so it is out of scope for this fix, but it is worth teaching the check to count imported sources.

A tree-wide scan for repeated paragraphs found no other real cases; the remaining hits are YAML fragments inside code blocks and legitimately repeated release-note boilerplate.
