### PR TITLE
fix(ci): stop base64 line-wrapping from breaking the Sui bump push, and retry all bump pushes

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -130,7 +130,7 @@ jobs:
           git commit -m "$BODY"
           # Push using the app token URL so the push is attributed to the GitHub App,
           # not github-actions[bot]. Pushes with GITHUB_TOKEN don't trigger CI workflows.
-          git push -u \
+          ./scripts/git_push_with_retry.sh -u \
             "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
             "$BRANCH"
 
@@ -153,4 +153,4 @@ jobs:
 
           git add Cargo.toml Cargo.lock
           git commit -m "$BODY"
-          git push origin HEAD:"$REF_NAME"
+          ./scripts/git_push_with_retry.sh origin HEAD:"$REF_NAME"

--- a/scripts/bump_sui_testnet_version.sh
+++ b/scripts/bump_sui_testnet_version.sh
@@ -6,6 +6,9 @@
 
 set -Eeuo pipefail
 
+# Resolve sibling scripts relative to this file so the script works from any working directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # Ensure required binaries are available
 for cmd in cargo gh sui git; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
@@ -112,49 +115,27 @@ git config user.email \
 # instead of github-actions[bot]. Pushes made with GITHUB_TOKEN do not trigger CI workflows.
 git commit -m "ci: bump Sui testnet version to ${NEW_TAG}"
 
-# Pushes a single attempt, using AUTOMERGE_TOKEN when available.
-push_branch_once() {
-  if [[ -n "${AUTOMERGE_TOKEN:-}" ]]; then
-    # Configure git to use the automerge token via an extra header to avoid leaking the token in
-    # git error messages or process listings.
-    #
-    # `tr -d '\n'` is required: `base64` wraps its output at 76 columns, so a long enough token
-    # yields a value containing a newline. That newline lands inside the Authorization header,
-    # which makes the request malformed and causes GitHub to reset the HTTP/2 stream with
-    # "HTTP/2 stream 1 was not closed cleanly before end of the underlying stream".
-    local auth
-    auth="$(printf '%s' "x-access-token:${AUTOMERGE_TOKEN}" | base64 | tr -d '\n')"
-    git -c "http.https://github.com/.extraheader=Authorization: basic ${auth}" \
-      push -u origin "$BRANCH"
-  else
-    git push -u origin "$BRANCH"
-  fi
-}
-
-# Pushes the branch, retrying to absorb transient network failures.
-push_branch() {
-  local attempt
-  for attempt in 1 2 3; do
-    if push_branch_once; then
-      return 0
-    fi
-    echo "Warning: push attempt ${attempt} failed" >&2
-    if [[ $attempt -lt 3 ]]; then
-      sleep $((attempt * 5))
-    fi
-  done
-  return 1
-}
-
-# Diagnostic: the token length is not sensitive, and lets us confirm whether a future push failure
-# is caused by an over-long token (see the base64 wrapping note above).
 if [[ -n "${AUTOMERGE_TOKEN:-}" ]]; then
-  echo "AUTOMERGE_TOKEN length: ${#AUTOMERGE_TOKEN}" >&2
-fi
+  # Authenticate with the automerge token through an extra header.
+  #
+  # `tr -d '\n'` is required: `base64` wraps its output at 76 columns, so a long enough token
+  # yields a value containing a newline. That newline lands inside the Authorization header, which
+  # makes the request malformed and causes GitHub to reset the HTTP/2 stream with "HTTP/2 stream 1
+  # was not closed cleanly before end of the underlying stream".
+  AUTH_HEADER="$(printf '%s' "x-access-token:${AUTOMERGE_TOKEN}" | base64 | tr -d '\n')"
 
-if ! push_branch; then
-  echo "Error: failed to push ${BRANCH} after 3 attempts" >&2
-  exit 1
+  # Diagnostic: the token length is not sensitive, and lets us confirm whether a future push
+  # failure is caused by an over-long token (see the wrapping note above).
+  echo "AUTOMERGE_TOKEN length: ${#AUTOMERGE_TOKEN}" >&2
+
+  # Pass the header through GIT_CONFIG_* rather than `git -c` so the token stays out of the
+  # command line, where a process listing would expose it.
+  GIT_CONFIG_COUNT=1 \
+  GIT_CONFIG_KEY_0="http.https://github.com/.extraheader" \
+  GIT_CONFIG_VALUE_0="Authorization: basic ${AUTH_HEADER}" \
+    "${SCRIPT_DIR}/git_push_with_retry.sh" -u origin "$BRANCH"
+else
+  "${SCRIPT_DIR}/git_push_with_retry.sh" -u origin "$BRANCH"
 fi
 
 # Generate PR body

--- a/scripts/bump_sui_testnet_version.sh
+++ b/scripts/bump_sui_testnet_version.sh
@@ -111,13 +111,50 @@ git config user.email \
 # Push branch using AUTOMERGE_TOKEN so the push comes from the walrus-automerge app
 # instead of github-actions[bot]. Pushes made with GITHUB_TOKEN do not trigger CI workflows.
 git commit -m "ci: bump Sui testnet version to ${NEW_TAG}"
+
+# Pushes a single attempt, using AUTOMERGE_TOKEN when available.
+push_branch_once() {
+  if [[ -n "${AUTOMERGE_TOKEN:-}" ]]; then
+    # Configure git to use the automerge token via an extra header to avoid leaking the token in
+    # git error messages or process listings.
+    #
+    # `tr -d '\n'` is required: `base64` wraps its output at 76 columns, so a long enough token
+    # yields a value containing a newline. That newline lands inside the Authorization header,
+    # which makes the request malformed and causes GitHub to reset the HTTP/2 stream with
+    # "HTTP/2 stream 1 was not closed cleanly before end of the underlying stream".
+    local auth
+    auth="$(printf '%s' "x-access-token:${AUTOMERGE_TOKEN}" | base64 | tr -d '\n')"
+    git -c "http.https://github.com/.extraheader=Authorization: basic ${auth}" \
+      push -u origin "$BRANCH"
+  else
+    git push -u origin "$BRANCH"
+  fi
+}
+
+# Pushes the branch, retrying to absorb transient network failures.
+push_branch() {
+  local attempt
+  for attempt in 1 2 3; do
+    if push_branch_once; then
+      return 0
+    fi
+    echo "Warning: push attempt ${attempt} failed" >&2
+    if [[ $attempt -lt 3 ]]; then
+      sleep $((attempt * 5))
+    fi
+  done
+  return 1
+}
+
+# Diagnostic: the token length is not sensitive, and lets us confirm whether a future push failure
+# is caused by an over-long token (see the base64 wrapping note above).
 if [[ -n "${AUTOMERGE_TOKEN:-}" ]]; then
-  # Configure git to use the automerge token via credential helper to avoid
-  # leaking the token in git error messages or process listings.
-  git -c "http.https://github.com/.extraheader=Authorization: basic $(echo -n "x-access-token:${AUTOMERGE_TOKEN}" | base64)" \
-    push -u origin "$BRANCH"
-else
-  git push -u origin "$BRANCH"
+  echo "AUTOMERGE_TOKEN length: ${#AUTOMERGE_TOKEN}" >&2
+fi
+
+if ! push_branch; then
+  echo "Error: failed to push ${BRANCH} after 3 attempts" >&2
+  exit 1
 fi
 
 # Generate PR body

--- a/scripts/git_push_with_retry.sh
+++ b/scripts/git_push_with_retry.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Copyright (c) Walrus Foundation
+# SPDX-License-Identifier: Apache-2.0
+#
+# Runs `git push` with the given arguments, retrying to absorb transient network failures.
+#
+# Every retryable failure is retried, not just network ones: distinguishing them would mean
+# pattern-matching git's stderr, which is brittle. A genuinely rejected push (non-fast-forward,
+# for example) fails all attempts and still exits non-zero, just 15 seconds later.
+#
+# Usage: git_push_with_retry.sh <git push arguments...>
+
+set -Eeuo pipefail
+
+if [[ $# -eq 0 ]]; then
+  echo "USAGE: git_push_with_retry.sh <git push arguments...>" >&2
+  exit 1
+fi
+
+ATTEMPTS="${GIT_PUSH_ATTEMPTS:-3}"
+
+for ((attempt = 1; attempt <= ATTEMPTS; attempt++)); do
+  if git push "$@"; then
+    exit 0
+  fi
+  echo "Warning: push attempt ${attempt}/${ATTEMPTS} failed" >&2
+  if ((attempt < ATTEMPTS)); then
+    sleep $((attempt * 5))
+  fi
+done
+
+echo "Error: git push failed after ${ATTEMPTS} attempts" >&2
+exit 1


### PR DESCRIPTION
## Problem

The `Generate Sui Version Upgrade PR` workflow has failed on every attempt since the `testnet-v1.78.0` dispatch ([run 32170302493](https://github.com/MystenLabs/walrus/actions/runs/32170302493)), so no 1.78.0 bump PR exists. All three attempts died in the same place with the same error:

```
fatal: unable to access 'https://github.com/MystenLabs/walrus/':
HTTP/2 stream 1 was not closed cleanly before end of the underlying stream
##[error]Process completed with exit code 128
```

The failing command is the branch push in `scripts/bump_sui_testnet_version.sh`. It fails ~1s in, versus the ~3.4s a successful push takes, on all three attempts — not a transient network failure:

| Attempt | last build line | failure | elapsed |
| --- | --- | --- | --- |
| Aug 12 (last success) | 21:52:21.976 | push OK 21:52:25.393 | 3.4s |
| 1 | 18:23:29.338 | `fatal:` 18:23:30.297 | 0.96s |
| 2 | 18:32:20.831 | `fatal:` 18:32:21.616 | 0.79s |
| 3 | 18:43:26.406 | `fatal:` 18:43:27.513 | 1.11s |

## Cause

`base64` wraps its output at 76 columns. The push builds an Authorization header from `base64` of `x-access-token:<token>`, and at the historical 40-character `ghs_` installation-token length that encodes to *exactly* 76 characters — one character under the wrap boundary:

```
token_len=42  ->  76 base64 chars, 0 embedded newlines   # OK
token_len=43  ->  80 base64 chars, 1 embedded newline    # malformed header
```

Once the token crosses that boundary the header value contains a newline, the request is malformed, and it fails at the transport layer before authentication.

Nothing in this repo changed to cause it: the script is untouched since #3190 (March), the workflow since #3598 (Aug 2, before the last success), and the `transferANDdelete-admin-only` ruleset added Aug 16 only covers `repository_transfer`/`repository_delete`. The trigger is external, which is exactly the class of change this one-character margin was waiting for.

## Changes

1. **Fix the wrapping** — strip newlines from the encoded header, removing the margin entirely.
2. **Add `scripts/git_push_with_retry.sh`** and route all three bump pushes through it (this script, plus both pushes in `version-bump.yml`, which were also single-shot). The workflow already hardens every other network call with `CARGO_NET_RETRY: 10` and `RUSTUP_MAX_RETRIES: 10`; these pushes were the bare ones. The `version-bump.yml` pushes authenticate through the remote URL, not a base64 header, so they were never exposed to the wrapping bug — they just gain retries.
3. **Pass the header through `GIT_CONFIG_*` instead of `git -c`** — the `git -c` form put the encoded token in the command line, where `ps` exposed it to any user on the machine. That is the exposure the original comment claimed to avoid, but didn't.
4. **Log the token length** (not sensitive) so a recurrence is diagnosable from the log alone.

The helper retries every failure rather than pattern-matching git's stderr for network errors, which would be brittle. A genuinely rejected push still fails, just 15 seconds later — verified below.

## Test plan

**Mechanism reproduced against real github.com**, using a **bogus** token so the test isolates header well-formedness from authentication:

```
40-char token, old code  -> remote: Invalid username or token        # header fine, auth rejected
64-char token, old code  -> fatal: ... Failed sending HTTP request   # header malformed, never authenticates
64-char token, this fix  -> remote: Invalid username or token        # header fine again
```

The local curl rejects it client-side while the runner's got far enough for GitHub to reset the stream, hence the differing message; both are the same failure class — malformed header, fast fail, no auth attempt.

**`GIT_CONFIG_*` delivery verified** the same way: with the header applied, a bogus token gets `Authentication failed`; with no header, the same command succeeds anonymously. So the header really is reaching the request.

**Token no longer in the process listing** — read straight out of `/proc/<pid>/cmdline` during a live push:

```
old (git -c ...)   -> basic eC1hY2Nlc3MtdG9rZW46Z2hzX1NFQ1JFVFNFTlRJTkVM...   FOUND in cmdline
new (GIT_CONFIG_*) -> token NOT present in any cmdline
```

**Helper exercised against real local git repos:**

| Case | Result |
| --- | --- |
| Normal push | exit 0, branch created |
| No arguments | usage message, exit 1 |
| Unreachable remote | 3 attempts, exit 1, 15s elapsed |
| **Transient failure** — remote unavailable, appears after 7s | retries and **recovers on attempt 3, exit 0** |
| Non-fast-forward rejection | retries, then exit 1 — real errors are not swallowed |

**Rewritten push block integration-tested** end to end against a local bare repo, with a 64-char token (fatal before this fix) and with no token at all: both push successfully and `-u` sets upstream tracking.

`shellcheck` and `bash -n` clean on both touched scripts. `actionlint` reports no new findings — the one pre-existing complaint (`label "ubuntu-ghcloud" is unknown`, our custom ghcloud runner label) is identical on `main`.

## Follow-up

Once this lands, re-dispatch the 1.78.0 bump. If it still fails, the logged token length tells us immediately whether this was the cause: `>=43` confirms it, `<=42` means we chase the transport instead (`GIT_CURL_VERBOSE=1`, `http.version=HTTP/1.1`).