### PR TITLE
fix: surface SafeIter deserialization failures as errors instead of ending iteration

### DIFF
--- a/crates/typed-store/src/rocks/safe_iter.rs
+++ b/crates/typed-store/src/rocks/safe_iter.rs
@@ -12,7 +12,7 @@ use super::{RocksDBRawIter, be_fix_int_ser};
 use crate::{
     TypedStoreError,
     metrics::{DBMetrics, RocksDBPerfContext},
-    rocks::errors::typed_store_err_from_bincode_err,
+    rocks::errors::{typed_store_err_from_bcs_err, typed_store_err_from_bincode_err},
     traits::SeekableIterator,
 };
 
@@ -93,13 +93,19 @@ impl<K: DeserializeOwned, V: DeserializeOwned> Iterator for SafeIter<'_, K, V> {
             self.key_bytes_scanned_counter += raw_key.len();
             self.value_bytes_scanned_counter += raw_value.len();
             self.keys_returned_counter += 1;
-            let key = config.deserialize(raw_key).ok();
-            let value = bcs::from_bytes(raw_value).ok();
+            // Surface deserialization failures as errors instead of silently ending the
+            // iterator: a truncated iteration is indistinguishable from a complete one for
+            // the caller. The underlying iterator still advances, so a caller that chooses
+            // to can skip the corrupt entry and continue.
+            let key = config
+                .deserialize(raw_key)
+                .map_err(typed_store_err_from_bincode_err);
+            let value = bcs::from_bytes(raw_value).map_err(typed_store_err_from_bcs_err);
             match self.direction {
                 Direction::Forward => self.db_iter.next(),
                 Direction::Reverse => self.db_iter.prev(),
             }
-            key.and_then(|k| value.map(|v| Ok((k, v))))
+            Some(key.and_then(|k| value.map(|v| (k, v))))
         } else {
             match self.db_iter.status() {
                 Ok(_) => None,

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -823,6 +823,44 @@ fn open_rocksdb<P: AsRef<Path>>(path: P, opt_cfs: &[&str]) -> Arc<RocksDB> {
 }
 
 #[tokio::test]
+async fn test_safe_iter_surfaces_deserialization_errors() {
+    let rocks = open_rocksdb(temp_dir(), &["test"]);
+    let db =
+        DBMap::<u32, String>::reopen(&rocks, Some("test"), &ReadWriteOptions::default(), false)
+            .expect("failed to open storage");
+    db.insert(&1, &"one".to_string()).expect("failed to insert");
+    db.insert(&3, &"three".to_string())
+        .expect("failed to insert");
+
+    // Write an entry through a differently-typed handle to the same column family, so that its
+    // value does not deserialize as `String`.
+    let corrupting_db =
+        DBMap::<u32, u64>::reopen(&rocks, Some("test"), &ReadWriteOptions::default(), false)
+            .expect("failed to open storage");
+    corrupting_db
+        .insert(&2, &u64::MAX)
+        .expect("failed to insert");
+
+    let mut iter = db.safe_iter().expect("failed to get iterator");
+    assert_eq!(
+        iter.next()
+            .transpose()
+            .expect("first entry should deserialize"),
+        Some((1, "one".to_string()))
+    );
+    // The corrupt entry surfaces as an error instead of silently ending the iterator.
+    assert!(matches!(iter.next(), Some(Err(_))));
+    // The iterator continues past the corrupt entry.
+    assert_eq!(
+        iter.next()
+            .transpose()
+            .expect("third entry should deserialize"),
+        Some((3, "three".to_string()))
+    );
+    assert!(iter.next().is_none());
+}
+
+#[tokio::test]
 async fn test_sampling() {
     let sampling_interval = SamplingInterval::new(Duration::ZERO, 10);
     for _i in 0..10 {

--- a/crates/walrus-service/src/node/node_recovery.rs
+++ b/crates/walrus-service/src/node/node_recovery.rs
@@ -36,6 +36,12 @@ const SHARD_NOT_CREATED_BACKOFF_MAX: Duration = Duration::from_secs(60);
 /// sync requires a node restart to be retried).
 const UNSYNCED_SHARD_RECHECK_INTERVAL: Duration = Duration::from_secs(60);
 
+/// Exponential backoff bounds for retrying a recovery scan pass after a certified-blob read
+/// error. A failed read leaves the pass's coverage unknown, so the pass must be retried rather
+/// than completed; the backoff keeps a persistent storage error from spinning the scan hot.
+const SCAN_READ_ERROR_BACKOFF_MIN: Duration = Duration::from_secs(1);
+const SCAN_READ_ERROR_BACKOFF_MAX: Duration = Duration::from_secs(60);
+
 #[derive(Debug, Clone)]
 pub struct NodeRecoveryHandler {
     node: Arc<StorageNodeInner>,
@@ -381,6 +387,16 @@ async fn run_recovery(
     baseline: u64,
     target_epoch: Epoch,
 ) -> RunOutcome {
+    // Backoff between scan-pass retries after a certified-blob read error. Recreated after a
+    // clean pass so a fresh failure episode starts at the small bound. The seed only feeds the
+    // jitter offset; a constant keeps it deterministic under the simulator.
+    let mut scan_read_error_backoff = ExponentialBackoff::new_with_seed(
+        SCAN_READ_ERROR_BACKOFF_MIN,
+        SCAN_READ_ERROR_BACKOFF_MAX,
+        None,
+        0,
+    );
+
     loop {
         // Block until the node is ready to run a recovery scan pass. Stops the recovery
         // task if the node started catching up.
@@ -407,29 +423,29 @@ async fn run_recovery(
         // verification re-scan is removed (WAL-669), an interrupted pass still requires
         // a new round of blob recovery.
         let mut scan_pass_interrupted = false;
+        // Whether a certified-blob read failed during this pass. A failed read leaves the
+        // pass's coverage unknown, so a failed pass must be retried; completing the run
+        // anyway would attest epoch sync done despite possibly missed blobs.
+        let mut scan_pass_failed = false;
         // Whether a newly published info superseded this run mid-pass.
         let mut superseded = false;
         tracing::info!(
             "scanning blobs to recover certified blobs before epoch {}",
             target_epoch
         );
-        // TODO(WAL-1272): dropping read errors here is unsound in one case. A persistent
-        // RocksDB status error re-yields on every pass, so the scan spins rather than falsely
-        // completing — but a key or value deserialization failure makes the underlying
-        // `SafeIter` yield `None` and silently *end* the iterator, so a truncated pass reads
-        // as clean and, with all owned shards active, the run completes and attests epoch
-        // sync done despite unknown coverage. Treat any `Err` as a pass failure (retry the
-        // pass with backoff) and make `SafeIter` surface deserialization failures as errors
-        // instead of iterator end.
-        for (blob_id, blob_info) in node
+        for blob_result in node
             .storage
             .certified_blob_info_iter_before_epoch(target_epoch)
-            .filter_map(|blob_result| {
-                blob_result
-                    .inspect_err(|error| tracing::error!(?error, "failed to read certified blob"))
-                    .ok()
-            })
         {
+            let (blob_id, blob_info) = match blob_result {
+                Ok(entry) => entry,
+                Err(error) => {
+                    tracing::error!(?error, "failed to read certified blob info; failing pass");
+                    scan_pass_failed = true;
+                    break;
+                }
+            };
+
             // An epoch change may have started shard syncs for newly gained shards while
             // this pass is running. Stop starting new blob syncs and park: per-blob
             // recovery would redundantly decode slivers for the shards that shard sync is
@@ -567,6 +583,27 @@ async fn run_recovery(
         if superseded {
             return RunOutcome::Superseded;
         }
+
+        // A failed pass has unknown coverage; retry it after a backoff so a persistent
+        // storage error does not spin the scan hot.
+        if scan_pass_failed {
+            let delay = scan_read_error_backoff
+                .next_delay()
+                .unwrap_or(SCAN_READ_ERROR_BACKOFF_MAX);
+            tracing::warn!(
+                ?delay,
+                "recovery scan pass failed due to a read error; retrying after backoff"
+            );
+            tokio::time::sleep(delay).await;
+            continue;
+        }
+        // The pass read cleanly; a later read error starts a fresh backoff episode.
+        scan_read_error_backoff = ExponentialBackoff::new_with_seed(
+            SCAN_READ_ERROR_BACKOFF_MIN,
+            SCAN_READ_ERROR_BACKOFF_MAX,
+            None,
+            0,
+        );
 
         // An interrupted pass has not verified all blobs; run a new pass (which parks
         // until the shard syncs that interrupted it have finished).


### PR DESCRIPTION
## Description

Addresses WAL-1272.

A key or value deserialization failure in `SafeIter::next` previously yielded `None`, silently *ending* the iterator. A truncated iteration is indistinguishable from a complete one for the caller. In the node-recovery scan this was unsound: a corrupt blob-info entry truncated the pass, the pass read as clean, and — with all owned shards active — the run completed and attested epoch sync done despite unknown coverage. (A persistent RocksDB status error, by contrast, re-yields on every pass, so that case only spun rather than falsely completing.)

Changes:
- `SafeIter::next` now yields the deserialization error (`Some(Err(...))`) and advances past the corrupt entry, so callers can either fail or skip and continue. This also matches the upstream Sui `typed-store` behavior.
- The node-recovery scan treats any read error as a pass failure and retries the pass with exponential backoff (1s–60s, reset after a clean pass), instead of dropping errors via `filter_map`. This also removes a hot spin: previously a persistent RocksDB status error re-yielded `Err` forever inside a single pass while `filter_map` discarded it.

All other `SafeIter` consumers already propagate `Result` items, so for them a corrupt entry changes from silent truncation to a visible error.

## Test plan

- New test `test_safe_iter_surfaces_deserialization_errors`: writes an entry through a differently-typed handle to the same column family and asserts the iterator yields `Ok`, `Err`, `Ok`, `None` — the error surfaces and iteration continues past the corrupt entry.
- Full `typed-store` suite and workspace unit tests pass; clippy and cargo-doc clean.