### PR TITLE
docs: fix goal frontmatter on index pages

### DIFF
--- a/docs/content/examples/index.mdx
+++ b/docs/content/examples/index.mdx
@@ -11,7 +11,7 @@ keywords:
   - git clone
 hide_table_of_contents: true
 goal:
-  description: Reader can browse the available Walrus example applications and choose one that fits their use case
+  description: Provide a brief introduction to Walrus examples and link to subtopics
   requires:
     - has_frontmatter:
         - title

--- a/docs/content/operator-guide/index.mdx
+++ b/docs/content/operator-guide/index.mdx
@@ -13,7 +13,7 @@ keywords:
   - operations
   - infrastructure
 goal:
-  description: Reader can identify which service-provider guide applies to the Walrus infrastructure they want to run
+  description: Introduce Walrus service providers and list available subtopics
   requires:
     - has_frontmatter:
         - title

--- a/docs/content/operator-guide/storage-nodes/index.mdx
+++ b/docs/content/operator-guide/storage-nodes/index.mdx
@@ -8,7 +8,7 @@ keywords:
   - setup
   - maintenance
 goal:
-  description: Reader can find the guides needed to set up and operate a Walrus storage node
+  description: Introduce storage node operation and link to subtopics
   requires:
     - has_frontmatter:
         - title

--- a/docs/content/system-overview/index.mdx
+++ b/docs/content/system-overview/index.mdx
@@ -7,7 +7,7 @@ keywords:
   - walrus info
   - system object
 goal:
-  description: Reader can understand at a high level how Walrus stores and retrieves data
+  description: Introduce the system overview section and list available subtopics
   requires:
     - has_frontmatter:
         - title

--- a/docs/content/walrus-client/index.mdx
+++ b/docs/content/walrus-client/index.mdx
@@ -9,7 +9,7 @@ keywords:
   - logging
   - json output
 goal:
-  description: Reader can store and retrieve blobs from the command line with the Walrus client
+  description: Introduce the Walrus client and list available subtopics
   requires:
     - has_frontmatter:
         - title


### PR DESCRIPTION
## Summary
- Updated `goal` frontmatter on 5 index.mdx pages to accurately reflect their role as thin DocCardList landing pages
- Replaced overpromising goals (e.g., "Reader can identify which guide applies...") with honest descriptions (e.g., "Introduce Walrus service providers and list available subtopics")

## Test plan
- [ ] Verify docs build passes
- [ ] Spot-check index pages to confirm goals match page content

🤖 Generated with [Claude Code](https://claude.com/claude-code)