### PR TITLE
docs(site): stop the audit reporting Walrus Memory links as broken

### DIFF
--- a/docs/site/src/scripts/audit-docs.mjs
+++ b/docs/site/src/scripts/audit-docs.mjs
@@ -147,6 +147,11 @@ function checkBrokenInternalLinks(body, docPaths, filePath) {
     if (target.startsWith('#')) continue;
     if (target.startsWith('mailto:')) continue;
     if (/\.\w+$/.test(target) && !target.endsWith('.mdx') && !target.endsWith('.md')) continue;
+    // Walrus Memory pages come from a separate plugin instance sourced from
+    // docs/walrus-memory-content, and docPaths only indexes docs/content. This
+    // checker cannot resolve those targets, so reporting them as broken is a
+    // false positive. Docusaurus validates them at build time instead.
+    if (target === '/walrus-memory' || target.startsWith('/walrus-memory/')) continue;
 
     // Normalize the target path
     let normalized = target;


### PR DESCRIPTION
## Description

Closes out the broken-link half of BEDU-1089. The finding turned out to be a checker bug rather than a content problem, so the fix is in the checker.

`checkBrokenInternalLinks` resolves every target against `docPaths`, which indexes `docs/content` only. Walrus Memory pages come from a separate Docusaurus plugin instance sourced from `docs/walrus-memory-content`, so a link into that section was reported broken no matter how it was written:

```js
normalized = normalized.replace(/^\/(docs|walrus-memory)\//, '/');
```

The prefix strip requires a trailing slash, so `/walrus-memory` never matched it and stayed unresolvable. Writing `/walrus-memory/` instead matched, normalized to `/`, and failed too, since `/` is not a page either. I confirmed this by trying the trailing-slash fix first: the finding did not move.

Those links are live. `/walrus-memory` is the target of the redirect at `docusaurus.config.js:148`, and `build-with-linkcheck` validates it on every PR and has been passing. The audit was the only thing reporting a problem.

## Result

| | Before | After |
| --- | --- | --- |
| Broken internal links | 3 across 3 pages | **0** |

The three were identical links on `legal/privacy.mdx`, `legal/testnet_tos.mdx`, and `legal/walrus_general_tos.mdx`, and they were the only remaining broken-link findings in the tree.

## Sources

| Claim | Source |
| --- | --- |
| The checker resolves against `docs/content` only | `docPaths` construction in `docs/site/src/scripts/audit-docs.mjs` |
| The prefix strip requires a trailing slash | `audit-docs.mjs:154` |
| Walrus Memory is a separate plugin instance | `routeBasePath: "walrus-memory"` in `docs/site/docusaurus.config.js:227` |
| `/walrus-memory` is a live route | redirect target at `docusaurus.config.js:148`; `build-with-linkcheck` passing on `main` |

## Test plan

- `node src/scripts/audit-docs.mjs` from `docs/site`: broken internal links drop from 3 to 0 across 106 pages, with no other finding counts changed.
- Verified the trailing-slash rewrite alone does not fix it, which is what identified the checker as the cause.

## Note on the rest of BEDU-1089

The ticket claimed 83 issues. Re-measured against `main`, broken imports are already 0 and broken links are now 0. The remaining item is the "very short page" count, which rose from 5 to 12 for a different reason: the metric counts fenced code blocks and prose words, so `<ImportContent>` pages read as nearly empty when they are almost entirely code. That is the same artifact that produced the duplicated-paragraph padding fixed in #3637, and it deserves its own ticket rather than a content change.

## Release notes

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
