### PR TITLE
fix: attest epoch_sync_done based on persisted shard statuses

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -4427,6 +4427,7 @@ mod tests {
     use crate::test_utils::{
         StorageNodeHandle,
         StorageNodeHandleTrait,
+        StubContractService,
         TestCluster,
         retry_until_success_or_timeout,
     };
@@ -10226,6 +10227,115 @@ mod tests {
             4
         );
         advance_cluster_to_epoch(&cluster, &[&events], 4).await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn epoch_change_without_gained_shards_waits_for_leftover_incomplete_sync() -> TestResult {
+        walrus_test_utils::init_tracing();
+
+        // A terminally failed shard sync leaves its shard persisted mid-sync (`ActiveSync`) with
+        // no live sync task and incomplete data. An epoch change that gains no shards must not
+        // attest `epoch_sync_done` until that shard is back up to date.
+        let events = Sender::new(48);
+        let contract_services = [
+            StubContractService::default(),
+            StubContractService::default(),
+        ];
+        let assignment: &[&[u16]] = &[&[0, 1], &[2, 3]];
+        let cluster: TestCluster = {
+            let _lock = global_test_lock().lock().await;
+            TestCluster::<StorageNodeHandle>::builder()
+                .with_shard_assignment(assignment)
+                .with_system_event_providers(events.clone())
+                .with_system_contract_services(contract_services.iter().cloned())
+                .build()
+                .await?
+        };
+        events.send(ContractEvent::EpochChangeEvent(
+            EpochChangeEvent::EpochChangeStart(EpochChangeStart {
+                epoch: 1,
+                event_id: walrus_sui::test_utils::event_id_for_testing(),
+            }),
+        ))?;
+        events.send(ContractEvent::EpochChangeEvent(
+            EpochChangeEvent::EpochChangeDone(EpochChangeDone {
+                epoch: 1,
+                event_id: walrus_sui::test_utils::event_id_for_testing(),
+            }),
+        ))?;
+        advance_cluster_to_epoch(&cluster, &[&events], 2).await?;
+
+        // With every owned shard active, the epoch change attests directly.
+        retry_until_success_or_timeout(TIMEOUT, || async {
+            if contract_services[0].epoch_sync_done_epochs().contains(&2) {
+                Ok(())
+            } else {
+                bail!("epoch 2 not yet attested")
+            }
+        })
+        .await?;
+
+        // Store and certify a blob so that the resumed sync below has real work to do (an
+        // empty sync would complete instantly, hiding the ordering under test).
+        let blob_details = EncodedBlob::new(BLOB, cluster.encoding_config());
+        let object_id = ObjectID::random();
+        events.send(
+            BlobRegistered::for_testing_with_object_id(*blob_details.blob_id(), object_id).into(),
+        )?;
+        store_at_shards(&blob_details, &cluster, |_, _| true).await?;
+        events.send(
+            BlobCertified::for_testing_with_object_id(*blob_details.blob_id(), object_id).into(),
+        )?;
+        wait_until_events_processed(&cluster.nodes[0], 6).await?;
+
+        // Simulate the leftover failed sync: persist shard 0 as mid-sync; no task is running.
+        let shard_storage = cluster.nodes[0]
+            .storage_node
+            .inner
+            .storage
+            .shard_storage(ShardIndex(0))
+            .await
+            .expect("shard 0 should exist");
+        shard_storage.record_start_shard_sync().await?;
+
+        // Advance to epoch 3 without gaining any shards, observing the attestations tightly
+        // from the moment the event is sent.
+        assert_eq!(
+            cluster
+                .lookup_service_handle
+                .as_ref()
+                .expect("should contain lookup service")
+                .advance_epoch(),
+            3
+        );
+        events.send(ContractEvent::EpochChangeEvent(
+            EpochChangeEvent::EpochChangeStart(EpochChangeStart {
+                epoch: 3,
+                event_id: walrus_sui::test_utils::event_id_for_testing(),
+            }),
+        ))?;
+        events.send(ContractEvent::EpochChangeEvent(
+            EpochChangeEvent::EpochChangeDone(EpochChangeDone {
+                epoch: 3,
+                event_id: walrus_sui::test_utils::event_id_for_testing(),
+            }),
+        ))?;
+
+        // The attestation must wait for the shard: when it is first observed, the reconciler
+        // must already have resumed the interrupted sync and brought the shard back to active.
+        let status_when_attested = tokio::time::timeout(Duration::from_secs(30), async {
+            loop {
+                if contract_services[0].epoch_sync_done_epochs().contains(&3) {
+                    break shard_storage.status().await;
+                }
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+        })
+        .await
+        .expect("the resumed sync should complete and attest epoch 3")?;
+        assert_eq!(status_when_attested, ShardStatus::Active);
 
         Ok(())
     }

--- a/crates/walrus-service/src/node/epoch_change.rs
+++ b/crates/walrus-service/src/node/epoch_change.rs
@@ -558,7 +558,6 @@ impl EpochChangeExecutor {
             in_previous_committee: committees
                 .previous_committee()
                 .is_some_and(|committee| committee.contains(public_key)),
-            has_ongoing_shard_syncs: self.shard_sync_handler.has_sync_in_progress(),
             shards: plan::ShardDiff {
                 gained: shard_diff_calculator
                     .gained_shards_from_prev_epoch()
@@ -932,10 +931,14 @@ impl EpochChangeExecutor {
             plan::EpochSyncDoneAttestationOwner::ShardSync => {
                 self.node_recovery_handler.clear_completion_instruction();
                 // Record the token's pending shard syncs: every owned shard whose persisted
-                // status is not yet `Active` — exactly the work the reconciler rebuilds. With
-                // all sync work quiesced above, the pending set cannot race stale completions.
-                // An empty pending set means the epoch-sync claim already holds (for example,
-                // when re-processing the event after a crash): the finisher attests directly.
+                // status is not yet `Active` — exactly the work the reconciler rebuilds. This
+                // deliberately consults the persisted statuses rather than any live-task
+                // count: a terminally failed sync from an earlier epoch leaves its shard
+                // persisted mid-sync with no running task, and its data is still incomplete.
+                // With all sync work quiesced above, the pending set cannot race stale
+                // completions. An empty pending set means the epoch-sync claim already holds
+                // (for example, when re-processing the event after a crash): the finisher
+                // attests directly.
                 let mut pending_shards = Vec::new();
                 for shard in &execution_info.owned_shards {
                     let is_active = match self.inner.storage.shard_storage(*shard).await {
@@ -951,6 +954,7 @@ impl EpochChangeExecutor {
                 if pending_shards.is_empty()
                     && self.inner.storage.node_status()? != NodeStatus::RecoverMetadata
                 {
+                    self.shard_sync_handler.clear_epoch_sync_done_token();
                     finisher_attestation = Some(token);
                 } else {
                     // Registered even when no shard is pending while metadata recovery is

--- a/crates/walrus-service/src/node/epoch_change/plan.rs
+++ b/crates/walrus-service/src/node/epoch_change/plan.rs
@@ -67,17 +67,6 @@ pub(crate) struct PlanInputs {
     pub in_current_committee: bool,
     /// Whether the node was a member of the previous committee.
     pub in_previous_committee: bool,
-    /// Whether shard-sync tasks (from this or earlier epochs) are still running at planning
-    /// time. Outstanding syncs mean the node's epoch-sync claim is not yet complete, so the
-    /// attestation must wait for them instead of being sent by the finisher.
-    // TODO(WAL-1271): the live-task count misses a terminally failed sync, which leaves its
-    // shard persisted as `ActiveSync`/`ActiveRecover` with incomplete data and zero running
-    // tasks. At the next epoch change without gained shards this routes the token to the
-    // finisher, which attests without consulting the persisted shard statuses — a false
-    // `epoch_sync_done`. Instead of this flag, the apply step should always compute the
-    // pending set from the persisted statuses (as the shard-sync owner arm already does) and
-    // hand the finisher the token only when that set is empty.
-    pub has_ongoing_shard_syncs: bool,
     /// The shard sets affected by this epoch change.
     pub shards: ShardDiff,
 }
@@ -108,12 +97,14 @@ pub(crate) enum StatusTransition {
 /// Exactly one component owns the attestation per epoch change.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum EpochSyncDoneAttestationOwner {
-    /// No shard-sync work exists at all — none started for this epoch, none still running
-    /// from earlier epochs — and the node is not recovering: the start-epoch-change finisher
-    /// attests directly (it skips the attestation if the node is not in the committee).
+    /// The node is not a member of the new committee and makes no epoch-sync claim: the
+    /// start-epoch-change finisher holds the token and drops it without attesting.
     StartEpochChangeFinisher,
-    /// Shard syncs were started for this epoch or are still running from earlier ones: the
-    /// sync completion that finishes the pending shard syncs attests.
+    /// The node is a committee member that is not recovering: its epoch-sync claim is complete
+    /// once every owned shard is up to date. The apply step computes the pending set from the
+    /// persisted shard statuses — which also covers syncs left over from earlier epochs,
+    /// including terminally failed ones with no live task — and the sync completion that
+    /// empties the set attests; with nothing pending, the finisher attests directly.
     ShardSync,
     /// The node is recovering: the recovery task attests once the blob scan is complete and all
     /// owned shards are active.
@@ -281,16 +272,15 @@ fn epoch_change_execution_info(
     inputs: &PlanInputs,
     status: Option<StatusTransition>,
 ) -> EpochChangeExecutionInfo {
-    // The epoch-sync claim is complete only once every sync has delivered: newly gained
-    // shards, syncs still draining from earlier epochs (for shards the node may still own),
-    // and an unfinished metadata recovery all defer the attestation to shard sync. The
-    // start-epoch-change finisher attests directly only when the node is a committee member
-    // with no sync work at all (and skips the attestation entirely for non-members).
-    let outstanding_sync_work =
-        inputs.has_ongoing_shard_syncs || inputs.node_status == NodeStatus::RecoverMetadata;
-    let sync_done_owner = if inputs.in_current_committee
-        && (!inputs.shards.gained.is_empty() || outstanding_sync_work)
-    {
+    // A member's epoch-sync claim is complete only once every owned shard is up to date:
+    // newly gained shards, syncs left over from earlier epochs (which may have failed
+    // terminally, leaving no live task), and an unfinished metadata recovery all defer the
+    // attestation. Whether any such work remains is a fact about the persisted shard
+    // statuses, which only the apply step can read reliably (after quiescing all sync work),
+    // so a member's attestation is always routed through shard sync; the apply step hands the
+    // token to the finisher when the pending set turns out to be empty. A non-member makes no
+    // epoch-sync claim: the finisher holds its token and drops it without attesting.
+    let sync_done_owner = if inputs.in_current_committee {
         EpochSyncDoneAttestationOwner::ShardSync
     } else {
         EpochSyncDoneAttestationOwner::StartEpochChangeFinisher
@@ -336,7 +326,6 @@ mod tests {
             node_status: NodeStatus::Active,
             in_current_committee: true,
             in_previous_committee: true,
-            has_ongoing_shard_syncs: false,
             shards: ShardDiff {
                 gained: shard_ids(&[1, 2]),
                 lost: shard_ids(&[3]),
@@ -474,7 +463,11 @@ mod tests {
     }
 
     #[test]
-    fn in_sync_member_without_gained_shards_lets_finisher_attest() {
+    fn member_without_gained_shards_still_routes_attestation_through_shard_sync() {
+        // Gaining no shards does not mean the epoch-sync claim is complete: a sync left over
+        // from an earlier epoch may still be mid-flight — or terminally failed, with its shard
+        // persisted mid-sync and no live task. The apply step decides from the persisted shard
+        // statuses, handing the finisher the token only when nothing is pending.
         let inputs = PlanInputs {
             shards: ShardDiff {
                 gained: vec![],
@@ -486,28 +479,6 @@ mod tests {
         };
         let execution_info = expect_apply(plan_epoch_change(&inputs));
         assert_eq!(execution_info.status, None);
-        assert!(execution_info.new_shards.is_none());
-        assert_eq!(
-            execution_info.sync_done_owner,
-            EpochSyncDoneAttestationOwner::StartEpochChangeFinisher
-        );
-    }
-
-    #[test]
-    fn outstanding_syncs_keep_shard_sync_as_attestation_owner() {
-        // Gaining no shards does not mean the epoch-sync claim is complete: syncs from earlier
-        // epochs may still be draining, and the attestation must wait for them.
-        let inputs = PlanInputs {
-            has_ongoing_shard_syncs: true,
-            shards: ShardDiff {
-                gained: vec![],
-                lost: vec![],
-                removed: vec![],
-                all_owned: shard_ids(&[0]),
-            },
-            ..base_inputs()
-        };
-        let execution_info = expect_apply(plan_epoch_change(&inputs));
         assert!(execution_info.new_shards.is_none());
         assert_eq!(
             execution_info.sync_done_owner,
@@ -531,28 +502,6 @@ mod tests {
         assert_eq!(
             execution_info.sync_done_owner,
             EpochSyncDoneAttestationOwner::ShardSync
-        );
-    }
-
-    #[test]
-    fn dropout_with_outstanding_syncs_uses_finisher() {
-        // A non-member makes no epoch-sync claim: the finisher (which skips attestation for
-        // non-members) owns the token even if old syncs are still draining.
-        let inputs = PlanInputs {
-            in_current_committee: false,
-            has_ongoing_shard_syncs: true,
-            shards: ShardDiff {
-                gained: vec![],
-                lost: shard_ids(&[0, 1]),
-                removed: vec![],
-                all_owned: vec![],
-            },
-            ..base_inputs()
-        };
-        let execution_info = expect_apply(plan_epoch_change(&inputs));
-        assert_eq!(
-            execution_info.sync_done_owner,
-            EpochSyncDoneAttestationOwner::StartEpochChangeFinisher
         );
     }
 
@@ -616,7 +565,7 @@ mod tests {
         assert_eq!(execution_info.status, None);
         assert_eq!(
             execution_info.sync_done_owner,
-            EpochSyncDoneAttestationOwner::StartEpochChangeFinisher
+            EpochSyncDoneAttestationOwner::ShardSync
         );
     }
 

--- a/crates/walrus-service/src/node/shard_sync.rs
+++ b/crates/walrus-service/src/node/shard_sync.rs
@@ -504,11 +504,9 @@ impl ShardSyncHandler {
     /// the change's quiesce — including for a shard the node just lost, which would
     /// re-activate the shard's locked storage.
     ///
-    /// The initial reconciliation runs synchronously, before this function returns: resumed
-    /// sync work is then already visible to `has_sync_in_progress` when the event processors
-    /// start, so the first epoch-change event cannot be planned against a zero live-task
-    /// count while a resumed sync is still incomplete (which would hand the attestation to
-    /// the finisher prematurely).
+    /// The initial reconciliation runs synchronously, before this function returns, so that
+    /// interrupted syncs resume before the event processors start instead of waiting for the
+    /// reconciler task to be scheduled.
     // TODO(WAL-1263): cancel the shard-sync service when the node is shut down.
     pub(crate) async fn spawn_background_shard_sync_driver(
         &self,

--- a/crates/walrus-service/src/node/start_epoch_change_finisher.rs
+++ b/crates/walrus-service/src/node/start_epoch_change_finisher.rs
@@ -38,8 +38,9 @@ impl StartEpochChangeFinisher {
     /// Starts background tasks to finish the epoch change.
     ///
     /// This includes the following:
-    /// - Attesting epoch sync done if the finisher was handed the attestation token (that is, no
-    ///   shard syncs were started and node recovery is not in progress).
+    /// - Attesting epoch sync done if the finisher was handed the attestation token (that is,
+    ///   every owned shard is already up to date and node recovery is not in progress; a
+    ///   non-member's token is dropped without attesting).
     /// - Removing no longer owned storage for shards.
     /// - Marking the event as completed.
     pub fn start_finish_epoch_change_tasks(
@@ -120,9 +121,9 @@ impl StartEpochChangeFinisher {
             .current_committee()
             .contains(self.node.public_key());
         if is_node_in_committee && committees.epoch() == event.epoch {
-            // We are in the current committee, but no shards were gained. Directly signal that
+            // We are in the current committee with no pending sync work. Directly signal that
             // the epoch sync is done.
-            tracing::info!("no shards gained, so signalling that epoch sync is done");
+            tracing::info!("no pending sync work, so signalling that epoch sync is done");
             debug_assert_eq!(token.epoch(), event.epoch);
             token.attest(&self.node).await;
             tracing::info!("epoch sync done signaled");

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -1758,7 +1758,7 @@ impl CommitteeService for StubCommitteeService {
 /// A stub [`SystemContractService`].
 ///
 /// Performs a no-op when calling [`invalidate_blob_id()`][Self::invalidate_blob_id]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct StubContractService {
     pub(crate) system_parameters: FixedSystemParameters,
     pub(crate) node_capability_object: StorageNodeCap,
@@ -1767,6 +1767,18 @@ pub struct StubContractService {
     #[allow(dead_code)]
     pub(crate) certify_event_blob_rx:
         Arc<std::sync::Mutex<tokio::sync::mpsc::Receiver<BlobObjectMetadata>>>,
+    epoch_sync_done_epochs: Arc<std::sync::Mutex<Vec<Epoch>>>,
+}
+
+impl StubContractService {
+    /// Returns the epochs for which `epoch_sync_done` has been called, in call order.
+    /// Clones observe the same calls.
+    pub fn epoch_sync_done_epochs(&self) -> Vec<Epoch> {
+        self.epoch_sync_done_epochs
+            .lock()
+            .expect("mutex should not be poisoned")
+            .clone()
+    }
 }
 
 impl Default for StubContractService {
@@ -1782,6 +1794,7 @@ impl Default for StubContractService {
             node_capability_object: StorageNodeCap::new_for_testing(),
             certify_event_blob_tx: Arc::new(std::sync::Mutex::new(tx)),
             certify_event_blob_rx: Arc::new(std::sync::Mutex::new(rx)),
+            epoch_sync_done_epochs: Arc::default(),
         }
     }
 }
@@ -1799,7 +1812,12 @@ impl SystemContractService for StubContractService {
 
     async fn invalidate_blob_id(&self, _certificate: &InvalidBlobCertificate) {}
 
-    async fn epoch_sync_done(&self, _epoch: Epoch, _node_capability_object_id: ObjectID) {}
+    async fn epoch_sync_done(&self, epoch: Epoch, _node_capability_object_id: ObjectID) {
+        self.epoch_sync_done_epochs
+            .lock()
+            .expect("mutex should not be poisoned")
+            .push(epoch);
+    }
 
     async fn get_epoch_and_state(&self) -> anyhow::Result<(Epoch, EpochState)> {
         anyhow::bail!("stub service does not store the epoch or state")


### PR DESCRIPTION
## Description

Fixes WAL-1271.

The epoch-change planner decided the `epoch_sync_done` attestation owner from the live shard-sync task count (`has_ongoing_shard_syncs`): with no gained shards and no running task, the start-epoch-change finisher attested directly. A terminally failed shard sync, however, leaves its shard persisted as `ActiveSync`/`ActiveRecover` with incomplete data and zero running tasks, so the next epoch change without gained shards attested `epoch_sync_done` without consulting the persisted shard statuses — a false attestation.

This PR removes the live-task count from the plan inputs and instead:

- The plan always routes a committee member's attestation through shard sync (non-members keep the finisher route, which drops the token without attesting).
- The apply step computes the token's pending set from the persisted shard statuses — every owned shard that is not `Active`, which covers syncs left over from earlier epochs, including terminally failed ones — and hands the finisher the token only when that set is empty (and no metadata recovery is outstanding).

The apply step already computed the pending set this way for the shard-sync owner arm; the change makes that the single source of truth for whether the epoch-sync claim holds.

## Test plan

- Updated the `plan_epoch_change` unit tests for the new routing (a member without gained shards now routes through shard sync).
- Added the regression test `epoch_change_without_gained_shards_waits_for_leftover_incomplete_sync`: a shard persisted mid-sync with no live task must delay the attestation until the reconciler resumes the sync and the shard is active again. `StubContractService` now records `epoch_sync_done` calls so the test can observe attestation ordering. Verified the test fails against the previous routing logic and passes with the fix.
- `cargo nextest run -p walrus-service`: all 1157 tests pass.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [x] Storage node: A storage node no longer sends a false `epoch_sync_done` attestation when a shard sync from an earlier epoch failed terminally; the attestation now waits until every owned shard is up to date.
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
