### PR TITLE
ci: fix the unresolvable action pin in editorial coverage

### DIFF
--- a/.github/workflows/editorial-coverage.yml
+++ b/.github/workflows/editorial-coverage.yml
@@ -32,9 +32,9 @@ jobs:
   check-editorial-coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # pin@v7.0.1
 
-      - uses: actions/setup-node@a309ff8b426b58ec0e2a45f0f869d46889d02405 # pin@v6.2.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # pin@v7.0.0
         with:
           node-version: "22"
 
@@ -47,7 +47,7 @@ jobs:
             --json editorial-coverage.json
 
       - name: Open tracking issues for uncovered releases
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # pin@v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # pin@v9.0.0
         with:
           script: |
             const fs = require("fs");


### PR DESCRIPTION
## Description

The editorial coverage workflow added in #3589 has never completed a run. Both attempts so far failed in about eight seconds while preparing actions, before executing any step:

- Monday schedule, 2026-08-17 — [run 32039055941](https://github.com/MystenLabs/walrus/actions/runs/32039055941)
- `devnet-v1.55.0` release trigger, 2026-08-20 — [run 32414785225](https://github.com/MystenLabs/walrus/actions/runs/32414785225)

```
Unable to resolve action `actions/setup-node@a309ff8b426b58ec0e2a45f0f869d46889d02405`,
unable to find version `a309ff8b426b58ec0e2a45f0f869d46889d02405`
```

That SHA does not exist in `actions/setup-node`. The failure only surfaces when the workflow fires, which is why it got through review on #3589.

All three action pins in the workflow turned out to be outliers, each the only use of its SHA in the repository while the rest of the workflows had moved on. Fixing only the one that happened to break first would leave the same latent problem in the other two, so all three are aligned with the dominant pins:

| Action | Was | Now | Other uses in repo |
| --- | --- | --- | --- |
| `actions/checkout` | `de0fac2` (v6.0.2) | `3d3c42e` (v7.0.1) | 44 |
| `actions/setup-node` | `a309ff8` (v6.2.0) — **unresolvable** | `8207627` (v7.0.0) | 7 |
| `actions/github-script` | `f28e40c` (v8.0.0) | `3a2844b` (v9.0.0) | 3 |

No logic changes; the diff is three pin lines.

## Test plan

- The workflow YAML parses, and the step list is unchanged: checkout, setup-node, "Find releases without editorial summaries", "Open tracking issues for uncovered releases".
- `node --check` passes on `check-editorial-coverage.js` and `generate-release-notes.js`.
- Devnet releases are still filtered out by the network check in `check-editorial-coverage.js` (`if (network === "Devnet" || network === "Other") continue;`), so the `devnet-v1.55.0` trigger that fired today stays a no-op once the workflow can run.
- Replacement SHAs were taken from workflows already running green on `main` rather than looked up externally, so each is known-good in this repository.

Not verified: the workflow itself cannot run from a fork branch on the `release` or `schedule` events, so the end-to-end path stays untested until this lands on `main`. The pins are the only thing that changed, and the failure was purely at action resolution, but the first post-merge run is still the real confirmation.

## Note for whoever merges

Because the workflow has never run to completion, the five tracking issues it was meant to open at launch do not exist yet. The first successful run will create them in one burst, one per uncovered release: v1.51.1, v1.51.2, v1.52.0, v1.52.1, and v1.53.0. That is the intended behaviour, not a runaway loop.

## Sources

- Failure message and timing: the two workflow run logs linked above.
- Replacement pins: `git grep` over `.github/workflows/` on `main`, counting existing uses of each action.
- Devnet filtering: `docs/site/src/scripts/check-editorial-coverage.js`.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoBWxqLzd9hAxrhoqv3iSv)_