### PR TITLE
fix(docs): move runnable examples off Sui JSON-RPC

### DIFF
--- a/docs/examples/javascript/system_stats.html
+++ b/docs/examples/javascript/system_stats.html
@@ -11,32 +11,35 @@
     <title>Walrus System Object Data</title>
     <script>
         async function fetchSuiObject() {
-            const endpoint = 'https://fullnode.mainnet.sui.io';
-            const objectId = '0xc5e430c7c517e99da14e67928b360f3260de47cb61f55338cdd9119f519c282c';
+            const endpoint = 'https://graphql.mainnet.sui.io/graphql';
+            // The Walrus system object on Sui Mainnet. Its single dynamic
+            // field holds the inner system state, so this query keeps working
+            // across Walrus contract upgrades.
+            const objectId = '0x2134d52768ea07e8c43570ef975eb3e4c27a39fa6396bef985b5abc58d03ddd2';
 
-            const payload = {
-                jsonrpc: '2.0',
-                id: 1,
-                method: 'sui_getObject',
-                params: [
-                    objectId,
-                    { showContent: true }
-                ]
-            };
+            const query = `query ($objectId: SuiAddress!) {
+                object(address: $objectId) {
+                    dynamicFields(first: 1) {
+                        nodes {
+                            value { ... on MoveValue { json } }
+                        }
+                    }
+                }
+            }`;
 
             try {
                 const response = await fetch(endpoint, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify(payload)
+                    body: JSON.stringify({ query, variables: { objectId } })
                 });
 
                 const data = await response.json();
                 const data_results =
-                    data.result.data.content.fields.value
-                    .fields.future_accounting.fields.ring_buffer;
+                    data.data.object.dynamicFields.nodes[0]
+                    .value.json.future_accounting.ring_buffer;
 
-                data_results.sort((a, b) => a.fields.epoch - b.fields.epoch);
+                data_results.sort((a, b) => a.epoch - b.epoch);
 
                 let totalRewards = 0;
 
@@ -44,12 +47,12 @@
                   '<thead><tr><th>Epoch</th><th>Rewards to Distribute (WAL)</th><th>Used Capacity (GiB)</th></tr></thead>' +
                   '<tbody>';
                 data_results.forEach(item => {
-                    const rewardsWal = parseInt(item.fields.rewards_to_distribute) / 1e9;
-                    const usedCapacityGib = parseInt(item.fields.used_capacity) / (1<<30);
+                    const rewardsWal = parseInt(item.rewards_to_distribute) / 1e9;
+                    const usedCapacityGib = parseInt(item.used_capacity) / (1<<30);
                     totalRewards += rewardsWal;
 
                     table += `<tr>` +
-                      `<td style="text-align:right;">${item.fields.epoch}</td>` +
+                      `<td style="text-align:right;">${item.epoch}</td>` +
                       `<td style="text-align:right;">${rewardsWal.toLocaleString(undefined, {maximumFractionDigits: 0})}</td>` +
                       `<td style="text-align:right;">${usedCapacityGib.toLocaleString(undefined, {maximumFractionDigits: 0})}</td>` +
                       `</tr>`;

--- a/docs/examples/python/hello_walrus_jsonapi.py
+++ b/docs/examples/python/hello_walrus_jsonapi.py
@@ -13,7 +13,7 @@ import base64
 
 import requests
 
-from utils import num_to_blob_id, PATH_TO_WALRUS, PATH_TO_WALRUS_CONFIG, FULL_NODE_URL
+from utils import num_to_blob_id, PATH_TO_WALRUS, PATH_TO_WALRUS_CONFIG, GRAPHQL_URL
 
 try:
     # Create a 1MiB file of random data
@@ -78,30 +78,27 @@ try:
 
     # Part 3. Check the availability of the blob
     if sui_object_id:
-        request = {
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "sui_getObject",
-            "params": [
-                sui_object_id,
-                {
-                    "showType": True,
-                    "showOwner": False,
-                    "showPreviousTransaction": True,
-                    "showDisplay": False,
-                    "showContent": True,
-                    "showBcs": False,
-                    "showStorageRebate": False,
-                },
-            ],
+        query = """
+        query ($objectId: SuiAddress!) {
+            object(address: $objectId) {
+                asMoveObject {
+                    contents { json }
+                }
+            }
         }
-        response = requests.post(FULL_NODE_URL, json=request)
-        object_content = response.json()["result"]["data"]["content"]
+        """
+        response = requests.post(
+            GRAPHQL_URL,
+            json={"query": query, "variables": {"objectId": sui_object_id}},
+        )
+        object_content = response.json()["data"]["object"]["asMoveObject"][
+            "contents"
+        ]["json"]
         print("Object content:")
         print(json.dumps(object_content, indent=4))
 
         # Check that the blob ID matches the one we uploaded
-        blob_id_downloaded = int(object_content["fields"]["blob_id"])
+        blob_id_downloaded = int(object_content["blob_id"])
         if num_to_blob_id(blob_id_downloaded) == blob_id:
             print("Blob ID matches certificate!")
         else:

--- a/docs/examples/python/track_walrus_events.py
+++ b/docs/examples/python/track_walrus_events.py
@@ -9,64 +9,68 @@ import datetime
 import requests
 import re
 
-from utils import num_to_blob_id, PATH_TO_WALRUS_CONFIG
+from utils import num_to_blob_id, GRAPHQL_URL, PATH_TO_WALRUS_CONFIG
 
 system_object_id = re.findall(
     r"system_object:[ ]*(.*)", open(PATH_TO_WALRUS_CONFIG).read()
 )[0]
 print(f"System object ID: {system_object_id}")
 
-# Query the Walrus system object on Sui
-request = {
-    "jsonrpc": "2.0",
-    "id": 1,
-    "method": "sui_getObject",
-    "params": [
-        system_object_id,
-        {
-            "showType": True,
-            "showOwner": False,
-            "showPreviousTransaction": False,
-            "showDisplay": False,
-            "showContent": False,
-            "showBcs": False,
-            "showStorageRebate": False,
-        },
-    ],
+# Query the Walrus system object on Sui through the GraphQL API
+query = """
+query ($objectId: SuiAddress!) {
+    object(address: $objectId) {
+        asMoveObject {
+            contents { type { repr } }
+        }
+    }
 }
-response = requests.post("https://fullnode.testnet.sui.io:443", json=request)
+"""
+response = requests.post(
+    GRAPHQL_URL,
+    json={"query": query, "variables": {"objectId": system_object_id}},
+)
 assert response.status_code == 200
 
-system_object_content = response.json()["result"]["data"]
-walrus_package = re.findall("(0x[0-9a-f]+)::system", system_object_content["type"])[0]
+object_type = response.json()["data"]["object"]["asMoveObject"]["contents"]["type"][
+    "repr"
+]
+walrus_package = re.findall("(0x[0-9a-f]+)::system", object_type)[0]
 print(f"Walrus type: {walrus_package}")
 
-# Query events for the appropriate Walrus type
-request = {
-    "jsonrpc": "2.0",
-    "id": 1,
-    "method": "suix_queryEvents",
-    "params": [
-        # Query by module type
-        {"MoveModule": {"package": walrus_package, "module": "blob"}},
-        None,
-        # Query the latest 100 events
-        100,
-        True, # Indicates descending order
-    ],
+# Query the latest 50 events emitted by the Walrus package (the maximum page size)
+query = """
+query ($eventType: String!) {
+    events(last: 50, filter: { type: $eventType }) {
+        nodes {
+            timestamp
+            contents { type { repr } json }
+            transaction { digest }
+        }
+    }
 }
-response = requests.post("https://fullnode.testnet.sui.io:443", json=request)
+"""
+response = requests.post(
+    GRAPHQL_URL,
+    # Filtering by the `<package>::events` prefix matches all Walrus event types
+    json={"query": query, "variables": {"eventType": f"{walrus_package}::events"}},
+)
 assert response.status_code == 200
 
-events = response.json()["result"]["data"]
-for event in events:
+events = response.json()["data"]["events"]["nodes"]
+# Print the most recent events first
+for event in reversed(events):
     # Parse the Walrus event
-    tx_digest = event["id"]["txDigest"]
-    event_type = event["type"][68 + 13 :] # Skip the package & module prefix
-    parsed_event = event["parsedJson"]
-    blob_id = num_to_blob_id(int(parsed_event["blob_id"]))
-    timestamp_ms = int(event["timestampMs"])
-    time_date = datetime.datetime.fromtimestamp(timestamp_ms / 1000.0)
+    tx_digest = event["transaction"]["digest"]
+    event_type = event["contents"]["type"]["repr"].split("::")[-1]
+    parsed_event = event["contents"]["json"]
+    time_date = datetime.datetime.fromisoformat(
+        event["timestamp"].replace("Z", "+00:00")
+    )
+
+    # Blob lifecycle events carry a blob ID; epoch events do not
+    blob_id_num = parsed_event.get("blob_id")
+    blob_id = num_to_blob_id(int(blob_id_num)) if blob_id_num is not None else ""
 
     # For registered blobs get their size in bytes
     if event_type == "BlobRegistered":

--- a/docs/examples/python/utils.py
+++ b/docs/examples/python/utils.py
@@ -4,7 +4,7 @@
 import base64
 
 # Configure these paths to match your system
-FULL_NODE_URL = "https://fullnode.testnet.sui.io:443"
+GRAPHQL_URL = "https://graphql.testnet.sui.io/graphql"
 PATH_TO_WALRUS = "../CONFIG/bin/walrus"
 PATH_TO_WALRUS_CONFIG = "../CONFIG/config_dir/client_config.yaml"
 

--- a/docs/examples/seal/config.ts
+++ b/docs/examples/seal/config.ts
@@ -8,7 +8,7 @@
 // fill in the two values below before running the scripts. See the tutorial
 // (Encrypting data with Seal) for the deployment steps and links.
 
-import { getJsonRpcFullnodeUrl, SuiJsonRpcClient } from '@mysten/sui/jsonRpc';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
 import { SealClient } from '@mysten/seal';
 import { walrus } from '@mysten/walrus';
 
@@ -27,12 +27,12 @@ export const ALLOWLIST_ID = '0xYOUR_ALLOWLIST_OBJECT_ID';
 // The Move module inside PACKAGE_ID that defines `seal_approve`.
 export const MODULE_NAME = 'allowlist';
 
-// One Sui client, extended with the Walrus SDK, reused everywhere. The same
-// client instance is passed to Seal and to SessionKey so that policy checks and
-// blob reads/writes all target the same network.
-export const suiClient = new SuiJsonRpcClient({
+// One Sui client (gRPC), extended with the Walrus SDK, reused everywhere. The
+// same client instance is passed to Seal and to SessionKey so that policy
+// checks and blob reads/writes all target the same network.
+export const suiClient = new SuiGrpcClient({
   network: NETWORK,
-  url: getJsonRpcFullnodeUrl(NETWORK),
+  baseUrl: `https://fullnode.${NETWORK}.sui.io:443`,
 }).$extend(walrus());
 
 // A Seal client configured against a single Testnet key server. For threshold

--- a/docs/examples/seal/funded-keypair.ts
+++ b/docs/examples/seal/funded-keypair.ts
@@ -23,8 +23,8 @@ export async function getFundedKeypair(): Promise<Ed25519Keypair> {
   const address = keypair.toSuiAddress();
 
   // Top up SUI from the faucet if the balance is low.
-  const { totalBalance } = await suiClient.getBalance({ owner: address });
-  if (BigInt(totalBalance) < MIST_PER_SUI) {
+  const { balance } = await suiClient.getBalance({ owner: address });
+  if (BigInt(balance.balance) < MIST_PER_SUI) {
     await requestSuiFromFaucetV2({
       host: getFaucetHost(NETWORK),
       recipient: address,


### PR DESCRIPTION
## Description

Public Sui full nodes no longer serve JSON-RPC, so every runnable example that posts raw JSON-RPC requests fails today. This PR moves them to supported transports:

- `docs/examples/python/track_walrus_events.py` and `docs/examples/python/hello_walrus_jsonapi.py` now use the Sui GraphQL API (`https://graphql.testnet.sui.io/graphql`) for the object and event reads; `utils.py` exposes `GRAPHQL_URL` instead of `FULL_NODE_URL`.
- `docs/examples/javascript/system_stats.html` reads the system state through GraphQL. It now resolves the inner state object through the system object's single dynamic field instead of a hard-coded inner object ID, so it keeps working across Walrus contract upgrades. The system object ID matches the documented Mainnet system object in `network-reference.mdx`; the previously hard-coded inner object ID was already stale after a contract upgrade, so the old page was broken twice over.
- The Seal example (`docs/examples/seal/`) constructs `SuiGrpcClient` from `@mysten/sui/grpc` instead of the removed JSON-RPC client and uses the core `getBalance` response shape.

Beyond the transport swap, the event tracker's filter is also a correctness fix: the old query filtered on `MoveModule: { module: "blob" }`, but every Walrus event is emitted from `walrus::events`, so it was pointed at the wrong module. The new filter matches the `<package>::events` type prefix, which also pulls in non-blob events such as `EpochChangeStart`/`EpochChangeDone`; the `parsed_event.get("blob_id")` guard handles those having no blob ID.

## Test plan

- Ran `track_walrus_events.py` against Testnet: prints the latest Walrus events with blob IDs, sizes, and transaction digests.
- Verified the `hello_walrus_jsonapi.py` availability query and the `system_stats.html` query against live Testnet/Mainnet GraphQL, including the `future_accounting.ring_buffer` shape and the 50-item page-size cap on `events`.
- Type-checked the Seal example with `tsc --strict` against `@mysten/sui@2.24.0`, `@mysten/seal@1.4.0`, and `@mysten/walrus@1.2.14`.