### PR TITLE
test: add e2e test for storage node cap transfer to a new wallet

### DIFF
--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -4532,6 +4532,8 @@ async fn store_and_read_with_grpc_only_sui_fullnode() -> TestResult {
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_storage_node_cap_transfer_to_new_wallet() -> TestResult {
+    // Box the test future to move its large state machine to the heap, preventing a stack
+    // overflow of the test thread.
     Box::pin(storage_node_cap_transfer_to_new_wallet()).await
 }
 

--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -12,7 +12,7 @@
 #[cfg(msim)]
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeSet, HashMap, HashSet},
     net::SocketAddr,
     num::NonZeroU16,
     path::PathBuf,
@@ -26,7 +26,12 @@ use rand::{Rng, random, seq::SliceRandom, thread_rng};
 use reqwest::Url;
 #[cfg(msim)]
 use sui_macros::{clear_fail_point, register_fail_point_if};
-use sui_types::base_types::{ObjectID, SUI_ADDRESS_LENGTH, SuiAddress};
+use sui_types::{
+    base_types::{FullObjectRef, ObjectID, SUI_ADDRESS_LENGTH, SuiAddress},
+    effects::TransactionEffectsAPI,
+    programmable_transaction_builder::ProgrammableTransactionBuilder,
+    transaction::TransactionData,
+};
 use tokio::{sync::Mutex, time::Instant};
 use tokio_stream::StreamExt;
 use walrus_core::{
@@ -47,6 +52,7 @@ use walrus_core::{
         encoded_blob_length_for_n_shards,
         quilt_encoding::{QuiltApi, QuiltStoreBlob, QuiltVersionV1},
     },
+    keys::{NetworkKeyPair, ProtocolKeyPair},
     merkle::Node,
     messages::BlobPersistenceType,
     metadata::{QuiltMetadata, VerifiedBlobMetadataWithId},
@@ -100,9 +106,11 @@ use walrus_sui::{
     test_utils::{self, fund_addresses, wallet_for_testing},
     types::{
         Blob,
+        NodeRegistrationParams,
         move_errors::MoveExecutionError,
         move_structs::{BlobAttribute, BlobWithAttribute, Credits, SharedBlob},
     },
+    utils::generate_proof_of_possession,
 };
 use walrus_test_utils::{Result as TestResult, WithTempDir, assert_unordered_eq, async_param_test};
 use walrus_upload_relay::{
@@ -4515,5 +4523,157 @@ async fn store_and_read_with_grpc_only_sui_fullnode() -> TestResult {
         })
         .await?;
 
+    basic_store_and_read(&client, 2, 31415, None, || Ok(())).await
+}
+
+/// Tests that a `StorageNodeCap` can be transferred to a new wallet — the operator flow of
+/// moving the capability object and then switching the node's wallet — and that this neither
+/// changes the capability nor affects the operation of the cluster.
+#[ignore = "ignore E2E tests by default"]
+#[walrus_simtest]
+async fn test_storage_node_cap_transfer_to_new_wallet() -> TestResult {
+    Box::pin(storage_node_cap_transfer_to_new_wallet()).await
+}
+
+async fn storage_node_cap_transfer_to_new_wallet() -> TestResult {
+    const GAS_BUDGET: u64 = 500_000_000;
+
+    walrus_test_utils::init_tracing();
+
+    let (sui_cluster_handle, _walrus_cluster, client, system_ctx, _) =
+        test_cluster::E2eTestSetupBuilder::new().build().await?;
+
+    // Wallet A plays the role of the node's original wallet; wallet B is the new wallet the
+    // capability is transferred to. Both are funded with SUI for gas.
+    let wallet_a = test_utils::new_wallet_on_sui_test_cluster(sui_cluster_handle.clone()).await?;
+    let wallet_b = test_utils::new_wallet_on_sui_test_cluster(sui_cluster_handle.clone()).await?;
+
+    let mut contract_client_a = wallet_a
+        .and_then_async(async |wallet| {
+            let rpc_urls = &[wallet.get_rpc_url().to_string()];
+            system_ctx
+                .new_contract_client(
+                    wallet,
+                    rpc_urls,
+                    Default::default(),
+                    None,
+                    DEFAULT_CHECKPOINT_WAIT_TIMEOUT,
+                )
+                .await
+        })
+        .await?;
+    let contract_client_b = wallet_b
+        .and_then_async(async |wallet| {
+            let rpc_urls = &[wallet.get_rpc_url().to_string()];
+            system_ctx
+                .new_contract_client(
+                    wallet,
+                    rpc_urls,
+                    Default::default(),
+                    None,
+                    DEFAULT_CHECKPOINT_WAIT_TIMEOUT,
+                )
+                .await
+        })
+        .await?;
+    let address_a = contract_client_a.as_ref().address();
+    let address_b = contract_client_b.as_ref().address();
+
+    // Register a candidate storage node from wallet A, which then owns the resulting
+    // `StorageNodeCap`; this mirrors the registration a node operator performs.
+    let protocol_key_pair = ProtocolKeyPair::generate();
+    let network_key_pair = NetworkKeyPair::generate();
+    let registration_params =
+        NodeRegistrationParams::new_for_test(protocol_key_pair.public(), network_key_pair.public());
+    let current_epoch = contract_client_a.as_ref().current_epoch().await?;
+    let proof_of_possession = generate_proof_of_possession(
+        &protocol_key_pair,
+        contract_client_a.as_ref(),
+        current_epoch,
+    );
+    let cap = contract_client_a
+        .as_ref()
+        .register_candidate(&registration_params, proof_of_possession)
+        .await?;
+
+    // The capability authorizes cap-gated node operations from wallet A, e.g., price votes.
+    contract_client_a
+        .as_ref()
+        .update_prices(cap.id, 42, 7)
+        .await?;
+    let pool = contract_client_a
+        .as_ref()
+        .read_client()
+        .get_staking_pool(cap.node_id)
+        .await?;
+    assert_eq!(pool.voting_params.storage_price, 42);
+    assert_eq!(pool.voting_params.write_price, 7);
+
+    // Transfer the capability to wallet B with a plain object transfer, as an operator would
+    // do with `sui client transfer`.
+    {
+        let wallet = contract_client_a.inner.wallet_mut();
+        #[allow(deprecated)]
+        let cap_ref = wallet.get_object_ref(cap.id).await?;
+        #[allow(deprecated)]
+        let gas = wallet
+            .gas_for_owner_budget(address_a, GAS_BUDGET, BTreeSet::new())
+            .await?
+            .1
+            .compute_object_reference();
+        let mut ptb = ProgrammableTransactionBuilder::new();
+        ptb.transfer_object(address_b, FullObjectRef::from_fastpath_ref(cap_ref))?;
+        #[allow(deprecated)]
+        let gas_price = wallet.get_reference_gas_price().await?;
+        let transaction = TransactionData::new_programmable(
+            address_a,
+            vec![gas],
+            ptb.finish(),
+            GAS_BUDGET,
+            gas_price,
+        );
+        #[allow(deprecated)]
+        let response = wallet
+            .execute_transaction_may_fail(wallet.sign_transaction(&transaction).await)
+            .await?;
+        assert!(response.effects.status().is_ok());
+    }
+
+    // Wallet B now discovers the capability by ownership — the same lookup a storage node
+    // performs at startup when its configured wallet holds the capability.
+    let cap_from_b = contract_client_b
+        .as_ref()
+        .read_client()
+        .get_address_capability_object(address_b)
+        .await?
+        .expect("wallet B must own the capability after the transfer");
+    // The capability object is unchanged by the transfer: same object ID and node ID.
+    assert_eq!(cap_from_b.id, cap.id);
+    assert_eq!(cap_from_b.node_id, cap.node_id);
+
+    // Wallet A no longer holds a capability.
+    assert!(
+        contract_client_a
+            .as_ref()
+            .read_client()
+            .get_address_capability_object(address_a)
+            .await?
+            .is_none()
+    );
+
+    // The capability remains fully functional from wallet B.
+    contract_client_b
+        .as_ref()
+        .update_prices(cap.id, 100, 50)
+        .await?;
+    let pool = contract_client_b
+        .as_ref()
+        .read_client()
+        .get_staking_pool(cap.node_id)
+        .await?;
+    assert_eq!(pool.voting_params.storage_price, 100);
+    assert_eq!(pool.voting_params.write_price, 50);
+
+    // The cluster's storage nodes are unaffected: blobs can still be stored and read.
     basic_store_and_read(&client, 2, 31415, None, || Ok(())).await
 }

--- a/crates/walrus-e2e-tests/tests/test_client.rs
+++ b/crates/walrus-e2e-tests/tests/test_client.rs
@@ -108,7 +108,7 @@ use walrus_sui::{
         Blob,
         NodeRegistrationParams,
         move_errors::MoveExecutionError,
-        move_structs::{BlobAttribute, BlobWithAttribute, Credits, SharedBlob},
+        move_structs::{Authorized, BlobAttribute, BlobWithAttribute, Credits, SharedBlob},
     },
     utils::generate_proof_of_possession,
 };
@@ -4528,7 +4528,9 @@ async fn store_and_read_with_grpc_only_sui_fullnode() -> TestResult {
 
 /// Tests that a `StorageNodeCap` can be transferred to a new wallet — the operator flow of
 /// moving the capability object and then switching the node's wallet — and that this neither
-/// changes the capability nor affects the operation of the cluster.
+/// changes the capability nor affects the operation of the cluster. In particular, epoch
+/// change participation (`epoch_sync_done`) and reward (commission) collection keep working
+/// through the capability from the new wallet.
 #[ignore = "ignore E2E tests by default"]
 #[walrus_simtest]
 async fn test_storage_node_cap_transfer_to_new_wallet() -> TestResult {
@@ -4542,8 +4544,19 @@ async fn storage_node_cap_transfer_to_new_wallet() -> TestResult {
 
     walrus_test_utils::init_tracing();
 
+    // Use a short epoch duration so that the test can exercise epoch changes. Two nodes with
+    // three shards each leave the real nodes with a quorum of shards after the candidate node
+    // registered below takes over a single shard.
     let (sui_cluster_handle, _walrus_cluster, client, system_ctx, _) =
-        test_cluster::E2eTestSetupBuilder::new().build().await?;
+        test_cluster::E2eTestSetupBuilder::new()
+            .with_epoch_duration(Duration::from_secs(20))
+            .with_test_nodes_config(
+                TestNodesConfig::builder()
+                    .with_node_weights(&[3, 3])
+                    .build(),
+            )
+            .build()
+            .await?;
 
     // Wallet A plays the role of the node's original wallet; wallet B is the new wallet the
     // capability is transferred to. Both are funded with SUI for gas.
@@ -4587,15 +4600,37 @@ async fn storage_node_cap_transfer_to_new_wallet() -> TestResult {
     let network_key_pair = NetworkKeyPair::generate();
     let registration_params =
         NodeRegistrationParams::new_for_test(protocol_key_pair.public(), network_key_pair.public());
-    let current_epoch = contract_client_a.as_ref().current_epoch().await?;
-    let proof_of_possession = generate_proof_of_possession(
-        &protocol_key_pair,
-        contract_client_a.as_ref(),
-        current_epoch,
-    );
-    let cap = contract_client_a
+    // Retry the registration in case an epoch change lands between generating the proof of
+    // possession (which commits to the current epoch) and executing the transaction.
+    let mut cap = None;
+    for _ in 0..3 {
+        let current_epoch = contract_client_a.as_ref().current_epoch().await?;
+        let proof_of_possession = generate_proof_of_possession(
+            &protocol_key_pair,
+            contract_client_a.as_ref(),
+            current_epoch,
+        );
+        match contract_client_a
+            .as_ref()
+            .register_candidate(&registration_params, proof_of_possession)
+            .await
+        {
+            Ok(registered_cap) => {
+                cap = Some(registered_cap);
+                break;
+            }
+            Err(error) => tracing::info!(%error, "retrying candidate registration"),
+        }
+    }
+    let cap = cap.expect("candidate registration must succeed");
+
+    // Tie the commission (reward collection) authorization to the capability object itself, so
+    // that reward collection follows the capability when it is transferred. At registration,
+    // the commission receiver defaults to the registering address (wallet A), which must
+    // authorize the change.
+    contract_client_a
         .as_ref()
-        .register_candidate(&registration_params, proof_of_possession)
+        .set_commission_receiver(cap.node_id, Authorized::Object(cap.id))
         .await?;
 
     // The capability authorizes cap-gated node operations from wallet A, e.g., price votes.
@@ -4676,6 +4711,102 @@ async fn storage_node_cap_transfer_to_new_wallet() -> TestResult {
     assert_eq!(pool.voting_params.storage_price, 100);
     assert_eq!(pool.voting_params.write_price, 50);
 
-    // The cluster's storage nodes are unaffected: blobs can still be stored and read.
-    basic_store_and_read(&client, 2, 31415, None, || Ok(())).await
+    // Stake with the candidate node so that it joins the committee: with D'Hondt apportionment
+    // over stakes [3, 3, 1.2] (in units of `FROST_PER_NODE_WEIGHT`), the candidate node is
+    // guaranteed exactly one of the six shards, so the two real nodes retain a quorum of
+    // shards and the cluster keeps operating.
+    client
+        .as_ref()
+        .stake_with_node_pool(cap.node_id, 6 * FROST_PER_NODE_WEIGHT / 5)
+        .await?;
+
+    // Wait for the epoch change that adds the candidate node to the committee.
+    let mut in_committee = false;
+    for _ in 0..60 {
+        let committees = contract_client_b
+            .as_ref()
+            .get_committees_and_state()
+            .await?;
+        if committees.current.find(&cap.node_id).is_some() {
+            in_committee = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+    assert!(
+        in_committee,
+        "the candidate node must join the committee after staking"
+    );
+
+    // Report "epoch sync done" for the candidate node from wallet B: the epoch change
+    // transaction a storage node sends with its capability every epoch. Retry in case an epoch
+    // change lands between reading the current epoch and executing the transaction.
+    let mut sync_done = false;
+    for _ in 0..10 {
+        let epoch = contract_client_b.as_ref().current_epoch().await?;
+        match contract_client_b
+            .as_ref()
+            .epoch_sync_done(epoch, cap.id)
+            .await
+        {
+            Ok(()) => {
+                sync_done = true;
+                break;
+            }
+            Err(error) => {
+                tracing::info!(%error, "retrying epoch_sync_done after an error");
+                tokio::time::sleep(Duration::from_secs(2)).await;
+            }
+        }
+    }
+    assert!(sync_done, "epoch_sync_done from wallet B must succeed");
+    // The sync must be recorded on the capability object on-chain.
+    let cap_after_sync = contract_client_b
+        .as_ref()
+        .read_client()
+        .get_address_capability_object(address_b)
+        .await?
+        .expect("wallet B still owns the capability");
+    assert!(cap_after_sync.last_epoch_sync_done > 0);
+
+    // The cluster is unaffected with the candidate node in the committee: blobs can still be
+    // stored and read. The storage payment also funds the rewards for the current epoch, of
+    // which the candidate node's pool receives a share at the next epoch change. The blobs
+    // must stay below the maximum blob size of the six-shard cluster (~1.3 MB), while paying
+    // for enough storage units for the candidate's commission to be non-zero.
+    basic_store_and_read(&client, 3, 1_000_000, None, || Ok(()))
+        .await
+        .expect("store and read must work with the candidate node in the committee");
+
+    // Reward collection works from wallet B through the capability. The commission becomes
+    // non-zero only once an epoch change has distributed the rewards, so poll across epoch
+    // changes; this also verifies that epoch changes keep happening after the cap transfer.
+    let mut commission = 0;
+    for _ in 0..60 {
+        if let Ok(amount) = contract_client_b
+            .as_ref()
+            .collect_commission(cap.node_id)
+            .await
+            && amount > 0
+        {
+            commission = amount;
+            break;
+        }
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+    assert!(
+        commission > 0,
+        "wallet B must collect a non-zero commission through the capability"
+    );
+
+    // Wallet A can no longer collect rewards, as it does not hold the capability anymore.
+    assert!(matches!(
+        contract_client_a
+            .as_ref()
+            .collect_commission(cap.node_id)
+            .await,
+        Err(SuiClientError::NotAuthorizedForPool(_))
+    ));
+
+    Ok(())
 }


### PR DESCRIPTION
## Description

Adds an e2e test covering the node-operator flow of transferring a `StorageNodeCap` to a new wallet and switching the wallet, verifying that the capability and node operation — including epoch change participation and reward collection — are unaffected.

The test:

- Registers a storage node candidate from wallet A, which receives the `StorageNodeCap`, and verifies the capability works from wallet A via a cap-gated price vote (`update_prices`) reflected in the on-chain staking pool.
- Ties the commission receiver to the capability object (`set_commission_receiver` with `Authorized::Object`), so reward collection follows the capability.
- Transfers the capability to wallet B with a plain object-transfer PTB (the equivalent of `sui client transfer`).
- Verifies wallet B discovers the capability by ownership (`get_address_capability_object`, the same lookup a storage node performs at startup), that the capability's object ID and node ID are unchanged, that wallet A no longer holds a capability, and that the capability remains fully functional from wallet B.
- Stakes with the candidate so it joins the committee with exactly one shard (D'Hondt over stakes [3, 3, 1.2] node weights), keeping a quorum of shards on the real nodes, and verifies `epoch_sync_done` succeeds from wallet B and is recorded on the capability.
- Confirms the cluster keeps operating with the candidate in the committee: blobs still store and read correctly.
- Verifies reward collection: wallet B collects a non-zero commission through the capability (polling across epoch changes, which also confirms epoch changes keep happening), while wallet A's attempt fails with `NotAuthorizedForPool`.

## Test plan

```
RUST_MIN_STACK=33554432 cargo nextest run -p walrus-e2e-tests --run-ignored ignored-only test_storage_node_cap_transfer_to_new_wallet
```

```
PASS [ 100.884s] walrus-e2e-tests::test_client test_storage_node_cap_transfer_to_new_wallet
```
