### PR TITLE
docs: add Schema.org structured data (JSON-LD) for SEO

### DIFF
--- a/docs/site/docusaurus.config.js
+++ b/docs/site/docusaurus.config.js
@@ -89,6 +89,24 @@ const config = {
         type: "application/xml",
       },
     },
+    {
+      tagName: "script",
+      attributes: {
+        type: "application/ld+json",
+      },
+      innerHTML: JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "@id": "https://docs.wal.app/#website",
+        url: "https://docs.wal.app",
+        name: "Walrus Docs",
+        description:
+          "Technical documentation for Walrus, a decentralized storage protocol built on Sui",
+        publisher: {
+          "@id": "https://walrus.xyz/#organization",
+        },
+      }),
+    },
   ],
 
   clientModules: [

--- a/docs/site/src/components/StructuredData.tsx
+++ b/docs/site/src/components/StructuredData.tsx
@@ -1,0 +1,152 @@
+// Copyright (c) Walrus Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// Injects per-page JSON-LD structured data into <head> for SEO.
+//
+// Rendered inside the DocItem/Layout wrapper, which passes doc metadata and TOC
+// as props (avoiding direct useDoc() calls from a separate module).
+//
+// Schemas emitted:
+//   - TechArticle on the docs root (/docs/getting-started)
+//   - HowTo + LearningResource on getting-started pages that contain steps
+//
+// BreadcrumbList is already handled by the default Docusaurus DocBreadcrumbs
+// theme component, and the sitewide WebSite schema lives in headTags in
+// docusaurus.config.js.
+
+import React from "react";
+import Head from "@docusaurus/Head";
+import { useLocation } from "@docusaurus/router";
+
+const SITE_URL = "https://docs.wal.app";
+const ORG_ID = "https://walrus.xyz/#organization";
+
+interface TOCItem {
+  value: string;
+  id: string;
+  level: number;
+}
+
+interface DocMetadata {
+  title: string;
+  description?: string;
+}
+
+interface StructuredDataProps {
+  metadata: DocMetadata;
+  toc: TOCItem[];
+}
+
+function buildTechArticle(pathname: string): object {
+  return {
+    "@context": "https://schema.org",
+    "@type": "TechArticle",
+    headline: "Walrus Documentation",
+    description:
+      "Technical documentation for Walrus, a decentralized storage protocol built on Sui.",
+    url: `${SITE_URL}${pathname}`,
+    publisher: { "@id": ORG_ID },
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": `${SITE_URL}${pathname}`,
+    },
+    inLanguage: "en",
+  };
+}
+
+function buildHowTo(
+  pathname: string,
+  title: string,
+  description: string,
+  toc: TOCItem[],
+): object | null {
+  const stepRegex = /^Step \d+:\s+(.+)$/;
+  const steps = toc
+    .filter((item) => stepRegex.test(item.value))
+    .map((item, index) => {
+      const match = item.value.match(stepRegex);
+      return {
+        "@type": "HowToStep",
+        position: index + 1,
+        name: item.value,
+        text: match ? match[1] : item.value,
+        url: `${SITE_URL}${pathname}#${item.id}`,
+      };
+    });
+
+  if (steps.length === 0) {
+    return null;
+  }
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "HowTo",
+    name: title,
+    description,
+    step: steps,
+  };
+}
+
+function buildLearningResource(
+  pathname: string,
+  title: string,
+  description: string,
+): object {
+  return {
+    "@context": "https://schema.org",
+    "@type": "LearningResource",
+    name: title,
+    description,
+    url: `${SITE_URL}${pathname}`,
+    educationalLevel: "Beginner",
+    learningResourceType: "tutorial",
+    provider: { "@id": ORG_ID },
+    inLanguage: "en",
+  };
+}
+
+export default function StructuredData({
+  metadata,
+  toc,
+}: StructuredDataProps): React.JSX.Element | null {
+  const { pathname } = useLocation();
+  const { title, description } = metadata;
+
+  const normalizedPath = pathname.replace(/\/$/, "");
+  const schemas: object[] = [];
+
+  // TechArticle on the docs root page
+  if (normalizedPath === "/docs/getting-started") {
+    schemas.push(buildTechArticle(normalizedPath));
+  }
+
+  // HowTo and LearningResource on getting-started pages that have steps
+  if (normalizedPath.startsWith("/docs/getting-started")) {
+    const howTo = buildHowTo(
+      normalizedPath,
+      title,
+      description || title,
+      toc,
+    );
+    if (howTo) {
+      schemas.push(howTo);
+    }
+    schemas.push(
+      buildLearningResource(normalizedPath, title, description || title),
+    );
+  }
+
+  if (schemas.length === 0) {
+    return null;
+  }
+
+  return (
+    <Head>
+      {schemas.map((schema, i) => (
+        <script key={`sd-${i}`} type="application/ld+json">
+          {JSON.stringify(schema)}
+        </script>
+      ))}
+    </Head>
+  );
+}

--- a/docs/site/src/theme/DocItem/index.js
+++ b/docs/site/src/theme/DocItem/index.js
@@ -4,11 +4,12 @@
 import React from "react";
 import DocItem from "@theme-original/DocItem";
 import { useLocation } from "@docusaurus/router";
+import StructuredData from "@site/src/components/StructuredData";
 
 export default function DocItemWrapper(props) {
   const doc = props?.content ?? {};
-  const frontMatter = doc.frontMatter ?? {};
   const metadata = doc.metadata ?? {};
+  const toc = doc.toc ?? [];
 
   const { pathname } = useLocation();
 
@@ -21,6 +22,7 @@ export default function DocItemWrapper(props) {
           }
         `}</style>
       )}
+      <StructuredData metadata={metadata} toc={toc} />
       <DocItem {...props} />
     </>
   );


### PR DESCRIPTION
## Summary

- Adds sitewide **WebSite** JSON-LD schema to `headTags` in `docusaurus.config.js`, referencing the existing Organization entity at `https://walrus.xyz/#organization`
- Creates a `StructuredData` component that injects per-page JSON-LD:
  - **TechArticle** on the docs root (`/docs/getting-started`)
  - **HowTo** with all 8 `##step` headings as `HowToStep` entries on getting-started pages
  - **LearningResource** with `educationalLevel: "Beginner"` on getting-started pages
- **BreadcrumbList** is already handled by Docusaurus's built-in `DocBreadcrumbs` component — no changes needed

### Output on `/docs/getting-started`
5 JSON-LD blocks: WebSite, TechArticle, HowTo (8 steps), LearningResource, BreadcrumbList

### Output on regular doc pages
2 JSON-LD blocks: WebSite, BreadcrumbList

## Test plan

- [x] `pnpm build` passes
- [ ] Verify structured data with [Google Rich Results Test](https://search.google.com/test/rich-results) after deploy
- [ ] Confirm HowTo steps match the visible step headings on the getting-started page

🤖 Generated with [Claude Code](https://claude.com/claude-code)