### PR TITLE
feat: add a metric tracking node-recovery baseline invalidations

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -2991,6 +2991,9 @@ impl StorageNodeInner {
             let previous = self.epoch_change_sync_and_recovery_info.borrow();
             info.generation = previous.generation + 1;
             info.node_recovery_baseline_generation = if info.invalidates_node_recovery_baseline() {
+                self.metrics
+                    .node_recovery_baseline_invalidations_total
+                    .inc();
                 info.generation
             } else {
                 previous.node_recovery_baseline_generation

--- a/crates/walrus-service/src/node/epoch_change/goal.rs
+++ b/crates/walrus-service/src/node/epoch_change/goal.rs
@@ -104,7 +104,6 @@ impl EpochChangeSyncAndRecoveryInfo {
     /// Returns `true` if publishing this info invalidates in-flight node-recovery work: while
     /// catching up the node's view of its shard assignment is not authoritative (and blob
     /// events are skipped), and a non-member has no sync work at all.
-    // TODO(WAL-1265): track baseline invalidations (for example, with a metric) for debugging.
     pub(crate) fn invalidates_node_recovery_baseline(&self) -> bool {
         self.catching_up || !self.membership.is_member()
     }

--- a/crates/walrus-service/src/node/metrics.rs
+++ b/crates/walrus-service/src/node/metrics.rs
@@ -163,6 +163,10 @@ walrus_utils::metrics::define_metric_set! {
         #[help = "Indicates the current node status"]
         current_node_status: IntGauge[],
 
+        #[help = "The number of published sync-and-recovery infos that invalidated the \
+        node-recovery baseline, superseding any in-flight node-recovery run"]
+        node_recovery_baseline_invalidations_total: IntCounter[],
+
         #[help = "The number of blob metadata synced"]
         sync_blob_metadata_count: IntCounter[],
 


### PR DESCRIPTION
## Description

Track node-recovery baseline invalidations for debugging.

Resolve WAL-1265

## Test plan

Existing tests; the counter is incremented on the existing, tested baseline-bump branch.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [x] Storage node: Adds a `node_recovery_baseline_invalidations_total` metric counting sync-and-recovery info publications that invalidate the node-recovery baseline and supersede in-flight node-recovery runs.
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
