### PR TITLE
docs(site): add quality evals and a scheduled health report for interactive diagrams

### DIFF
--- a/.github/workflows/diagram-health.yml
+++ b/.github/workflows/diagram-health.yml
@@ -1,0 +1,58 @@
+# Copyright (c) Walrus Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+# Repository-wide health report for the interactive diagrams standard.
+#
+# The lint job in lint.yml is diff-scoped: it only checks diagrams a PR adds or
+# modifies, so a diagram that predates the standard never fails until someone
+# happens to touch it. That keeps the gate fair, and it also means nobody sees
+# the real compliance number.
+#
+# This workflow runs the full audit on a schedule and reports it. It does not
+# gate anything, because the point is visibility, not another red X.
+name: Diagram health
+
+on:
+  schedule:
+    # Mondays, early UTC, so the report is waiting at the start of the week.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  diagram-health:
+    runs-on: ubuntu-latest
+    name: Interactive diagram health report
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # pin@v7.0.1
+        with:
+          # Full history so the fidelity check can compare commit timestamps
+          # between a diagram and its fallback assets.
+          fetch-depth: 0
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # pin@v7.0.0
+        with:
+          node-version: "22"
+
+      - name: Fallback asset coverage
+        id: coverage
+        # Never fails the job: a repository below full coverage still needs the
+        # number reported rather than the workflow switched off.
+        continue-on-error: true
+        working-directory: docs/site
+        run: |
+          echo "## Interactive diagram fallback coverage" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          node src/scripts/check-diagram-fallbacks.mjs --all 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fallback asset quality
+        continue-on-error: true
+        working-directory: docs/site
+        run: |
+          echo "## Interactive diagram quality findings" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          node src/scripts/eval-diagram-quality.mjs --all 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/docs/site/README.md
+++ b/docs/site/README.md
@@ -63,3 +63,32 @@ To audit every diagram in the repository locally, run:
 ```bash
 node src/scripts/check-diagram-fallbacks.mjs --all
 ```
+
+### Fallback quality
+
+Presence alone proves little. A diagram passes the gate above with a blank SVG and a one-pixel PNG,
+which satisfies a presence check without giving a reader anything.
+`src/scripts/eval-diagram-quality.mjs` evaluates the fallbacks that do exist:
+
+| **Dimension** | **What it catches** |
+| --- | --- |
+| Substance | Placeholder assets: an SVG under 1 KiB, an SVG with no drawing elements, a PNG under 4 KiB |
+| Accessibility | An SVG with no `<title>`, which announces nothing to a screen reader |
+| Fidelity | A fallback whose last commit predates the diagram it stands in for, so it shows stale content while reporting as compliant |
+| Weight | Interactive HTML over 2 MiB, which a reader waits on |
+
+```bash
+node src/scripts/eval-diagram-quality.mjs --all
+```
+
+Findings do not fail by default, because teams switch off a gate nobody can pass. Pass `--strict`
+to exit non-zero once coverage arrives, and `--json` for machine-readable output. The script
+reports a diagram missing its fallbacks as unevaluated rather than failed, so it and the presence
+gate never disagree about the same file.
+
+### Scheduled health report
+
+`.github/workflows/diagram-health.yml` runs both scripts across the whole repository every Monday,
+and on demand through **Run workflow**. It writes the results to the job summary and never fails,
+because the lint gate only checks diffs and would otherwise hide the true coverage number until
+someone happened to touch a diagram.

--- a/docs/site/src/scripts/eval-diagram-quality.mjs
+++ b/docs/site/src/scripts/eval-diagram-quality.mjs
@@ -1,0 +1,240 @@
+// Copyright (c) Walrus Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Quality evaluation for interactive diagram fallback assets.
+ *
+ * check-diagram-fallbacks.mjs answers one question: do the three artifacts
+ * exist? That is necessary and not sufficient. A diagram passes that gate with
+ * a blank SVG and a one-pixel PNG, which is the obvious way to satisfy a
+ * presence check without giving a reader anything.
+ *
+ * This script evaluates the fallbacks that do exist, across four dimensions:
+ *
+ *   substance     - the fallback holds real content rather than a placeholder
+ *   accessibility - the SVG names itself, which is what a screen reader reads
+ *   fidelity      - the fallback is not older than the diagram it stands in for
+ *   weight        - the interactive HTML stays within a size budget
+ *
+ * Presence is deliberately not re-checked here. A diagram with no fallbacks is
+ * reported as unevaluated rather than as a failure, so that the two scripts
+ * report on different things and neither hides the other.
+ *
+ * Warnings do not fail by default, because the repository starts below these
+ * thresholds and teams switch off a gate nobody can pass. Pass --strict to
+ * turn findings into a non-zero exit once coverage arrives.
+ *
+ * Usage:
+ *   node eval-diagram-quality.mjs --all              # evaluate every diagram
+ *   node eval-diagram-quality.mjs --base <git-ref>   # evaluate changed diagrams
+ *   node eval-diagram-quality.mjs [file...]          # evaluate the given files
+ *
+ *   --strict   exit 1 when any finding is reported
+ *   --json     emit machine-readable output for dashboards
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+const DIAGRAM_PATTERN = /(^|\/)interactive_[^/]+\.html?$/;
+const EXCLUDED_PATH_FRAGMENTS = ["/.cache-walrus-memory/", "/node_modules/", "/build/"];
+
+// An SVG carrying a real diagram is comfortably larger than this; the floor is
+// set to catch empty documents and one-shape placeholders, not to judge detail.
+const MIN_SVG_BYTES = 1024;
+// A PNG export of a diagram at any usable resolution clears this easily. A
+// 1x1 transparent PNG is about 70 bytes.
+const MIN_PNG_BYTES = 4096;
+// Interactive diagrams are self-contained, so they carry their own scripts and
+// styles and run large. This budget flags the ones a reader waits on.
+const MAX_HTML_BYTES = 2 * 1024 * 1024;
+
+// Elements that mean the SVG actually draws something.
+const SVG_CONTENT_PATTERN = /<(path|rect|circle|ellipse|line|polygon|polyline|text|image|use)\b/i;
+
+function gitLines(args) {
+    return execFileSync("git", args, { encoding: "utf8" })
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean);
+}
+
+function isExcluded(file) {
+    return EXCLUDED_PATH_FRAGMENTS.some((fragment) => `/${file}`.includes(fragment));
+}
+
+function collectTargets(argv) {
+    if (argv.includes("--all")) {
+        return gitLines(["ls-files", "*.html"]).filter(
+            (file) => DIAGRAM_PATTERN.test(file) && !isExcluded(file),
+        );
+    }
+
+    const baseIndex = argv.indexOf("--base");
+    if (baseIndex !== -1) {
+        const base = argv[baseIndex + 1];
+        if (!base) {
+            console.error("--base requires a git ref argument.");
+            process.exit(2);
+        }
+        return gitLines([
+            "diff",
+            "--name-only",
+            "--diff-filter=AMR",
+            `${base}...HEAD`,
+        ]).filter((file) => DIAGRAM_PATTERN.test(file) && !isExcluded(file));
+    }
+
+    return argv.filter((file) => DIAGRAM_PATTERN.test(file) && !isExcluded(file));
+}
+
+/** Last commit timestamp for a path, or null when git does not know the file. */
+function lastCommitSeconds(file) {
+    try {
+        const [stamp] = gitLines(["log", "-1", "--format=%ct", "--", file]);
+        return stamp ? Number(stamp) : null;
+    } catch {
+        return null;
+    }
+}
+
+function humanBytes(bytes) {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;
+}
+
+function evaluate(file) {
+    const dir = path.dirname(file);
+    const stem = path.basename(file).replace(/\.html?$/, "");
+    const svg = path.join(dir, `${stem}.svg`);
+    const png = path.join(dir, `${stem}.png`);
+    const findings = [];
+
+    // Presence belongs to check-diagram-fallbacks.mjs. Report and step aside so
+    // the two scripts never disagree about the same file.
+    if (!existsSync(svg) || !existsSync(png)) {
+        return { file, evaluated: false, findings };
+    }
+
+    const htmlBytes = statSync(file).size;
+    if (htmlBytes > MAX_HTML_BYTES) {
+        findings.push({
+            dimension: "weight",
+            message:
+                `interactive HTML is ${humanBytes(htmlBytes)}, over the ` +
+                `${humanBytes(MAX_HTML_BYTES)} budget`,
+        });
+    }
+
+    const svgBytes = statSync(svg).size;
+    if (svgBytes < MIN_SVG_BYTES) {
+        findings.push({
+            dimension: "substance",
+            message: `${path.basename(svg)} is ${humanBytes(svgBytes)}, which reads as a placeholder`,
+        });
+    }
+
+    const svgSource = readFileSync(svg, "utf8");
+    if (!SVG_CONTENT_PATTERN.test(svgSource)) {
+        findings.push({
+            dimension: "substance",
+            message: `${path.basename(svg)} contains no drawing elements`,
+        });
+    }
+
+    // The accessibility rationale in the standard rests on the fallback being
+    // readable by assistive technology, and an untitled SVG announces nothing.
+    if (!/<title\b/i.test(svgSource)) {
+        findings.push({
+            dimension: "accessibility",
+            message: `${path.basename(svg)} has no <title>, so a screen reader has nothing to announce`,
+        });
+    }
+
+    const pngBytes = statSync(png).size;
+    if (pngBytes < MIN_PNG_BYTES) {
+        findings.push({
+            dimension: "substance",
+            message: `${path.basename(png)} is ${humanBytes(pngBytes)}, which reads as a placeholder`,
+        });
+    }
+
+    // A fallback older than its diagram is worse than a missing one, because
+    // the presence gate reports it as compliant while it shows stale content.
+    const htmlCommitted = lastCommitSeconds(file);
+    for (const sibling of [svg, png]) {
+        const siblingCommitted = lastCommitSeconds(sibling);
+        if (htmlCommitted && siblingCommitted && siblingCommitted < htmlCommitted) {
+            findings.push({
+                dimension: "fidelity",
+                message: `${path.basename(sibling)} was last updated before the diagram it stands in for`,
+            });
+        }
+    }
+
+    return { file, evaluated: true, findings };
+}
+
+const argv = process.argv.slice(2);
+const strict = argv.includes("--strict");
+const asJson = argv.includes("--json");
+const targets = collectTargets(argv.filter((arg) => !arg.startsWith("--") || arg === "--all"));
+
+if (targets.length === 0) {
+    if (asJson) {
+        console.log(JSON.stringify({ targets: 0, evaluated: 0, unevaluated: 0, findings: [] }, null, 2));
+    } else {
+        console.log("No interactive diagram files to evaluate.");
+    }
+    process.exit(0);
+}
+
+const results = targets.map(evaluate);
+const evaluated = results.filter((result) => result.evaluated);
+const unevaluated = results.filter((result) => !result.evaluated);
+const withFindings = evaluated.filter((result) => result.findings.length > 0);
+const findingCount = withFindings.reduce((total, result) => total + result.findings.length, 0);
+
+if (asJson) {
+    console.log(
+        JSON.stringify(
+            {
+                targets: targets.length,
+                evaluated: evaluated.length,
+                unevaluated: unevaluated.map((result) => result.file),
+                findings: withFindings.flatMap((result) =>
+                    result.findings.map((finding) => ({ file: result.file, ...finding })),
+                ),
+            },
+            null,
+            2,
+        ),
+    );
+} else {
+    console.log(
+        `Evaluated ${evaluated.length} of ${targets.length} interactive diagram(s).`,
+    );
+
+    if (unevaluated.length > 0) {
+        console.log(
+            `\n${unevaluated.length} diagram(s) skipped because their fallback assets are missing. ` +
+                "Run check-diagram-fallbacks.mjs to list them.",
+        );
+    }
+
+    if (findingCount > 0) {
+        console.log(`\n${findingCount} finding(s):\n`);
+        for (const result of withFindings) {
+            console.log(`  ${result.file}`);
+            for (const finding of result.findings) {
+                console.log(`    [${finding.dimension}] ${finding.message}`);
+            }
+        }
+    } else if (evaluated.length > 0) {
+        console.log("No quality findings.");
+    }
+}
+
+process.exit(strict && findingCount > 0 ? 1 : 0);


### PR DESCRIPTION
## Description

Closes BEDU-424 and BEDU-423. Completes the interactive diagrams framework with the two pieces it was missing: something that judges fallback quality, and something that reports coverage on a schedule.

### Evals (BEDU-424)

`check-diagram-fallbacks.mjs` answers one question: do the three artifacts exist? That is necessary and not sufficient. A diagram passes it with a blank SVG and a one-pixel PNG, which satisfies a presence check without giving a reader anything.

New `src/scripts/eval-diagram-quality.mjs` evaluates the fallbacks that do exist:

| Dimension | What it catches |
| --- | --- |
| **Substance** | An SVG under 1 KiB, an SVG containing no drawing elements, a PNG under 4 KiB |
| **Accessibility** | An SVG with no `<title>`, which announces nothing to a screen reader |
| **Fidelity** | A fallback whose last commit predates the diagram it stands in for, which is worse than a missing one because the presence gate reports it as compliant while it shows stale content |
| **Weight** | Interactive HTML over 2 MiB |

Accessibility is the rationale the whole standard rests on, and nothing tested it until now.

Two design decisions worth surfacing:

- **Findings do not fail by default.** The repository currently sits below these thresholds, and teams turn off a gate nobody can pass. `--strict` converts findings to a non-zero exit once coverage exists. `--json` gives machine-readable output.
- **Presence is not re-checked here.** A diagram with no fallbacks reports as *unevaluated* rather than failed, so this script and the presence gate report on different things and neither hides the other.

### Maintenance (BEDU-423)

The lint gate only checks diffs, so a diagram predating the standard never fails until someone happens to touch it. That keeps the gate fair, and it also means nobody sees the real number.

New `.github/workflows/diagram-health.yml` runs both scripts across the whole repository every Monday and on demand, writes results to the job summary, and never fails. The point is visibility, not another red X.

## Current baseline

**11 interactive diagrams, 0 with fallback assets, 22 files missing.** Every diagram lacks both its `.svg` and `.png`:

`interactive_blob-lifecycle_v2`, `interactive_quilt-vs-blobs_v3`, `interactive_redstuff-encoding_v2`, `interactive_trust-boundary_v1`, `interactive_upload-relay-flow_v1`, `interactive_walrus-memory-recall_v1`, `interactive_walrus-memory-remember_v1`, `interactive_walrus-memory-restore_v1`, `interactive_walrus-read-path_v1`, `interactive_walrus-sites-request_v1`, `interactive_walrus-write-path_v1`.

Reproduce with `node src/scripts/check-diagram-fallbacks.mjs --all` from `docs/site`.

This PR does not fill that gap, deliberately. Filling it means building a generation path that does not exist today (`src/scripts/` holds a checker and no generator), and the diagrams are multi-megabyte JS-rendered pages rather than inline SVG that could be extracted, so PNG export is tractable through Playwright while SVG needs each diagram to expose an export or needs re-authoring. That is engineering work with its own shape, tracked in BEDU-1278.

## Test plan

- `node --check` passes on the new script.
- Ran `eval-diagram-quality.mjs --all` against the repository: reports `Evaluated 0 of 11`, correctly declining to pass or fail diagrams whose fallbacks are absent.
- Created synthetic placeholder assets for one diagram (a 46-byte empty SVG and an 8-byte PNG stub) and re-ran: all four dimensions fired, reporting the weight overage at 5.5 MiB, both substance floors, the missing drawing elements, and the missing `<title>`. Confirmed `--strict` exits 1 and the default exits 0. Removed the synthetic files afterwards.
- The workflow YAML parses, and its `actions/checkout` and `actions/setup-node` pins match the ones used across the rest of `.github/workflows/`.

**Not verified:** the fidelity check compares git commit timestamps, so it needs both files committed and did not fire in the synthetic test. Only its guard clauses are exercised; it degrades to a no-op when git does not know a file.

## Sources

- The standard, the three-artifact requirement, and the accessibility rationale: `docs/site/README.md`, "Interactive diagram fallback assets".
- Diff-scoped enforcement and its consequence for pre-standard diagrams: the `diagram-fallbacks` job in `.github/workflows/lint.yml`, and `check-diagram-fallbacks.mjs`, whose `--base` path filters to `--diff-filter=AMR`.
- The baseline count: `check-diagram-fallbacks.mjs --all`, run 2026-08-21.
- Diagram weight and structure: `wc -c` and tag counts over `static/diagrams/interactive_trust-boundary_v1.html` (5.7 MB, eleven inline scripts, one `<svg>` element).
- Absence of a generator: contents of `docs/site/src/scripts/` and the `scripts` block of `docs/site/package.json`.
- Action pins: `git grep` over `.github/workflows/`, matching the dominant SHAs.

Thresholds (1 KiB SVG, 4 KiB PNG, 2 MiB HTML) are chosen to catch placeholders and outliers rather than to judge detail, and are constants at the top of the script with their rationale in comments.

_Generated by [Claude Code](https://claude.ai/code)_

---

## Release notes

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI: