### PR TITLE
chore: rename stale JSON-RPC naming in walrus-proxy and tests

### DIFF
--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -2012,7 +2012,7 @@ async fn test_get_owned_objects_of_type_blob() -> TestResult {
     assert_eq!(fetched_blob.id, blob_object.id);
     assert_eq!(fetched_blob.size, blob_object.size);
 
-    // Cross-check with the JSON-RPC owned_blobs path.
+    // Cross-check with the higher-level owned_blobs path.
     let owned = sui_client
         .owned_blobs(None, ExpirySelectionPolicy::Valid)
         .await?;

--- a/crates/walrus-proxy/src/config.rs
+++ b/crates/walrus-proxy/src/config.rs
@@ -52,7 +52,7 @@ pub struct RemoteWriteConfig {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct DynamicPeerValidationConfig {
-    /// url is the json-rpc url we use to obtain valid peers on the blockchain
+    /// url is the Sui full node RPC URL we use to obtain valid peers on the blockchain
     pub url: String,
     /// the interval we will update our peer cache
     #[serde_as(as = "DurationSeconds<u64>")]

--- a/crates/walrus-proxy/src/providers/walrus/provider.rs
+++ b/crates/walrus-proxy/src/providers/walrus/provider.rs
@@ -16,11 +16,11 @@ use prometheus::{CounterVec, HistogramOpts, HistogramVec, Opts};
 use super::query::{NodeInfo, get_walrus_nodes};
 use crate::{Allower, NetworkPublicKey, register_metric};
 
-static JSON_RPC_STATE: Lazy<CounterVec> = Lazy::new(|| {
+static SUI_RPC_STATE: Lazy<CounterVec> = Lazy::new(|| {
     register_metric!(
         CounterVec::new(
             Opts::new(
-                "json_rpc_state",
+                "sui_rpc_state",
                 "Number of successful/failed requests made.",
             ),
             &["rpc_method", "status"]
@@ -28,12 +28,12 @@ static JSON_RPC_STATE: Lazy<CounterVec> = Lazy::new(|| {
         .expect("metric creation cannot fail with valid parameters")
     )
 });
-static JSON_RPC_DURATION: Lazy<HistogramVec> = Lazy::new(|| {
+static SUI_RPC_DURATION: Lazy<HistogramVec> = Lazy::new(|| {
     register_metric!(
         HistogramVec::new(
             HistogramOpts::new(
-                "json_rpc_duration_seconds",
-                "The json-rpc latencies in seconds.",
+                "sui_rpc_duration_seconds",
+                "The Sui RPC latencies in seconds.",
             )
             .buckets(vec![
                 0.0008, 0.0016, 0.0032, 0.0064, 0.0128, 0.0256, 0.0512, 0.1024, 0.2048, 0.4096,
@@ -102,7 +102,7 @@ impl WalrusNodeProvider {
             loop {
                 interval.tick().await;
                 let timer =
-                    walrus_utils::with_label!(JSON_RPC_DURATION, "update_peer_count").start_timer();
+                    walrus_utils::with_label!(SUI_RPC_DURATION, "update_peer_count").start_timer();
                 cloned_self.update_walrus_nodes().await;
                 timer.observe_duration();
             }
@@ -119,12 +119,12 @@ impl WalrusNodeProvider {
         .await
         {
             Ok(node_infos) => {
-                walrus_utils::with_label!(JSON_RPC_STATE, "update_peer_count", "success").inc();
+                walrus_utils::with_label!(SUI_RPC_STATE, "update_peer_count", "success").inc();
                 node_infos
             }
             Err(e) => {
                 tracing::error!("unable to perform committee update; {e}");
-                walrus_utils::with_label!(JSON_RPC_STATE, "update_peer_count", "failed").inc();
+                walrus_utils::with_label!(SUI_RPC_STATE, "update_peer_count", "failed").inc();
                 return;
             }
         };


### PR DESCRIPTION
## Description

The walrus-proxy peer provider talks to Sui through the gRPC-backed `SuiReadClient`, but its naming still said JSON-RPC:

- The Prometheus metrics `json_rpc_state` and `json_rpc_duration_seconds` are renamed to `sui_rpc_state` and `sui_rpc_duration_seconds` (statics renamed to match, help text updated).
- The `DynamicPeerValidationConfig.url` doc comment no longer calls the full node URL a "json-rpc url".
- A stale e2e-test comment described the `owned_blobs` call as "the JSON-RPC path"; at the default migration level it runs over gRPC.

No behavior changes; the config file format is unchanged (only a doc comment).

:warning: Dashboards or alerts that reference the old walrus-proxy metric names need to switch to `sui_rpc_state` / `sui_rpc_duration_seconds` when picking up this change.

## Test plan

- `cargo check -p walrus-proxy` passes.
- Full pre-commit suite (fmt, clippy with tests, cargo test, cargo doc) passes; the `cargo-deny` advisories hook is skipped because it already fails on `main` due to unrelated newly published advisories (RUSTSEC-2026-0178 `tokio-postgres`, `sized-chunks`).