### PR TITLE
test: add regression test for shard sync resumed behind its gain epoch

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -7518,6 +7518,55 @@ mod tests {
         Ok(())
     }
 
+    // Regression test for the stale shard-sync bound.
+    //
+    // A node gains shard 0 at epoch 2 and its sync is interrupted by a crash. On restart the
+    // durable event cursor is still below the epoch-2 `EpochChangeStart` (an earlier event was
+    // incomplete), so the node's event position is epoch 1. `start_shard_sync_impl` takes its
+    // bound from `current_event_epoch()`, so the resumed sync enumerates only blobs certified
+    // before epoch 1. The test blobs are certified at epoch 1, so it finds nothing to fetch and
+    // flips the shard to `Active` while empty, and nothing revisits an `Active` shard
+    // afterwards. The shard must instead hold every blob certified before the epoch at which it
+    // was gained.
+    #[tokio::test(start_paused = false)]
+    async fn sync_shard_resumed_behind_event_epoch_must_not_activate_empty_shard() -> TestResult {
+        let (cluster, blob_details, storage_dst, shard_storage_set) =
+            setup_cluster_for_shard_sync_tests(None, None, false).await?;
+        let shard_storage_dst = shard_storage_set.shard_storage[0].clone();
+        let node = &cluster.nodes[1].storage_node;
+
+        // The shard was gained at epoch 2 and its sync was interrupted mid-flight.
+        shard_storage_dst
+            .update_status_in_test(ShardStatus::ActiveSync)
+            .await?;
+
+        // After the restart, event replay is still behind the epoch at which the shard was
+        // gained.
+        let _ = node.inner.latest_event_epoch_sender.send(Some(1));
+
+        // Startup republishes the sync-and-recovery info, which is what makes the shard-sync
+        // reconciler resume the interrupted sync.
+        node.epoch_change_executor
+            .publish_startup_sync_and_recovery_info()
+            .await?;
+
+        // Give the resumed sync time to run under whatever bound it chose.
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        // Event replay catches up to the epoch at which the shard was gained.
+        let _ = node.inner.latest_event_epoch_sender.send(Some(2));
+
+        // The shard must not be reported as synced until it actually holds the blobs.
+        wait_for_shard_in_active_state(shard_storage_dst.as_ref()).await?;
+        assert_eq!(shard_storage_dst.sliver_count(SliverType::Primary), Ok(23));
+        assert_eq!(
+            shard_storage_dst.sliver_count(SliverType::Secondary),
+            Ok(23)
+        );
+        check_all_blobs_are_synced(&blob_details, &storage_dst, &shard_storage_dst, &[])?;
+        Ok(())
+    }
+
     /// Sets up a test cluster for shard recovery tests.
     async fn setup_shard_recovery_test_cluster_with_blob_count<F, G, H>(
         blob_count: u8,

--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -7521,15 +7521,25 @@ mod tests {
     // Regression test for the stale shard-sync bound.
     //
     // A node gains shard 0 at epoch 2 and its sync is interrupted by a crash. On restart the
-    // durable event cursor is still below the epoch-2 `EpochChangeStart` (an earlier event was
-    // incomplete), so the node's event position is epoch 1. `start_shard_sync_impl` takes its
-    // bound from `current_event_epoch()`, so the resumed sync enumerates only blobs certified
-    // before epoch 1. The test blobs are certified at epoch 1, so it finds nothing to fetch and
-    // flips the shard to `Active` while empty, and nothing revisits an `Active` shard
-    // afterwards. The shard must instead hold every blob certified before the epoch at which it
-    // was gained.
-    #[tokio::test(start_paused = false)]
-    async fn sync_shard_resumed_behind_event_epoch_must_not_activate_empty_shard() -> TestResult {
+    // durable event cursor can still be below the epoch-2 `EpochChangeStart` (an earlier event
+    // was incomplete), which puts the node's event position back at epoch 1.
+    // `start_shard_sync_impl` takes its bound from `current_event_epoch()`, so the resumed sync
+    // then enumerates only blobs certified before epoch 1. The test blobs are certified at
+    // epoch 1, so it finds nothing to fetch and flips the shard to `Active` while empty, and
+    // nothing revisits an `Active` shard afterwards.
+    //
+    // The two cases differ only in the event position the resume observes, which isolates the
+    // bound as the cause: `resumed_at_gain_epoch` transfers all 23 blobs, while
+    // `resumed_behind_gain_epoch` must not report the shard as synced without them.
+    async_param_test! {
+        sync_shard_resumed_must_not_activate_empty_shard -> TestResult: [
+            resumed_at_gain_epoch: (2),
+            resumed_behind_gain_epoch: (1),
+        ]
+    }
+    async fn sync_shard_resumed_must_not_activate_empty_shard(
+        event_epoch_at_resume: Epoch,
+    ) -> TestResult {
         let (cluster, blob_details, storage_dst, shard_storage_set) =
             setup_cluster_for_shard_sync_tests(None, None, false).await?;
         let shard_storage_dst = shard_storage_set.shard_storage[0].clone();
@@ -7540,9 +7550,11 @@ mod tests {
             .update_status_in_test(ShardStatus::ActiveSync)
             .await?;
 
-        // After the restart, event replay is still behind the epoch at which the shard was
-        // gained.
-        let _ = node.inner.latest_event_epoch_sender.send(Some(1));
+        // Where event replay stands when the resumed sync reads its bound.
+        let _ = node
+            .inner
+            .latest_event_epoch_sender
+            .send(Some(event_epoch_at_resume));
 
         // Startup republishes the sync-and-recovery info, which is what makes the shard-sync
         // reconciler resume the interrupted sync.


### PR DESCRIPTION
## Description

Adds a regression test for a shard-sync issue: a sync that resumes while event replay is behind the shard's gain epoch enumerates too few blobs, finds nothing to fetch, and flips the shard from `ActiveSync` to `Active` while empty. Nothing revisits an `Active` shard afterwards, so the loss is permanent.

The test drives the production resume path (`publish_startup_sync_and_recovery_info` into the shard-sync reconciler), not the test-only `restart_syncs`. The two cases differ only in the event position at resume, isolating the bound as the cause:

- `resumed_at_gain_epoch` (epoch 2): passes, all 23 blobs transferred.
- `resumed_behind_gain_epoch` (epoch 1): fails with 0 slivers.

Assertions are fix-agnostic: whichever way the fix goes, the shard must end up `Active` holding every blob certified before its gain epoch.

## Test plan

`cargo nextest run -p walrus-service sync_shard_resumed_must_not_activate_empty_shard` to test the fix of the issue.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
