### PR TITLE
docs: route legacy Walrus Sites traffic to a real entry point

### DIFF
--- a/docs/blog/01_announcing_walrus.mdx
+++ b/docs/blog/01_announcing_walrus.mdx
@@ -128,4 +128,4 @@ faucet](https://discord.com/channels/916379725201563759/1037811694564560966).
 
 The [Walrus Sites website](https://walrus.site), the [Walrus docs](/docs/getting-started), and
 [this very blog](https://blog.walrus.site) are hosted on Walrus. To learn more about Walrus Sites
-and how you can deploy your own, [click here](/docs/sites/introduction/components).
+and how you can deploy your own, see [Walrus Sites](/docs/sites).

--- a/docs/blog/03_whitepaper.mdx
+++ b/docs/blog/03_whitepaper.mdx
@@ -42,4 +42,4 @@ To be part of this journey:
 - Follow us on [Twitter](https://x.com/WalrusProtocol)
 - Join our [Discord](https://discord.com/invite/walrusprotocol)
 - [Build apps](/docs/getting-started) on Walrus
-- [Publish a Walrus Site](/docs/sites/introduction/components) and share it
+- [Publish a Walrus Site](/docs/sites/getting-started/publishing-your-first-site) and share it

--- a/docs/content/sites/index.mdx
+++ b/docs/content/sites/index.mdx
@@ -23,13 +23,33 @@ goal:
     - has_answer: true
       label: Needs answer summary for AI citation
 questions:
-  - What is Walrus Sites?
+  - What is a Walrus Site?
   - How do I deploy a website on Walrus?
-  - How do I get started with walrus sites?
-answer: Deploy decentralized websites on Walrus.
+  - Can Walrus Sites host a React or Vue app?
+  - Do Walrus Sites support a backend or a database?
+  - How do I give a Walrus Site a readable domain name?
+answer: >-
+  A Walrus Site is a static website that keeps its files as blobs on Walrus and
+  indexes them with an object on Sui. You publish one with the site-builder CLI,
+  which uploads the build output to Walrus and writes the resource map to Sui,
+  and visitors reach it through a portal such as wal.app. Any static build works,
+  including single-page apps, but there is no server-side runtime, so backends,
+  databases, and server-side rendering are out of scope.
 ---
 
 Walrus Sites are decentralized websites built on [Sui](https://docs.sui.io/) and Walrus. Your site's files are stored on Walrus, a decentralized storage network, while a Sui smart contract records ownership and maps each resource path to its content. Anyone can publish a Walrus Site using the [`site-builder` CLI tool](/docs/sites/getting-started/installing-the-site-builder) and browse it through a [portal](/docs/sites/portals/deploy-locally).
+
+Because there is no server behind a Walrus Site, no single host can take it offline, and no one but the wallet that owns the Sui site object can change it. The same absence of a server sets the limits: a Walrus Site serves static files only, so backends, databases, and server-side rendering are out of scope. Any framework that produces a static build works once you point `site-builder` at its output directory, and client-side routing works through the `routes` field in `ws-resources.json`.
+
+## Where to start
+
+If you want to deploy something now, [install the site-builder](/docs/sites/getting-started/installing-the-site-builder) and follow [Publishing Your First Site](/docs/sites/getting-started/publishing-your-first-site). The two together take you from an empty machine to a live site.
+
+If you want to understand the system first, [Technical Overview](/docs/sites/introduction/technical-overview) traces a single page load from the browser to Walrus, and [Walrus Sites Components](/docs/sites/introduction/components) describes each moving part on its own.
+
+If you already have a site running, [Setting a SuiNS Name](/docs/sites/custom-domains/setting-a-suins-name) replaces the Base36 subdomain with a readable name, [Site Configuration](/docs/sites/configuration/site-configuration) covers headers, routes, and metadata, and [Creating a GitHub Actions Workflow](/docs/sites/ci-cd/github-actions-workflow) redeploys the site on every push.
+
+Before you commit to Walrus Sites for production, read [Known Restrictions](/docs/sites/known-restrictions) so the constraints are not a surprise later.
 
 import DocCardList from '@theme/DocCardList';
 

--- a/docs/content/sites/introduction/components.mdx
+++ b/docs/content/sites/introduction/components.mdx
@@ -36,16 +36,22 @@ goal:
     - has_answer: true
       label: Needs answer summary for AI citation
 questions:
-  - What is Walrus Sites Components?
-  - How do I get started with walrus sites components?
-  - What are the requirements for walrus sites components?
+  - What are the components of a Walrus Site?
+  - What does the Sui site object store?
+  - What does the site-builder CLI do?
+  - What is ws-resources.json used for?
+  - How does a Walrus Sites portal serve a site?
 answer: >-
-  A Walrus Site consists of data stored as blobs on Walrus, a site object on Sui
-  that maps resource paths to blob IDs, the site-builder CLI for publishing and
-  updating, a ws-resources.
+  A Walrus Site has four components. Walrus holds the site's static files as
+  blobs, a Sui object maps each resource path to the blob that holds it, the
+  site-builder CLI publishes and updates both, and a portal resolves the site
+  and serves it to browsers. A ws-resources.json file configures how
+  site-builder deploys the site, and site-builder never uploads it.
 ---
 
 A Walrus Site is made up of 4 main components that work together: the site's files stored on Walrus, a [Sui object](https://docs.sui.io/guides/developer/objects/object-model) that indexes those files as resources, the [`site-builder` CLI](/docs/sites/getting-started/installing-the-site-builder) that publishes and updates the site, and a portal that serves the site to browsers.
+
+Each section below covers one component on its own. To follow all four through a single page load, read [Technical Overview](/docs/sites/introduction/technical-overview). To skip the theory and deploy something, go straight to [Publishing Your First Site](/docs/sites/getting-started/publishing-your-first-site), or browse the full guide set from [Walrus Sites](/docs/sites).
 
 ## Site files on Walrus
 
@@ -53,7 +59,7 @@ Your site's static assets (HTML, CSS, JavaScript, images, fonts, and so on) are 
 
 ## The Sui site object
 
-Each Walrus Site corresponds to a single object on Sui, defined by the Move smart contract in the [`move/walrus_site`](https://github.com/MystenLabs/walrus-sites/tree/main/move/walrus_site) directory of the repository. Unlike storing a single blob directly on Walrus, a Walrus Site bundles all its files into a quilt and represents the entire site as one Sui object. At its core, a site object is a simple structure:
+Each Walrus Site corresponds to a single object on Sui, defined by the Move smart contract in the [`move/walrus_site`](https://github.com/MystenLabs/walrus-sites/tree/main/move/walrus_site) directory of the repository. Unlike storing a single blob directly on Walrus, a Walrus Site bundles all its files into a quilt and represents the entire site as one Sui object. At its core, a site object is a basic structure:
 
 ```move
 struct Site has key, store {
@@ -155,4 +161,4 @@ You can iterate on a Walrus Site entirely on your own machine by running each co
 - **Local portal:** Run a portal on `localhost` to resolve and serve your site in the browser. See [Deploy a Local Portal](/docs/sites/portals/deploy-locally).
 - **Local Walrus and Sui networks:** Run a local Walrus network, backed by a local Sui network, so the `site-builder` publishes to storage you control. See [Run a local Walrus network](/docs/system-overview/available-networks).
 
-Point your `sites-config.yaml` and `client_config.yaml` at the local context, deploy with `site-builder`, then open the site through the local portal. Once the site works locally, switch the context back to Testnet or Mainnet to publish it.
+Point your `sites-config.yaml` and `client_config.yaml` at the local context, deploy with `site-builder`, then open the site through the local portal. Once the site works locally, switch the context back to Testnet or Mainnet to publish it. To deploy the same way on every push instead, see [Creating a GitHub Actions Workflow for Walrus Sites](/docs/sites/ci-cd/github-actions-workflow).

--- a/docs/content/sites/known-restrictions.mdx
+++ b/docs/content/sites/known-restrictions.mdx
@@ -51,7 +51,7 @@ Walrus Sites store all site resources (HTML, CSS, JS, images, fonts) as blobs on
 
 - **No server-side rendering (SSR):** Frameworks that require a Node.js (or equivalent) server to render pages per request (such as Next.js in SSR mode, Nuxt.js, or Remix) cannot run their server component on Walrus Sites. Only the pre-built static output of those frameworks (i.e., exported HTML/CSS/JS) can be deployed.
 - **No server-side logic:** There are no endpoints, no request handlers, and no databases. Operations that would normally be handled by a backend (such as form processing, authentication sessions, or database queries) must be implemented using client-side code integrated with external APIs or Sui smart contracts.
-- **No runtime redirects:** Redirect plugins that execute at serve time (for example, the Docusaurus redirect plugin that routes `/old-path` to `/new-path` at the server level) do not function as expected. Client-side redirect workarounds must be used instead. See the [routing documentation](https://docs.wal.app/walrus-sites/routing.html) for supported approaches.
+- **No runtime redirects:** Redirect plugins that execute at serve time (for example, the Docusaurus redirect plugin that routes `/old-path` to `/new-path` at the server level) do not function as expected. Client-side redirect workarounds must be used instead. See [Redirects](/docs/sites/linking/redirects) for supported approaches.
 
 ## No secret values
 

--- a/docs/site/ws-resources.manual.json
+++ b/docs/site/ws-resources.manual.json
@@ -160,7 +160,7 @@
     "/docs/walrus-sites/ci-cd-gh-workflow.md": "/markdown/sites/ci-cd/github-actions-workflow.md",
     "/docs/walrus-sites/ci-cd.md": "/markdown/sites/ci-cd/github-actions-workflow.md",
     "/docs/walrus-sites/commands.md": "/markdown/sites/getting-started/using-the-site-builder.md",
-    "/docs/walrus-sites/intro.md": "/markdown/sites/introduction/components.md",
+    "/docs/walrus-sites/intro.md": "/markdown/sites/index.md",
     "/docs/walrus-sites/overview.md": "/markdown/sites/introduction/technical-overview.md",
     "/docs/walrus-sites/portal.md": "/markdown/sites/portals/deploy-locally.md",
     "/docs/walrus-sites/redirects.md": "/markdown/sites/linking/redirects.md",
@@ -428,7 +428,7 @@
       "status_code": 301
     },
     "/docs/walrus-sites/intro": {
-      "location": "/docs/sites/introduction/components",
+      "location": "/docs/sites",
       "status_code": 301
     },
     "/docs/walrus-sites/linking": {
@@ -612,7 +612,7 @@
       "status_code": 301
     },
     "/walrus-sites/intro": {
-      "location": "/docs/sites/introduction/components",
+      "location": "/docs/sites",
       "status_code": 301
     },
     "/walrus-sites/linking": {
@@ -1024,11 +1024,11 @@
       "status_code": 301
     },
     "/walrus-sites/intro.html": {
-      "location": "/docs/sites/introduction/components",
+      "location": "/docs/sites",
       "status_code": 301
     },
     "/walrus-sites/intro/index": {
-      "location": "/docs/sites/introduction/components",
+      "location": "/docs/sites",
       "status_code": 301
     },
     "/walrus-sites/overview.html": {


### PR DESCRIPTION
## Description

Part of BEDU-1279 (investigating Walrus traffic). Plausible showed `/docs/sites/introduction/components` taking 2,868 pageviews — 42% of all Walrus docs pageviews — at a 15s average visit duration. The ticket asked whether that was bots, an iframe, or real demand.

It is none of those. It is a redirect funnel.

Four legacy paths all `301` to that page in `docs/site/ws-resources.manual.json`:

```
/docs/walrus-sites/intro
/walrus-sites/intro
/walrus-sites/intro.html
/walrus-sites/intro/index
```

`/walrus-sites/intro` was the canonical Walrus Sites entry point before the Docusaurus restructure, so it is still what external links, older tutorials, and stale search results point at. All of that traffic lands on a component reference — the last page a first-time visitor should see. The 15s duration is consistent with arriving for an introduction, finding a reference, and leaving.

This PR sends that traffic somewhere useful and makes the destination worth landing on.

**Redirects**

- Repointed all four `/walrus-sites/intro` variants to `/docs/sites`, matching what `/docs/walrus-sites/tutorial` and `/docs/walrus-sites/advanced` already do in the same file.
- Repointed the matching markdown route `/docs/walrus-sites/intro.md` from `/markdown/sites/introduction/components.md` to `/markdown/sites/index.md` so the `.md` export follows the HTML route.

**`docs/content/sites/index.mdx`** — the new destination, previously 76 words of one paragraph plus a `DocCardList`

- Expanded to 328 words with a "Where to start" section that splits readers three ways: deploy now, understand first, already running. Added a paragraph on what Walrus Sites can and cannot do, so the static-only constraint is visible before someone invests in it.
- Replaced placeholder frontmatter questions (`How do I get started with walrus sites?`) with ones a reader would actually type, and replaced the `answer`, which was just the `description` echoed back.

**`docs/content/sites/introduction/components.mdx`** — still reachable from `technical-overview` and the sidebar, so it should not dead-end

- Added forward links after the opening paragraph, pointing at the technical overview, the first-site guide, and the Walrus Sites index.
- Added a CI pointer at the end of the local-development section.
- Replaced three placeholder frontmatter questions (`What is Walrus Sites Components?`, `How do I get started with walrus sites components?`, `What are the requirements for walrus sites components?`).
- Completed the `answer`, which was truncated mid-sentence at `a ws-resources.`
- `simple` → `basic` per the style guide.

**Link fixes**

- `docs/blog/01_announcing_walrus.mdx` and `docs/blog/03_whitepaper.mdx` both promised deployment ("how you can deploy your own", "Publish a Walrus Site") and linked to the component reference. Repointed to `/docs/sites` and `/docs/sites/getting-started/publishing-your-first-site`. Also replaced a `click here` link label.
- `docs/content/sites/known-restrictions.mdx` linked to `https://docs.wal.app/walrus-sites/routing.html`, a legacy absolute URL that only resolves through a 301. Replaced with the internal route `/docs/sites/linking/redirects`.

## Test plan

- `npm run docs:audit` — `pagesWithIssues` drops 17 → 16. `sites/index.mdx` no longer fails ("Very short page (76 words)" → 328 words). All three edited content pages report `brokenLinks: []` and `issues: []`.
- Deterministic style-guide audit passes on every edited content file.
- Verified each new link target exists on disk: `sites/getting-started/installing-the-site-builder.mdx`, `publishing-your-first-site.mdx`, `sites/custom-domains/setting-a-suins-name.mdx`, `sites/configuration/site-configuration.mdx`, `sites/ci-cd/github-actions-workflow.mdx`, `sites/known-restrictions.mdx`, `sites/linking/redirects.mdx`, `sites/index.mdx`.
- `ws-resources.manual.json` re-parsed as valid JSON after editing.

## Sources

- Redirect inventory and targets: `docs/site/ws-resources.manual.json` (`redirects` and `routes` keys), read directly.
- Route structure: `docs/site/docusaurus.config.js` — the classic preset has no `routeBasePath`, so docs live under `/docs`; `walrus-memory` is a separate plugin instance at line 226.
- Redirect stub mechanics: `docs/site/src/scripts/generate-routes.js`, whose `isRedirectStub()` identifies Docusaurus meta-refresh stubs and comments on why they need routes on the deployed Walrus Site.
- Deployment target: `.github/workflows/publish-docs.yaml` — `docs/site/build` published via `walrus-sites-github-actions/deploy`, with a GitHub Pages mirror.
- Traffic figures (2,868 pageviews, 42%, 15s, 309 vs 1,204 visitors): the Plausible numbers quoted in BEDU-1279, not independently measured here.
- Static-only claims added to `sites/index.mdx`: summarized from the existing `docs/content/sites/known-restrictions.mdx`, not written fresh.
- Audit and style results: measured by running `node src/scripts/audit-docs.mjs` from `docs/site`, and the deterministic docs style-guide audit, against this branch.
- Prose in `sites/index.mdx` and the new links in `components.mdx` were written fresh for this PR; no existing source.

## Not changed, flagged instead

Two things surfaced that need an owner who knows the portal's actual behavior:

1. `site-builder` prints a legacy docs URL in its own deploy output — `📖 Setup instructions: https://docs.wal.app/walrus-sites/portal.html#running-the-portal-locally`, captured verbatim in `sites/getting-started/publishing-your-first-site.mdx:187`. The CLI is actively generating the legacy-redirect traffic this PR is cleaning up. That fix belongs in `walrus-sites`, and the docs snippet should not be edited while it still reflects what the tool prints.
2. Three pages disagree about redirects. `sites/configuration/site-configuration.mdx:126` documents the `redirects` field as "server-side redirects", while `sites/known-restrictions.mdx` says "No runtime redirects" and `sites/introduction/components.mdx` carries a caution that "Walrus Sites does not support dynamic redirects." I did not guess at which is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoBWxqLzd9hAxrhoqv3iSv

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI: