### PR TITLE
docs: stop showing the deprecated Sui JSON-RPC client in doc

### DIFF
--- a/docs/content/examples/browser-and-mobile.mdx
+++ b/docs/content/examples/browser-and-mobile.mdx
@@ -72,11 +72,12 @@ These are also listed in the [Network Reference](/docs/network-reference#upload-
 Create a `WalrusClient` with an `uploadRelay` configuration. The `host` points at the relay, and `sendTip` sets the maximum tip your client is willing to pay a paid relay. A free relay reports `no_tip` and the client pays only the onchain storage fee.
 
 ```ts
-import { getFullnodeUrl, SuiClient } from "@mysten/sui/client";
+import { SuiGrpcClient } from "@mysten/sui/grpc";
 import { WalrusClient } from "@mysten/walrus";
 
-export const suiClient = new SuiClient({
-  url: getFullnodeUrl("testnet"),
+export const suiClient = new SuiGrpcClient({
+  network: "testnet",
+  baseUrl: "https://fullnode.testnet.sui.io:443",
 });
 
 export const walrusClient = new WalrusClient({

--- a/docs/content/examples/browser-and-mobile.mdx
+++ b/docs/content/examples/browser-and-mobile.mdx
@@ -69,28 +69,28 @@ These are also listed in the [Network Reference](/docs/network-reference#upload-
 
 ## Configure the client
 
-Create a `WalrusClient` with an `uploadRelay` configuration. The `host` points at the relay, and `sendTip` sets the maximum tip your client is willing to pay a paid relay. A free relay reports `no_tip` and the client pays only the onchain storage fee.
+Extend the Sui client with the Walrus SDK, passing an `uploadRelay` configuration. The `host` points at the relay, and `sendTip` sets the maximum tip your client is willing to pay a paid relay. A free relay reports `no_tip` and the client pays only the onchain storage fee.
 
 ```ts
 import { SuiGrpcClient } from "@mysten/sui/grpc";
-import { WalrusClient } from "@mysten/walrus";
+import { walrus } from "@mysten/walrus";
 
 export const suiClient = new SuiGrpcClient({
   network: "testnet",
   baseUrl: "https://fullnode.testnet.sui.io:443",
-});
-
-export const walrusClient = new WalrusClient({
-  network: "testnet",
-  suiClient,
-  uploadRelay: {
-    host: "https://upload-relay.testnet.walrus.space",
-    sendTip: {
-      max: 1_000,
+}).$extend(
+  walrus({
+    uploadRelay: {
+      host: "https://upload-relay.testnet.walrus.space",
+      sendTip: {
+        max: 1_000,
+      },
+      timeout: 600_000,
     },
-    timeout: 600_000,
-  },
-});
+  }),
+);
+
+export const walrusClient = suiClient.walrus;
 ```
 
 ## Store a file through the relay

--- a/docs/content/network-reference.mdx
+++ b/docs/content/network-reference.mdx
@@ -254,11 +254,12 @@ For the full configuration reference, see the [Site Builder Reference](/docs/sit
 The TypeScript SDK bundles the package and object IDs for each network. Select the network with the `network` option, and the SDK applies the correct values:
 
 ```ts
-import { getFullnodeUrl, SuiClient } from '@mysten/sui/client';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
 import { WalrusClient } from '@mysten/walrus';
 
-const suiClient = new SuiClient({
-  url: getFullnodeUrl('mainnet'),
+const suiClient = new SuiGrpcClient({
+  network: 'mainnet',
+  baseUrl: 'https://fullnode.mainnet.sui.io:443',
 });
 
 const walrusClient = new WalrusClient({

--- a/docs/content/network-reference.mdx
+++ b/docs/content/network-reference.mdx
@@ -255,17 +255,15 @@ The TypeScript SDK bundles the package and object IDs for each network. Select t
 
 ```ts
 import { SuiGrpcClient } from '@mysten/sui/grpc';
-import { WalrusClient } from '@mysten/walrus';
+import { walrus } from '@mysten/walrus';
 
 const suiClient = new SuiGrpcClient({
   network: 'mainnet',
   baseUrl: 'https://fullnode.mainnet.sui.io:443',
-});
+}).$extend(walrus());
 
-const walrusClient = new WalrusClient({
-  network: 'mainnet',
-  suiClient,
-});
+// Walrus SDK methods are available on suiClient.walrus.
+const walrusClient = suiClient.walrus;
 ```
 
 To connect to a custom or updated deployment, pass an explicit package configuration using the system and staking object IDs from this page. For full details, see the [Walrus TypeScript SDK](https://sdk.mystenlabs.com/walrus) and the [SDKs](/docs/typescript-sdk/sdks) page.

--- a/docs/content/sites/linking/redirects.mdx
+++ b/docs/content/sites/linking/redirects.mdx
@@ -184,7 +184,7 @@ When creating the `Display` for your object type, include the `walrus site addre
 
 ```move
 const VISUALIZATION_SITE: address = @0x901fb0...;
- 
+
 display.add(b"walrus site address".to_string(), VISUALIZATION_SITE.to_string());
 ```
 
@@ -196,7 +196,7 @@ The Walrus Site at `VISUALIZATION_SITE` is a single shared site, but it can rend
 
 1. Read `window.location.hostname` to get the subdomain.
 2. Decode the Base36 subdomain back to the original hex object ID.
-3. Query the Sui RPC for that object's onchain data.
+3. Query a Sui full node for that object's onchain data.
 4. Render the page using the object's properties (color, image, name, and so on).
 
 This produces a unique page for every object without requiring a separate Walrus Site deployment per item. For a complete implementation, see the [`flatland` example](https://github.com/MystenLabs/example-walrus-sites/tree/main/flatland).

--- a/docs/content/system-overview/core-concepts.mdx
+++ b/docs/content/system-overview/core-concepts.mdx
@@ -108,7 +108,7 @@ You can find the Walrus system object ID in the Walrus [`client_config.yaml` fil
 
 #### Events
 
-Storage nodes monitor blockchain events to coordinate their operations and respond to system changes. Walrus uses [custom Sui events](https://github.com/MystenLabs/walrus/blob/main/contracts/walrus/sources/system/events.move) to notify storage nodes of updates concerning stored blobs and the state of the network. Applications can also use [Sui RPC facilities](https://docs.sui.io/references/sui-api) to observe Walrus-related events.
+Storage nodes monitor blockchain events to coordinate their operations and respond to system changes. Walrus uses [custom Sui events](https://github.com/MystenLabs/walrus/blob/main/contracts/walrus/sources/system/events.move) to notify storage nodes of updates concerning stored blobs and the state of the network. Applications can also use the Sui [gRPC](https://docs.sui.io/references/fullnode-protocol) or [GraphQL](https://docs.sui.io/references/sui-graphql) APIs to observe Walrus-related events.
 
 When a blob is first registered, a [`BlobRegistered`](https://github.com/MystenLabs/walrus/blob/main/contracts/walrus/sources/system/events.move#L12-L23) event is emitted that informs storage nodes that they should expect slivers associated with its blob ID. When the blob is certified, a [`BlobCertified`](https://github.com/MystenLabs/walrus/blob/main/contracts/walrus/sources/system/events.move#L25-L35) event is emitted containing information about the blob ID and the epoch after which the blob is deleted. Before that epoch, the blob is guaranteed to be available.
 

--- a/docs/content/system-overview/storage-costs.mdx
+++ b/docs/content/system-overview/storage-costs.mdx
@@ -191,7 +191,7 @@ Walrus blobs are represented as [Sui objects](https://docs.sui.io/guides/develop
 
 ## Measuring costs
 
-The most accurate way to measure costs is to upload a blob and observe SUI and WAL costs in a Sui explorer or through Sui RPC calls. Blob contents do not affect cost.
+The most accurate way to measure costs is to upload a blob and observe SUI and WAL costs in a Sui explorer or through the Sui gRPC API. Blob contents do not affect cost.
 
 For example, the following command results in 2 transactions:
 ```sh

--- a/docs/content/walrus-client/verifying-availability.mdx
+++ b/docs/content/walrus-client/verifying-availability.mdx
@@ -129,28 +129,16 @@ $ walrus blob-status --blob-id <BLOB_ID>
 
 This reports whether the blob is stored and its availability period. When it reports a certified permanent blob, it also returns the related Sui event ID, a transaction ID and a sequence number. Read the current epoch with `walrus info`.
 
-To check programmatically after writing a blob, use the `Blob` object ID from the write result and re-read that object from Sui before depending on it:
+To check programmatically after writing a blob, use the `Blob` object ID from the write result and re-read that object from Sui before depending on it. The TypeScript SDK's `getBlobObject` helper reads the object over gRPC and returns the parsed Move struct. For the client construction, see the [Network Reference](/docs/network-reference#typescript-sdk).
 
 ```ts
-const res = await suiClient.getObject({
-  id: blobObjectId, // blobObject.id from the write result
-  options: { showContent: true },
-});
-if (res.data?.content?.dataType !== "moveObject") {
-  throw new Error("Blob object was not found on Sui");
-}
+const blob = await walrusClient.getBlobObject(blobObjectId); // blobObject.id from the write result
 
-const fields = res.data.content.fields as Record<string, any>;
-const storageFields = fields.storage?.fields;
+// certified_epoch is a parsed Move Option<u32>: null until the blob is certified.
+const certified = blob.certified_epoch != null;
+const endEpoch = blob.storage.end_epoch;
 
-// The parsed Move Option<u32> is Some(epoch) when vec contains one value.
-const certifiedEpoch = fields.certified_epoch?.fields?.vec?.[0] ?? null;
-
-const certified = certifiedEpoch != null;
-const endEpoch = Number(storageFields.end_epoch);
-const deletable = fields.deletable === true;
-
-const durable = certified && currentEpoch < endEpoch && !deletable;
+const durable = certified && currentEpoch < endEpoch && !blob.deletable;
 if (!durable) {
   throw new Error("Blob is not durably available yet; do not depend on it");
 }
@@ -191,28 +179,22 @@ if any check fails. Set `aggregator` to an endpoint from the
 with `walrus info` or from Walrus system state.
 
 ```ts
+import { WalrusClient } from "@mysten/walrus";
+
 async function readVerifiedBlob(
-  suiClient: SuiClient,
+  walrusClient: WalrusClient,
   aggregator: string,
   blobObjectId: string,
   currentEpoch: number,
 ): Promise<Uint8Array> {
   // 1. Read the Blob object from Sui.
-  const res = await suiClient.getObject({
-    id: blobObjectId,
-    options: { showContent: true },
-  });
-  if (res.data?.content?.dataType !== "moveObject") {
-    throw new Error("Blob object was not found on Sui");
-  }
+  const blob = await walrusClient.getBlobObject(blobObjectId);
 
   // 2. Check availability: certified, within its storage period, not deletable.
-  const fields = res.data.content.fields as Record<string, any>;
-  const certifiedEpoch = fields.certified_epoch?.fields?.vec?.[0] ?? null;
-  const endEpoch = Number(fields.storage?.fields?.end_epoch);
-  const deletable = fields.deletable === true;
-
-  const durable = certifiedEpoch != null && currentEpoch < endEpoch && !deletable;
+  const durable =
+    blob.certified_epoch != null &&
+    currentEpoch < blob.storage.end_epoch &&
+    !blob.deletable;
   if (!durable) {
     throw new Error("Blob is not durably available; do not depend on it");
   }


### PR DESCRIPTION
## Description

Sui full nodes no longer serve JSON-RPC, but several docs pages still showed the JSON-RPC `SuiClient` from `@mysten/sui/client` as the way to reach Sui from TypeScript, and some prose still pointed readers at the JSON-RPC API reference.

- The [Network Reference](docs/content/network-reference.mdx) and [browser-and-mobile](docs/content/examples/browser-and-mobile.mdx) client snippets now construct `SuiGrpcClient` from `@mysten/sui/grpc`, matching the pattern the error-handling page already uses.
- The [verifying-availability](docs/content/walrus-client/verifying-availability.mdx) snippets read the `Blob` object through the Walrus SDK's `getBlobObject` helper instead of the JSON-RPC `getObject({ showContent: true })` shape. This also removes the manual `Option<u32>` field spelunking, because the helper returns the parsed Move struct.
- Event-observation prose in core-concepts now links to the Sui gRPC and GraphQL API references instead of the JSON-RPC API reference; the storage-costs and redirects pages no longer say "Sui RPC" for what is gRPC today.

## Test plan

- `cd docs/site && pnpm build` passes; no new broken links or anchors (the two pre-existing anchor warnings are unrelated pages).
- All new TypeScript snippets type-check with `tsc --strict` against `@mysten/sui@2.24.0` and `@mysten/walrus@1.2.14`.
- Verified the new external links (`references/fullnode-protocol`, `references/sui-graphql`) resolve.