### PR TITLE
docs: add a pre-upload network health check guide

### DIFF
--- a/docs/content/walrus-client/network-health.mdx
+++ b/docs/content/walrus-client/network-health.mdx
@@ -58,6 +58,7 @@ The other statuses come from the node itself:
 | `RecoverMetadata` | In recovery mode, syncing metadata |
 | `RecoveryCatchUp` | In recovery mode, catching up with the chain |
 | `RecoveryInProgress` | In recovery mode, recovering missing slivers |
+| `RecoveryCatchUpWithIncompleteHistory` | In recovery mode, catching up with an incomplete history because event blobs expired |
 
 A node in a recovery status answers the health endpoint, so it never lands in `Error`, but it might not hold every sliver for the shards it owns yet. Count the recovery statuses alongside `Error` when you want a pessimistic reading.
 

--- a/docs/content/walrus-client/network-health.mdx
+++ b/docs/content/walrus-client/network-health.mdx
@@ -41,7 +41,7 @@ Active: 98
 Error: 7
 ```
 
-Two numbers matter here.
+Read the summary as follows.
 
 `Owned shards` sums only the nodes that answered. Unreachable nodes contribute nothing to it, so on a 1,000-shard network this figure is already your healthy shard count, and 930 means 70 shards sit behind nodes you cannot reach. Compare that number against the thresholds below rather than counting nodes.
 
@@ -75,6 +75,14 @@ You can select a different set of nodes instead. Exactly one selector is require
 
 Walrus tolerates faults as a fraction of **shards**, not of nodes, and one node can own many shards. A committee where 7 of 105 nodes fail can lose far more or far less than 7% of its shards, so the node counts alone tell you little.
 
+For the write threshold, ask the CLI rather than working it out:
+
+```sh
+walrus info bft
+```
+
+That prints the tolerated faults `f`, the quorum threshold `2f + 1`, and the minimum number of correct shards `n - f`, which is the write threshold, for the network you are on. It does not print the read threshold, so derive that one yourself.
+
 Write `n` for the shard count and `f` for the number of faulty shards the protocol tolerates:
 
 1. `f = (n - 1) / 3`, using integer division.
@@ -90,7 +98,7 @@ For a 1,000-shard network:
 | Write | 667 | 333 (33.3%) |
 | Read | 334 | 666 (66.6%) |
 
-Run `walrus info committee` to get the shard count for the network you are on, then apply the same arithmetic.
+Run `walrus info committee` to get the shard count for the network you are on, then apply the same arithmetic for the read threshold.
 
 ## Decide whether to upload
 

--- a/docs/content/walrus-client/network-health.mdx
+++ b/docs/content/walrus-client/network-health.mdx
@@ -1,5 +1,5 @@
 ---
-title: Check network health before uploading
+title: Check Network Health
 description: Run walrus health --committee to see how many storage nodes are reachable, compare the result against the write and read thresholds, and decide whether to upload now.
 keywords: [walrus health, committee, storage nodes, node outage, upload failures, shards, thresholds, diagnostics]
 questions:
@@ -16,7 +16,7 @@ answer: >-
   consistently usually mean the network sits above the write threshold but without much margin.
 ---
 
-Intermittent upload failures usually mean storage nodes are unreachable, not that your client is misconfigured. Query the committee first, compare the result against the thresholds below, and you can tell the difference before you open a support request.
+Intermittent upload failures usually mean storage nodes are unreachable, not that your client is misconfigured. Query the committee first, then compare the result against the thresholds below:
 
 ## Query the committee
 
@@ -24,7 +24,7 @@ Intermittent upload failures usually mean storage nodes are unreachable, not tha
 walrus health --committee
 ```
 
-This contacts every storage node in the current committee and prints a table with one row per node, then a summary:
+This contacts every storage node in the current committee and prints a table with one row per node, then a summary. Add `--detail` for extended per-node health information, or `--json` to get the same data as structured output for scripting:
 
 ```
 Summary
@@ -41,13 +41,13 @@ Active: 98
 Error: 7
 ```
 
-Read the summary as follows.
+`Owned shards` sums only the nodes that answered. On a 1,000-shard network, this figure of 930 means 70 shards sit behind nodes you cannot reach.
 
-`Owned shards` sums only the nodes that answered. Unreachable nodes contribute nothing to it, so on a 1,000-shard network this figure is already your healthy shard count, and 930 means 70 shards sit behind nodes you cannot reach. Compare that number against the thresholds below rather than counting nodes.
+The per-node `# Shards (Ready / Owned)` column reports how many of the shards a node owns are ready to serve.
 
-The per-node `# Shards (Ready / Owned)` column splits it further. A node reports how many of the shards it owns are ready to serve, so a node part-way through recovery shows a ready count below its owned count.
+`Error` counts nodes the client could not reach or that failed to answer the health endpoint. The client queries up to 60 nodes at once, so lower `--concurrent-requests <N>` if querying the whole committee saturates your own connection and produces false `Error` results.
 
-`Error` counts nodes the client could not reach or that failed to answer the health endpoint. Those are the nodes to care about first.
+Add `--sort-by status` to group the failing nodes together, which is what you want when you are counting them. It also accepts `id`, `name`, and `url`, and defaults to `status`.
 
 The other statuses come from the node itself:
 
@@ -60,9 +60,9 @@ The other statuses come from the node itself:
 | `RecoveryInProgress` | In recovery mode, recovering missing slivers |
 | `RecoveryCatchUpWithIncompleteHistory` | In recovery mode, catching up with an incomplete history because event blobs expired |
 
-A node in a recovery status answers the health endpoint, so it never lands in `Error`, but it might not hold every sliver for the shards it owns yet. Count the recovery statuses alongside `Error` when you want a pessimistic reading.
+A node in a recovery status answers the health endpoint, so it never lands in `Error`, but it might not hold every sliver for the shards it owns yet.
 
-You can select a different set of nodes instead. Exactly one selector is required:
+You can select a different set of nodes instead:
 
 | **Selector** | **What it queries** |
 | --- | --- |
@@ -71,17 +71,15 @@ You can select a different set of nodes instead. Exactly one selector is require
 | `--node-ids <ID>...` | Specific nodes by object ID |
 | `--node-urls <URL>...` | Specific nodes by URL |
 
-## Work out your thresholds
+## Fault tolerance thresholds
 
-Walrus tolerates faults as a fraction of **shards**, not of nodes, and one node can own many shards. A committee where 7 of 105 nodes fail can lose far more or far less than 7% of its shards, so the node counts alone tell you little.
-
-For the write threshold, ask the CLI rather than working it out:
+Walrus tolerates faults as a fraction of shards, not of nodes, and one node can own many shards. For the write threshold, use the following command to get tolerated fault thresholds:
 
 ```sh
 walrus info bft
 ```
 
-That prints the tolerated faults `f`, the quorum threshold `2f + 1`, and the minimum number of correct shards `n - f`, which is the write threshold, for the network you are on. It does not print the read threshold, so derive that one yourself.
+This returns the tolerated faults `f`, the quorum threshold `2f + 1`, and the minimum number of correct shards `n - f` for the network you are on. `n - f` represents the write threshold. It does not print the read threshold.
 
 Write `n` for the shard count and `f` for the number of faulty shards the protocol tolerates:
 
@@ -89,7 +87,7 @@ Write `n` for the shard count and `f` for the number of faulty shards the protoc
 2. A write certifies when at least `n - f` shards respond.
 3. A read reconstructs when at least `n - 2f` shards respond.
 
-Reads survive far more damage than writes, because a read rebuilds from the primary slivers while a write has to reach a quorum.
+Reads have a higher fault tolerance than writes because a read rebuilds from the primary slivers while a write has to reach a quorum.
 
 For a 1,000-shard network:
 
@@ -109,19 +107,3 @@ Compare the healthy shard count against the write threshold:
 - **Healthy shards below `n - f`.** Writes cannot certify. Wait for the network to recover rather than retrying, and read traffic keeps working down to `n - 2f`.
 
 A 24% shard outage on a 1,000-shard network illustrates the middle case: 760 shards stay healthy against a threshold of 667, so writes still certify, with 93 shards of margin. That is why the failures look intermittent rather than total.
-
-## Useful flags
-
-| **Flag** | **Default** | **Effect** |
-| --- | --- | --- |
-| `--detail` | off | Prints extended health information per node |
-| `--sort-by <FIELD>` | `status` | Sorts by `status`, `id`, `name`, or `url` |
-| `--concurrent-requests <N>` | `60` | Caps how many nodes the client queries at once |
-
-Sorting by `status` groups the failing nodes together, which is what you want when you are counting them. Lower `--concurrent-requests` if querying the whole committee saturates your own connection and produces false `Error` results.
-
-Pass `--json` to get the same data as structured output for scripting:
-
-```sh
-walrus health --committee --json
-```

--- a/docs/content/walrus-client/network-health.mdx
+++ b/docs/content/walrus-client/network-health.mdx
@@ -1,0 +1,118 @@
+---
+title: Check network health before uploading
+description: Run walrus health --committee to see how many storage nodes are reachable, compare the result against the write and read thresholds, and decide whether to upload now.
+keywords: [walrus health, committee, storage nodes, node outage, upload failures, shards, thresholds, diagnostics]
+questions:
+  - How do I check Walrus network health before uploading?
+  - What does walrus health --committee show?
+  - How many storage nodes can be down before Walrus uploads fail?
+  - Why do my Walrus uploads fail intermittently?
+answer: >-
+  Run `walrus health --committee` to query every storage node in the current committee and print
+  each node's status along with a summary of total nodes, owned shards, and read-only shards. A
+  write certifies when at least `n_shards - f` shards respond, and a read reconstructs from
+  `n_shards - 2f` shards, where `f = (n_shards - 1) / 3`. On a 1,000-shard network that means
+  writes need 667 shards and reads need 334. Uploads that fail intermittently rather than
+  consistently usually mean the network sits above the write threshold but without much margin.
+---
+
+Intermittent upload failures usually mean storage nodes are unreachable, not that your client is misconfigured. Query the committee first, compare the result against the thresholds below, and you can tell the difference before you open a support request.
+
+## Query the committee
+
+```sh
+walrus health --committee
+```
+
+This contacts every storage node in the current committee and prints a table with one row per node, then a summary:
+
+```
+Summary
+
+ Idx | Name | Node ID | Address | # Shards         | Status
+     |      |         |         | (Ready / Owned)  |
+
+Total nodes: 105
+Owned shards: 930
+Read-only shards: 0
+
+Node Status Breakdown
+Active: 98
+Error: 7
+```
+
+Two numbers matter here.
+
+`Owned shards` sums only the nodes that answered. Unreachable nodes contribute nothing to it, so on a 1,000-shard network this figure is already your healthy shard count, and 930 means 70 shards sit behind nodes you cannot reach. Compare that number against the thresholds below rather than counting nodes.
+
+The per-node `# Shards (Ready / Owned)` column splits it further. A node reports how many of the shards it owns are ready to serve, so a node part-way through recovery shows a ready count below its owned count.
+
+`Error` counts nodes the client could not reach or that failed to answer the health endpoint. Those are the nodes to care about first.
+
+The other statuses come from the node itself:
+
+| **Status** | **Meaning** |
+| --- | --- |
+| `Active` | A committee member that is up to date with events |
+| `Standby` | Up to date with events, but not a committee member |
+| `RecoverMetadata` | In recovery mode, syncing metadata |
+| `RecoveryCatchUp` | In recovery mode, catching up with the chain |
+| `RecoveryInProgress` | In recovery mode, recovering missing slivers |
+
+A node in a recovery status answers the health endpoint, so it never lands in `Error`, but it might not hold every sliver for the shards it owns yet. Count the recovery statuses alongside `Error` when you want a pessimistic reading.
+
+You can select a different set of nodes instead. Exactly one selector is required:
+
+| **Selector** | **What it queries** |
+| --- | --- |
+| `--committee` | Every node in the current committee |
+| `--active-set` | Every node in the active set |
+| `--node-ids <ID>...` | Specific nodes by object ID |
+| `--node-urls <URL>...` | Specific nodes by URL |
+
+## Work out your thresholds
+
+Walrus tolerates faults as a fraction of **shards**, not of nodes, and one node can own many shards. A committee where 7 of 105 nodes fail can lose far more or far less than 7% of its shards, so the node counts alone tell you little.
+
+Write `n` for the shard count and `f` for the number of faulty shards the protocol tolerates:
+
+1. `f = (n - 1) / 3`, using integer division.
+2. A write certifies when at least `n - f` shards respond.
+3. A read reconstructs when at least `n - 2f` shards respond.
+
+Reads survive far more damage than writes, because a read rebuilds from the primary slivers while a write has to reach a quorum.
+
+For a 1,000-shard network:
+
+| **Operation** | **Shards needed** | **Shards that can be down** |
+| --- | --- | --- |
+| Write | 667 | 333 (33.3%) |
+| Read | 334 | 666 (66.6%) |
+
+Run `walrus info committee` to get the shard count for the network you are on, then apply the same arithmetic.
+
+## Decide whether to upload
+
+Compare the healthy shard count against the write threshold:
+
+- **Healthy shards well above `n - f`.** Upload normally.
+- **Healthy shards just above `n - f`.** Expect slow and intermittent writes. The network can still certify, but individual attempts fail whenever the specific nodes a write needs fall in the unreachable set, and the client spends longer retrying. Large uploads suffer most, because they hold the write open for longer.
+- **Healthy shards below `n - f`.** Writes cannot certify. Wait for the network to recover rather than retrying, and read traffic keeps working down to `n - 2f`.
+
+A 24% shard outage on a 1,000-shard network illustrates the middle case: 760 shards stay healthy against a threshold of 667, so writes still certify, with 93 shards of margin. That is why the failures look intermittent rather than total.
+
+## Useful flags
+
+| **Flag** | **Default** | **Effect** |
+| --- | --- | --- |
+| `--detail` | off | Prints extended health information per node |
+| `--sort-by <FIELD>` | `status` | Sorts by `status`, `id`, `name`, or `url` |
+| `--concurrent-requests <N>` | `60` | Caps how many nodes the client queries at once |
+
+Sorting by `status` groups the failing nodes together, which is what you want when you are counting them. Lower `--concurrent-requests` if querying the whole committee saturates your own connection and produces false `Error` results.
+
+Pass `--json` to get the same data as structured output for scripting:
+
+```sh
+walrus health --committee --json
+```

--- a/docs/site/sidebars.js
+++ b/docs/site/sidebars.js
@@ -49,6 +49,7 @@ const sidebars = {
         "walrus-client/storing-blobs",
         "walrus-client/reading-blobs",
         "walrus-client/managing-blobs",
+        "walrus-client/network-health",
         "large-uploads",
         "sponsored-uploads",
         "walrus-client/quilts",


### PR DESCRIPTION
Closes BEDU-1020. Developers found a 24% node outage on their own, with no documented way to check network health before uploading.

_Generated by [Claude Code](https://claude.ai/code)._

## Description

Adds `walrus-client/network-health`, a pre-upload health check guide, plus its sidebar entry under Store and Retrieve Data.

The page answers the question behind most intermittent-upload reports: is the network degraded, or is my client misconfigured? It covers three things:

- **Reading `walrus health --committee` output.** The key point is that `Owned shards` in the summary sums only the nodes that answered, so it is already the healthy-shard count rather than the committee total. A reader who counts failing nodes instead gets a misleading picture, because one node can own many shards.
- **Finding the thresholds.** `walrus info bft` prints the tolerated faults `f`, the quorum threshold, and the write threshold `n - f` directly. The formulas are kept for the read threshold `n - 2f`, which that command does not print, and worked through for a 1,000-shard network: writes need 667, reads need 334.
- **Deciding whether to upload,** split into the three cases that matter: well above the write threshold, just above it, and below it. The middle case is the one that produces intermittent failures rather than clean ones, and the 24% outage from the original report lands there, with 760 healthy shards against a threshold of 667.

Also documents the node status values, the four node selectors, and the useful flags.

## Sources

| Claim | Source |
| --- | --- |
| `--detail`, `--sort-by`, and `--concurrent-requests` exist, with `--concurrent-requests` defaulting to 60 | the `Health` subcommand in `crates/walrus-service/src/client/cli/args.rs`, and `default::concurrent_requests_for_health()` which returns `60` |
| `--sort-by` accepts `status`, `id`, `name`, `url`, and defaults to `status` | `enum HealthSortBy` in the same file |
| Exactly one of `--node-ids`, `--node-urls`, `--committee`, `--active-set` is required | `struct NodeSelection` and its `check_exactly_one_is_set` in the same file |
| `--json` works with `health` | the `json` flag in the same file is declared `global = true` |
| The six node status values and their meanings | `enum NodeStatus` in `crates/walrus-service/src/node/storage.rs`, including the doc comment wording |
| `walrus info committee` and `walrus info bft` exist | `enum InfoCommands` in `crates/walrus-service/src/client/cli/args.rs` |
| `walrus info bft` prints `f`, the quorum threshold, and `n - f` | `InfoBftOutput::print_cli_output` in `crates/walrus-service/src/client/cli/cli_output.rs`, which prints "Tolerated faults (f)", "Quorum threshold (2f+1)", and "Minimum number of correct shards (n-f)" |
| `f = (n - 1) / 3` | `bft::max_n_faulty` in `crates/walrus-core/src/bft.rs` |
| A write needs `n - f` shards | `bft::min_n_correct` in the same file, which returns `n - max_n_faulty(n)` |
| `Owned shards` sums only nodes that answered | `owned_shards += health_info.shard_summary.owned` sits inside the `Ok` branch of the per-node match in `cli_output.rs`; the `Err` branch only increments the `Error` status count |
| `Total nodes` counts every node queried, including failures | `self.health_info.len()` in the same block |

Prose written fresh. The threshold arithmetic in the tables is computed from the formulas above rather than copied from another page.

## Test plan

- `node src/scripts/audit-docs.mjs` from `docs/site`: the page reports `issues: []`, `brokenLinks: []`, `brokenImports: []`, and passes frontmatter validation.
- Style gate passes on the page.
- The branch merges cleanly into `main` (`git merge-tree` reports no conflict), including `sidebars.js`.
- Arithmetic checked by hand against the formulas: for n=1,000, `f`=333, write=667, read=334, and the 24% example leaves 760 healthy shards with 93 of margin.

Not verified: the sample `walrus health --committee` output is illustrative of the shape the CLI prints. I did not run the command against a live network, so the specific node and shard counts in that block are not a capture of real output.

---

## Release notes

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI: