### PR TITLE
fix: cancel the shard-sync and node-recovery services on node shutdown

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -627,8 +627,8 @@ pub(crate) async fn create_read_client(
 pub struct StorageNode {
     inner: Arc<StorageNodeInner>,
     blob_sync_handler: Arc<BlobSyncHandler>,
-    _shard_sync_handler: Arc<ShardSyncHandler>,
-    _node_recovery_handler: Arc<NodeRecoveryHandler>,
+    shard_sync_handler: Arc<ShardSyncHandler>,
+    node_recovery_handler: Arc<NodeRecoveryHandler>,
     epoch_change_driver: EpochChangeDriver,
     start_epoch_change_finisher: Arc<StartEpochChangeFinisher>,
     num_blob_event_processors: NonZeroUsize,
@@ -1002,8 +1002,8 @@ impl StorageNode {
         Ok(StorageNode {
             inner,
             blob_sync_handler,
-            _shard_sync_handler: shard_sync_handler,
-            _node_recovery_handler: node_recovery_handler,
+            shard_sync_handler,
+            node_recovery_handler,
             epoch_change_driver,
             start_epoch_change_finisher,
             epoch_change_executor,
@@ -1057,6 +1057,10 @@ impl StorageNode {
                     checkpoint_manager.shutdown();
                 }
                 self.inner.shut_down();
+                // Shut down the recovery and shard-sync services before cancelling the blob
+                // syncs, so that neither service starts new sync work afterwards.
+                self.node_recovery_handler.shut_down().await;
+                self.shard_sync_handler.shut_down().await;
                 self.blob_sync_handler.cancel_all().await?;
                 self.garbage_collector.abort().await;
             },
@@ -7452,7 +7456,7 @@ mod tests {
             // the epoch-change executor does in production.
             cluster.nodes[1]
                 .storage_node
-                ._shard_sync_handler
+                .shard_sync_handler
                 .set_metadata_recovery_completion(
                     epoch_change::completion::BackgroundSyncTaskCompletionInstruction::new(
                         NodeStatus::Active,
@@ -7483,7 +7487,7 @@ mod tests {
         // Starts the shard syncing process.
         cluster.nodes[1]
             .storage_node
-            ._shard_sync_handler
+            .shard_sync_handler
             .start_sync_shards(shard_indices)
             .await?;
 
@@ -7613,7 +7617,7 @@ mod tests {
 
         cluster.nodes[1]
             .storage_node
-            ._shard_sync_handler
+            .shard_sync_handler
             .start_sync_shards(vec![ShardIndex(0)])
             .await?;
         wait_for_shard_in_active_state(shard_storage_dst.as_ref()).await?;
@@ -7692,7 +7696,7 @@ mod tests {
 
         cluster.nodes[1]
             .storage_node
-            ._shard_sync_handler
+            .shard_sync_handler
             .start_sync_shards(vec![ShardIndex(0)])
             .await?;
         wait_for_shard_in_active_state(shard_storage_dst.as_ref()).await?;
@@ -7754,7 +7758,7 @@ mod tests {
 
         cluster.nodes[1]
             .storage_node
-            ._shard_sync_handler
+            .shard_sync_handler
             .start_sync_shards(vec![ShardIndex(0)])
             .await?;
         wait_for_shard_in_active_state(shard_storage_dst.as_ref()).await?;
@@ -7854,7 +7858,7 @@ mod tests {
 
         cluster.nodes[1]
             .storage_node
-            ._shard_sync_handler
+            .shard_sync_handler
             .start_sync_shards(vec![ShardIndex(0)])
             .await?;
         wait_for_shard_in_active_state(shard_storage_dst.as_ref()).await?;
@@ -7901,7 +7905,7 @@ mod tests {
         let start = std::time::Instant::now();
         cluster.nodes[1]
             .storage_node
-            ._shard_sync_handler
+            .shard_sync_handler
             .start_sync_shards(vec![ShardIndex(0)])
             .await?;
 
@@ -8077,12 +8081,12 @@ mod tests {
             // break index.
             cluster.nodes[1]
                 .storage_node
-                ._shard_sync_handler
+                .shard_sync_handler
                 .start_sync_shards(vec![ShardIndex(0)])
                 .await?;
 
             // Waits for the shard sync process to stop.
-            wait_until_no_sync_tasks(&cluster.nodes[1].storage_node._shard_sync_handler).await?;
+            wait_until_no_sync_tasks(&cluster.nodes[1].storage_node.shard_sync_handler).await?;
 
             // Check that shard sync process is not finished.
             let shard_storage_src = cluster.nodes[0]
@@ -8104,12 +8108,12 @@ mod tests {
             // restart the shard syncing process, to simulate a reboot.
             cluster.nodes[1]
                 .storage_node
-                ._shard_sync_handler
+                .shard_sync_handler
                 .restart_syncs()
                 .await?;
 
             // Waits for the shard to be synced.
-            wait_until_no_sync_tasks(&cluster.nodes[1].storage_node._shard_sync_handler).await?;
+            wait_until_no_sync_tasks(&cluster.nodes[1].storage_node.shard_sync_handler).await?;
 
             // Checks that the shard is completely migrated.
             check_all_blobs_are_synced(&blob_details, &storage_dst, &shard_storage_dst, &[])?;
@@ -8162,12 +8166,12 @@ mod tests {
             // break index.
             cluster.nodes[1]
                 .storage_node
-                ._shard_sync_handler
+                .shard_sync_handler
                 .start_sync_shards(vec![ShardIndex(0)])
                 .await?;
 
             // Waits for the shard sync process to stop.
-            wait_until_no_sync_tasks(&cluster.nodes[1].storage_node._shard_sync_handler).await?;
+            wait_until_no_sync_tasks(&cluster.nodes[1].storage_node.shard_sync_handler).await?;
 
             // Check that shard sync process is not finished.
             let shard_storage_src = cluster.nodes[0]
@@ -8194,17 +8198,17 @@ mod tests {
             // restart the shard syncing process, to simulate a reboot.
             cluster.nodes[1]
                 .storage_node
-                ._shard_sync_handler
+                .shard_sync_handler
                 .clear_shard_sync_tasks()
                 .await;
             cluster.nodes[1]
                 .storage_node
-                ._shard_sync_handler
+                .shard_sync_handler
                 .restart_syncs()
                 .await?;
 
             // Waits for the shard to be synced.
-            wait_until_no_sync_tasks(&cluster.nodes[1].storage_node._shard_sync_handler).await?;
+            wait_until_no_sync_tasks(&cluster.nodes[1].storage_node.shard_sync_handler).await?;
 
             // Checks that the shard is completely migrated.
             check_all_blobs_are_synced(&blob_details, &storage_dst, &shard_storage_dst, &[])?;
@@ -8279,12 +8283,12 @@ mod tests {
             // break index.
             cluster.nodes[1]
                 .storage_node
-                ._shard_sync_handler
+                .shard_sync_handler
                 .start_sync_shards(vec![ShardIndex(0)])
                 .await?;
 
             // Waits for the shard sync process to stop.
-            wait_until_no_sync_tasks(&cluster.nodes[1].storage_node._shard_sync_handler).await?;
+            wait_until_no_sync_tasks(&cluster.nodes[1].storage_node.shard_sync_handler).await?;
 
             // Checks that the shard is completely migrated.
             check_all_blobs_are_synced(&blob_details, &storage_dst, &shard_storage_dst, &[])?;
@@ -8330,12 +8334,12 @@ mod tests {
             // Starts the shard syncing process in the new shard, which will return empty slivers.
             cluster.nodes[1]
                 .storage_node
-                ._shard_sync_handler
+                .shard_sync_handler
                 .start_sync_shards(vec![ShardIndex(0)])
                 .await?;
 
             // Waits for the shard sync process to stop.
-            wait_until_no_sync_tasks(&cluster.nodes[1].storage_node._shard_sync_handler).await?;
+            wait_until_no_sync_tasks(&cluster.nodes[1].storage_node.shard_sync_handler).await?;
             check_all_blobs_are_synced(&_blob_details, &storage_dst, &shard_storage_dst, &[])?;
 
             // Checks that the shard sync progress is reset.
@@ -8460,12 +8464,12 @@ mod tests {
             // shard sync to sync non-expired certified blobs.
             cluster.nodes[1]
                 .storage_node
-                ._shard_sync_handler
+                .shard_sync_handler
                 .start_sync_shards(vec![ShardIndex(0)])
                 .await?;
 
             // Waits for the shard sync process to stop.
-            wait_until_no_sync_tasks(&cluster.nodes[1].storage_node._shard_sync_handler).await?;
+            wait_until_no_sync_tasks(&cluster.nodes[1].storage_node.shard_sync_handler).await?;
 
             // All blobs should be recovered in the new dst node.
             check_all_blobs_are_synced(&details, &node_inner.storage, &shard_storage_dst, &[])?;
@@ -8543,11 +8547,11 @@ mod tests {
 
             cluster.nodes[1]
                 .storage_node
-                ._shard_sync_handler
+                .shard_sync_handler
                 .start_sync_shards(vec![ShardIndex(0)])
                 .await?;
             // Waits for the shard sync process to stop.
-            wait_until_no_sync_tasks(&cluster.nodes[1].storage_node._shard_sync_handler).await?;
+            wait_until_no_sync_tasks(&cluster.nodes[1].storage_node.shard_sync_handler).await?;
 
             // Check that shard sync process is not finished.
             if !restart_after_recovery {
@@ -8574,7 +8578,7 @@ mod tests {
             // restart the shard syncing process, to simulate a reboot.
             cluster.nodes[1]
                 .storage_node
-                ._shard_sync_handler
+                .shard_sync_handler
                 .restart_syncs()
                 .await?;
 
@@ -8633,7 +8637,7 @@ mod tests {
             storage_dst.set_node_status(NodeStatus::RecoverMetadata)?;
             cluster.nodes[1]
                 .storage_node
-                ._shard_sync_handler
+                .shard_sync_handler
                 .set_metadata_recovery_completion(
                     epoch_change::completion::BackgroundSyncTaskCompletionInstruction::new(
                         NodeStatus::Active,
@@ -8645,12 +8649,12 @@ mod tests {
             // break index.
             cluster.nodes[1]
                 .storage_node
-                ._shard_sync_handler
+                .shard_sync_handler
                 .start_sync_shards(vec![ShardIndex(0)])
                 .await?;
 
             // Waits for the shard sync process to stop.
-            wait_until_no_sync_tasks(&cluster.nodes[1].storage_node._shard_sync_handler).await?;
+            wait_until_no_sync_tasks(&cluster.nodes[1].storage_node.shard_sync_handler).await?;
 
             assert!(
                 shard_storage_dst
@@ -8669,12 +8673,12 @@ mod tests {
             // restart the shard syncing process, to simulate a reboot.
             cluster.nodes[1]
                 .storage_node
-                ._shard_sync_handler
+                .shard_sync_handler
                 .restart_syncs()
                 .await?;
 
             // Waits for the shard to be synced.
-            wait_until_no_sync_tasks(&cluster.nodes[1].storage_node._shard_sync_handler).await?;
+            wait_until_no_sync_tasks(&cluster.nodes[1].storage_node.shard_sync_handler).await?;
 
             // Checks that the shard is completely migrated.
             check_all_blobs_are_synced(&blob_details, &storage_dst, &shard_storage_dst, &[])?;
@@ -8725,7 +8729,7 @@ mod tests {
             storage_dst.clear_metadata_in_test()?;
             storage_dst.set_node_status(NodeStatus::RecoverMetadata)?;
 
-            let shard_sync_handler = &cluster.nodes[1].storage_node._shard_sync_handler;
+            let shard_sync_handler = &cluster.nodes[1].storage_node.shard_sync_handler;
             // Setting `RecoverMetadata` authorizes the metadata-recovery task's completion, as
             // the epoch-change executor does in production. A later epoch change that keeps the
             // node in metadata recovery leaves the instruction in place.
@@ -8820,7 +8824,7 @@ mod tests {
             storage_dst.set_node_status(NodeStatus::RecoverMetadata)?;
             cluster.nodes[1]
                 .storage_node
-                ._shard_sync_handler
+                .shard_sync_handler
                 .set_metadata_recovery_completion(
                     epoch_change::completion::BackgroundSyncTaskCompletionInstruction::new(
                         NodeStatus::Active,
@@ -8830,11 +8834,11 @@ mod tests {
 
             cluster.nodes[1]
                 .storage_node
-                ._shard_sync_handler
+                .shard_sync_handler
                 .start_sync_shards(vec![ShardIndex(0), ShardIndex(1)])
                 .await?;
 
-            wait_until_no_sync_tasks(&cluster.nodes[1].storage_node._shard_sync_handler).await?;
+            wait_until_no_sync_tasks(&cluster.nodes[1].storage_node.shard_sync_handler).await?;
 
             // The owned shards must be synced and the node must be active.
             assert_eq!(storage_dst.node_status()?, NodeStatus::Active);
@@ -8893,7 +8897,7 @@ mod tests {
             storage_dst.clear_metadata_in_test()?;
             storage_dst.set_node_status(NodeStatus::RecoverMetadata)?;
 
-            let shard_sync_handler = &cluster.nodes[1].storage_node._shard_sync_handler;
+            let shard_sync_handler = &cluster.nodes[1].storage_node.shard_sync_handler;
             // Setting `RecoverMetadata` authorizes the metadata-recovery task's completion, as
             // the epoch-change executor does in production.
             shard_sync_handler.set_metadata_recovery_completion(
@@ -8968,7 +8972,7 @@ mod tests {
             storage_dst.clear_metadata_in_test()?;
             storage_dst.set_node_status(NodeStatus::RecoverMetadata)?;
 
-            let shard_sync_handler = &cluster.nodes[1].storage_node._shard_sync_handler;
+            let shard_sync_handler = &cluster.nodes[1].storage_node.shard_sync_handler;
             // Setting `RecoverMetadata` authorizes the metadata-recovery task's completion, as
             // the epoch-change executor does in production.
             shard_sync_handler.set_metadata_recovery_completion(
@@ -9281,7 +9285,7 @@ mod tests {
 
             cluster.nodes[1]
                 .storage_node
-                ._shard_sync_handler
+                .shard_sync_handler
                 .start_sync_shards(vec![ShardIndex(0)])
                 .await?;
 
@@ -9353,7 +9357,7 @@ mod tests {
 
             cluster.nodes[1]
                 .storage_node
-                ._shard_sync_handler
+                .shard_sync_handler
                 .start_sync_shards(vec![ShardIndex(0)])
                 .await?;
 

--- a/crates/walrus-service/src/node/node_recovery.rs
+++ b/crates/walrus-service/src/node/node_recovery.rs
@@ -108,7 +108,6 @@ impl NodeRecoveryHandler {
     /// run only repeats its scan). This replaces the previous start/ensure/abort lifecycle
     /// driven by the epoch-change logic: epoch changes only publish infos and mint completion
     /// instructions; the service makes its own decisions.
-    // TODO(WAL-1263): cancel the node-recovery service when the node is shut down.
     pub(crate) fn spawn_background_recovery(
         &self,
         info_receiver: watch::Receiver<EpochChangeSyncAndRecoveryInfo>,
@@ -136,6 +135,15 @@ impl NodeRecoveryHandler {
             max_concurrent_blob_syncs_during_recovery,
             info_receiver,
         )));
+    }
+
+    /// Shuts down the node-recovery service, aborting the permanent recovery task and waiting
+    /// for it to exit so that it cannot start new blob syncs afterwards.
+    pub(crate) async fn shut_down(&self) {
+        if let Some(service) = self.service_handle.lock().await.take() {
+            service.abort();
+            let _ = service.await;
+        }
     }
 }
 

--- a/crates/walrus-service/src/node/shard_sync.rs
+++ b/crates/walrus-service/src/node/shard_sync.rs
@@ -509,7 +509,6 @@ impl ShardSyncHandler {
     /// start, so the first epoch-change event cannot be planned against a zero live-task
     /// count while a resumed sync is still incomplete (which would hand the attestation to
     /// the finisher prematurely).
-    // TODO(WAL-1263): cancel the shard-sync service when the node is shut down.
     pub(crate) async fn spawn_background_shard_sync_driver(
         &self,
         mut info_receiver: watch::Receiver<EpochChangeSyncAndRecoveryInfo>,
@@ -709,6 +708,17 @@ impl ShardSyncHandler {
             task.abort();
             let _ = task.await;
         }
+    }
+
+    /// Shuts down the shard-sync service: aborts the permanent reconciler task — waiting for
+    /// it to exit so that it cannot start new syncs afterwards — and then quiesces the
+    /// sync-driving task and every per-shard sync task.
+    pub(crate) async fn shut_down(&self) {
+        if let Some(service) = self.service_handle.lock().await.take() {
+            service.abort();
+            let _ = service.await;
+        }
+        self.quiesce_all_syncs().await;
     }
 
     /// Ensures syncs are running for the persisted sync state, as the production startup
@@ -1154,7 +1164,7 @@ mod tests {
         // settle before manipulating the shard statuses with a standalone handler.
         cluster.nodes[0]
             .storage_node
-            ._shard_sync_handler
+            .shard_sync_handler
             .wait_until_no_sync_in_progress()
             .await;
         for i in [0, 2] {


### PR DESCRIPTION
## Description

Resolves WAL-1263.

The permanent shard-sync reconciler and node-recovery service tasks (spawned once at node startup) were never cancelled when the node was cancelled; both spawn sites carried a `TODO(WAL-1263)`.

- Add `NodeRecoveryHandler::shut_down()`: aborts the permanent recovery service task and waits for it to exit, so it cannot start new blob syncs afterwards.
- Add `ShardSyncHandler::shut_down()`: aborts the permanent reconciler task, waits for it to exit, and then reuses `quiesce_all_syncs()` to abort the sync-driving task and every per-shard sync task.
- Call both from the cancellation branch of `StorageNode::run`, before `blob_sync_handler.cancel_all()`, so that neither service can start new sync work after the blob syncs are cancelled. The recovery service is shut down first because it is the one that starts blob syncs.
- Rename the `_shard_sync_handler`/`_node_recovery_handler` fields to drop the unused-marker underscore, and remove the TODO comments.

Aborting the tasks is safe for the same reason the existing `quiesce_all_syncs` relies on: aborts land at await points, so critical-section guards and the `SyncTaskCountGuard` drop cleanly, and sync progress is persisted per batch.

## Test plan

Covered by existing CI (the change is shutdown-path only); existing shard-sync and node-recovery tests exercise the renamed fields.