### PR TITLE
fix(ci): retry the version-bump pushes

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -130,7 +130,7 @@ jobs:
           git commit -m "$BODY"
           # Push using the app token URL so the push is attributed to the GitHub App,
           # not github-actions[bot]. Pushes with GITHUB_TOKEN don't trigger CI workflows.
-          git push -u \
+          ./scripts/git_push_with_retry.sh -u \
             "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
             "$BRANCH"
 
@@ -153,4 +153,4 @@ jobs:
 
           git add Cargo.toml Cargo.lock
           git commit -m "$BODY"
-          git push origin HEAD:"$REF_NAME"
+          ./scripts/git_push_with_retry.sh origin HEAD:"$REF_NAME"

--- a/scripts/git_push_with_retry.sh
+++ b/scripts/git_push_with_retry.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Copyright (c) Walrus Foundation
+# SPDX-License-Identifier: Apache-2.0
+#
+# Runs `git push` with the given arguments, retrying to absorb transient network failures.
+#
+# Every retryable failure is retried, not just network ones: distinguishing them would mean
+# pattern-matching git's stderr, which is brittle. A genuinely rejected push (non-fast-forward,
+# for example) fails all attempts and still exits non-zero, just 15 seconds later.
+#
+# Usage: git_push_with_retry.sh <git push arguments...>
+
+set -Eeuo pipefail
+
+if [[ $# -eq 0 ]]; then
+  echo "USAGE: git_push_with_retry.sh <git push arguments...>" >&2
+  exit 1
+fi
+
+ATTEMPTS="${GIT_PUSH_ATTEMPTS:-3}"
+
+for ((attempt = 1; attempt <= ATTEMPTS; attempt++)); do
+  if git push "$@"; then
+    exit 0
+  fi
+  echo "Warning: push attempt ${attempt}/${ATTEMPTS} failed" >&2
+  if ((attempt < ATTEMPTS)); then
+    sleep $((attempt * 5))
+  fi
+done
+
+echo "Error: git push failed after ${ATTEMPTS} attempts" >&2
+exit 1


### PR DESCRIPTION
## Problem

`version-bump.yml` has two single-shot `git push` calls — one in the PR-delivery path (L133) and one in the direct-delivery path (L156). A single transient network failure fails the job, leaving a committed but unpushed version bump behind.

This is the same fragility that broke the Sui bump workflow, spotted while investigating [run 32170302493](https://github.com/MystenLabs/walrus/actions/runs/32170302493) (fixed in #3663).

To be clear about scope: these two pushes authenticate with the token in the remote URL, not a base64 `Authorization` header, so **neither is exposed to the header-wrapping bug** from #3663. This PR only adds retries.

## Fix

New `scripts/git_push_with_retry.sh`, used by both call sites. Three attempts with 5s/10s backoff.

It retries every failure rather than pattern-matching git's stderr for network errors, which would be brittle. A genuinely rejected push still fails, just 15 seconds later — verified below.

## Test plan

Exercised the helper against real local git repos:

| Case | Result |
| --- | --- |
| Normal push | exit 0, branch created |
| No arguments | usage message, exit 1 |
| Unreachable remote | 3 attempts, exit 1, 15s elapsed |
| **Transient failure** — remote unavailable, appears after 7s | retries and **recovers on attempt 3, exit 0** |
| Non-fast-forward rejection | retries, then exit 1 — real errors are not swallowed |

The transient case is the one that matters: it reproduces the shape of the flake this is meant to absorb, and confirms the job now self-heals instead of failing.

`shellcheck` clean, `bash -n` clean. `actionlint` reports no new findings — the one pre-existing complaint (`label "ubuntu-ghcloud" is unknown`, our custom ghcloud runner label) is identical on `main`.

## Note

Once #3663 lands, `bump_sui_testnet_version.sh` can drop its own inline retry loop and adopt this shared helper. I kept them separate here so the two PRs don't conflict — happy to do that consolidation as a follow-up.