### PR TITLE
refactor: build EventEnvelope directly from checkpoint events

### DIFF
--- a/crates/walrus-service/src/event/event_processor/checkpoint.rs
+++ b/crates/walrus-service/src/event/event_processor/checkpoint.rs
@@ -12,14 +12,13 @@ use std::{
 
 use anyhow::{Result, anyhow};
 use futures_util::future::try_join_all;
-use move_core_types::annotated_value::{MoveDatatypeLayout, MoveTypeLayout};
 use sui_package_resolver::Resolver;
-use sui_sdk::rpc_types::SuiEvent;
 use sui_types::{
     SYSTEM_PACKAGE_ADDRESSES,
     base_types::ObjectID,
     committee::Committee,
     effects::TransactionEffectsAPI,
+    event::EventID,
     full_checkpoint_content::CheckpointData,
     message_envelope::Message,
     messages_checkpoint::VerifiedCheckpoint,
@@ -162,27 +161,15 @@ impl CheckpointProcessor {
                 .enumerate()
             {
                 tracing::trace!(?tx_event, "event received");
-                let move_type_layout = self
-                    .package_resolver
-                    .type_layout(move_core_types::language_storage::TypeTag::Struct(
-                        Box::new(tx_event.type_.clone()),
-                    ))
-                    .await?;
-                let move_datatype_layout = match move_type_layout {
-                    MoveTypeLayout::Struct(s) => Some(MoveDatatypeLayout::Struct(s)),
-                    MoveTypeLayout::Enum(e) => Some(MoveDatatypeLayout::Enum(e)),
-                    _ => None,
-                }
-                .ok_or(anyhow!("Failed to get move datatype layout"))?;
-                let sui_event = SuiEvent::try_from(
-                    tx_event,
-                    *tx.transaction.digest(),
-                    seq as u64,
-                    None,
-                    move_datatype_layout,
-                )?;
-                let contract_event: ContractEvent =
-                    walrus_sui::types::EventEnvelope::from(sui_event).try_into()?;
+                let envelope = walrus_sui::types::EventEnvelope {
+                    id: EventID {
+                        tx_digest: *tx.transaction.digest(),
+                        event_seq: u64::try_from(seq).expect("event index fits in u64"),
+                    },
+                    type_: tx_event.type_,
+                    bcs: tx_event.contents,
+                };
+                let contract_event: ContractEvent = envelope.try_into()?;
                 let event_sequence_number = CheckpointEventPosition::new(
                     *checkpoint.checkpoint_summary.sequence_number(),
                     counter,


### PR DESCRIPTION
## Description

Part of cleaning up the remaining Sui JSON-RPC type usage. The checkpoint processor resolved the full Move type layout of every Walrus event through the package resolver just to construct a JSON-RPC `SuiEvent`, then immediately discarded everything except the event ID, type, and BCS bytes when converting to `EventEnvelope`.

This change constructs the `EventEnvelope` directly from the raw checkpoint event, the same way the gRPC read path in `walrus-sui` already does. Effects:

- Removes the per-event Move layout resolution and BCS-to-JSON parse from the event-processing hot path. The parsed JSON only fed the `SuiEvent` field that nothing read; decoding is still validated when the BCS bytes convert into the concrete Walrus event types.
- Drops the last JSON-RPC type (`sui_sdk::rpc_types::SuiEvent`) from production code paths in `walrus-service`.

The `From<SuiEvent> for EventEnvelope` impl in `walrus-sui` stays for now: the legacy JSON-RPC fallback paths (gated behind `WALRUS_GRPC_MIGRATION_LEVEL < 11`) still use it, and it disappears with them when that fallback machinery is removed.

## Test plan

- `cargo check -p walrus-service` and the walrus-service event-processor unit tests pass.
- Full pre-commit suite (fmt, clippy with tests, cargo test, cargo doc) passes; the `cargo-deny` advisories hook is skipped because it already fails on `main` due to unrelated newly published advisories (RUSTSEC-2026-0178 `tokio-postgres`, `sized-chunks`).