### PR TITLE
ci: fix unresolvable action pin in editorial coverage (1.55 release branch)

### DIFF
--- a/.github/workflows/editorial-coverage.yml
+++ b/.github/workflows/editorial-coverage.yml
@@ -32,9 +32,9 @@ jobs:
   check-editorial-coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # pin@v7.0.1
 
-      - uses: actions/setup-node@a309ff8b426b58ec0e2a45f0f869d46889d02405 # pin@v6.2.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # pin@v7.0.0
         with:
           node-version: "22"
 
@@ -47,7 +47,7 @@ jobs:
             --json editorial-coverage.json
 
       - name: Open tracking issues for uncovered releases
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # pin@v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # pin@v9.0.0
         with:
           script: |
             const fs = require("fs");


### PR DESCRIPTION
Cherry-picks 3c1cacc11c92 (#3672) onto the 1.55 release branch.

## Problem

`Editorial coverage` fails on every `release` event cut from this branch — most recently [run 33538666635](https://github.com/MystenLabs/walrus/actions/runs/33538666635) (`testnet-v1.55.2`), which died in 7 seconds during `Set up job`:

```
Unable to resolve action `actions/setup-node@a309ff8b426b58ec0e2a45f0f869d46889d02405`,
unable to find version `a309ff8b426b58ec0e2a45f0f869d46889d02405`
```

That SHA does not exist upstream — `GET repos/actions/setup-node/commits/a309ff8b...` returns HTTP 422 `No commit found for SHA`. The `# pin@v6.2.0` comment is wrong.

This was already fixed on `main` in #3672 on 2026-08-20, but was never cherry-picked here. Because a `release` event resolves the workflow file **from the tag**, not from `main`, the fix on `main` has no effect on release runs — which is why scheduled runs on `main` are green while every release run fails.

| Date | Event / ref | Result |
| --- | --- | --- |
| 2026-08-17 | schedule / main | fail |
| 2026-08-20 20:34 | release / devnet-v1.55.0 | fail |
| 2026-08-20 20:54 | **#3672 lands on main** | — |
| 2026-08-20 21:01 | workflow_dispatch / main | pass |
| 2026-08-24, 08-31 | schedule / main | pass |
| 2026-08-28 | release / testnet-v1.55.1 | fail |
| 2026-09-01 | release / testnet-v1.55.2 | fail |

Deterministic, not flaky. Every future tag cut from this branch fails identically until this lands.

## Scope

Only `releases/walrus-v1.55.0-release` is affected. All 39 earlier release branches (v1.15–v1.54) predate the workflow — `editorial-coverage.yml` was added 2026-08-12 in #3589, so 1.55.x is the first release line that carries it. No other branch needs this.

## Impact

Low. The workflow only opens tracking issues for releases missing editorial changelog summaries (`Issues: write` + `github-script`). Nothing in the Walrus build, release, or deploy path depends on it. The effect is that 1.55.x releases are not getting changelog-coverage tracking.

Already-published tags (`testnet-v1.55.1`, `testnet-v1.55.2`, `devnet-v1.55.0`) bake in the old workflow file and cannot be repaired retroactively — re-running them will fail identically. Per the network check in `check-editorial-coverage.js`, the devnet trigger was a no-op anyway.

## Test plan

Verified before opening:

- [x] `actions/setup-node@a309ff8b...` returns HTTP 422 upstream — the pin is genuinely dead, not a transient resolution failure
- [x] Branch tip `631776c9e043` is byte-identical to the `testnet-v1.55.2` tag, and carries the dead pin
- [x] Diff between this branch's workflow file and `main`'s is **exactly** the three pin lines — no other divergence, so this is a clean cherry-pick with no unrelated drift
- [x] The three replacement pins all resolve upstream
- [x] `main` runs this identical post-fix file green on schedule (2026-08-24, 2026-08-31), so the `checkout` v7.0.1 and `github-script` v9.0.0 bumps are already proven against this exact script
- [x] Audited all 40 release branches; only this one carries the workflow at all

Not verifiable pre-merge: the workflow triggers on `release` and `schedule`, neither of which fires on a PR branch. The definitive check is the next tag cut from this branch reaching `check-editorial-coverage` instead of dying in `Set up job`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AB5yaPRbU5FpDcpCZnPNUG
