### PR TITLE
feat: add on-chain certification of blob info snapshots to the system contract

### DIFF
--- a/contracts/walrus/sources/init.move
+++ b/contracts/walrus/sources/init.move
@@ -83,6 +83,8 @@ public fun migrate(_staking: &mut Staking, _system: &mut System) {
 ///   - Do not use migration epoch.
 /// Migrate to version 4:
 ///   - Increase the max size of the active set to the updated `TEMP_ACTIVE_SET_SIZE_LIMIT`.
+/// Migrate to version 5:
+///   - Create the blob info snapshot certification state dynamic field on the system object.
 entry fun migrate_v2(staking: &mut Staking, system: &mut System, _ctx: &mut TxContext) {
     staking.migrate();
     system.migrate();

--- a/contracts/walrus/sources/staking.move
+++ b/contracts/walrus/sources/staking.move
@@ -29,7 +29,7 @@ const EWrongVersion: u64 = 1;
 const EDeprecatedFunction: u64 = 2;
 
 /// Flag to indicate the version of the Walrus system.
-const VERSION: u64 = 4;
+const VERSION: u64 = 5;
 
 /// The key for the migration epoch.
 const MIGRATION_EPOCH_KEY: vector<u8> = b"migration_epoch";
@@ -437,10 +437,10 @@ entry fun set_migration_epoch(staking: &mut Staking) {
 /// This function sets the new package id and version and can be modified in future versions
 /// to migrate changes in the `staking_inner` object if needed.
 public(package) fun migrate(staking: &mut Staking) {
-    // Below logic is for upgrading to version 4. When upgrading to future versions, this function
+    // Below logic is for upgrading to version 5. When upgrading to future versions, this function
     // needs to be revisited to perform correct migration steps.
     assert!(staking.version < VERSION, EInvalidMigration);
-    assert!(VERSION == 4, EInvalidMigration);
+    assert!(VERSION == 5, EInvalidMigration);
 
     // Move the old staking inner to the new version.
     let staking_inner: StakingInnerV1 = df::remove(&mut staking.id, staking.version);
@@ -452,9 +452,10 @@ public(package) fun migrate(staking: &mut Staking) {
     staking.package_id = staking.new_package_id.extract();
 
     // Apply the updated `TEMP_ACTIVE_SET_SIZE_LIMIT` to the existing `ActiveSet`, since the
-    // limit is only read when the `ActiveSet` is created.
-    // Note that this step is needed for version 4. When upgrading to future versions, this
-    // step needs to be revisited.
+    // limit is only read when the `ActiveSet` is created. This step was introduced for the
+    // version 4 migration and is safe to re-apply; it runs as part of this migration since no
+    // network has executed it yet. When upgrading to future versions, this step needs to be
+    // revisited.
     staking.inner_mut().update_active_set_max_size();
 }
 

--- a/contracts/walrus/sources/system.move
+++ b/contracts/walrus/sources/system.move
@@ -11,6 +11,7 @@ use walrus::{
     blob::Blob,
     bls_aggregate::BlsCommittee,
     epoch_parameters::EpochParams,
+    snapshot_blob::{Self, SnapshotBlobCertificationState},
     storage_accounting::FutureAccountingRingBuffer,
     storage_node::StorageNodeCap,
     storage_pool::StoragePool,
@@ -28,7 +29,13 @@ const EWrongVersion: u64 = 1;
 const EZeroExtractSize: u64 = 2;
 
 /// Flag to indicate the version of the system.
-const VERSION: u64 = 4;
+const VERSION: u64 = 5;
+
+/// Key for the dynamic field on `System` holding the blob info snapshot certification state.
+///
+/// A dedicated key type is used (rather than a `u64`) so that the key can never collide with
+/// the `u64` version keys under which the system state inner is stored.
+public struct SnapshotStateKey() has copy, drop, store;
 
 /// The one and only system object.
 public struct System has key {
@@ -49,6 +56,11 @@ public(package) fun create_empty(max_epochs_ahead: u32, package_id: ID, ctx: &mu
     };
     let system_state_inner = system_state_inner::create_empty(max_epochs_ahead, ctx);
     dynamic_field::add(&mut system.id, VERSION, system_state_inner);
+    dynamic_field::add(
+        &mut system.id,
+        SnapshotStateKey(),
+        snapshot_blob::create_with_empty_state(max_epochs_ahead),
+    );
     transfer::share_object(system);
 }
 
@@ -118,6 +130,61 @@ public fun certify_event_blob(
             epoch,
             ctx,
         )
+}
+
+/// Certifies a blob info snapshot blob for the given epoch.
+public fun certify_snapshot_blob(
+    system: &mut System,
+    cap: &StorageNodeCap,
+    blob_id: u256,
+    root_hash: u256,
+    size: u64,
+    encoding_type: u8,
+    snapshot_epoch: u32,
+    ctx: &mut TxContext,
+) {
+    assert!(system.version == VERSION, EWrongVersion);
+    // The certification state is temporarily detached because the system state inner is
+    // another dynamic field of the same object, and both must be mutably borrowed.
+    let mut state: SnapshotBlobCertificationState = dynamic_field::remove(
+        &mut system.id,
+        SnapshotStateKey(),
+    );
+    system
+        .inner_mut()
+        .certify_snapshot_blob(
+            &mut state,
+            cap,
+            blob_id,
+            root_hash,
+            size,
+            encoding_type,
+            snapshot_epoch,
+            ctx,
+        );
+    dynamic_field::add(&mut system.id, SnapshotStateKey(), state);
+}
+
+/// Sets the number of epochs ahead for which certified blob info snapshot blobs are stored.
+///
+/// The authorization is checked by the caller, `upgrade::set_snapshot_epochs_ahead`. The new
+/// value applies to snapshots certified after the change.
+public(package) fun set_snapshot_epochs_ahead(system: &mut System, epochs_ahead: u32) {
+    assert!(system.version == VERSION, EWrongVersion);
+    let max_epochs_ahead = system.inner().future_accounting().max_epochs_ahead();
+    let state: &mut SnapshotBlobCertificationState = dynamic_field::borrow_mut(
+        &mut system.id,
+        SnapshotStateKey(),
+    );
+    state.set_epochs_ahead(epochs_ahead, max_epochs_ahead);
+}
+
+/// Returns the blob info snapshot certification state.
+public(package) fun snapshot_blob_certification_state(
+    system: &System,
+): &SnapshotBlobCertificationState {
+    assert!(system.version == VERSION, EWrongVersion);
+    dynamic_field::borrow(&system.id, SnapshotStateKey())
 }
 
 /// Allows buying a storage reservation for a given period of epochs.
@@ -462,10 +529,10 @@ public(package) fun set_new_package_id(system: &mut System, new_package_id: ID) 
 /// This function sets the new package id and version and can be modified in future versions
 /// to migrate changes in the `system_state_inner` object if needed.
 public(package) fun migrate(system: &mut System) {
-    // Below logic is for upgrading to version 4. When upgrading to future versions, this function
+    // Below logic is for upgrading to version 5. When upgrading to future versions, this function
     // needs to be revisited to perform correct migration steps.
     assert!(system.version < VERSION, EInvalidMigration);
-    assert!(VERSION == 4, EInvalidMigration);
+    assert!(VERSION == 5, EInvalidMigration);
 
     // Move the old system state inner to the new version.
     let system_state_inner: SystemStateInnerV1 = dynamic_field::remove(
@@ -474,6 +541,14 @@ public(package) fun migrate(system: &mut System) {
     );
     dynamic_field::add(&mut system.id, VERSION, system_state_inner);
     system.version = VERSION;
+
+    // Create the blob info snapshot certification state introduced in version 5.
+    let max_epochs_ahead = system.inner().future_accounting().max_epochs_ahead();
+    dynamic_field::add(
+        &mut system.id,
+        SnapshotStateKey(),
+        snapshot_blob::create_with_empty_state(max_epochs_ahead),
+    );
 
     // Set the new package id.
     assert!(system.new_package_id.is_some(), EInvalidMigration);
@@ -516,7 +591,13 @@ public fun new_for_testing(ctx: &mut TxContext): System {
         new_package_id: option::none(),
     };
     let system_state_inner = system_state_inner::new_for_testing();
+    let max_epochs_ahead = system_state_inner.future_accounting().max_epochs_ahead();
     dynamic_field::add(&mut system.id, VERSION, system_state_inner);
+    dynamic_field::add(
+        &mut system.id,
+        SnapshotStateKey(),
+        snapshot_blob::create_with_empty_state(max_epochs_ahead),
+    );
     system
 }
 
@@ -529,7 +610,13 @@ public(package) fun new_for_testing_with_multiple_members(ctx: &mut TxContext): 
         new_package_id: option::none(),
     };
     let system_state_inner = system_state_inner::new_for_testing_with_multiple_members(ctx);
+    let max_epochs_ahead = system_state_inner.future_accounting().max_epochs_ahead();
     dynamic_field::add(&mut system.id, VERSION, system_state_inner);
+    dynamic_field::add(
+        &mut system.id,
+        SnapshotStateKey(),
+        snapshot_blob::create_with_empty_state(max_epochs_ahead),
+    );
     system
 }
 

--- a/contracts/walrus/sources/system/events.move
+++ b/contracts/walrus/sources/system/events.move
@@ -34,6 +34,12 @@ public struct BlobCertified has copy, drop {
     is_extension: bool,
 }
 
+#[test_only]
+/// Returns the end epoch of the certified blob, for tests that check storage lifetimes.
+public fun blob_certified_end_epoch(event: &BlobCertified): u32 {
+    event.end_epoch
+}
+
 /// Signals that a blob has been deleted.
 public struct BlobDeleted has copy, drop {
     epoch: u32,

--- a/contracts/walrus/sources/system/snapshot_blob.move
+++ b/contracts/walrus/sources/system/snapshot_blob.move
@@ -1,0 +1,269 @@
+// Copyright (c) Walrus Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+/// Module to certify blob info snapshot blobs.
+///
+/// A blob info snapshot is a deterministic serialization of the blob info tables that every
+/// storage node produces at the epoch boundary. All honest nodes produce bit-identical bytes,
+/// and therefore the same blob id, so certification is a per-epoch quorum vote on that blob id.
+/// This follows the event blob certification pattern (`event_blob.move`) with one
+/// simplification: there is exactly one snapshot per epoch, so attestations are keyed by epoch
+/// instead of by checkpoint, and no per-capability attestation bookkeeping is needed — a node
+/// may attest at most once per epoch, tracked in this state directly.
+module walrus::snapshot_blob;
+
+use sui::{vec_map::{Self, VecMap}, vec_set::{Self, VecSet}};
+
+// Error codes
+// Error types in `walrus-sui/types/move_errors.rs` are auto-generated from the Move error codes.
+/// The epoch of the certified snapshot must be strictly increasing.
+const EInvalidEpoch: u64 = 0;
+/// The snapshot storage lifetime must be at most the system's `max_epochs_ahead` and at least
+/// `MIN_SNAPSHOT_EPOCHS_AHEAD`, or `max_epochs_ahead` if that is smaller.
+const EInvalidEpochsAhead: u64 = 1;
+
+/// The smallest number of epochs ahead for which a certified snapshot blob may be stored.
+///
+/// A snapshot certified in epoch E with a lifetime of L epochs expires at epoch E + L. Storage
+/// nodes check whether it certified at the start of epoch E + 1, after expiring the blobs whose
+/// storage ends there, so a lifetime of one epoch would make every snapshot expire before that
+/// check and never leave it available for recovery.
+///
+/// A system whose `max_epochs_ahead` is below this minimum cannot store any blob that long. It
+/// is not made unmigratable for that: its lifetime is bounded by its maximum instead, and its
+/// snapshots expire before the next boundary's check, as described above.
+const MIN_SNAPSHOT_EPOCHS_AHEAD: u32 = 2;
+
+/// A certified blob info snapshot.
+public struct SnapshotBlob has copy, drop, store {
+    /// The walrus epoch whose boundary state the snapshot captures.
+    epoch: u32,
+    /// Blob id of the certified snapshot blob.
+    blob_id: u256,
+    /// The epoch at which the storage of the snapshot blob ends (exclusive). Recorded here
+    /// because the blob object is burned at certification, so the chain has no other record
+    /// of how long the snapshot stays retrievable.
+    end_epoch: u32,
+}
+
+/// State of blob info snapshot certification.
+///
+/// Lives in a dynamic field on the `System` object (see `system.move`) because the layout of
+/// `SystemStateInnerV1` is frozen and cannot gain a field.
+public struct SnapshotBlobCertificationState has store {
+    /// The certified snapshot blobs, oldest first: after every certification, the newest
+    /// entry, the previous one whatever its lifetime, and every older entry whose storage has
+    /// not ended. Expired entries are dropped only when a snapshot is certified, so readers
+    /// must compare `end_epoch` with the current epoch. Bounded by `max_epochs_ahead + 1`
+    /// entries, since at most one snapshot is certified per epoch.
+    certified: vector<SnapshotBlob>,
+    /// Number of epochs ahead for which a certified snapshot blob is stored.
+    epochs_ahead: u32,
+    /// The epoch the attestations below belong to. Attestations of an older epoch are cleared
+    /// lazily when the first attestation of a newer epoch arrives.
+    tally_epoch: u32,
+    /// Aggregate attested shard weight per snapshot blob id for `tally_epoch`.
+    aggregate_weight_per_blob: VecMap<u256, u16>,
+    /// Nodes that have attested a snapshot for `tally_epoch`.
+    attested_nodes: VecSet<ID>,
+}
+
+// === Accessors for SnapshotBlob ===
+
+/// Returns the epoch of the snapshot blob.
+public(package) fun epoch(self: &SnapshotBlob): u32 {
+    self.epoch
+}
+
+/// Returns the epoch at which the storage of the snapshot blob ends (exclusive).
+public(package) fun end_epoch(self: &SnapshotBlob): u32 {
+    self.end_epoch
+}
+
+/// Returns the blob id of the snapshot blob.
+public(package) fun blob_id(self: &SnapshotBlob): u256 {
+    self.blob_id
+}
+
+// === Accessors for SnapshotBlobCertificationState ===
+
+/// Creates a certification state with no certified snapshot and no attestations.
+///
+/// The snapshot storage lifetime starts at the system's `max_epochs_ahead`, the longest a blob
+/// can be stored: a recovering node needs the last certified snapshot to still be stored, so the
+/// lifetime bounds the certification outage the network can recover from, and the cost of the
+/// superseded snapshots this keeps is accepted for that. It can be lowered later through
+/// `set_epochs_ahead`.
+public(package) fun create_with_empty_state(max_epochs_ahead: u32): SnapshotBlobCertificationState {
+    assert_valid_epochs_ahead(max_epochs_ahead, max_epochs_ahead);
+    SnapshotBlobCertificationState {
+        certified: vector[],
+        epochs_ahead: max_epochs_ahead,
+        tally_epoch: 0,
+        aggregate_weight_per_blob: vec_map::empty(),
+        attested_nodes: vec_set::empty(),
+    }
+}
+
+/// Returns the number of epochs ahead for which a certified snapshot blob is stored.
+public(package) fun epochs_ahead(self: &SnapshotBlobCertificationState): u32 {
+    self.epochs_ahead
+}
+
+/// Sets the number of epochs ahead for which certified snapshot blobs are stored.
+///
+/// Applies to snapshots certified after the change; the storage of already certified snapshots
+/// is unaffected.
+public(package) fun set_epochs_ahead(
+    self: &mut SnapshotBlobCertificationState,
+    epochs_ahead: u32,
+    max_epochs_ahead: u32,
+) {
+    assert_valid_epochs_ahead(epochs_ahead, max_epochs_ahead);
+    self.epochs_ahead = epochs_ahead;
+}
+
+/// Aborts unless `min_epochs_ahead <= epochs_ahead <= max_epochs_ahead`, where the lower bound
+/// is `MIN_SNAPSHOT_EPOCHS_AHEAD` or, on a system whose `max_epochs_ahead` is smaller, that
+/// maximum: see the lower bound for why a shorter lifetime is useless, and the reservation is
+/// bounded by the system's accounting horizon.
+fun assert_valid_epochs_ahead(epochs_ahead: u32, max_epochs_ahead: u32) {
+    let min_epochs_ahead = MIN_SNAPSHOT_EPOCHS_AHEAD.min(max_epochs_ahead);
+    assert!(
+        epochs_ahead >= min_epochs_ahead && epochs_ahead <= max_epochs_ahead,
+        EInvalidEpochsAhead,
+    );
+}
+
+#[test_only]
+public fun destroy_for_testing(self: SnapshotBlobCertificationState) {
+    let SnapshotBlobCertificationState {
+        certified: _,
+        epochs_ahead: _,
+        tally_epoch: _,
+        aggregate_weight_per_blob: _,
+        attested_nodes: _,
+    } = self;
+}
+
+/// Returns the certified snapshot blobs kept in the state (see `certified`), oldest first.
+public(package) fun certified_history(
+    self: &SnapshotBlobCertificationState,
+): &vector<SnapshotBlob> {
+    &self.certified
+}
+
+/// Returns the latest certified snapshot blob.
+public(package) fun latest_certified(self: &SnapshotBlobCertificationState): Option<SnapshotBlob> {
+    let length = self.certified.length();
+    if (length == 0) {
+        option::none()
+    } else {
+        option::some(self.certified[length - 1])
+    }
+}
+
+/// Returns the certified snapshot blob of `epoch`, if it is among the ones kept in the state.
+public(package) fun certified_for_epoch(
+    self: &SnapshotBlobCertificationState,
+    epoch: u32,
+): Option<SnapshotBlob> {
+    let mut index = 0;
+    while (index < self.certified.length()) {
+        if (self.certified[index].epoch == epoch) {
+            return option::some(self.certified[index])
+        };
+        index = index + 1;
+    };
+    option::none()
+}
+
+/// Returns the epoch of the latest certified snapshot blob.
+public(package) fun get_latest_certified_epoch(self: &SnapshotBlobCertificationState): Option<u32> {
+    self.latest_certified().map!(|snapshot| snapshot.epoch())
+}
+
+/// Returns the blob id of the latest certified snapshot blob.
+public(package) fun get_latest_certified_blob_id(
+    self: &SnapshotBlobCertificationState,
+): Option<u256> {
+    self.latest_certified().map!(|snapshot| snapshot.blob_id())
+}
+
+/// Returns the number of snapshot blob ids being tracked for the current tally epoch.
+public(package) fun get_num_tracked_blobs(self: &SnapshotBlobCertificationState): u64 {
+    self.aggregate_weight_per_blob.length()
+}
+
+/// Returns true if a snapshot for `epoch` (or a later epoch) is already certified.
+public(package) fun is_epoch_certified(self: &SnapshotBlobCertificationState, epoch: u32): bool {
+    self.latest_certified().map!(|snapshot| snapshot.epoch() >= epoch).destroy_or!(false)
+}
+
+/// Returns true if `node_id` has already attested a snapshot for the current tally epoch.
+public(package) fun has_attested(self: &SnapshotBlobCertificationState, node_id: &ID): bool {
+    self.attested_nodes.contains(node_id)
+}
+
+/// Moves the tally to `epoch`, clearing all attestations of older epochs.
+///
+/// Called lazily on each attestation instead of during the epoch change, so that the epoch
+/// change transaction does not need to touch this state.
+public(package) fun advance_tally_epoch(self: &mut SnapshotBlobCertificationState, epoch: u32) {
+    if (self.tally_epoch != epoch) {
+        self.tally_epoch = epoch;
+        self.aggregate_weight_per_blob = vec_map::empty();
+        self.attested_nodes = vec_set::empty();
+    }
+}
+
+/// Records that `node_id` attested a snapshot for the current tally epoch.
+public(package) fun record_attestation(self: &mut SnapshotBlobCertificationState, node_id: ID) {
+    self.attested_nodes.insert(node_id);
+}
+
+/// Adds `weight` to the aggregate weight of the snapshot with the given blob id and returns
+/// the updated aggregate weight.
+public(package) fun add_aggregate_weight(
+    self: &mut SnapshotBlobCertificationState,
+    blob_id: u256,
+    weight: u16,
+): u16 {
+    if (!self.aggregate_weight_per_blob.contains(&blob_id)) {
+        self.aggregate_weight_per_blob.insert(blob_id, 0);
+    };
+    let aggregate_weight = &mut self.aggregate_weight_per_blob[&blob_id];
+    *aggregate_weight = *aggregate_weight + weight;
+    *aggregate_weight
+}
+
+/// Records the snapshot with the given blob id as certified for `epoch`, with storage ending at
+/// `end_epoch` (exclusive), drops the recorded snapshots whose storage has ended by `epoch`
+/// except the previously certified one, and stops tracking the attestations that led to it.
+///
+/// `epoch` is the current epoch, since only attestations for the current epoch are accepted.
+public(package) fun certify(
+    self: &mut SnapshotBlobCertificationState,
+    epoch: u32,
+    blob_id: u256,
+    end_epoch: u32,
+) {
+    self.get_latest_certified_epoch().do!(|latest_epoch| {
+        assert!(epoch > latest_epoch, EInvalidEpoch);
+    });
+    let length = self.certified.length();
+    let mut kept = vector[];
+    length.do!(|index| {
+        let snapshot = self.certified[index];
+        // Expired snapshots are dropped, except the latest one: storage nodes reconcile it at
+        // the next epoch boundary and a recovering node needs it as a fallback, whatever its
+        // lifetime.
+        if (snapshot.end_epoch > epoch || index + 1 == length) {
+            kept.push_back(snapshot);
+        };
+    });
+    kept.push_back(SnapshotBlob { epoch, blob_id, end_epoch });
+    self.certified = kept;
+    self.aggregate_weight_per_blob = vec_map::empty();
+    self.attested_nodes = vec_set::empty();
+}

--- a/contracts/walrus/sources/system/system_state_inner.move
+++ b/contracts/walrus/sources/system/system_state_inner.move
@@ -15,6 +15,7 @@ use walrus::{
     events,
     extended_field::{Self, ExtendedField},
     messages,
+    snapshot_blob::SnapshotBlobCertificationState,
     storage_accounting::{Self, FutureAccountingRingBuffer},
     storage_node::StorageNodeCap,
     storage_pool::{Self, StoragePool},
@@ -559,6 +560,82 @@ public(package) fun certify_event_blob(
     //       blob requires a pointer to previous certified blob, and we just certified blob at
     //       checkpoint X
     self.event_blob_certification_state.reset();
+    blob.burn();
+}
+
+/// Certifies a blob info snapshot blob for the current epoch.
+///
+/// Follows `certify_event_blob` with per-epoch keying: each committee member may attest at
+/// most one snapshot blob id per epoch, and the blob id reaching a quorum of shard weight is
+/// certified, stored without payment for the certification state's `epochs_ahead`, and
+/// burned. The certification state lives in a dynamic field on the `System` object because
+/// the layout of `SystemStateInnerV1` is frozen, so it is detached and passed in by
+/// `system.move`.
+public(package) fun certify_snapshot_blob(
+    self: &mut SystemStateInnerV1,
+    state: &mut SnapshotBlobCertificationState,
+    cap: &StorageNodeCap,
+    blob_id: u256,
+    root_hash: u256,
+    size: u64,
+    encoding_type: u8,
+    snapshot_epoch: u32,
+    ctx: &mut TxContext,
+) {
+    assert!(self.committee().contains(&cap.node_id()), ENotCommitteeMember);
+    assert!(snapshot_epoch == self.epoch(), EInvalidIdEpoch);
+
+    // Clears attestations of older epochs; done lazily here instead of in `advance_epoch` so
+    // that the epoch change transaction does not need to touch the snapshot state.
+    state.advance_tally_epoch(snapshot_epoch);
+
+    // A late attestation after this epoch's snapshot is already certified is a no-op.
+    if (state.is_epoch_certified(snapshot_epoch)) {
+        return
+    };
+
+    // There is exactly one snapshot per epoch, so each node may attest at most once per epoch.
+    assert!(!state.has_attested(&cap.node_id()), ERepeatedAttestation);
+    state.record_attestation(cap.node_id());
+
+    let weight = self.committee().get_member_weight(&cap.node_id());
+    let agg_weight = state.add_aggregate_weight(blob_id, weight);
+    if (!self.committee().is_quorum(agg_weight)) {
+        return
+    };
+
+    let num_shards = self.n_shards();
+    // The lifetime is a system parameter (see `snapshot_blob::set_epochs_ahead`), bounded by
+    // `max_epochs_ahead` when it is set.
+    let epochs_ahead = state.epochs_ahead();
+    let storage = self.reserve_space_without_payment(
+        encoded_blob_length(size, encoding_type, num_shards),
+        0,
+        epochs_ahead,
+        // Do not check total capacity, snapshot blobs are certified already at this point.
+        false,
+        ctx,
+    );
+    let mut blob = blob::new(
+        storage,
+        blob_id,
+        root_hash,
+        size,
+        encoding_type,
+        false,
+        self.epoch(),
+        self.n_shards(),
+        ctx,
+    );
+    // The snapshot blob is a permanent system blob exactly like an event blob, so the same
+    // certified message applies.
+    let certified_blob_msg = messages::certified_event_blob_message(blob_id);
+    blob.certify_with_certified_msg(self.epoch(), certified_blob_msg);
+    // Records the certification, with the storage end so that the chain keeps a record of how
+    // long the snapshot stays retrievable after the blob object is burned, and stops tracking
+    // this epoch's attestations. Late attestations for this epoch are rejected by the
+    // `is_epoch_certified` check above.
+    state.certify(snapshot_epoch, blob_id, blob.storage().end_epoch());
     blob.burn();
 }
 

--- a/contracts/walrus/sources/upgrade.move
+++ b/contracts/walrus/sources/upgrade.move
@@ -208,6 +208,20 @@ public fun cleanup_upgrade_proposals(
 
 // === Emergency Upgrade Cap Public API ===
 
+/// TODO(WAL-1344): no client call yet; invoke through a programmable transaction.
+/// Sets the number of epochs ahead for which certified blob info snapshot blobs are stored.
+///
+/// This is an internal system parameter without an economic stake for storage nodes, so it is
+/// gated by the emergency upgrade capability instead of a committee vote. The new value applies
+/// to snapshots certified after the change; already certified snapshots keep their storage.
+public fun set_snapshot_epochs_ahead(
+    _emergency_upgrade_cap: &EmergencyUpgradeCap,
+    system: &mut System,
+    epochs_ahead: u32,
+) {
+    system.set_snapshot_epochs_ahead(epochs_ahead);
+}
+
 /// Burns the emergency upgrade cap.
 ///
 /// This will prevent any further upgrades using the `EmergencyUpgradeCap` and will
@@ -246,6 +260,14 @@ macro fun package_digest($digest: vector<u8>): PackageDigest {
 }
 
 // === Test only ===
+
+#[test_only]
+public fun new_emergency_upgrade_cap_for_testing(ctx: &mut TxContext): EmergencyUpgradeCap {
+    EmergencyUpgradeCap {
+        id: object::new(ctx),
+        upgrade_manager_id: object::id_from_address(@0x0),
+    }
+}
 
 #[test_only]
 public fun digest_for_testing(ctx: &mut TxContext): vector<u8> {

--- a/contracts/walrus/tests/system/snapshot_blob_tests.move
+++ b/contracts/walrus/tests/system/snapshot_blob_tests.move
@@ -1,0 +1,392 @@
+// Copyright (c) Walrus Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module walrus::snapshot_blob_tests;
+
+use sui::event;
+use walrus::{
+    blob,
+    epoch_parameters::epoch_params_for_testing,
+    events::{Self, BlobCertified},
+    snapshot_blob,
+    storage_node,
+    system::{Self, System},
+    system_state_inner,
+    test_node::{test_nodes, TestStorageNode},
+    upgrade
+};
+
+const RS2: u8 = 1;
+
+const ROOT_HASH: u256 = 0xABC;
+const SIZE: u64 = 5_000_000;
+
+#[test]
+public fun test_snapshot_blob_certify_happy_path() {
+    let ctx = &mut tx_context::dummy();
+    let mut system = system::new_for_testing_with_multiple_members(ctx);
+    // Total of 10 nodes all with equal weights
+    assert!(system.committee().to_vec_map().length() == 10);
+    let mut nodes = test_nodes();
+    set_storage_node_caps(&system, &mut nodes, ctx);
+    let blob_id = blob::derive_blob_id(ROOT_HASH, RS2, SIZE);
+    let mut index = 0;
+    while (index < 10) {
+        system.certify_snapshot_blob(
+            nodes.borrow(index).cap(),
+            blob_id,
+            ROOT_HASH,
+            SIZE,
+            RS2,
+            0,
+            ctx,
+        );
+        let state = system.snapshot_blob_certification_state();
+        if (index < 6) {
+            assert!(state.get_latest_certified_epoch().is_none());
+        } else {
+            // 7th node attesting the blob triggers certification; further attestations for
+            // the same epoch are no-ops.
+            assert!(state.get_latest_certified_epoch() == option::some(0));
+            assert!(state.get_latest_certified_blob_id() == option::some(blob_id));
+            assert!(state.get_num_tracked_blobs() == 0);
+        };
+        index = index + 1
+    };
+    nodes.destroy!(|node| node.destroy());
+    system.destroy_for_testing()
+}
+
+#[test, expected_failure(abort_code = system_state_inner::ERepeatedAttestation)]
+public fun test_snapshot_blob_certify_repeated_attestation() {
+    let ctx = &mut tx_context::dummy();
+    let mut system = system::new_for_testing_with_multiple_members(ctx);
+    let mut nodes = test_nodes();
+    set_storage_node_caps(&system, &mut nodes, ctx);
+    let blob_id = blob::derive_blob_id(ROOT_HASH, RS2, SIZE);
+    let divergent_blob_id = blob::derive_blob_id(0xDEF, RS2, SIZE);
+
+    system.certify_snapshot_blob(
+        nodes.borrow(0).cap(),
+        blob_id,
+        ROOT_HASH,
+        SIZE,
+        RS2,
+        0,
+        ctx,
+    );
+
+    // A second attestation by the same node in the same epoch fails, even for a different
+    // blob id.
+    system.certify_snapshot_blob(
+        nodes.borrow(0).cap(),
+        divergent_blob_id,
+        0xDEF,
+        SIZE,
+        RS2,
+        0,
+        ctx,
+    );
+
+    nodes.destroy!(|node| node.destroy());
+    system.destroy_for_testing();
+}
+
+#[test]
+public fun test_snapshot_blob_divergent_attestations_and_epoch_rollover() {
+    let ctx = &mut tx_context::dummy();
+    let mut system = system::new_for_testing_with_multiple_members(ctx);
+    let mut nodes = test_nodes();
+    set_storage_node_caps(&system, &mut nodes, ctx);
+    let blob_id = blob::derive_blob_id(ROOT_HASH, RS2, SIZE);
+    let divergent_blob_id = blob::derive_blob_id(0xDEF, RS2, SIZE);
+
+    // 6 nodes attest the correct blob (one short of quorum), 4 divergent nodes attest a
+    // different blob: no certification, both blob ids are tracked.
+    let mut index = 0;
+    while (index < 10) {
+        let attested_blob_id = if (index < 6) { blob_id } else { divergent_blob_id };
+        let attested_root_hash = if (index < 6) { ROOT_HASH } else { 0xDEF };
+        system.certify_snapshot_blob(
+            nodes.borrow(index).cap(),
+            attested_blob_id,
+            attested_root_hash,
+            SIZE,
+            RS2,
+            0,
+            ctx,
+        );
+        index = index + 1
+    };
+    let state = system.snapshot_blob_certification_state();
+    assert!(state.get_latest_certified_epoch().is_none());
+    assert!(state.get_num_tracked_blobs() == 2);
+
+    // Increment epoch: the uncertified epoch-0 attestations become irrelevant.
+    let mut new_committee = *system.committee();
+    new_committee.increment_epoch_for_testing();
+    let (_, balances) = system
+        .advance_epoch(new_committee, &epoch_params_for_testing())
+        .into_keys_values();
+    balances.do!(|b| { b.destroy_for_testing(); });
+
+    // All nodes (including the previously divergent ones) attest the same blob for epoch 1;
+    // the stale epoch-0 attestations are lazily cleared, so re-attesting succeeds and the
+    // 7th node triggers certification.
+    index = 0;
+    while (index < 10) {
+        system.certify_snapshot_blob(
+            nodes.borrow(index).cap(),
+            blob_id,
+            ROOT_HASH,
+            SIZE,
+            RS2,
+            1,
+            ctx,
+        );
+        let state = system.snapshot_blob_certification_state();
+        if (index < 6) {
+            assert!(state.get_latest_certified_epoch().is_none());
+        } else {
+            assert!(state.get_latest_certified_epoch() == option::some(1));
+            assert!(state.get_latest_certified_blob_id() == option::some(blob_id));
+        };
+        index = index + 1
+    };
+    nodes.destroy!(|node| node.destroy());
+    system.destroy_for_testing();
+}
+
+#[test, expected_failure(abort_code = system_state_inner::EInvalidIdEpoch)]
+public fun test_snapshot_blob_certify_wrong_epoch() {
+    let ctx = &mut tx_context::dummy();
+    let mut system = system::new_for_testing_with_multiple_members(ctx);
+    let mut nodes = test_nodes();
+    set_storage_node_caps(&system, &mut nodes, ctx);
+    let blob_id = blob::derive_blob_id(ROOT_HASH, RS2, SIZE);
+
+    // The system is at epoch 0, so attesting a snapshot for epoch 1 fails.
+    system.certify_snapshot_blob(
+        nodes.borrow(0).cap(),
+        blob_id,
+        ROOT_HASH,
+        SIZE,
+        RS2,
+        1,
+        ctx,
+    );
+
+    nodes.destroy!(|node| node.destroy());
+    system.destroy_for_testing();
+}
+
+#[test, expected_failure(abort_code = system_state_inner::ENotCommitteeMember)]
+public fun test_snapshot_blob_certify_non_committee_member() {
+    let ctx = &mut tx_context::dummy();
+    let mut system = system::new_for_testing_with_multiple_members(ctx);
+    let blob_id = blob::derive_blob_id(ROOT_HASH, RS2, SIZE);
+
+    // A capability whose node is not part of the committee cannot attest.
+    let foreign_cap = storage_node::new_cap(
+        object::id_from_address(ctx.fresh_object_address()),
+        ctx,
+    );
+    system.certify_snapshot_blob(
+        &foreign_cap,
+        blob_id,
+        ROOT_HASH,
+        SIZE,
+        RS2,
+        0,
+        ctx,
+    );
+
+    transfer::public_transfer(foreign_cap, ctx.sender());
+    system.destroy_for_testing();
+}
+
+#[test, expected_failure(abort_code = snapshot_blob::EInvalidEpoch)]
+public fun test_snapshot_blob_certified_epoch_must_increase() {
+    // Unit test against the state module directly: the certified epoch is strictly
+    // monotonic. This cannot be reached through `certify_snapshot_blob`, which
+    // short-circuits on an already-certified epoch; the assertion is defense in depth.
+    let mut state = snapshot_blob::create_with_empty_state(53);
+    state.certify(1, 0xABC, 3);
+    state.certify(1, 0xDEF, 3);
+    abort 0
+}
+
+// === Helper functions ===
+
+#[test]
+public fun test_snapshot_epochs_ahead_defaults_to_max_epochs_ahead() {
+    let ctx = &mut tx_context::dummy();
+    let system = system::new_for_testing_with_multiple_members(ctx);
+    let max_epochs_ahead = system.future_accounting().max_epochs_ahead();
+    assert!(system.snapshot_blob_certification_state().epochs_ahead() == max_epochs_ahead);
+    system.destroy_for_testing()
+}
+
+#[test]
+public fun test_one_epoch_system_gets_a_one_epoch_snapshot_lifetime() {
+    // A system whose `max_epochs_ahead` is below the usual minimum lifetime must still be
+    // creatable and migratable; its lifetime is bounded by its maximum instead.
+    let mut state = snapshot_blob::create_with_empty_state(1);
+    assert!(state.epochs_ahead() == 1);
+    state.set_epochs_ahead(1, 1);
+    assert!(state.epochs_ahead() == 1);
+    state.destroy_for_testing();
+}
+
+#[test]
+public fun test_set_snapshot_epochs_ahead() {
+    let ctx = &mut tx_context::dummy();
+    let mut system = system::new_for_testing_with_multiple_members(ctx);
+    let cap = upgrade::new_emergency_upgrade_cap_for_testing(ctx);
+    let max_epochs_ahead = system.future_accounting().max_epochs_ahead();
+    upgrade::set_snapshot_epochs_ahead(&cap, &mut system, 2);
+    assert!(system.snapshot_blob_certification_state().epochs_ahead() == 2);
+    upgrade::set_snapshot_epochs_ahead(&cap, &mut system, max_epochs_ahead);
+    assert!(system.snapshot_blob_certification_state().epochs_ahead() == max_epochs_ahead);
+    upgrade::burn_emergency_upgrade_cap(cap);
+    system.destroy_for_testing()
+}
+
+#[test, expected_failure(abort_code = snapshot_blob::EInvalidEpochsAhead)]
+public fun test_set_snapshot_epochs_ahead_rejects_below_min() {
+    let ctx = &mut tx_context::dummy();
+    let mut system = system::new_for_testing_with_multiple_members(ctx);
+    let cap = upgrade::new_emergency_upgrade_cap_for_testing(ctx);
+    upgrade::set_snapshot_epochs_ahead(&cap, &mut system, 1);
+    upgrade::burn_emergency_upgrade_cap(cap);
+    system.destroy_for_testing()
+}
+
+#[test, expected_failure(abort_code = snapshot_blob::EInvalidEpochsAhead)]
+public fun test_set_snapshot_epochs_ahead_rejects_above_max() {
+    let ctx = &mut tx_context::dummy();
+    let mut system = system::new_for_testing_with_multiple_members(ctx);
+    let cap = upgrade::new_emergency_upgrade_cap_for_testing(ctx);
+    let max_epochs_ahead = system.future_accounting().max_epochs_ahead();
+    upgrade::set_snapshot_epochs_ahead(&cap, &mut system, max_epochs_ahead + 1);
+    upgrade::burn_emergency_upgrade_cap(cap);
+    system.destroy_for_testing()
+}
+
+#[test]
+public fun test_certified_snapshot_is_stored_for_the_configured_lifetime() {
+    let ctx = &mut tx_context::dummy();
+    let mut system = system::new_for_testing_with_multiple_members(ctx);
+    let mut nodes = test_nodes();
+    set_storage_node_caps(&system, &mut nodes, ctx);
+    let cap = upgrade::new_emergency_upgrade_cap_for_testing(ctx);
+    upgrade::set_snapshot_epochs_ahead(&cap, &mut system, 5);
+    let blob_id = blob::derive_blob_id(ROOT_HASH, RS2, SIZE);
+    let mut index = 0;
+    while (index < 7) {
+        system.certify_snapshot_blob(
+            nodes.borrow(index).cap(),
+            blob_id,
+            ROOT_HASH,
+            SIZE,
+            RS2,
+            0,
+            ctx,
+        );
+        index = index + 1;
+    };
+    let state = system.snapshot_blob_certification_state();
+    assert!(state.get_latest_certified_epoch() == option::some(0));
+    // The certified snapshot blob is stored for exactly the configured lifetime.
+    let certified_events = event::events_by_type<BlobCertified>();
+    assert!(certified_events.length() == 1);
+    assert!(events::blob_certified_end_epoch(&certified_events[0]) == 5);
+    // The recorded storage end matches the certified blob's.
+    assert!(state.latest_certified().map!(|s| s.end_epoch()) == option::some(5));
+    upgrade::burn_emergency_upgrade_cap(cap);
+    nodes.destroy!(|node| node.destroy());
+    system.destroy_for_testing()
+}
+
+#[test]
+public fun test_snapshot_certification_history_keeps_live_and_latest_snapshots() {
+    let ctx = &mut tx_context::dummy();
+    let mut system = system::new_for_testing_with_multiple_members(ctx);
+    let cap = upgrade::new_emergency_upgrade_cap_for_testing(ctx);
+    // With a lifetime of two epochs, the snapshot certified in epoch E is stored until epoch
+    // E + 2 (exclusive), so it expires by the certification of epoch E + 2.
+    upgrade::set_snapshot_epochs_ahead(&cap, &mut system, 2);
+    let mut nodes = test_nodes();
+    set_storage_node_caps(&system, &mut nodes, ctx);
+    // Certify one distinct snapshot per epoch for epochs 0, 1, and 3; no snapshot reaches a
+    // quorum in epoch 2.
+    let mut epoch: u32 = 0;
+    while (epoch < 4) {
+        if (epoch > 0) {
+            let mut new_committee = *system.committee();
+            new_committee.increment_epoch_for_testing();
+            let (_, balances) = system
+                .advance_epoch(new_committee, &epoch_params_for_testing())
+                .into_keys_values();
+            balances.do!(|b| { b.destroy_for_testing(); });
+        };
+        if (epoch == 2) {
+            epoch = epoch + 1;
+            continue
+        };
+        let root_hash = ROOT_HASH + (epoch as u256);
+        let blob_id = blob::derive_blob_id(root_hash, RS2, SIZE);
+        let mut index = 0;
+        while (index < 7) {
+            system.certify_snapshot_blob(
+                nodes.borrow(index).cap(),
+                blob_id,
+                root_hash,
+                SIZE,
+                RS2,
+                epoch,
+                ctx,
+            );
+            index = index + 1;
+        };
+        assert!(
+            system.snapshot_blob_certification_state().get_latest_certified_epoch()
+                == option::some(epoch),
+        );
+        epoch = epoch + 1;
+    };
+    let state = system.snapshot_blob_certification_state();
+    // By the certification of epoch 3, the snapshots of epochs 0 and 1 have both expired. The
+    // snapshot of epoch 0 was dropped; the snapshot of epoch 1 is kept because it was the latest
+    // certified one; epoch 3 is live.
+    let history = state.certified_history();
+    assert!(history.length() == 2);
+    assert!(history[0].epoch() == 1);
+    assert!(history[0].end_epoch() == 3);
+    assert!(history[1].epoch() == 3);
+    assert!(history[1].end_epoch() == 5);
+    assert!(state.certified_for_epoch(0).is_none());
+    assert!(state.certified_for_epoch(2).is_none());
+    let expected_epoch_1 = blob::derive_blob_id(ROOT_HASH + 1, RS2, SIZE);
+    assert!(state.certified_for_epoch(1).map!(|s| s.blob_id()) == option::some(expected_epoch_1));
+    let latest_blob_id = state.certified_for_epoch(3).map!(|s| s.blob_id());
+    assert!(state.get_latest_certified_blob_id() == latest_blob_id);
+    upgrade::burn_emergency_upgrade_cap(cap);
+    nodes.destroy!(|node| node.destroy());
+    system.destroy_for_testing()
+}
+
+fun set_storage_node_caps(
+    system: &System,
+    nodes: &mut vector<TestStorageNode>,
+    ctx: &mut TxContext,
+) {
+    let (node_ids, _values) = system.committee().to_vec_map().into_keys_values();
+    let mut index = 0;
+    node_ids.do!(|node_id| {
+        let storage_cap = storage_node::new_cap(node_id, ctx);
+        nodes[index].set_storage_node_cap(storage_cap);
+        index = index + 1;
+    });
+}

--- a/crates/walrus-sdk/src/node_client.rs
+++ b/crates/walrus-sdk/src/node_client.rs
@@ -3411,6 +3411,17 @@ mod tests {
         async fn last_certified_event_blob(&self) -> SuiClientResult<Option<EventBlob>> {
             unimplemented!()
         }
+        async fn last_certified_snapshot_blob(
+            &self,
+        ) -> SuiClientResult<Option<walrus_sui::types::move_structs::SnapshotBlob>> {
+            unimplemented!()
+        }
+        async fn certified_snapshot_blob_for_epoch(
+            &self,
+            _epoch: walrus_core::Epoch,
+        ) -> SuiClientResult<Option<walrus_sui::types::move_structs::SnapshotBlob>> {
+            unimplemented!()
+        }
         async fn refresh_package_id(&self) -> SuiClientResult<()> {
             unimplemented!()
         }

--- a/crates/walrus-simtest/tests/simtest_core.rs
+++ b/crates/walrus-simtest/tests/simtest_core.rs
@@ -1448,7 +1448,8 @@ mod tests {
         assert_eq!(end_upgrade_epoch, upgrade_epoch);
         tracing::info!(upgrade_epoch, "upgraded contract");
 
-        // Migrate the objects (v4 migration does not require set_migration_epoch or epoch wait)
+        // Migrate the objects (the v5 migration does not require set_migration_epoch or an epoch
+        // wait)
         client
             .as_ref()
             .inner
@@ -1458,17 +1459,20 @@ mod tests {
 
         client.as_ref().inner.sui_client().flush_cache().await;
 
-        // Check the version
-        assert_eq!(
-            client
-                .as_ref()
-                .inner
-                .sui_client()
-                .read_client()
-                .system_object_version()
-                .await?,
-            previous_version + 1
-        );
+        // Check the version: the migration lands on the development contracts' current version,
+        // which can be more than one ahead of the deployed testnet-contracts lineage (a single
+        // migration applies all pending steps). Keep in sync with `VERSION` in
+        // `contracts/walrus/sources/system.move`.
+        const EXPECTED_POST_MIGRATION_VERSION: u64 = 5;
+        let migrated_version = client
+            .as_ref()
+            .inner
+            .sui_client()
+            .read_client()
+            .system_object_version()
+            .await?;
+        assert!(migrated_version > previous_version);
+        assert_eq!(migrated_version, EXPECTED_POST_MIGRATION_VERSION);
 
         let blobs = walrus_test_utils::random_data_list(314, 1);
         let store_args = StoreArgs::default_with_epochs(1)

--- a/crates/walrus-sui/src/client.rs
+++ b/crates/walrus-sui/src/client.rs
@@ -101,7 +101,7 @@ pub mod rpc_client;
 pub mod rpc_config;
 
 pub mod transaction_builder;
-use crate::types::move_structs::EventBlob;
+use crate::types::move_structs::{EventBlob, SnapshotBlob};
 
 pub mod contract_config;
 
@@ -2041,6 +2041,19 @@ impl ReadClient for SuiContractClient {
 
     async fn last_certified_event_blob(&self) -> SuiClientResult<Option<EventBlob>> {
         self.read_client.last_certified_event_blob().await
+    }
+
+    async fn last_certified_snapshot_blob(&self) -> SuiClientResult<Option<SnapshotBlob>> {
+        self.read_client.last_certified_snapshot_blob().await
+    }
+
+    async fn certified_snapshot_blob_for_epoch(
+        &self,
+        epoch: walrus_core::Epoch,
+    ) -> SuiClientResult<Option<SnapshotBlob>> {
+        self.read_client
+            .certified_snapshot_blob_for_epoch(epoch)
+            .await
     }
 
     async fn refresh_package_id(&self) -> SuiClientResult<()> {

--- a/crates/walrus-sui/src/client/owned_blob_ops.rs
+++ b/crates/walrus-sui/src/client/owned_blob_ops.rs
@@ -135,6 +135,27 @@ impl SuiContractClient {
         .await
     }
 
+    /// Certifies the specified blob info snapshot blob on Sui, with the given metadata and epoch.
+    pub async fn certify_snapshot_blob(
+        &self,
+        blob_metadata: BlobObjectMetadata,
+        snapshot_epoch: u32,
+        node_capability_object_id: ObjectID,
+    ) -> SuiClientResult<()> {
+        self.retry_on_wrong_version(|| async {
+            self.inner
+                .lock()
+                .await
+                .certify_snapshot_blob(
+                    blob_metadata.clone(),
+                    snapshot_epoch,
+                    node_capability_object_id,
+                )
+                .await
+        })
+        .await
+    }
+
     /// Invalidates the specified blob id on Sui, given a certificate that confirms that it is
     /// invalid.
     pub async fn invalidate_blob_id(
@@ -728,6 +749,32 @@ impl SuiContractClientInner {
             .await?;
         let transaction = pt_builder.build_transaction_data(self.gas_budget).await?;
         self.sign_and_send_transaction(transaction, "certify_event_blob")
+            .await?;
+        Ok(())
+    }
+
+    /// Certifies the specified blob info snapshot blob on Sui, with the given metadata and epoch.
+    pub async fn certify_snapshot_blob(
+        &mut self,
+        blob_metadata: BlobObjectMetadata,
+        snapshot_epoch: u32,
+        node_capability_object_id: ObjectID,
+    ) -> SuiClientResult<()> {
+        tracing::debug!(
+            %node_capability_object_id,
+            "calling certify_snapshot_blob"
+        );
+
+        let mut pt_builder = self.transaction_builder();
+        pt_builder
+            .certify_snapshot_blob(
+                blob_metadata,
+                node_capability_object_id.into(),
+                snapshot_epoch,
+            )
+            .await?;
+        let transaction = pt_builder.build_transaction_data(self.gas_budget).await?;
+        self.sign_and_send_transaction(transaction, "certify_snapshot_blob")
             .await?;
         Ok(())
     }

--- a/crates/walrus-sui/src/client/read_client.rs
+++ b/crates/walrus-sui/src/client/read_client.rs
@@ -52,6 +52,9 @@ use crate::{
             EventBlob,
             NodeMetadata,
             SharedBlob,
+            SnapshotBlob,
+            SnapshotBlobCertificationState,
+            SnapshotStateKey,
             StakingInnerV1,
             StakingObjectForDeserialization,
             StakingPool,
@@ -190,6 +193,29 @@ pub trait ReadClient: Send + Sync {
     fn last_certified_event_blob(
         &self,
     ) -> impl Future<Output = SuiClientResult<Option<EventBlob>>> + Send;
+
+    /// Returns the last certified blob info snapshot blob.
+    ///
+    /// Returns `None` if no snapshot has been certified yet, or if the deployed contract
+    /// version does not support snapshot certification. The blob's storage may have ended:
+    /// the contract keeps the latest certification whatever its lifetime, so compare the
+    /// returned `end_epoch` with the current epoch before fetching the blob.
+    fn last_certified_snapshot_blob(
+        &self,
+    ) -> impl Future<Output = SuiClientResult<Option<SnapshotBlob>>> + Send;
+
+    /// Returns the certified blob info snapshot blob of `epoch`.
+    ///
+    /// Returns `None` if no snapshot was certified for that epoch, if the contract dropped the
+    /// entry (it drops expired entries at each certification, except the latest one), or if the
+    /// deployed contract version does not support snapshot certification. A returned entry may
+    /// still have expired: the latest certification is kept whatever its lifetime, and entries
+    /// are only pruned when a snapshot certifies, so compare its `end_epoch` with the current
+    /// epoch before fetching the blob. The certification itself is a fact regardless of expiry.
+    fn certified_snapshot_blob_for_epoch(
+        &self,
+        epoch: walrus_core::Epoch,
+    ) -> impl Future<Output = SuiClientResult<Option<SnapshotBlob>>> + Send;
 
     /// Refreshes the Walrus package ID.
     ///
@@ -1228,6 +1254,48 @@ enum WhichCommittee {
     Next,
 }
 
+impl SuiReadClient {
+    /// Reads the blob info snapshot certification state from the system object.
+    ///
+    /// Returns `None` if the deployed contract version does not define the state.
+    async fn snapshot_certification_state(
+        &self,
+    ) -> SuiClientResult<Option<SnapshotBlobCertificationState>> {
+        // The key type only exists in contract versions that support snapshot certification;
+        // for older deployed contracts, and for a supporting version whose migration has not
+        // run yet, report that no snapshot is certified.
+        let Ok(key_tag) = contracts::system::SnapshotStateKey
+            .to_move_struct_tag_with_type_map(&self.type_origin_map().clone(), &[])
+        else {
+            tracing::debug!(
+                "the deployed contract does not define the snapshot certification state"
+            );
+            return Ok(None);
+        };
+        let state: SnapshotBlobCertificationState = match self
+            .sui_client
+            .get_dynamic_field(
+                self.system_object_id,
+                key_tag.into(),
+                SnapshotStateKey { dummy_field: false },
+            )
+            .await
+        {
+            Ok(state) => state,
+            // Between the publication of a package version that defines the key type and the
+            // migration that creates the field, the type exists but the field does not.
+            Err(SuiClientError::GrpcError(status)) if status.code() == tonic::Code::NotFound => {
+                tracing::debug!(
+                    "the snapshot certification state does not exist yet on the deployed contract"
+                );
+                return Ok(None);
+            }
+            Err(error) => return Err(error),
+        };
+        Ok(Some(state))
+    }
+}
+
 impl ReadClient for SuiReadClient {
     #[tracing::instrument(err, skip(self))]
     async fn storage_price_per_unit_size(&self) -> SuiClientResult<u64> {
@@ -1259,6 +1327,28 @@ impl ReadClient for SuiReadClient {
             .await?
             .latest_certified_event_blob();
         Ok(blob)
+    }
+
+    async fn last_certified_snapshot_blob(&self) -> SuiClientResult<Option<SnapshotBlob>> {
+        Ok(self
+            .snapshot_certification_state()
+            .await?
+            .and_then(|state| state.certified.last().cloned()))
+    }
+
+    async fn certified_snapshot_blob_for_epoch(
+        &self,
+        epoch: walrus_core::Epoch,
+    ) -> SuiClientResult<Option<SnapshotBlob>> {
+        Ok(self
+            .snapshot_certification_state()
+            .await?
+            .and_then(|state| {
+                state
+                    .certified
+                    .into_iter()
+                    .find(|snapshot| snapshot.epoch == epoch)
+            }))
     }
 
     async fn get_blob_event(&self, event_id: EventID) -> SuiClientResult<BlobEvent> {

--- a/crates/walrus-sui/src/client/transaction_builder/owned_blob_ops.rs
+++ b/crates/walrus-sui/src/client/transaction_builder/owned_blob_ops.rs
@@ -225,6 +225,27 @@ impl WalrusPtbBuilder {
         Ok(())
     }
 
+    /// Adds a call to `certify_snapshot_blob` to the `pt_builder`.
+    pub async fn certify_snapshot_blob(
+        &mut self,
+        blob_metadata: BlobObjectMetadata,
+        storage_node_cap: ArgumentOrOwnedObject,
+        snapshot_epoch: u32,
+    ) -> SuiClientResult<()> {
+        let arguments = vec![
+            self.system_arg(SharedObjectMutability::Mutable)?,
+            self.argument_from_arg_or_obj(storage_node_cap).await?,
+            self.pt_builder.pure(blob_metadata.blob_id)?,
+            self.pt_builder.pure(blob_metadata.root_hash.bytes())?,
+            self.pt_builder.pure(blob_metadata.unencoded_size)?,
+            self.pt_builder
+                .pure(u8::from(blob_metadata.encoding_type))?,
+            self.pt_builder.pure(snapshot_epoch)?,
+        ];
+        self.walrus_move_call(contracts::system::certify_snapshot_blob, arguments)?;
+        Ok(())
+    }
+
     /// Adds a call to `delete_blob` to the `pt_builder` and returns the result [`Argument`].
     pub async fn delete_blob(
         &mut self,

--- a/crates/walrus-sui/src/contracts.rs
+++ b/crates/walrus-sui/src/contracts.rs
@@ -225,6 +225,8 @@ pub mod system {
     contract_ident!(fn system::invalidate_blob_id);
     contract_ident!(fn system::delete_blob);
     contract_ident!(fn system::certify_event_blob);
+    contract_ident!(fn system::certify_snapshot_blob);
+    contract_ident!(struct system::SnapshotStateKey);
     contract_ident!(fn system::extend_blob);
     contract_ident!(fn system::create_storage_pool);
     contract_ident!(fn system::register_pooled_blob);

--- a/crates/walrus-sui/src/types/move_structs.rs
+++ b/crates/walrus-sui/src/types/move_structs.rs
@@ -631,6 +631,45 @@ pub struct EventBlobCertificationState {
     pub aggregate_weight_per_blob: Vec<(EventBlob, u16)>,
 }
 
+/// A certified blob info snapshot blob.
+#[derive(Debug, PartialEq, Eq, Clone, Deserialize)]
+pub struct SnapshotBlob {
+    /// The walrus epoch whose boundary state the snapshot captures.
+    pub epoch: u32,
+    /// The blob ID of the certified snapshot blob.
+    pub blob_id: BlobId,
+    /// The epoch at which the storage of the snapshot blob ends (exclusive).
+    pub end_epoch: u32,
+}
+
+/// State holding the certification of blob info snapshot blobs.
+///
+/// Lives in a dynamic field on the `System` object keyed by `SnapshotStateKey`.
+#[derive(Debug, PartialEq, Eq, Clone, Deserialize)]
+pub struct SnapshotBlobCertificationState {
+    /// The most recently certified snapshot blobs, oldest first (at most three).
+    pub certified: Vec<SnapshotBlob>,
+    /// Number of epochs ahead for which a certified snapshot blob is stored.
+    pub epochs_ahead: u32,
+    /// The epoch the attestations below belong to.
+    pub tally_epoch: u32,
+    /// Aggregate attested shard weight per snapshot blob id for the tally epoch.
+    pub aggregate_weight_per_blob: Vec<(BlobId, u16)>,
+    /// Nodes that have attested a snapshot for the tally epoch.
+    pub attested_nodes: Vec<ObjectID>,
+}
+
+/// Sui type for the dynamic field key of the snapshot blob certification state on `System`.
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+pub(crate) struct SnapshotStateKey {
+    /// To match empty struct in Move.
+    pub dummy_field: bool,
+}
+
+impl AssociatedContractStruct for SnapshotStateKey {
+    const CONTRACT_STRUCT: StructTag<'static> = contracts::system::SnapshotStateKey;
+}
+
 /// State holding the certification of event blobs.
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize)]
 pub struct EventBlobCertificationStateTestnet {


### PR DESCRIPTION
## Description

Storage nodes already serialize a deterministic blob info snapshot of their storage-pool tables at every epoch boundary and encode it into a Walrus blob (#3480 and follow-ups; byte identity across nodes has held in production and in the determinism simtest #3633 since v1.51.1). This is the first of two PRs for the second milestone of WAL-1185, in which the network agrees on one snapshot per epoch and certifies it on chain so that a recovering node has a quorum-backed snapshot to load. This PR adds the contract and the Rust client side, in two commits; the storage node follows in #3752, and nothing in the node uses these calls yet, so main stays inert after merge. Loading the snapshot is the next milestone.

**Contract** (`contracts/walrus`, package version 4 → 5). A new module `snapshot_blob` holds the certification state as a dynamic field of the `System` object under a dedicated key type, created in `create_empty`, by `migrate`, and by the test constructors. The system and staking package versions move from 4 to 5 in lockstep; the version-4 active-set migration step is re-applied as part of this migration, which is safe because no network has executed it yet.

`system::certify_snapshot_blob` accepts one attestation per node and epoch from a current committee member for the current epoch, tallies attestations per blob ID by shard weight, and on a quorum reserves storage without payment, creates a non-deletable blob, certifies it through the ordinary `BlobRegistered` and `BlobCertified` events (no new event types, so older binaries keep parsing the stream), burns the object, and records the epoch, blob ID, and storage end of the certified snapshot in a list readable by epoch that keeps, after every certification, the newest entry, the previous one whatever its lifetime, and every older one whose storage has not ended. The blob object is burned, so this list is the chain's only record of which snapshots are still retrievable and until when, for external users and for out-of-band backups, and the previous entry is what storage nodes reconcile at the next boundary. Expired entries are dropped at certification, which bounds the list by `max_epochs_ahead + 1`. The tally is cleared lazily when the epoch advances. An attestation for another epoch, a repeated attestation, or one from a non-member aborts; an attestation arriving after the epoch's snapshot is already certified is a no-op.

The certified snapshot's lifetime is an on-chain parameter, initialized to `max_epochs_ahead` and settable by the emergency upgrade capability through `upgrade::set_snapshot_epochs_ahead`, bounded to at least two epochs because a node reconciles its publication one epoch after the certification and must still find the blob certified (or to the system's maximum where that is smaller, so that a system with a one-epoch storage horizon stays creatable and migratable). Certified lifetimes are frozen at certification time. The setter has no client call yet (WAL-1344); it is callable through a programmable transaction meanwhile.

**Rust client** (`walrus-sui`, `walrus-sdk`). Move mirrors for `SnapshotBlob` (epoch, blob ID, storage end) and the certification state, the two typed dynamic-field reads `last_certified_snapshot_blob` and `certified_snapshot_blob_for_epoch`, and the `certify_snapshot_blob` transaction with the usual retry on a stale package version. Both reads return `None` when the deployed contract predates the key type, and also when the type exists but the field does not, which is the window between publishing the package version and running its migration; other errors propagate. A returned entry may have expired, since the contract keeps the latest certification whatever its lifetime and prunes expired entries only when a snapshot certifies, so callers that fetch the blob compare its `end_epoch` with the current epoch.

Rollout: this contract change ships through the usual emergency-cap upgrade and `migrate`; the node-side PR is gated by a config flag that defaults to off, so the order of the two deployments does not matter.

## Test plan

- Move tests: the full `contracts/walrus` suite passes (`./scripts/move_tests.sh`), including new tests for the quorum path, repeated, late, wrong-epoch, and non-member attestations, divergent attestations across an epoch rollover, the lifetime parameter and its bounds, the stored lifetime, the expiry-pruned history with a missed epoch, and a one-epoch system.
- `test_quorum_contract_upgrade` (v3/v4 → v5 migration rehearsal) passes; a live upgrade rehearsal on a local testbed from a testnet-contracts v3 genesis through emergency upgrade and migrate 3 → 5 created the new state.
- The repository's pre-commit hooks pass on the changed files (cargo fmt, clippy with `-D warnings`, `cargo doc` with `-D warnings`, Move tests and formatting).
- #3752 exercises the contract end to end in simtests and on a local testbed.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
