### PR TITLE
fix: stop retrying process_subsidies when the subsidy pool is empty

### DIFF
--- a/crates/walrus-service/src/node/contract_service.rs
+++ b/crates/walrus-service/src/node/contract_service.rs
@@ -32,7 +32,7 @@ use walrus_sui::{
     types::{
         StorageNodeCap,
         UpdatePublicKeyParams,
-        move_errors::{MoveExecutionError, StakingInnerError},
+        move_errors::{MoveExecutionError, StakingInnerError, WalrusSubsidiesInnerError},
         move_structs::{EpochState, EventBlob},
     },
 };
@@ -45,6 +45,7 @@ use super::{
     committee::CommitteeService,
     config::{CommissionRateData, StorageNodeConfig, SyncedNodeConfigSet, defaults},
     errors::SyncNodeConfigError,
+    network_overrides::{NetworkKind, network_kind_for_contracts},
 };
 use crate::common::config::SuiConfig;
 
@@ -288,6 +289,17 @@ impl SuiSystemContractService {
     /// `SuiSystemContractService`.
     pub fn builder() -> SuiSystemContractServiceBuilder {
         Default::default()
+    }
+
+    /// Returns true if an abort on an empty subsidy pool should be ignored rather than retried.
+    ///
+    /// The network is derived from the contract objects this node is configured against, so no
+    /// caller has to know or pass it down.
+    fn tolerates_empty_subsidy_pool(&self) -> bool {
+        network_kind_for_contracts(
+            self.read_client.system_object_id(),
+            self.read_client.staking_object_id(),
+        ) == NetworkKind::Testnet
     }
 
     /// Fetches the synced node config set from the contract.
@@ -598,12 +610,25 @@ impl SystemContractService for SuiSystemContractService {
     }
 
     async fn process_subsidies(&self) -> anyhow::Result<()> {
-        self.contract_tx_client
+        let result = self
+            .contract_tx_client
             .lock()
             .await
             .process_subsidies()
-            .await?;
-        Ok(())
+            .await;
+
+        match result {
+            Err(error)
+                if is_empty_subsidy_pool_abort(&error) && self.tolerates_empty_subsidy_pool() =>
+            {
+                tracing::warn!(
+                    %error,
+                    "the subsidy pool cannot fund the payout, not retrying process subsidies"
+                );
+                Ok(())
+            }
+            result => Ok(result?),
+        }
     }
 
     async fn certify_event_blob(
@@ -753,6 +778,23 @@ fn calculate_protocol_key_action(
     }
 }
 
+/// Returns true if `error` is the abort raised when the subsidy pool cannot fund a payout.
+///
+/// The testnet subsidy pool has been empty since 2025-12-24, so `process_subsidies` aborts with
+/// `EInsufficientFundsInPool`. The abort reverts `last_subsidized_ts`, which is what the
+/// client-side deduplication reads, so the call is retried every few minutes forever and burns gas
+/// on a transaction that cannot succeed until the pool is refilled. That drained operator wallets
+/// to the point where nodes could no longer pay for epoch change (WAL-1328). Both asserts in
+/// `walrus_subsidies_inner` raise this same error.
+fn is_empty_subsidy_pool_abort(error: &SuiClientError) -> bool {
+    matches!(
+        error,
+        SuiClientError::TransactionExecutionError(MoveExecutionError::WalrusSubsidiesInner(
+            WalrusSubsidiesInnerError::EInsufficientFundsInPool(_)
+        ))
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use walrus_core::keys::ProtocolKeyPair;
@@ -856,6 +898,39 @@ mod tests {
                 result,
                 Ok(ProtocolKeyAction::UpdateRemoteNextPublicKey(k)) if k == key3
             ));
+        }
+    }
+
+    mod empty_subsidy_pool_abort {
+        use super::*;
+
+        /// The abort that `process_fixed_rate_subsidies` raises when the pool cannot fund a
+        /// payout, as observed in production, for example in transaction
+        /// 943gE8Utp44ntEqSpuYdZ4UYLHg8xaMSJofFWKFDm7T2.
+        #[test]
+        fn recognizes_the_production_abort() {
+            let error = SuiClientError::TransactionExecutionError(MoveExecutionError::from(
+                "MoveAbort(MoveLocation { module: ModuleId { address: \
+                bf0eb79ce75d6cf6c18b6d480b85726aab06a2639569e54ddf1e25d89b549239, name: \
+                Identifier(\"walrus_subsidies_inner\") }, function: 12, instruction: 21, \
+                function_name: Some(\"process_fixed_rate_subsidies\") }, 1) in command 0",
+            ));
+
+            assert!(is_empty_subsidy_pool_abort(&error));
+        }
+
+        #[test]
+        fn ignores_other_errors() {
+            let transient = SuiClientError::Internal(anyhow::anyhow!("transient rpc failure"));
+            assert!(!is_empty_subsidy_pool_abort(&transient));
+
+            let other_abort = SuiClientError::TransactionExecutionError(MoveExecutionError::from(
+                "MoveAbort(MoveLocation { module: ModuleId { address: \
+                bf0eb79ce75d6cf6c18b6d480b85726aab06a2639569e54ddf1e25d89b549239, name: \
+                Identifier(\"walrus_subsidies_inner\") }, function: 12, instruction: 21, \
+                function_name: Some(\"set_subsidy_rate\") }, 0) in command 0",
+            ));
+            assert!(!is_empty_subsidy_pool_abort(&other_abort));
         }
     }
 }

--- a/crates/walrus-service/src/node/epoch_change_driver.rs
+++ b/crates/walrus-service/src/node/epoch_change_driver.rs
@@ -768,17 +768,7 @@ impl EpochOperation for SubsidiesOperation {
         }
 
         tracing::info!("initiating subsidy distribution");
-        // Move transaction execution to a separate task so that it cannot be cancelled when
-        // invoke() is cancelled. Otherwise, cancelling inflight transaction may cause object
-        // conflicts.
-        tokio::spawn({
-            let contract = contract.clone();
-            async move { contract.process_subsidies().await }
-        })
-        .await
-        .map_err(|e| {
-            anyhow::anyhow!("call to initiate subsidy distribution panicked: {:?}", e)
-        })??;
+        call_process_subsidies(contract).await?;
         tracing::debug!("successfully initiated subsidy distribution");
         Ok(())
     }
@@ -830,23 +820,25 @@ impl EpochOperation for PostEpochChangeSubsidiesOperation {
         }
 
         tracing::info!(epoch_to_be_paid, "processing subsidies after epoch change");
-        // Move transaction execution to a separate task so that it cannot be cancelled when
-        // invoke() is cancelled. Otherwise, cancelling inflight transaction may cause object
-        // conflicts.
-        tokio::spawn({
-            let contract = contract.clone();
-            async move { contract.process_subsidies().await }
-        })
-        .await
-        .map_err(|e| {
-            anyhow::anyhow!(
-                "call to process subsidies after epoch change panicked: {:?}",
-                e
-            )
-        })??;
+        call_process_subsidies(contract).await?;
         tracing::debug!("successfully processed subsidies after epoch change");
         Ok(())
     }
+}
+
+/// Calls `process_subsidies` on the contract.
+///
+/// Whether a failure is retried is decided by the contract service: it recognises the abort raised
+/// when the subsidy pool cannot fund a payout and, on networks where that is expected, reports
+/// success so that this call is only attempted again when it is scheduled anew (WAL-1328).
+async fn call_process_subsidies(
+    contract: Arc<dyn SystemContractService>,
+) -> Result<(), anyhow::Error> {
+    // Move transaction execution to a separate task so that it cannot be cancelled when invoke()
+    // is cancelled. Otherwise, cancelling inflight transaction may cause object conflicts.
+    tokio::spawn(async move { contract.process_subsidies().await })
+        .await
+        .map_err(|e| anyhow::anyhow!("call to process subsidies panicked: {:?}", e))?
 }
 
 /// Return a random duration uniformly sampled from the interval `[0..max)`.
@@ -1355,6 +1347,38 @@ mod tests {
             drop(driver);
 
             Ok(())
+        }
+
+        /// A failing call is retried until it succeeds.
+        #[tokio::test(start_paused = true)]
+        async fn retries_failing_process_subsidies() -> TestResult {
+            let mut service = failing_subsidies_service();
+            service
+                .expect_process_subsidies()
+                .times(2..)
+                .returning(|| Err(anyhow::anyhow!("transient rpc failure")));
+
+            let driver = driver_under_test(service, /*seed=*/ 14, UtcInstant::now());
+            driver.schedule_post_epoch_change_subsidies();
+
+            let _ = tokio::time::timeout(MAX_BACKOFF * 10, driver.run()).await;
+            drop(driver);
+
+            Ok(())
+        }
+
+        /// A contract service whose `process_subsidies` expectation is set by the caller.
+        fn failing_subsidies_service() -> MockSystemContractService {
+            let mut service = MockSystemContractService::new();
+            service
+                .expect_is_subsidies_object_configured()
+                .returning(|| true);
+            service
+                .expect_get_epoch_and_state()
+                .returning(|| Ok((2, EpochState::EpochChangeSync(0))));
+            service.expect_current_epoch().returning(|| 2);
+            service.expect_latest_subsidized_epoch().returning(|| Ok(0));
+            service
         }
     }
 }

--- a/crates/walrus-service/src/node/network_overrides.rs
+++ b/crates/walrus-service/src/node/network_overrides.rs
@@ -40,6 +40,18 @@ pub(crate) fn detect_network_kind(config_value: &Value) -> NetworkKind {
     let Some(config_ids) = extract_contract_ids(config_value) else {
         return default_network_kind();
     };
+    network_kind_for_contracts(config_ids.system_object, config_ids.staking_object)
+}
+
+/// Detects the network kind from the system and staking object IDs the node is configured with.
+pub(crate) fn network_kind_for_contracts(
+    system_object: ObjectID,
+    staking_object: ObjectID,
+) -> NetworkKind {
+    let config_ids = ContractIds {
+        system_object,
+        staking_object,
+    };
     let known = known_network_ids();
     if known.mainnet.as_ref() == Some(&config_ids) {
         return NetworkKind::Mainnet;


### PR DESCRIPTION
## Description
Closes WAL-1328.

The testnet subsidy pool has been empty for long time, so process_subsidies aborts with `EInsufficientFundsInPool`. The abort reverts last_subsidized_ts, which is what the client-side dedup reads, so every node retries the call every few minutes forever and burns gas on a transaction that cannot succeed until the pool is refilled. That has drained operator wallets to the point where nodes can no longer pay for `epoch_sync_done` and deadlock at epoch change. 

On testnet, empty subsidy pool is not a issue and nodes can simply ignore the error and stop retrying. The match is on the specific error, so every other failure is retried as before, and every network other than testnet is unchanged.


## Test plan

`recognizes_the_production_abort` test passes.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
