### PR TITLE
docs(site): count imported code toward the code-block goal check

### DIFF
--- a/docs/site/src/scripts/audit-docs.mjs
+++ b/docs/site/src/scripts/audit-docs.mjs
@@ -311,6 +311,16 @@ function findDuplicateTitles(allPages) {
 
 // ─── Layer 2: Goal Checklist ────────────────────────
 
+// `<ImportContent … mode="code">` renders a code block from a real source file
+// but contains no backticks, so a fence-counting check reads zero on pages that
+// are almost entirely code. Count each code import as one complete fence pair,
+// the same as an inline block, so importing a snippet never scores worse than
+// pasting a copy of it.
+function countCodeImports(body) {
+  const matches = body.match(/<ImportContent\s[^>]*mode="code"[^>]*>/g) || [];
+  return matches.length;
+}
+
 function evaluateGoalRequires(goal, body, data, headings) {
   if (!goal || !goal.requires) return null;
 
@@ -323,8 +333,10 @@ function evaluateGoalRequires(goal, body, data, headings) {
       // Count regex pattern occurrences in body
       const re = new RegExp(req.pattern, 'gi');
       const matches = body.match(re) || [];
-      result.pass = matches.length >= req.min;
-      result.detail = `found ${matches.length}, need >= ${req.min}`;
+      let count = matches.length;
+      if (req.pattern === '```') count += countCodeImports(body) * 2;
+      result.pass = count >= req.min;
+      result.detail = `found ${count}, need >= ${req.min}`;
     } else if (req.headings) {
       // Check that headings matching each pattern exist
       const missing = [];


### PR DESCRIPTION
## Description

A goal requirement of `pattern: '```'` counts backticks in the body. `<ImportContent … mode="code">` renders a code block from a real source file without any backticks, so a page that imports its examples scores zero on a check it should pass, while an inline copy of the same snippet passes.

Every import-based example page fails `Has code blocks for setup, source, and output: found 0, need >= 3` today.

## Why this matters beyond the score

This scoring is what produced padding the repo has already had to fix. `examples/javascript.mdx` and `examples/move.mdx` each carried their intro sentence three times, which #3637 removed:

```
The following Move example showcases how to import and use Walrus onchain objects.

The following Move example showcases how to import and use Walrus onchain objects.

The following Move example showcases how to import and use Walrus onchain objects.
```

Those pages are one sentence plus an imported source file, so they could not clear `min_words: 100` on their own. The checks reward pasting a copy over importing the source, which is the opposite of the house preference and the opposite of what review asks for.

## Change

Each `<ImportContent … mode="code">` counts as one complete fence pair for the `'```'` pattern, so importing a snippet never scores worse than pasting it. The check is otherwise untouched.

## Test plan

`node src/scripts/audit-docs.mjs` from `docs/site`, before and after:

| Page | Before | After |
| --- | --- | --- |
| `examples/python.mdx` | found 6 | found 6, unchanged |
| `examples/walrus-relay.mdx` | found 6 | found 6, unchanged |
| `examples/browser-and-mobile.mdx` | found 14 | found 14, unchanged |
| `examples/javascript.mdx` | found 0 | found 2 |
| `examples/move.mdx` | found 0 | found 2 |
| `examples/checkpoint-data.mdx` | found 0 | found 2 |

Counts only increase, so no page that passed before can start failing.

The three pages that still sit below the threshold of 3 on `main` reach it once their open PRs land, which is where their additional imports live: `examples/javascript.mdx` and `examples/checkpoint-data.mdx` in #3627, and `examples/data-marketplace.mdx` in #3626.

## Note on the related word-count check

`min_words` has the same blind spot: it measures prose, so an import-heavy page reads as short however good the imported code is. I have not changed it here, because unlike the fence count there is a real editorial argument that a page should carry enough prose to explain what its example does. The pages fixed in #3637 now clear it on real content rather than repetition. Raising it as a known adjacent issue rather than folding it into this change.

## Release notes

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
