### PR TITLE
feat: certify blob info snapshots on chain from the storage node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13893,6 +13893,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "twox-hash 2.1.3",
  "typed-store 1.57.0",
  "walrus-core",
  "walrus-proc-macros",

--- a/crates/walrus-service/node_config_example.yaml
+++ b/crates/walrus-service/node_config_example.yaml
@@ -80,6 +80,7 @@ db_config:
   storage_pool_info: null
   event_cursor: null
   pending_recover_blobs: null
+  blob_info_snapshot_publication: null
   shard: null
   shard_status: null
   shard_sync_progress: null
@@ -234,6 +235,7 @@ consistency_check:
   sliver_data_existence_check_sample_rate_percentage: 100
 blob_info_snapshot:
   enabled: true
+  certify: false
 checkpoint_config:
   max_db_checkpoints: 3
   db_checkpoint_interval:

--- a/crates/walrus-service/src/node/blob_info_snapshot_writer.rs
+++ b/crates/walrus-service/src/node/blob_info_snapshot_writer.rs
@@ -650,6 +650,11 @@ async fn encode_snapshot(
 
 /// Encodes the snapshot file, reports its blob ID for cross-node comparison, and returns the
 /// sliver pairs so that certification can store and attest them.
+///
+/// TODO(WAL-1345): this encodes every sliver pair, holding the full expansion of the snapshot
+/// (roughly 4.5x its size) while the node needs only its own shards' pairs. Once
+/// `compute_metadata_with_slivers_for_shards` (PR #3758) is available, use it with the node's
+/// shard assignment when certification is on, and `compute_metadata` when it is off.
 async fn try_encode_snapshot(
     node: &Arc<StorageNodeInner>,
     epoch: Epoch,

--- a/crates/walrus-service/src/node/blob_info_snapshot_writer.rs
+++ b/crates/walrus-service/src/node/blob_info_snapshot_writer.rs
@@ -6,7 +6,9 @@
 //! When enabled, this module serializes the three blob-info column families in-process at the
 //! post-GC-phase-1 epoch boundary and removes the previous epoch's snapshot, keeping at most one.
 //! The size and content digest are reported through metrics and a log line for cross-node
-//! comparison.
+//! comparison. Once the node's shard ownership has moved to the new epoch, the snapshot is
+//! encoded to report its blob ID and, when certification is enabled, stored and attested on chain
+//! (see [`publish_snapshot_after_epoch_change`]).
 
 #[cfg(msim)]
 use std::{collections::HashMap, sync::Mutex};
@@ -16,19 +18,35 @@ use std::{
     io::{BufWriter, Read as _, Write as _},
     path::{Path, PathBuf},
     sync::Arc,
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use anyhow::{Context, Result};
+use futures::future::try_join_all;
 use serde::{Deserialize, Serialize};
 #[cfg(msim)]
 use sui_types::base_types::ObjectID;
 use twox_hash::XxHash64;
-use walrus_core::{DEFAULT_ENCODING, Epoch, encoding::EncodingFactory as _};
+#[cfg(msim)]
+use walrus_core::BlobId;
+use walrus_core::{
+    DEFAULT_ENCODING,
+    Epoch,
+    Sliver,
+    SliverPairIndex,
+    encoding::{EncodingFactory as _, SliverPair},
+    metadata::VerifiedBlobMetadataWithId,
+};
+use walrus_sui::client::BlobObjectMetadata;
 
 use super::{
     StorageNodeInner,
-    storage::blob_info_snapshot::{SnapshotHeader, SnapshotStats},
+    errors::StoreSliverError,
+    storage::{
+        SnapshotPublication,
+        SnapshotPublicationState,
+        blob_info_snapshot::{SnapshotHeader, SnapshotStats},
+    },
 };
 use crate::event::events::EventStreamCursor;
 
@@ -44,13 +62,28 @@ pub struct BlobInfoSnapshotWriterConfig {
     /// encodes the snapshot to report its blob ID. Note that disabling this flag leaves the
     /// last snapshot file on disk until it is removed manually.
     pub enabled: bool,
+    /// Whether to certify the serialized snapshot on chain.
+    ///
+    /// The snapshot is encoded at every epoch boundary regardless, to report its blob ID.
+    /// When this is enabled (together with `enabled`), the node additionally stores its own
+    /// shards' slivers and attests the snapshot blob through the system contract, synchronously
+    /// once the epoch change has been applied locally. Has no effect if `enabled` is false.
+    pub certify: bool,
 }
 
 impl Default for BlobInfoSnapshotWriterConfig {
     fn default() -> Self {
-        Self { enabled: true }
+        Self {
+            enabled: true,
+            certify: false,
+        }
     }
 }
+
+/// Bound on the background chain read that reports the epoch of the latest certified snapshot.
+/// The read is best-effort and runs off the epoch-change path; the bound keeps a stuck full node
+/// from holding the task open indefinitely.
+const CHAIN_READ_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Number of epoch buckets used as the label of `blob_info_snapshot_blob_id`.
 ///
@@ -118,13 +151,16 @@ fn hash_file(path: &Path) -> std::io::Result<u64> {
 }
 
 /// Serializes the three blob info column families in-process at the epoch boundary, reports the
-/// duration, size, and digest, and removes older snapshot files. Then encodes the durable
-/// snapshot to report its blob ID.
+/// duration, size, and digest, and removes older snapshot files.
 ///
-/// Must be called at the post-GC-phase-1 point while event processing is blocked. `event_cursor`
-/// is the position of the `EpochChangeStart` being processed.
+/// Must be called at the post-GC-phase-1 point while event processing is blocked, and before
+/// `execute_epoch_change` spawns the finisher that marks the event complete: the durable file
+/// must exist before the boundary can stop being replayed, so a crash never skips a snapshot.
+/// `event_cursor` is the position of the `EpochChangeStart` being processed. Everything derived
+/// from the file (encoding, storing, attesting) happens in
+/// [`publish_snapshot_after_epoch_change`].
 pub(super) async fn serialize_snapshot_at_epoch_boundary(
-    node: Arc<StorageNodeInner>,
+    node: &Arc<StorageNodeInner>,
     epoch: Epoch,
     event_cursor: EventStreamCursor,
 ) -> Result<()> {
@@ -137,14 +173,39 @@ pub(super) async fn serialize_snapshot_at_epoch_boundary(
         // restart. Still drop any older snapshots so that at most one remains.
         tracing::debug!(walrus.epoch = epoch, "blob info snapshot already exists");
         remove_snapshot_files_matching(&base_dir, |snapshot_epoch| snapshot_epoch != epoch);
-    } else {
-        write_snapshot_file(&node, epoch, event_cursor, &base_dir, &final_path).await?;
+        return Ok(());
     }
+    write_snapshot_file(node, epoch, event_cursor, &base_dir, &final_path).await
+}
 
-    // TODO(WAL-1252): resume an interrupted publication here once snapshots are published and
-    // certified.
-    encode_snapshot(&node, epoch, &final_path).await;
-    Ok(())
+/// Encodes the durable snapshot of `epoch` to report its blob ID and, when certification is
+/// enabled, stores this node's slivers and attests it on chain, reporting errors through the log
+/// and metrics without failing the epoch change.
+///
+/// Must be called after `execute_epoch_change` has applied the epoch change locally, i.e., after
+/// the committee service has advanced to `epoch` and the storage holds this node's shards for
+/// that epoch. The contract tallies attestations by the new committee's shard weights and readers
+/// route the certified blob by the new committee's shard assignment, so the slivers must be stored
+/// under that assignment: storing them at the boundary, under the outgoing assignment, would leave
+/// them where the new epoch's shard sync deliberately does not look (it skips blobs certified in
+/// the epoch it is syncing, which are expected to have been written to their new owners
+/// directly). Runs whether the file was just written or already existed (a replayed boundary).
+/// Deliberately synchronous, like the serialization, to measure the full inline cost.
+///
+/// TODO(WAL-1252): resume an interrupted publication here once snapshots are published and
+/// certified.
+pub(super) async fn publish_snapshot_after_epoch_change(
+    node: &Arc<StorageNodeInner>,
+    epoch: Epoch,
+) {
+    let final_path = snapshot_file_path(&node.blob_info_snapshot_dir, epoch);
+    let Some((sliver_pairs, verified_metadata)) = encode_snapshot(node, epoch, &final_path).await
+    else {
+        return;
+    };
+    if node.blob_info_snapshot_config.certify {
+        certify_snapshot(node, epoch, &sliver_pairs, &verified_metadata).await;
+    }
 }
 
 /// Serializes the snapshot to `final_path` durably (write, fsync, rename, fsync dir), removes
@@ -242,26 +303,358 @@ async fn write_snapshot_file(
     Ok(())
 }
 
-/// Encodes the snapshot into a Walrus blob to report its blob ID, logging errors and counting
-/// them in metrics without failing the epoch change.
-async fn encode_snapshot(node: &Arc<StorageNodeInner>, epoch: Epoch, snapshot_path: &Path) {
-    if let Err(error) = try_encode_snapshot(node, epoch, snapshot_path).await {
-        node.metrics.blob_info_snapshot_encode_error_total.inc();
+/// Certifies the snapshot on chain, reporting errors through the log and metrics without
+/// failing the epoch change.
+async fn certify_snapshot(
+    node: &Arc<StorageNodeInner>,
+    epoch: Epoch,
+    sliver_pairs: &[SliverPair],
+    verified_metadata: &VerifiedBlobMetadataWithId,
+) {
+    if let Err(error) = try_certify_snapshot(node, epoch, sliver_pairs, verified_metadata).await {
+        // TODO(WAL-1342): benign contract aborts (a late attestation, a committee change, a
+        // replayed boundary) are counted as errors here; classify them as the event blob writer
+        // does.
+        node.metrics.blob_info_snapshot_certify_error_total.inc();
         tracing::warn!(
             ?error,
             walrus.epoch = epoch,
-            "failed to encode the blob info snapshot"
+            "failed to certify the blob info snapshot"
         );
     }
 }
 
-/// Computes the blob ID of the snapshot file and reports it for cross-node comparison; nothing
-/// is stored.
+/// Stores this node's slivers and the blob metadata, then attests the snapshot blob through the
+/// system contract.
+async fn try_certify_snapshot(
+    node: &Arc<StorageNodeInner>,
+    epoch: Epoch,
+    sliver_pairs: &[SliverPair],
+    verified_metadata: &VerifiedBlobMetadataWithId,
+) -> Result<()> {
+    // Only committee members can certify (the contract enforces membership), so skip the
+    // storage work and the doomed transaction locally, mirroring the event blob writer. This
+    // runs after the epoch change has been applied locally, so the committee service reports
+    // the committee of `epoch`: a node joining the committee at `epoch` attests and stores
+    // its new shards' slivers, and a node leaving at `epoch` skips, matching what the contract
+    // would decide. Note that a node processing this boundary late (after the chain moved past
+    // `epoch`) cannot be detected locally, since the committee service tracks the node's own
+    // processed position; the contract rejects such an attestation with `EInvalidIdEpoch`, and
+    // the catching-up and reprocessing cases never reach this code (see `should_serialize` at
+    // the call site in `epoch_change.rs`).
+    if !node
+        .committee_service
+        .active_committees()
+        .current_committee()
+        .contains(node.public_key())
+    {
+        tracing::debug!(
+            walrus.epoch = epoch,
+            "node is not in the committee; skipping blob info snapshot certification"
+        );
+        return Ok(());
+    }
+
+    // Record the publication before the first write, so that whatever gets stored is tracked
+    // and reconciled at the next epoch boundary even if the store or the attestation fails
+    // partway (see `reconcile_previous_publication`). This overwrites the single publication
+    // record, which is safe because the boundary handler reconciles the previous publication
+    // before publishing and fails the epoch change if that reconciliation errors.
+    let blob_id = *verified_metadata.blob_id();
+    let record = SnapshotPublication::new(epoch, blob_id);
+    node.storage()
+        .set_snapshot_publication(&record)
+        .context("failed to record the snapshot publication")?;
+
+    // TODO(WAL-1340): until the blob-info entry exists, garbage collection can delete these
+    // bytes if a stale entry for the same blob ID is left by another registration; make it
+    // honor the publication record.
+    let store_start = Instant::now();
+    node.storage()
+        .put_verified_metadata_without_blob_info(verified_metadata)
+        .context("failed to store the snapshot blob metadata")?;
+    store_own_slivers(node, verified_metadata, sliver_pairs).await?;
+    let store_elapsed = store_start.elapsed();
+    node.storage()
+        .set_snapshot_publication(&record.with_state(SnapshotPublicationState::Stored))
+        .context("failed to record the snapshot publication")?;
+    // No-op outside of simtest.
+    sui_macros::fail_point_arg!(
+        "storage_node_blob_info_snapshot_stored",
+        |stored_map: Arc<Mutex<HashMap<Epoch, HashMap<ObjectID, BlobId>>>>| {
+            stored_map
+                .lock()
+                .expect("failed to lock the stored map")
+                .entry(epoch)
+                .or_default()
+                .insert(node.node_capability, blob_id);
+        }
+    );
+
+    let certify_start = Instant::now();
+    let blob_metadata: BlobObjectMetadata = verified_metadata
+        .try_into()
+        .context("failed to convert the snapshot blob metadata")?;
+    node.contract_service
+        .certify_snapshot_blob(blob_metadata, epoch, node.node_capability())
+        .await?;
+    let certify_elapsed = certify_start.elapsed();
+    node.storage()
+        .set_snapshot_publication(&record.with_state(SnapshotPublicationState::Attested))
+        .context("failed to record the snapshot publication")?;
+    node.metrics
+        .blob_info_snapshot_certify_duration_seconds
+        .set(certify_elapsed.as_secs_f64());
+
+    tracing::info!(
+        walrus.epoch = epoch,
+        walrus.blob_id = %blob_id,
+        ?store_elapsed,
+        ?certify_elapsed,
+        "attested blob info snapshot on chain"
+    );
+    Ok(())
+}
+
+/// Reports the epoch of the latest blob info snapshot certified on chain through the
+/// `blob_info_snapshot_last_certified_epoch` gauge, so that an alert can detect a network that
+/// stops certifying (the distance to the current epoch grows). Every node reports it, whether or
+/// not it certifies, since it is a property of the network rather than of the node. A failed read
+/// is logged and the gauge keeps its previous value; a contract that predates certification
+/// reads as no certification. Runs in a background task at the epoch boundary, since only the
+/// gauge depends on the result.
+pub(super) async fn report_last_certified_snapshot_epoch(node: &Arc<StorageNodeInner>) {
+    match tokio::time::timeout(
+        CHAIN_READ_TIMEOUT,
+        node.contract_service.last_certified_snapshot_blob(),
+    )
+    .await
+    {
+        Ok(Ok(Some(certified))) => node
+            .metrics
+            .blob_info_snapshot_last_certified_epoch
+            .set(i64::from(certified.epoch)),
+        Ok(Ok(None)) => {}
+        Ok(Err(error)) => tracing::warn!(
+            ?error,
+            "failed to read the latest certified blob info snapshot"
+        ),
+        Err(_) => tracing::warn!(
+            timeout = ?CHAIN_READ_TIMEOUT,
+            "timed out reading the latest certified blob info snapshot"
+        ),
+    }
+}
+
+/// Reconciles the publication of the previous epoch's snapshot at the boundary of
+/// `current_epoch`, before this epoch's snapshot is produced.
+///
+/// Whether the previous snapshot certified is decided locally: a certification during epoch E
+/// emits `BlobCertified` before `EpochChangeStart(E + 1)` in the checkpoint-ordered event
+/// stream, and the boundary handler drains all blob events before calling this, so a blob-info
+/// entry for the snapshot's blob ID exists if and only if it certified. This relies on the
+/// contract's lower bound of two epochs on the snapshot lifetime: garbage collection phase 1
+/// runs before this and expires blobs whose storage ends at `E + 1`, which a one-epoch snapshot
+/// certified in E would, so its entry would be gone before it is checked. A snapshot that did not
+/// certify never will (the contract only accepts the current epoch), and its metadata and
+/// slivers have no blob-info entry, so garbage collection would never find them: they are
+/// deleted here. Why a snapshot did not certify (no quorum, or a divergence of this node's tables
+/// from the network's) is not classified here yet; fleet-wide detection comes from comparing the
+/// `blob_info_snapshot_blob_id` gauges across nodes (see `TODO(WAL-1341)` below).
+///
+/// Storage errors are returned to the caller, which fails the epoch change; the boundary is then
+/// replayed on restart and this function runs again. It is idempotent: the record is cleared only
+/// after the stored data is deleted, and deleting already-deleted data is a no-op.
+pub(super) async fn reconcile_previous_publication(
+    node: &Arc<StorageNodeInner>,
+    current_epoch: Epoch,
+) -> Result<()> {
+    let Some(record) = node
+        .storage()
+        .snapshot_publication()
+        .context("failed to read the snapshot publication record")?
+    else {
+        return Ok(());
+    };
+    let epoch = record.epoch();
+    if epoch >= current_epoch {
+        // The current epoch's publication (a replayed boundary) or, defensively, a newer one.
+        return Ok(());
+    }
+    let blob_id = record.blob_id();
+    // Lets a simtest crash the node here, where a storage error in the lookup below would stop
+    // it, to exercise the replay of this boundary. No-op outside of simtest.
+    sui_macros::fail_point_async!("storage_node_blob_info_snapshot_reconcile");
+    if node.is_blob_certified(&blob_id)? {
+        // Certified: from here on the blob is ordinary certified data owned by garbage
+        // collection. The metadata was stored before the blob had a blob-info entry, so mark
+        // it stored now, as for event blobs, provided it is still there; the node's own slivers
+        // were stored the same way and are found by the regular existence checks.
+        if node
+            .storage()
+            .get_metadata(&blob_id)
+            .context("failed to read the snapshot blob metadata")?
+            .is_some()
+        {
+            node.storage()
+                .update_blob_info_with_metadata(&blob_id)
+                .context("failed to mark the certified snapshot's metadata as stored")?;
+        }
+        node.storage()
+            .clear_snapshot_publication()
+            .context("failed to clear the snapshot publication record")?;
+        // No-op outside of simtest.
+        sui_macros::fail_point_arg!(
+            "storage_node_blob_info_snapshot_reconciled",
+            |reconciled_map: Arc<Mutex<HashMap<Epoch, HashMap<ObjectID, bool>>>>| {
+                reconciled_map
+                    .lock()
+                    .expect("failed to lock the reconciled map")
+                    .entry(epoch)
+                    .or_default()
+                    .insert(node.node_capability, true);
+            }
+        );
+        return Ok(());
+    }
+
+    // Never certified as a snapshot. Delete whatever was stored for it, unless a blob-info
+    // entry exists for the blob ID: the same content can be registered by anyone, and an entry
+    // means the regular lifecycle owns the bytes (garbage collection deletes them once nothing
+    // registers the blob), whereas without an entry nothing else would ever find them.
+    if node
+        .storage()
+        .get_blob_info(&blob_id)
+        .context("failed to read the snapshot blob info")?
+        .is_none()
+    {
+        node.storage
+            .delete_blob_data(&blob_id)
+            .await
+            .context("failed to delete the uncertified snapshot blob data")?;
+    }
+    node.metrics
+        .blob_info_snapshot_uncertified_cleanup_total
+        .inc();
+    node.storage()
+        .clear_snapshot_publication()
+        .context("failed to clear the snapshot publication record")?;
+    // No-op outside of simtest.
+    sui_macros::fail_point_arg!(
+        "storage_node_blob_info_snapshot_reconciled",
+        |reconciled_map: Arc<Mutex<HashMap<Epoch, HashMap<ObjectID, bool>>>>| {
+            reconciled_map
+                .lock()
+                .expect("failed to lock the reconciled map")
+                .entry(epoch)
+                .or_default()
+                .insert(node.node_capability, false);
+        }
+    );
+
+    // TODO(WAL-1341): classify why the snapshot did not certify (no quorum, or a divergence
+    // from the snapshot the network certified) from the on-chain history, and expose it through
+    // metrics; acting on a divergence is part of the recovery milestone (WAL-1252).
+    tracing::warn!(
+        walrus.epoch = epoch,
+        walrus.blob_id = %blob_id,
+        state = ?record.state(),
+        "the blob info snapshot was not certified; its stored data is cleaned up"
+    );
+    Ok(())
+}
+
+/// Stores the slivers of the shards assigned to this node in the current committee.
+///
+/// Only those sliver pairs are touched: the others belong to shards this node never looks up,
+/// including shards whose storage is being removed in the background at this boundary. A shard
+/// that is assigned but not yet owned by this node (still being synced) is skipped, as in the
+/// event blob writer.
+async fn store_own_slivers(
+    node: &Arc<StorageNodeInner>,
+    verified_metadata: &VerifiedBlobMetadataWithId,
+    sliver_pairs: &[SliverPair],
+) -> Result<()> {
+    let n_shards = node.encoding_config().n_shards();
+    let own_shards = node
+        .committee_service
+        .active_committees()
+        .current_committee()
+        .shards_for_node_public_key(node.public_key())
+        .to_vec();
+    let own_pairs: Vec<&SliverPair> = sliver_pairs
+        .iter()
+        .filter(|pair| {
+            own_shards.contains(
+                &pair
+                    .index()
+                    .to_shard_index(n_shards, verified_metadata.blob_id()),
+            )
+        })
+        .collect();
+    let metadata = Arc::new(verified_metadata.clone());
+    store_slivers_of_type(node, &metadata, &own_pairs, |pair| {
+        Sliver::Primary(pair.primary.clone())
+    })
+    .await?;
+    store_slivers_of_type(node, &metadata, &own_pairs, |pair| {
+        Sliver::Secondary(pair.secondary.clone())
+    })
+    .await
+}
+
+async fn store_slivers_of_type(
+    node: &Arc<StorageNodeInner>,
+    metadata: &Arc<VerifiedBlobMetadataWithId>,
+    sliver_pairs: &[&SliverPair],
+    sliver_of_pair: impl Fn(&SliverPair) -> Sliver,
+) -> Result<()> {
+    try_join_all(sliver_pairs.iter().map(|&sliver_pair| {
+        let metadata = metadata.clone();
+        let sliver = sliver_of_pair(sliver_pair);
+        let index: SliverPairIndex = sliver_pair.index();
+        async move {
+            match node.store_sliver_unchecked(metadata, index, sliver).await {
+                Err(StoreSliverError::ShardNotAssigned(_)) | Ok(_) => Ok(()),
+                Err(error) => Err(error),
+            }
+        }
+    }))
+    .await
+    .context("failed to store the snapshot blob slivers")?;
+    Ok(())
+}
+
+/// Encodes the snapshot into a Walrus blob and reports its blob ID, logging errors and counting
+/// them in metrics without failing the epoch change.
+///
+/// Returns `None` when the encoding failed, in which case certification cannot proceed either.
+async fn encode_snapshot(
+    node: &Arc<StorageNodeInner>,
+    epoch: Epoch,
+    snapshot_path: &Path,
+) -> Option<(Vec<SliverPair>, VerifiedBlobMetadataWithId)> {
+    match try_encode_snapshot(node, epoch, snapshot_path).await {
+        Ok(encoded) => Some(encoded),
+        Err(error) => {
+            node.metrics.blob_info_snapshot_encode_error_total.inc();
+            tracing::warn!(
+                ?error,
+                walrus.epoch = epoch,
+                "failed to encode the blob info snapshot"
+            );
+            None
+        }
+    }
+}
+
+/// Encodes the snapshot file, reports its blob ID for cross-node comparison, and returns the
+/// sliver pairs so that certification can store and attest them.
 async fn try_encode_snapshot(
     node: &Arc<StorageNodeInner>,
     epoch: Epoch,
     snapshot_path: &Path,
-) -> Result<()> {
+) -> Result<(Vec<SliverPair>, VerifiedBlobMetadataWithId)> {
     let encoding_config = node.encoding_config().get_for_type(DEFAULT_ENCODING);
     // Encoding is inherent to the protocol, so every valid system can encode. Committees of
     // fewer than four shards cannot: no shard may be faulty, so the encoding is left without
@@ -274,12 +667,24 @@ async fn try_encode_snapshot(
 
     let encode_start = Instant::now();
     let path = snapshot_path.to_path_buf();
-    let verified_metadata = tokio::task::spawn_blocking(move || {
+    let (sliver_pairs, verified_metadata) = tokio::task::spawn_blocking(move || {
         let content = fs::read(path)?;
-        // TODO(WAL-1250): certifying the snapshot needs its slivers, so this becomes a full
-        // encode rather than only the metadata.
+        // Lets a simtest make one node's snapshot blob differ from the other nodes', to exercise
+        // the divergence detection, without changing the snapshot file on disk.
+        #[cfg(msim)]
+        let content = {
+            let mut diverge = false;
+            sui_macros::fail_point_if!("storage_node_blob_info_snapshot_diverge", || {
+                diverge = true;
+            });
+            let mut content = content;
+            if diverge {
+                content.push(0);
+            }
+            content
+        };
         encoding_config
-            .compute_metadata(&content)
+            .encode_with_metadata(content)
             .map_err(anyhow::Error::from)
     })
     .await
@@ -311,7 +716,20 @@ async fn try_encode_snapshot(
         ?encode_elapsed,
         "encoded blob info snapshot"
     );
-    Ok(())
+
+    // No-op outside of simtest.
+    sui_macros::fail_point_arg!(
+        "storage_node_blob_info_snapshot_blob_id",
+        |blob_id_map: Arc<Mutex<HashMap<Epoch, HashMap<ObjectID, BlobId>>>>| {
+            blob_id_map
+                .lock()
+                .expect("failed to lock the blob id map")
+                .entry(epoch)
+                .or_default()
+                .insert(node.node_capability, blob_id);
+        }
+    );
+    Ok((sliver_pairs, verified_metadata))
 }
 
 /// Removes all snapshot files (including temporary ones) whose epoch matches `should_remove`.
@@ -343,15 +761,18 @@ mod tests {
 
     #[test]
     fn config_default_is_enabled() {
-        // Default is enabled, and an omitted field falls back to it.
+        // Default is enabled, and an omitted field falls back to it; certification is opt-in.
         assert!(BlobInfoSnapshotWriterConfig::default().enabled);
+        assert!(!BlobInfoSnapshotWriterConfig::default().certify);
         let empty: BlobInfoSnapshotWriterConfig =
             serde_yaml::from_str("{}\n").expect("config should deserialize");
         assert!(empty.enabled);
+        assert!(!empty.certify);
         // An explicit `enabled: false` still disables it.
         let disabled: BlobInfoSnapshotWriterConfig =
             serde_yaml::from_str("enabled: false\n").expect("config should deserialize");
         assert!(!disabled.enabled);
+        assert!(!disabled.certify);
     }
 
     #[test]

--- a/crates/walrus-service/src/node/contract_service.rs
+++ b/crates/walrus-service/src/node/contract_service.rs
@@ -33,7 +33,7 @@ use walrus_sui::{
         StorageNodeCap,
         UpdatePublicKeyParams,
         move_errors::{MoveExecutionError, StakingInnerError, WalrusSubsidiesInnerError},
-        move_structs::{EpochState, EventBlob},
+        move_structs::{EpochState, EventBlob, SnapshotBlob},
     },
 };
 use walrus_utils::{
@@ -114,6 +114,14 @@ pub trait SystemContractService: std::fmt::Debug + Sync + Send {
         node_capability_object_id: ObjectID,
     ) -> Result<(), SuiClientError>;
 
+    /// Certifies a blob info snapshot blob to the contract for the given epoch.
+    async fn certify_snapshot_blob(
+        &self,
+        blob_metadata: BlobObjectMetadata,
+        snapshot_epoch: u32,
+        node_capability_object_id: ObjectID,
+    ) -> Result<(), SuiClientError>;
+
     /// Refreshes the contract package that the service is using.
     async fn refresh_contract_package(&self) -> anyhow::Result<()>;
 
@@ -136,6 +144,9 @@ pub trait SystemContractService: std::fmt::Debug + Sync + Send {
 
     /// Returns the last certified event blob.
     async fn last_certified_event_blob(&self) -> Result<Option<EventBlob>, SuiClientError>;
+
+    /// Returns the last certified blob info snapshot blob.
+    async fn last_certified_snapshot_blob(&self) -> Result<Option<SnapshotBlob>, SuiClientError>;
 
     /// Flushes any cached data to ensure that the next requests are not affected by stale data.
     async fn flush_cache(&self);
@@ -651,6 +662,19 @@ impl SystemContractService for SuiSystemContractService {
             .await
     }
 
+    async fn certify_snapshot_blob(
+        &self,
+        blob_metadata: BlobObjectMetadata,
+        snapshot_epoch: u32,
+        node_capability_object_id: ObjectID,
+    ) -> Result<(), SuiClientError> {
+        self.contract_tx_client
+            .lock()
+            .await
+            .certify_snapshot_blob(blob_metadata, snapshot_epoch, node_capability_object_id)
+            .await
+    }
+
     async fn refresh_contract_package(&self) -> anyhow::Result<()> {
         self.contract_tx_client
             .lock()
@@ -698,6 +722,10 @@ impl SystemContractService for SuiSystemContractService {
 
     async fn last_certified_event_blob(&self) -> Result<Option<EventBlob>, SuiClientError> {
         self.read_client.last_certified_event_blob().await
+    }
+
+    async fn last_certified_snapshot_blob(&self) -> Result<Option<SnapshotBlob>, SuiClientError> {
+        self.read_client.last_certified_snapshot_blob().await
     }
 
     async fn flush_cache(&self) {

--- a/crates/walrus-service/src/node/epoch_change.rs
+++ b/crates/walrus-service/src/node/epoch_change.rs
@@ -296,34 +296,61 @@ impl StorageNode {
         // Serialize only when enabled, not reprocessing, and not catching up (a catching-up node's
         // blob info tables are not at the clean cross-node boundary). The node-status DB lookup
         // runs only after the other two checks short-circuit.
-        let should_serialize = self.inner.blob_info_snapshot_config.enabled
-            && !node_is_reprocessing_events
-            && !self.inner.storage.node_status()?.is_catching_up();
+        let at_clean_boundary =
+            !node_is_reprocessing_events && !self.inner.storage.node_status()?.is_catching_up();
+        let should_serialize = self.inner.blob_info_snapshot_config.enabled && at_clean_boundary;
+
+        // Report the latest certified snapshot epoch on chain, for the no-certification alert.
+        // Only a gauge depends on it, so the read runs in a background task and a slow full node
+        // cannot delay the boundary.
+        if should_serialize {
+            let node = self.inner.clone();
+            tokio::spawn(async move {
+                blob_info_snapshot_writer::report_last_certified_snapshot_epoch(&node).await;
+            });
+        }
+
+        // Reconcile the previous epoch's snapshot publication first: it decides, from the local
+        // blob info, whether that snapshot certified, and cleans up the stored data otherwise.
+        // It only touches local storage, so an error is a storage
+        // error and fails the epoch change like any other: the node stops before this boundary
+        // is marked complete and replays it on restart, so the publication below never
+        // overwrites an unreconciled record (the reconciliation is idempotent). It runs whether
+        // or not snapshots are enabled, so that disabling them after a publication still cleans
+        // that publication up; without a publication record it does nothing.
+        if at_clean_boundary {
+            blob_info_snapshot_writer::reconcile_previous_publication(&self.inner, event.epoch)
+                .await
+                .context("failed to reconcile the previous blob info snapshot publication")?;
+        }
 
         // Serialize after GC phase 1 has settled the tables and before `execute_epoch_change`
         // spawns the finisher that marks the event complete (so a crash before completion replays
         // and re-creates it). Errors are logged and counted, never failing epoch processing.
-        //
-        // TODO(WAL-1250): this only writes the snapshot to local disk. Publishing and certifying it
-        // on-chain (encode, store the node's own slivers, attest, track to certified) is future
-        // work.
-        if should_serialize
-            && let Err(error) = blob_info_snapshot_writer::serialize_snapshot_at_epoch_boundary(
-                self.inner.clone(),
+        // Everything derived from the durable file (encoding, storing, attesting) happens below,
+        // after the epoch change has been applied locally.
+        let snapshot_serialized = should_serialize
+            && match blob_info_snapshot_writer::serialize_snapshot_at_epoch_boundary(
+                &self.inner,
                 event.epoch,
                 // Mirror what the node persists after completing this event: the
                 // `EpochChangeStart`'s id, and its index + 1 as the next index to process.
                 EventStreamCursor::new(Some(event_handle.event_id()), event_index + 1),
             )
             .await
-        {
-            self.inner.metrics.blob_info_snapshot_error_total.inc();
-            tracing::warn!(
-                ?error,
-                walrus.epoch = event.epoch,
-                "failed to serialize the blob info snapshot in-process at the epoch boundary"
-            );
-        }
+            {
+                Ok(()) => true,
+                Err(error) => {
+                    self.inner.metrics.blob_info_snapshot_error_total.inc();
+                    tracing::warn!(
+                        ?error,
+                        walrus.epoch = event.epoch,
+                        "failed to serialize the blob info snapshot in-process at the epoch \
+                        boundary"
+                    );
+                    false
+                }
+            };
 
         // Now the general tasks around epoch change are done. Next, entering epoch change logic
         // to bring the node state to the next epoch. `execute_epoch_change` ends by spawning
@@ -338,6 +365,23 @@ impl StorageNode {
         self.inner
             .latest_event_epoch_sender
             .send(Some(event.epoch))?;
+
+        // Publish the snapshot (encode; store and attest when configured) only now:
+        // `execute_epoch_change` has advanced the committee and created this node's shards for
+        // the new epoch, so the slivers are stored under the assignment the contract tallies by
+        // and readers route by. Still inline, to measure the full cost at the boundary; the
+        // finisher may already have marked the event complete, so a crash from here on skips
+        // this epoch's publication (absorbed by the quorum; resume is TODO(WAL-1252)).
+        // A node that discovered inside `execute_epoch_change` that it is far behind enters
+        // catch-up there; its snapshot is then stale and its committee view has moved on, so
+        // the publication is skipped like the serialization would have been.
+        if snapshot_serialized && !self.inner.storage.node_status()?.is_catching_up() {
+            blob_info_snapshot_writer::publish_snapshot_after_epoch_change(
+                &self.inner,
+                event.epoch,
+            )
+            .await;
+        }
 
         // Schedule post-epoch-change subsidies to distribute usage-independent subsidies
         // for the epoch that just ended.

--- a/crates/walrus-service/src/node/metrics.rs
+++ b/crates/walrus-service/src/node/metrics.rs
@@ -239,6 +239,20 @@ walrus_utils::metrics::define_metric_set! {
         is epoch % SNAPSHOT_EPOCH_BUCKET_COUNT (see blob_info_snapshot_writer.rs)."]
         blob_info_snapshot_blob_id: IntGaugeVec["epoch"],
 
+        #[help = "The duration of the certify_snapshot_blob contract call, in seconds."]
+        blob_info_snapshot_certify_duration_seconds: Gauge[],
+
+        #[help = "The number of errors while certifying blob info snapshots."]
+        blob_info_snapshot_certify_error_total: IntCounter[],
+
+        #[help = "The number of blob info snapshot publications found uncertified at the next \
+        epoch boundary and cleaned up (no quorum, divergence, or a failed publication)."]
+        blob_info_snapshot_uncertified_cleanup_total: IntCounter[],
+
+        #[help = "The epoch of the latest blob info snapshot certified on chain, as read by this \
+        node at its last epoch boundary; 0 until a certification has been observed."]
+        blob_info_snapshot_last_certified_epoch: IntGauge[],
+
         #[help = "The number of certified per-object blobs scanned during the per-object blob info \
         consistency check."]
         per_object_blob_info_consistency_check_certified_scanned: IntCounterVec["epoch"],

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -83,6 +83,9 @@ mod metrics;
 mod pending_recover_blobs;
 pub(crate) use pending_recover_blobs::PendingRecoverBlob;
 use pending_recover_blobs::PendingRecoverBlobsTable;
+mod blob_info_snapshot_publication;
+use blob_info_snapshot_publication::SnapshotPublicationTable;
+pub(crate) use blob_info_snapshot_publication::{SnapshotPublication, SnapshotPublicationState};
 
 mod shard;
 
@@ -347,6 +350,7 @@ pub struct Storage {
     blob_info: BlobInfoTable,
     event_cursor: EventCursorTable,
     pending_recover_blobs: PendingRecoverBlobsTable,
+    snapshot_publication: SnapshotPublicationTable,
     garbage_collector_table: DBMap<String, Epoch>,
     shards: Arc<RwLock<HashMap<ShardIndex, Arc<ShardStorage>>>>,
     db_table_opts_factory: DatabaseTableOptionsFactory,
@@ -447,6 +451,8 @@ impl Storage {
             EventCursorTable::options(&db_table_opts_factory);
         let (pending_recover_blobs_cf_name, pending_recover_blobs_options) =
             PendingRecoverBlobsTable::options(&db_table_opts_factory);
+        let (snapshot_publication_cf_name, snapshot_publication_options) =
+            SnapshotPublicationTable::options(&db_table_opts_factory);
         let garbage_collector_table_cf_name = garbage_collector_table_cf_name();
         let garbage_collector_table_options = db_table_opts_factory.garbage_collector();
 
@@ -458,6 +464,7 @@ impl Storage {
                 (metadata_cf_name, metadata_options),
                 (event_cursor_cf_name, event_cursor_options),
                 (pending_recover_blobs_cf_name, pending_recover_blobs_options),
+                (snapshot_publication_cf_name, snapshot_publication_options),
                 (
                     garbage_collector_table_cf_name,
                     garbage_collector_table_options,
@@ -524,6 +531,7 @@ impl Storage {
 
         let event_cursor = EventCursorTable::reopen(&database)?;
         let pending_recover_blobs = PendingRecoverBlobsTable::reopen(&database)?;
+        let snapshot_publication = SnapshotPublicationTable::reopen(&database)?;
         let blob_info = BlobInfoTable::reopen(&database)?;
         let shards = Arc::new(RwLock::new(
             existing_shards_ids
@@ -553,6 +561,7 @@ impl Storage {
             blob_info,
             event_cursor,
             pending_recover_blobs,
+            snapshot_publication,
             garbage_collector_table,
             shards,
             db_table_opts_factory,
@@ -1552,6 +1561,26 @@ impl Storage {
     }
 
     /// Returns the number of pending-recovery records.
+    /// Returns the current blob info snapshot publication record, if any.
+    pub(crate) fn snapshot_publication(
+        &self,
+    ) -> Result<Option<SnapshotPublication>, TypedStoreError> {
+        self.snapshot_publication.get()
+    }
+
+    /// Sets the current blob info snapshot publication record.
+    pub(crate) fn set_snapshot_publication(
+        &self,
+        record: &SnapshotPublication,
+    ) -> Result<(), TypedStoreError> {
+        self.snapshot_publication.set(record)
+    }
+
+    /// Removes the current blob info snapshot publication record.
+    pub(crate) fn clear_snapshot_publication(&self) -> Result<(), TypedStoreError> {
+        self.snapshot_publication.clear()
+    }
+
     pub(crate) fn pending_recover_blob_count(&self) -> u64 {
         self.pending_recover_blobs.count()
     }

--- a/crates/walrus-service/src/node/storage/blob_info_snapshot_publication.rs
+++ b/crates/walrus-service/src/node/storage/blob_info_snapshot_publication.rs
@@ -1,0 +1,133 @@
+// Copyright (c) Walrus Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! The record of the blob info snapshot this node is publishing (storing and attesting).
+//!
+//! A snapshot that is not certified during its epoch is never certified: the contract rejects
+//! attestations for any epoch but the current one, and the next epoch produces a different blob
+//! ID. Metadata and slivers stored for such a snapshot have no blob-info entry and are therefore
+//! invisible to garbage collection, so the node tracks every publication attempt durably, from
+//! before the first write, and reconciles it at the next epoch boundary (see
+//! `blob_info_snapshot_writer::reconcile_previous_publication`).
+
+use std::sync::Arc;
+
+use rocksdb::Options;
+use serde::{Deserialize, Serialize};
+use typed_store::{
+    Map,
+    TypedStoreError,
+    rocks::{DBMap, ReadWriteOptions, RocksDB},
+};
+use walrus_core::{BlobId, Epoch};
+
+use super::{DatabaseTableOptionsFactory, constants::blob_info_snapshot_publication_cf_name};
+
+/// The progress of a snapshot publication attempt.
+#[derive(Eq, PartialEq, Debug, Clone, Copy, Deserialize, Serialize)]
+pub(crate) enum SnapshotPublicationState {
+    /// The record is written; metadata and slivers may be partially stored.
+    Pending,
+    /// The metadata and this node's slivers are stored.
+    Stored,
+    /// The snapshot blob is attested on chain.
+    Attested,
+    /// The snapshot blob is certified on chain.
+    Certified,
+}
+
+/// A versioned snapshot publication record.
+#[derive(Eq, PartialEq, Debug, Clone, Deserialize, Serialize)]
+pub(crate) enum SnapshotPublication {
+    V1(SnapshotPublicationV1),
+}
+
+/// Version 1 of the snapshot publication record.
+#[derive(Eq, PartialEq, Debug, Clone, Deserialize, Serialize)]
+pub(crate) struct SnapshotPublicationV1 {
+    epoch: Epoch,
+    blob_id: BlobId,
+    state: SnapshotPublicationState,
+}
+
+impl SnapshotPublication {
+    /// Creates a pending publication record for the snapshot of `epoch` with the given blob ID.
+    pub fn new(epoch: Epoch, blob_id: BlobId) -> Self {
+        Self::V1(SnapshotPublicationV1 {
+            epoch,
+            blob_id,
+            state: SnapshotPublicationState::Pending,
+        })
+    }
+
+    /// Returns the epoch of the snapshot.
+    pub fn epoch(&self) -> Epoch {
+        match self {
+            Self::V1(v1) => v1.epoch,
+        }
+    }
+
+    /// Returns the blob ID of the snapshot.
+    pub fn blob_id(&self) -> BlobId {
+        match self {
+            Self::V1(v1) => v1.blob_id,
+        }
+    }
+
+    /// Returns the state of the publication.
+    pub fn state(&self) -> SnapshotPublicationState {
+        match self {
+            Self::V1(v1) => v1.state,
+        }
+    }
+
+    /// Returns the record with the given state.
+    pub fn with_state(&self, state: SnapshotPublicationState) -> Self {
+        match self {
+            Self::V1(v1) => Self::V1(SnapshotPublicationV1 {
+                state,
+                ..v1.clone()
+            }),
+        }
+    }
+}
+
+/// The table holding the single current snapshot publication record.
+#[derive(Debug, Clone)]
+pub(super) struct SnapshotPublicationTable {
+    inner: DBMap<(), SnapshotPublication>,
+}
+
+impl SnapshotPublicationTable {
+    pub fn reopen(database: &Arc<RocksDB>) -> Result<Self, TypedStoreError> {
+        let inner = DBMap::reopen(
+            database,
+            Some(blob_info_snapshot_publication_cf_name()),
+            &ReadWriteOptions::default(),
+            false,
+        )?;
+        Ok(Self { inner })
+    }
+
+    pub fn options(db_table_opts_factory: &DatabaseTableOptionsFactory) -> (&'static str, Options) {
+        (
+            blob_info_snapshot_publication_cf_name(),
+            db_table_opts_factory.blob_info_snapshot_publication(),
+        )
+    }
+
+    /// Returns the current publication record, if any.
+    pub fn get(&self) -> Result<Option<SnapshotPublication>, TypedStoreError> {
+        self.inner.get(&())
+    }
+
+    /// Sets the current publication record, replacing any previous one.
+    pub fn set(&self, record: &SnapshotPublication) -> Result<(), TypedStoreError> {
+        self.inner.insert(&(), record)
+    }
+
+    /// Removes the current publication record.
+    pub fn clear(&self) -> Result<(), TypedStoreError> {
+        self.inner.remove(&())
+    }
+}

--- a/crates/walrus-service/src/node/storage/constants.rs
+++ b/crates/walrus-service/src/node/storage/constants.rs
@@ -17,6 +17,7 @@ const GARBAGE_COLLECTOR_TABLE_COLUMN_FAMILY_NAME: &str = "garbage_collector_last
 const GARBAGE_COLLECTOR_LAST_STARTED_EPOCH_KEY: &str = "started";
 const GARBAGE_COLLECTOR_LAST_COMPLETED_EPOCH_KEY: &str = "completed";
 const PENDING_RECOVER_BLOBS_COLUMN_FAMILY_NAME: &str = "pending_recover_blobs";
+const BLOB_INFO_SNAPSHOT_PUBLICATION_COLUMN_FAMILY_NAME: &str = "blob_info_snapshot_publication";
 
 // Base name for shard-related column families
 const SHARD_BASE_COLUMN_FAMILY_NAME: &str = "shard";
@@ -93,6 +94,11 @@ pub fn pending_recover_blobs_cf_name() -> &'static str {
     PENDING_RECOVER_BLOBS_COLUMN_FAMILY_NAME
 }
 
+/// Returns the name of the blob info snapshot publication column family.
+pub fn blob_info_snapshot_publication_cf_name() -> &'static str {
+    BLOB_INFO_SNAPSHOT_PUBLICATION_COLUMN_FAMILY_NAME
+}
+
 /// Returns the column family name for primary slivers of a shard.
 pub fn primary_slivers_column_family_name(id: ShardIndex) -> String {
     format!(
@@ -151,6 +157,10 @@ mod tests {
         assert_eq!(node_status_cf_name(), "node_status");
         assert_eq!(event_index_cf_name(), "latest_handled_event_index");
         assert_eq!(pending_recover_blobs_cf_name(), "pending_recover_blobs");
+        assert_eq!(
+            blob_info_snapshot_publication_cf_name(),
+            "blob_info_snapshot_publication"
+        );
 
         let shard = ShardIndex(900);
         assert_eq!(base_column_family_name(shard), "shard-900");

--- a/crates/walrus-service/src/node/storage/database_config.rs
+++ b/crates/walrus-service/src/node/storage/database_config.rs
@@ -350,6 +350,8 @@ pub struct DatabaseConfig {
     pub(super) event_cursor: Option<DatabaseTableOptions>,
     /// Pending recover blobs database options.
     pub(super) pending_recover_blobs: Option<DatabaseTableOptions>,
+    /// Blob info snapshot publication database options.
+    pub(super) blob_info_snapshot_publication: Option<DatabaseTableOptions>,
     /// Shard database options.
     pub(super) shard: Option<DatabaseTableOptions>,
     /// Shard status database options.
@@ -475,6 +477,11 @@ impl DatabaseConfig {
         Self::inherit_from_or_use_template(&self.pending_recover_blobs, self.standard())
     }
 
+    /// Returns the blob info snapshot publication database option.
+    pub fn blob_info_snapshot_publication(&self) -> DatabaseTableOptions {
+        Self::inherit_from_or_use_template(&self.blob_info_snapshot_publication, self.standard())
+    }
+
     /// Returns the shard database option.
     pub fn shard(&self) -> DatabaseTableOptions {
         Self::inherit_from_or_use_template(&self.shard, self.optimized_for_blobs())
@@ -557,6 +564,7 @@ impl Default for DatabaseConfig {
             storage_pool_info: None,
             event_cursor: None,
             pending_recover_blobs: None,
+            blob_info_snapshot_publication: None,
             shard: None,
             shard_status: None,
             shard_sync_progress: None,
@@ -782,6 +790,11 @@ impl DatabaseTableOptionsFactory {
     /// Returns the pending recover blobs database option.
     pub fn pending_recover_blobs(&self) -> Options {
         self.to_options(&self.config.pending_recover_blobs(), false)
+    }
+
+    /// Returns the blob info snapshot publication database option.
+    pub fn blob_info_snapshot_publication(&self) -> Options {
+        self.to_options(&self.config.blob_info_snapshot_publication(), false)
     }
 
     // Below 4 options are for shard storage column families.

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -96,6 +96,7 @@ use crate::{
         GarbageCollectionConfig,
         Storage,
         StorageNode,
+        blob_info_snapshot_writer::BlobInfoSnapshotWriterConfig,
         committee::{
             BeginCommitteeChangeError,
             CommitteeLookupService,
@@ -225,6 +226,7 @@ pub struct TestNodesConfig {
     blocklist_dir: Option<PathBuf>,
     enable_node_config_synchronizer: bool,
     node_recovery_config: Option<NodeRecoveryConfig>,
+    blob_info_snapshot_certify: Vec<bool>,
 }
 
 impl TestNodesConfig {
@@ -253,6 +255,13 @@ impl TestNodesConfig {
         self.node_recovery_config.as_ref()
     }
 
+    /// Returns, per node, whether the node certifies blob info snapshots on chain.
+    ///
+    /// Empty if no node certifies.
+    pub fn blob_info_snapshot_certify(&self) -> &[bool] {
+        &self.blob_info_snapshot_certify
+    }
+
     /// Creates a new builder for `TestNodesConfig`.
     pub fn builder() -> TestNodesConfigBuilder {
         TestNodesConfigBuilder::new()
@@ -273,6 +282,7 @@ pub struct TestNodesConfigBuilder {
     blocklist_dir: Option<PathBuf>,
     enable_node_config_synchronizer: bool,
     node_recovery_config: Option<NodeRecoveryConfig>,
+    blob_info_snapshot_certify: Vec<bool>,
 }
 
 impl Default for TestNodesConfigBuilder {
@@ -294,6 +304,7 @@ impl TestNodesConfigBuilder {
             blocklist_dir: None,
             enable_node_config_synchronizer: false,
             node_recovery_config: None,
+            blob_info_snapshot_certify: vec![],
         }
     }
 
@@ -336,6 +347,14 @@ impl TestNodesConfigBuilder {
         self
     }
 
+    /// Sets, per node, whether the node certifies blob info snapshots on chain.
+    ///
+    /// The slice must have one entry per node weight.
+    pub fn with_blob_info_snapshot_certify(mut self, certify: &[bool]) -> Self {
+        self.blob_info_snapshot_certify = certify.to_vec();
+        self
+    }
+
     /// Builds the [`TestNodesConfig`], validating constraints.
     ///
     /// # Panics
@@ -353,12 +372,22 @@ impl TestNodesConfigBuilder {
             );
         }
 
+        assert!(
+            self.blob_info_snapshot_certify.is_empty()
+                || self.blob_info_snapshot_certify.len() == self.node_weights.len(),
+            "TestNodesConfig: blob_info_snapshot_certify must have one entry per node, but \
+            {:?} was given for node_weights {:?}.",
+            self.blob_info_snapshot_certify,
+            self.node_weights
+        );
+
         TestNodesConfig {
             node_weights: self.node_weights,
             disable_event_blob_writer: self.disable_event_blob_writer,
             blocklist_dir: self.blocklist_dir,
             enable_node_config_synchronizer: self.enable_node_config_synchronizer,
             node_recovery_config: self.node_recovery_config,
+            blob_info_snapshot_certify: self.blob_info_snapshot_certify,
         }
     }
 }
@@ -872,6 +901,7 @@ pub struct StorageNodeHandleBuilder {
     garbage_collection_config: Option<GarbageCollectionConfig>,
     event_stream_catchup_min_checkpoint_lag: Option<u64>,
     max_epochs_ahead: Option<u32>,
+    blob_info_snapshot_certify: bool,
 }
 
 impl StorageNodeHandleBuilder {
@@ -949,6 +979,12 @@ impl StorageNodeHandleBuilder {
     /// Enable or disable event blob writer on the node.
     pub fn with_disabled_event_blob_writer(mut self, disable: bool) -> Self {
         self.disable_event_blob_writer = disable;
+        self
+    }
+
+    /// Enable or disable certifying blob info snapshots on chain.
+    pub fn with_blob_info_snapshot_certify(mut self, certify: bool) -> Self {
+        self.blob_info_snapshot_certify = certify;
         self
     }
 
@@ -1114,6 +1150,10 @@ impl StorageNodeHandleBuilder {
             blocklist_path: self.blocklist_path,
             shard_sync_config: self.shard_sync_config.unwrap_or_default(),
             disable_event_blob_writer: self.disable_event_blob_writer,
+            blob_info_snapshot: BlobInfoSnapshotWriterConfig {
+                certify: self.blob_info_snapshot_certify,
+                ..Default::default()
+            },
             config_synchronizer: ConfigSynchronizerConfig {
                 interval: Duration::from_secs(5),
                 enabled: self.enable_node_config_synchronizer,
@@ -1295,6 +1335,10 @@ impl StorageNodeHandleBuilder {
             },
             pending_sliver_cache: Default::default(),
             disable_event_blob_writer,
+            blob_info_snapshot: BlobInfoSnapshotWriterConfig {
+                certify: self.blob_info_snapshot_certify,
+                ..Default::default()
+            },
             sui: Some(SuiConfig {
                 rpc: sui_rpc_urls.remove(0),
                 contract_config: ContractConfig::new(
@@ -1407,6 +1451,7 @@ impl Default for StorageNodeHandleBuilder {
             garbage_collection_config: None,
             event_stream_catchup_min_checkpoint_lag: None,
             max_epochs_ahead: None,
+            blob_info_snapshot_certify: false,
         }
     }
 }
@@ -2069,6 +2114,7 @@ pub struct TestClusterBuilder {
     num_checkpoints_per_blob: Option<u32>,
     blocklist_files: Vec<Option<PathBuf>>,
     disable_event_blob_writer: Vec<bool>,
+    blob_info_snapshot_certify: Vec<bool>,
     enable_node_config_synchronizer: bool,
     node_recovery_config: Option<NodeRecoveryConfig>,
     event_stream_catchup_min_checkpoint_lag: Option<u64>,
@@ -2127,6 +2173,7 @@ impl TestClusterBuilder {
         self.committee_services = configs.iter().map(|_| None).collect();
         self.storage_capabilities = configs.iter().map(|_| None).collect();
         self.node_wallet_dirs = configs.iter().map(|_| None).collect();
+        self.blob_info_snapshot_certify = configs.iter().map(|_| false).collect();
         self.storage_node_configs = configs;
 
         self.n_shards = assignment
@@ -2251,6 +2298,14 @@ impl TestClusterBuilder {
         self
     }
 
+    /// Specifies, per node, whether the node certifies blob info snapshots on chain.
+    ///
+    /// Should be called after the storage nodes have been specified.
+    pub fn with_blob_info_snapshot_certify(mut self, certify: Vec<bool>) -> Self {
+        self.blob_info_snapshot_certify = certify;
+        self
+    }
+
     /// Sets the sui wallet config directory for each storage node.
     pub fn with_blocklist_files(mut self, blocklist_files: Vec<PathBuf>) -> Self {
         self.blocklist_files = blocklist_files.into_iter().map(Some).collect();
@@ -2303,6 +2358,7 @@ impl TestClusterBuilder {
             start_node_from_beginning: bool,
             blocklist_file: Option<PathBuf>,
             disable_event_blob_writer: bool,
+            blob_info_snapshot_certify: bool,
         }
 
         let node_setups = izip!(
@@ -2314,7 +2370,8 @@ impl TestClusterBuilder {
             self.node_wallet_dirs.into_iter(),
             self.start_node_from_beginning.into_iter(),
             self.blocklist_files.into_iter(),
-            self.disable_event_blob_writer.into_iter()
+            self.disable_event_blob_writer.into_iter(),
+            self.blob_info_snapshot_certify.into_iter()
         )
         .map(
             |(
@@ -2327,6 +2384,7 @@ impl TestClusterBuilder {
                 start_node_from_beginning,
                 blocklist_file,
                 disable_event_blob_writer,
+                blob_info_snapshot_certify,
             )| NodeSetup {
                 storage_node_config,
                 event_provider,
@@ -2337,6 +2395,7 @@ impl TestClusterBuilder {
                 start_node_from_beginning,
                 blocklist_file,
                 disable_event_blob_writer,
+                blob_info_snapshot_certify,
             },
         )
         .collect::<Vec<_>>();
@@ -2354,6 +2413,7 @@ impl TestClusterBuilder {
                 .with_blocklist_file(node_setup.blocklist_file)
                 .with_shard_sync_config(self.shard_sync_config.clone().unwrap_or_default())
                 .with_disabled_event_blob_writer(node_setup.disable_event_blob_writer)
+                .with_blob_info_snapshot_certify(node_setup.blob_info_snapshot_certify)
                 .with_enable_node_config_synchronizer(self.enable_node_config_synchronizer)
                 .with_node_recovery_config(self.node_recovery_config.clone().unwrap_or_default())
                 .with_event_stream_catchup_min_checkpoint_lag(
@@ -2565,6 +2625,7 @@ impl Default for TestClusterBuilder {
             start_node_from_beginning: shard_assignment.iter().map(|_| true).collect(),
             blocklist_files: shard_assignment.iter().map(|_| None).collect(),
             disable_event_blob_writer: shard_assignment.iter().map(|_| false).collect(),
+            blob_info_snapshot_certify: shard_assignment.iter().map(|_| false).collect(),
             storage_node_configs: shard_assignment
                 .into_iter()
                 .map(|shards| StorageNodeTestConfig::new(shards, false))
@@ -2943,6 +3004,7 @@ pub mod test_cluster {
             let mut node_wallet_dirs = Vec::with_capacity(n_nodes);
             let mut blocklist_files = Vec::with_capacity(n_nodes);
             let mut disable_event_blob_writers = Vec::with_capacity(n_nodes);
+            let mut blob_info_snapshot_certify = Vec::with_capacity(n_nodes);
 
             for (i, wallet) in
                 test_utils::create_and_fund_wallets_on_cluster(sui_cluster.clone(), n_nodes)
@@ -2970,6 +3032,13 @@ pub mod test_cluster {
                 let blocklist_dir = test_nodes_config.blocklist_dir.clone().unwrap_or(temp_dir);
                 blocklist_files.push(blocklist_dir.join(format!("blocklist-{i}.yaml")));
                 disable_event_blob_writers.push(test_nodes_config.disable_event_blob_writer);
+                blob_info_snapshot_certify.push(
+                    test_nodes_config
+                        .blob_info_snapshot_certify
+                        .get(i)
+                        .copied()
+                        .unwrap_or(false),
+                );
                 // In simtest, storage nodes load the Sui wallet config from the `temp_dir`. We
                 // need to keep the directory alive throughout the test.
                 #[cfg(msim)]
@@ -3071,6 +3140,7 @@ pub mod test_cluster {
                         .collect(),
                 )
                 .with_disable_event_blob_writer(disable_event_blob_writers)
+                .with_blob_info_snapshot_certify(blob_info_snapshot_certify)
                 .with_blocklist_files(blocklist_files)
                 .with_enable_node_config_synchronizer(
                     test_nodes_config.enable_node_config_synchronizer,

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -72,7 +72,7 @@ use walrus_sui::{
         NodeRegistrationParams,
         StorageNode as SuiStorageNode,
         StorageNodeCap,
-        move_structs::{EpochState, EventBlob, NodeMetadata},
+        move_structs::{EpochState, EventBlob, NodeMetadata, SnapshotBlob},
     },
 };
 use walrus_test_utils::WithTempDir;
@@ -1855,6 +1855,19 @@ impl SystemContractService for StubContractService {
         Ok(None)
     }
 
+    async fn certify_snapshot_blob(
+        &self,
+        _blob_metadata: BlobObjectMetadata,
+        _snapshot_epoch: u32,
+        _node_capability_object_id: ObjectID,
+    ) -> Result<(), SuiClientError> {
+        Ok(())
+    }
+
+    async fn last_certified_snapshot_blob(&self) -> Result<Option<SnapshotBlob>, SuiClientError> {
+        Ok(None)
+    }
+
     fn is_subsidies_object_configured(&self) -> bool {
         false
     }
@@ -2655,6 +2668,22 @@ where
 
     async fn last_certified_event_blob(&self) -> Result<Option<EventBlob>, SuiClientError> {
         self.as_ref().inner.last_certified_event_blob().await
+    }
+
+    async fn certify_snapshot_blob(
+        &self,
+        blob_metadata: BlobObjectMetadata,
+        snapshot_epoch: u32,
+        node_capability_object_id: ObjectID,
+    ) -> Result<(), SuiClientError> {
+        self.as_ref()
+            .inner
+            .certify_snapshot_blob(blob_metadata, snapshot_epoch, node_capability_object_id)
+            .await
+    }
+
+    async fn last_certified_snapshot_blob(&self) -> Result<Option<SnapshotBlob>, SuiClientError> {
+        self.as_ref().inner.last_certified_snapshot_blob().await
     }
 
     fn is_subsidies_object_configured(&self) -> bool {

--- a/crates/walrus-simtest/Cargo.toml
+++ b/crates/walrus-simtest/Cargo.toml
@@ -22,6 +22,7 @@ sui-types.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+twox-hash.workspace = true
 typed-store.workspace = true
 walrus-core.workspace = true
 walrus-proc-macros = { workspace = true, features = ["walrus-simtest"] }

--- a/crates/walrus-simtest/src/test_utils.rs
+++ b/crates/walrus-simtest/src/test_utils.rs
@@ -7,7 +7,11 @@
 pub mod simtest_utils {
     use std::{
         collections::{HashMap, HashSet},
-        sync::{Arc, Mutex, atomic::AtomicBool},
+        sync::{
+            Arc,
+            Mutex,
+            atomic::{AtomicBool, AtomicUsize},
+        },
         time::{Duration, Instant},
     };
 
@@ -17,6 +21,7 @@ pub mod simtest_utils {
     use sui_types::base_types::ObjectID;
     use tokio::{sync::RwLock, task::JoinHandle};
     use walrus_core::{
+        BlobId,
         Epoch,
         EpochCount,
         encoding::{Primary, Secondary},
@@ -35,7 +40,7 @@ pub mod simtest_utils {
     use walrus_storage_node_client::api::ServiceHealthInfo;
     use walrus_sui::{
         client::{BlobPersistence, ReadClient, SuiContractClient},
-        types::move_structs::EventBlob,
+        types::move_structs::{EventBlob, SnapshotBlob},
     };
     use walrus_test_utils::WithTempDir;
 
@@ -115,6 +120,87 @@ pub mod simtest_utils {
             tokio::time::sleep(Duration::from_secs(1)).await;
         }
         None
+    }
+
+    /// Makes the blob info snapshot blob of the given node differ from the other nodes' from now
+    /// on, so that its publications diverge from the certified snapshot.
+    ///
+    /// The snapshot file is left untouched; the node encodes a modified copy, so the digest
+    /// consistency check still passes.
+    pub fn diverge_blob_info_snapshot_of_node(node: &SimStorageNodeHandle) {
+        let target_node_id = node.node_id.expect("simulator nodes have a node id");
+        sui_macros::register_fail_point_if("storage_node_blob_info_snapshot_diverge", move || {
+            sui_simulator::current_simnode_id() == target_node_id
+        });
+    }
+
+    /// Crashes each of the given nodes once, the next time it reconciles a previous blob info
+    /// snapshot publication at an epoch boundary, where a storage error would stop the node.
+    /// The node restarts after `down_duration` and replays the boundary.
+    ///
+    /// Returns a counter of the crashes that have happened.
+    pub fn crash_nodes_once_at_blob_info_snapshot_reconciliation<'a>(
+        nodes: impl IntoIterator<Item = &'a SimStorageNodeHandle>,
+        down_duration: Duration,
+    ) -> Arc<AtomicUsize> {
+        let remaining: Arc<Mutex<HashSet<_>>> = Arc::new(Mutex::new(
+            nodes
+                .into_iter()
+                .map(|node| node.node_id.expect("simulator nodes have a node id"))
+                .collect(),
+        ));
+        let crashes = Arc::new(AtomicUsize::new(0));
+        let crashes_clone = crashes.clone();
+        sui_macros::register_fail_point_async(
+            "storage_node_blob_info_snapshot_reconcile",
+            move || {
+                let remaining = remaining.clone();
+                let crashes = crashes_clone.clone();
+                async move {
+                    let current_node = sui_simulator::current_simnode_id();
+                    if !remaining.lock().unwrap().remove(&current_node) {
+                        return;
+                    }
+                    crashes.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    tracing::info!(
+                        ?current_node,
+                        "crashing the node at the blob info snapshot reconciliation"
+                    );
+                    sui_simulator::task::kill_current_node(Some(down_duration));
+                    // Do not put any code after this point, as it won't be executed.
+                    // kill_current_node is implemented using a panic.
+                }
+            },
+        );
+        crashes
+    }
+
+    /// Waits until the last certified blob info snapshot on chain is of `min_epoch` or later, and
+    /// returns it.
+    pub async fn wait_for_certified_snapshot_blob(
+        client: &Arc<WithTempDir<WalrusNodeClient<SuiContractClient>>>,
+        min_epoch: Epoch,
+        timeout: Duration,
+    ) -> SnapshotBlob {
+        let start = Instant::now();
+        loop {
+            let latest = client
+                .inner
+                .sui_client()
+                .read_client
+                .last_certified_snapshot_blob()
+                .await
+                .expect("reading the certified blob info snapshot should succeed");
+            match latest {
+                Some(snapshot) if snapshot.epoch >= min_epoch => return snapshot,
+                latest => assert!(
+                    start.elapsed() < timeout,
+                    "timed out waiting for a certified blob info snapshot of epoch {min_epoch} or \
+                    later; latest: {latest:?}"
+                ),
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
     }
 
     /// Helper function to write a random blob, read it back and check that it is the same.
@@ -466,6 +552,13 @@ pub mod simtest_utils {
         // Per epoch, the blob info snapshot digest of all nodes, paired with the number of
         // entries the snapshot holds in its two pool sections.
         blob_info_snapshot_digest_map: Arc<Mutex<HashMap<Epoch, HashMap<ObjectID, u64>>>>,
+        // Per epoch, the blob info snapshot blob ID of all nodes.
+        blob_info_snapshot_blob_id_map: Arc<Mutex<HashMap<Epoch, HashMap<ObjectID, BlobId>>>>,
+        // Per epoch, the blob ID of the blob info snapshot each node stored for certification.
+        blob_info_snapshot_stored_map: Arc<Mutex<HashMap<Epoch, HashMap<ObjectID, BlobId>>>>,
+        // Per epoch, whether each node found its blob info snapshot certified when reconciling
+        // the publication at the next epoch boundary (`false` means it was cleaned up).
+        blob_info_snapshot_reconciled_map: Arc<Mutex<HashMap<Epoch, HashMap<ObjectID, bool>>>>,
         checked: Arc<AtomicBool>,
     }
 
@@ -484,6 +577,12 @@ pub mod simtest_utils {
             let blob_existence_check_map_clone = blob_existence_check_map.clone();
             let blob_info_snapshot_digest_map = Arc::new(Mutex::new(HashMap::new()));
             let blob_info_snapshot_digest_map_clone = blob_info_snapshot_digest_map.clone();
+            let blob_info_snapshot_blob_id_map = Arc::new(Mutex::new(HashMap::new()));
+            let blob_info_snapshot_blob_id_map_clone = blob_info_snapshot_blob_id_map.clone();
+            let blob_info_snapshot_stored_map = Arc::new(Mutex::new(HashMap::new()));
+            let blob_info_snapshot_stored_map_clone = blob_info_snapshot_stored_map.clone();
+            let blob_info_snapshot_reconciled_map = Arc::new(Mutex::new(HashMap::new()));
+            let blob_info_snapshot_reconciled_map_clone = blob_info_snapshot_reconciled_map.clone();
 
             sui_macros::register_fail_point_arg(
                 "storage_node_event_index_source",
@@ -527,6 +626,27 @@ pub mod simtest_utils {
                 },
             );
 
+            sui_macros::register_fail_point_arg(
+                "storage_node_blob_info_snapshot_blob_id",
+                move || -> Option<Arc<Mutex<HashMap<Epoch, HashMap<ObjectID, BlobId>>>>> {
+                    Some(blob_info_snapshot_blob_id_map_clone.clone())
+                },
+            );
+
+            sui_macros::register_fail_point_arg(
+                "storage_node_blob_info_snapshot_stored",
+                move || -> Option<Arc<Mutex<HashMap<Epoch, HashMap<ObjectID, BlobId>>>>> {
+                    Some(blob_info_snapshot_stored_map_clone.clone())
+                },
+            );
+
+            sui_macros::register_fail_point_arg(
+                "storage_node_blob_info_snapshot_reconciled",
+                move || -> Option<Arc<Mutex<HashMap<Epoch, HashMap<ObjectID, bool>>>>> {
+                    Some(blob_info_snapshot_reconciled_map_clone.clone())
+                },
+            );
+
             Self {
                 event_source_map,
                 certified_blob_digest_map,
@@ -534,6 +654,9 @@ pub mod simtest_utils {
                 per_object_pooled_blob_digest_map,
                 blob_existence_check_map,
                 blob_info_snapshot_digest_map,
+                blob_info_snapshot_blob_id_map,
+                blob_info_snapshot_stored_map,
+                blob_info_snapshot_reconciled_map,
                 checked: Arc::new(AtomicBool::new(false)),
             }
         }
@@ -591,6 +714,117 @@ pub mod simtest_utils {
                     continue;
                 }
                 Self::check_digests_are_equal(*epoch, node_digest_map);
+            }
+        }
+
+        /// Returns the blob info snapshot digest each node reported for `epoch`.
+        pub fn blob_info_snapshot_digests(&self, epoch: Epoch) -> HashMap<ObjectID, u64> {
+            self.blob_info_snapshot_digest_map
+                .lock()
+                .unwrap()
+                .get(&epoch)
+                .cloned()
+                .unwrap_or_default()
+        }
+
+        /// Returns the blob info snapshot blob ID each node reported for `epoch`.
+        pub fn blob_info_snapshot_blob_ids(&self, epoch: Epoch) -> HashMap<ObjectID, BlobId> {
+            Self::entries_for_epoch(&self.blob_info_snapshot_blob_id_map, epoch)
+        }
+
+        /// Waits until `n_nodes` nodes have reported their blob info snapshot blob ID for `epoch`
+        /// and returns the blob IDs.
+        pub async fn wait_for_blob_info_snapshot_blob_ids(
+            &self,
+            epoch: Epoch,
+            n_nodes: usize,
+            timeout: Duration,
+        ) -> HashMap<ObjectID, BlobId> {
+            Self::wait_for_entries(
+                &self.blob_info_snapshot_blob_id_map,
+                "blob ID",
+                epoch,
+                n_nodes,
+                timeout,
+            )
+            .await
+        }
+
+        /// Returns the blob ID of the blob info snapshot each node stored for certification in
+        /// `epoch`. Nodes that do not certify have no entry.
+        pub fn blob_info_snapshot_stored(&self, epoch: Epoch) -> HashMap<ObjectID, BlobId> {
+            Self::entries_for_epoch(&self.blob_info_snapshot_stored_map, epoch)
+        }
+
+        /// Waits until `n_nodes` nodes have stored their blob info snapshot of `epoch` for
+        /// certification and returns the stored blob IDs.
+        pub async fn wait_for_blob_info_snapshot_stored(
+            &self,
+            epoch: Epoch,
+            n_nodes: usize,
+            timeout: Duration,
+        ) -> HashMap<ObjectID, BlobId> {
+            Self::wait_for_entries(
+                &self.blob_info_snapshot_stored_map,
+                "stored blob ID",
+                epoch,
+                n_nodes,
+                timeout,
+            )
+            .await
+        }
+
+        /// Returns, per node that reconciled its blob info snapshot publication of `epoch` at the
+        /// next epoch boundary, whether the snapshot was found certified (`true`) or was cleaned
+        /// up (`false`). Nodes that did not publish have no entry.
+        pub fn blob_info_snapshot_reconciled(&self, epoch: Epoch) -> HashMap<ObjectID, bool> {
+            Self::entries_for_epoch(&self.blob_info_snapshot_reconciled_map, epoch)
+        }
+
+        /// Waits until `n_nodes` nodes have reconciled their blob info snapshot publication of
+        /// `epoch` and returns the outcomes (see [`Self::blob_info_snapshot_reconciled`]).
+        pub async fn wait_for_blob_info_snapshot_reconciled(
+            &self,
+            epoch: Epoch,
+            n_nodes: usize,
+            timeout: Duration,
+        ) -> HashMap<ObjectID, bool> {
+            Self::wait_for_entries(
+                &self.blob_info_snapshot_reconciled_map,
+                "reconciliation outcome",
+                epoch,
+                n_nodes,
+                timeout,
+            )
+            .await
+        }
+
+        fn entries_for_epoch<V: Clone>(
+            map: &Mutex<HashMap<Epoch, HashMap<ObjectID, V>>>,
+            epoch: Epoch,
+        ) -> HashMap<ObjectID, V> {
+            map.lock().unwrap().get(&epoch).cloned().unwrap_or_default()
+        }
+
+        async fn wait_for_entries<V: Clone + std::fmt::Debug>(
+            map: &Mutex<HashMap<Epoch, HashMap<ObjectID, V>>>,
+            what: &str,
+            epoch: Epoch,
+            n_nodes: usize,
+            timeout: Duration,
+        ) -> HashMap<ObjectID, V> {
+            let start = Instant::now();
+            loop {
+                let entries = Self::entries_for_epoch(map, epoch);
+                if entries.len() >= n_nodes {
+                    return entries;
+                }
+                assert!(
+                    start.elapsed() < timeout,
+                    "timed out waiting for {n_nodes} nodes to report the blob info snapshot \
+                    {what} of epoch {epoch}; reported: {entries:?}"
+                );
+                tokio::time::sleep(Duration::from_secs(1)).await;
             }
         }
 

--- a/crates/walrus-simtest/tests/simtest_blob_info_snapshot.rs
+++ b/crates/walrus-simtest/tests/simtest_blob_info_snapshot.rs
@@ -1,17 +1,31 @@
 // Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-//! Contains simtests for the cross-node determinism of blob info snapshots.
+//! Contains simtests for the cross-node determinism and the on-chain certification of blob info
+//! snapshots.
 
 #![recursion_limit = "256"]
 
 #[cfg(msim)]
 mod tests {
-    use std::{sync::Arc, time::Duration};
+    use std::{
+        collections::{HashMap, HashSet},
+        sync::Arc,
+        time::Duration,
+    };
 
+    use sui_types::base_types::ObjectID;
+    use twox_hash::XxHash64;
+    use walrus_core::{BlobId, Epoch, encoding::Primary};
     use walrus_proc_macros::walrus_simtest;
     use walrus_service::test_utils::{SimStorageNodeHandle, TestNodesConfig, test_cluster};
     use walrus_simtest::test_utils::simtest_utils::{self, BlobInfoConsistencyCheck};
+    use walrus_sui::client::ReadClient;
+
+    const EPOCH_DURATION: Duration = Duration::from_secs(30);
+
+    /// The node weights of the certification clusters: 13 shards, so that a quorum needs 9.
+    const NODE_WEIGHTS: [u16; 5] = [1, 2, 3, 3, 4];
 
     /// Checks that all nodes serialize identical blob info snapshots at each epoch boundary.
     #[ignore = "ignore integration simtests by default"]
@@ -40,5 +54,512 @@ mod tests {
         workload_handle.abort();
 
         blob_info_consistency_check.check_storage_node_consistency();
+    }
+
+    /// Returns a cluster builder with [`NODE_WEIGHTS`] in which the nodes flagged in `certify`
+    /// certify their blob info snapshots on chain.
+    fn certification_cluster_builder(certify: &[bool]) -> test_cluster::E2eTestSetupBuilder {
+        test_cluster::E2eTestSetupBuilder::new()
+            .with_epoch_duration(EPOCH_DURATION)
+            .with_test_nodes_config(
+                TestNodesConfig::builder()
+                    .with_node_weights(&NODE_WEIGHTS)
+                    .with_blob_info_snapshot_certify(certify)
+                    .build(),
+            )
+    }
+
+    fn node_capability_id(node: &SimStorageNodeHandle) -> ObjectID {
+        node.storage_node_capability
+            .as_ref()
+            .expect("nodes of an e2e cluster have a storage node capability")
+            .id
+    }
+
+    /// Returns the blob ID all nodes reported for the snapshot of `epoch`, asserting that they
+    /// agree.
+    fn single_blob_id(blob_ids: &HashMap<ObjectID, BlobId>, epoch: Epoch) -> BlobId {
+        let distinct: HashSet<_> = blob_ids.values().copied().collect();
+        assert_eq!(
+            distinct.len(),
+            1,
+            "nodes disagree on the snapshot blob ID of epoch {epoch}: {blob_ids:?}"
+        );
+        *distinct
+            .into_iter()
+            .next()
+            .as_ref()
+            .expect("one distinct blob ID")
+    }
+
+    /// Checks that, with certification enabled on every node, the snapshot of each epoch is
+    /// certified on chain, that the certified blob ID is the one every node produced, that every
+    /// node finds its snapshot certified at the next boundary (and so keeps it), and that a
+    /// certified snapshot can be read back through the regular read path.
+    #[ignore = "ignore integration simtests by default"]
+    #[walrus_simtest]
+    async fn test_blob_info_snapshot_certified_by_quorum() {
+        certified_by_quorum_scenario([true; 5]).await;
+    }
+
+    /// Checks the same with certification enabled on a quorum subset only (the staged rollout):
+    /// the non-attesting node produces the same snapshot, keeps nothing to reconcile, and the
+    /// snapshots of all nodes stay identical after the certified blob is recovered by it.
+    #[ignore = "ignore integration simtests by default"]
+    #[walrus_simtest]
+    async fn test_blob_info_snapshot_certified_by_quorum_subset() {
+        // The lightest node does not certify; the other four hold 12 of the 13 shards.
+        certified_by_quorum_scenario([false, true, true, true, true]).await;
+    }
+
+    async fn certified_by_quorum_scenario(certify: [bool; 5]) {
+        let consistency_check = BlobInfoConsistencyCheck::new();
+        let (_sui_cluster, walrus_cluster, client, _, _) = certification_cluster_builder(&certify)
+            .build_generic::<SimStorageNodeHandle>()
+            .await
+            .unwrap();
+        let client = Arc::new(client);
+        let workload_handle =
+            simtest_utils::start_background_workload(client.clone(), false, None, None);
+        let nodes = &walrus_cluster.nodes;
+        let node_ids: Vec<_> = nodes.iter().map(node_capability_id).collect();
+
+        // The snapshot of epoch E is certified during E, and the contract keeps every
+        // certification whose storage has not ended, so waiting for epoch 4 leaves a few epochs
+        // of history to check.
+        const TARGET_EPOCH: Epoch = 4;
+        let latest = simtest_utils::wait_for_certified_snapshot_blob(
+            &client,
+            TARGET_EPOCH,
+            EPOCH_DURATION * (TARGET_EPOCH + 2),
+        )
+        .await;
+        tracing::info!(?latest, "latest certified blob info snapshot");
+        // Once every node has applied the latest epoch, all of them have processed the
+        // certification events of the earlier epochs and reconciled those publications.
+        simtest_utils::wait_for_nodes_to_reach_epoch(nodes, latest.epoch, 2 * EPOCH_DURATION).await;
+
+        let mut certified_blob_ids = HashMap::new();
+        for epoch in latest.epoch - 2..=latest.epoch {
+            let certified = client
+                .inner
+                .sui_client()
+                .read_client
+                .certified_snapshot_blob_for_epoch(epoch)
+                .await
+                .expect("reading the certification history should succeed")
+                .unwrap_or_else(|| panic!("the snapshot of epoch {epoch} must be certified"));
+            let blob_ids = consistency_check
+                .wait_for_blob_info_snapshot_blob_ids(epoch, node_ids.len(), EPOCH_DURATION)
+                .await;
+            for node_id in &node_ids {
+                assert_eq!(
+                    blob_ids.get(node_id),
+                    Some(&certified.blob_id),
+                    "node {node_id} must have produced the certified snapshot of epoch {epoch}"
+                );
+            }
+            if epoch < latest.epoch {
+                let reconciled = consistency_check.blob_info_snapshot_reconciled(epoch);
+                for (node_id, certifies) in node_ids.iter().zip(certify) {
+                    let expected = if certifies { Some(&true) } else { None };
+                    assert_eq!(
+                        reconciled.get(node_id),
+                        expected,
+                        "node {node_id} (certifies: {certifies}) has the wrong reconciliation \
+                        outcome for epoch {epoch}"
+                    );
+                }
+            }
+            certified_blob_ids.insert(epoch, certified.blob_id);
+        }
+        workload_handle.abort();
+
+        // Reading a certified snapshot back exercises the slivers stored by the committee of its
+        // epoch, and the content must hash to the digest the nodes reported.
+        let read_epoch = latest.epoch - 1;
+        let content = client
+            .inner
+            .read_blob::<Primary>(&certified_blob_ids[&read_epoch])
+            .await
+            .expect("the certified blob info snapshot must be readable");
+        let digest = XxHash64::oneshot(0, &content);
+        let node_digests = consistency_check.blob_info_snapshot_digests(read_epoch);
+        assert_eq!(node_digests.len(), node_ids.len());
+        for (node_id, node_digest) in node_digests {
+            assert_eq!(
+                node_digest, digest,
+                "the certified snapshot of epoch {read_epoch} read back must match the digest \
+                reported by node {node_id}"
+            );
+        }
+
+        consistency_check.check_storage_node_consistency();
+    }
+
+    /// Checks that, with certification enabled on a sub-quorum of the committee only, nothing is
+    /// certified on chain, and that the attesting nodes store the snapshot blob during its epoch
+    /// and clean it up at the next epoch boundary.
+    #[ignore = "ignore integration simtests by default"]
+    #[walrus_simtest]
+    async fn test_blob_info_snapshot_cleanup_without_quorum() {
+        let consistency_check = BlobInfoConsistencyCheck::new();
+        // The two heaviest nodes hold 7 of the 13 shards, below the quorum of 9.
+        let certify = [false, false, false, true, true];
+        let (_sui_cluster, walrus_cluster, client, _, _) = certification_cluster_builder(&certify)
+            .build_generic::<SimStorageNodeHandle>()
+            .await
+            .unwrap();
+        let client = Arc::new(client);
+        let workload_handle =
+            simtest_utils::start_background_workload(client.clone(), false, None, None);
+        let nodes = &walrus_cluster.nodes;
+        let attesting_node_ids: HashSet<_> = nodes
+            .iter()
+            .zip(certify)
+            .filter(|(_, certifies)| *certifies)
+            .map(|(node, _)| node_capability_id(node))
+            .collect();
+        let silent_node_ids: Vec<_> = nodes
+            .iter()
+            .zip(certify)
+            .filter(|(_, certifies)| !*certifies)
+            .map(|(node, _)| node_capability_id(node))
+            .collect();
+
+        // The first boundary is processed while the cluster starts up; observe the next ones.
+        for epoch in 2..=3 {
+            simtest_utils::wait_for_nodes_to_reach_epoch(nodes, epoch, 2 * EPOCH_DURATION).await;
+            let blob_ids = consistency_check
+                .wait_for_blob_info_snapshot_blob_ids(epoch, nodes.len(), EPOCH_DURATION)
+                .await;
+            let blob_id = single_blob_id(&blob_ids, epoch);
+
+            let stored = consistency_check
+                .wait_for_blob_info_snapshot_stored(epoch, attesting_node_ids.len(), EPOCH_DURATION)
+                .await;
+            assert_eq!(
+                stored.keys().copied().collect::<HashSet<_>>(),
+                attesting_node_ids,
+                "exactly the attesting nodes must store the snapshot of epoch {epoch}"
+            );
+            for (node_id, stored_blob_id) in &stored {
+                assert_eq!(
+                    *stored_blob_id, blob_id,
+                    "node {node_id} must store the snapshot it produced for epoch {epoch}"
+                );
+            }
+
+            // The uncertified attempts are reconciled at the next boundary, before the nodes
+            // apply the new epoch.
+            simtest_utils::wait_for_nodes_to_reach_epoch(nodes, epoch + 1, 2 * EPOCH_DURATION)
+                .await;
+            let reconciled = consistency_check.blob_info_snapshot_reconciled(epoch);
+            for node_id in &attesting_node_ids {
+                assert_eq!(
+                    reconciled.get(node_id),
+                    Some(&false),
+                    "node {node_id} must clean up its uncertified snapshot of epoch {epoch}"
+                );
+            }
+            for node_id in &silent_node_ids {
+                assert_eq!(
+                    reconciled.get(node_id),
+                    None,
+                    "node {node_id} does not certify and has nothing to reconcile for epoch \
+                    {epoch}"
+                );
+            }
+            assert!(
+                client
+                    .inner
+                    .sui_client()
+                    .read_client
+                    .last_certified_snapshot_blob()
+                    .await
+                    .expect("reading the certified blob info snapshot should succeed")
+                    .is_none(),
+                "no snapshot may be certified without a quorum"
+            );
+        }
+        workload_handle.abort();
+
+        consistency_check.check_storage_node_consistency();
+    }
+
+    /// Checks that a node whose snapshot blob differs from the one a quorum certifies cleans up
+    /// its uncertified attempt at the next epoch boundary, while the other nodes certify and keep
+    /// theirs.
+    #[ignore = "ignore integration simtests by default"]
+    #[walrus_simtest]
+    async fn test_blob_info_snapshot_divergent_node_cleans_up() {
+        let consistency_check = BlobInfoConsistencyCheck::new();
+        let (_sui_cluster, walrus_cluster, client, _, _) =
+            certification_cluster_builder(&[true; 5])
+                .build_generic::<SimStorageNodeHandle>()
+                .await
+                .unwrap();
+        let client = Arc::new(client);
+        let workload_handle =
+            simtest_utils::start_background_workload(client.clone(), false, None, None);
+        let nodes = &walrus_cluster.nodes;
+
+        // The lightest node diverges; the other four hold 12 of the 13 shards and still certify.
+        let divergent_node = &nodes[0];
+        assert_eq!(NODE_WEIGHTS[0], 1);
+        let divergent_node_id = node_capability_id(divergent_node);
+        let honest_node_ids: Vec<_> = nodes.iter().skip(1).map(node_capability_id).collect();
+        simtest_utils::diverge_blob_info_snapshot_of_node(divergent_node);
+
+        // The first boundary may have been processed before the divergence was armed; observe
+        // the next ones.
+        for epoch in 2..=3 {
+            simtest_utils::wait_for_nodes_to_reach_epoch(nodes, epoch, 2 * EPOCH_DURATION).await;
+            let blob_ids = consistency_check
+                .wait_for_blob_info_snapshot_blob_ids(epoch, nodes.len(), EPOCH_DURATION)
+                .await;
+            let honest_blob_ids: HashMap<_, _> = blob_ids
+                .iter()
+                .filter(|(node_id, _)| **node_id != divergent_node_id)
+                .map(|(node_id, blob_id)| (*node_id, *blob_id))
+                .collect();
+            let honest_blob_id = single_blob_id(&honest_blob_ids, epoch);
+            let divergent_blob_id = blob_ids[&divergent_node_id];
+            assert_ne!(
+                divergent_blob_id, honest_blob_id,
+                "the divergent node must produce a different snapshot blob for epoch {epoch}"
+            );
+
+            // The honest nodes' quorum certifies their snapshot during the epoch.
+            simtest_utils::wait_for_certified_snapshot_blob(&client, epoch, 2 * EPOCH_DURATION)
+                .await;
+            let certified = client
+                .inner
+                .sui_client()
+                .read_client
+                .certified_snapshot_blob_for_epoch(epoch)
+                .await
+                .expect("reading the certification history should succeed")
+                .unwrap_or_else(|| panic!("the snapshot of epoch {epoch} must be certified"));
+            assert_eq!(
+                certified.blob_id, honest_blob_id,
+                "the quorum must certify the honest nodes' snapshot of epoch {epoch}"
+            );
+
+            // At the next boundary, the honest nodes keep their certified snapshot, and the
+            // divergent node cleans up its attempt.
+            simtest_utils::wait_for_nodes_to_reach_epoch(nodes, epoch + 1, 2 * EPOCH_DURATION)
+                .await;
+            let reconciled = consistency_check.blob_info_snapshot_reconciled(epoch);
+            for node_id in &honest_node_ids {
+                assert_eq!(
+                    reconciled.get(node_id),
+                    Some(&true),
+                    "node {node_id} must have found its snapshot of epoch {epoch} certified"
+                );
+            }
+            assert_eq!(
+                reconciled.get(&divergent_node_id),
+                Some(&false),
+                "the divergent node must clean up its uncertified snapshot of epoch {epoch}"
+            );
+        }
+        workload_handle.abort();
+
+        // The snapshot files stay identical across nodes: the divergence is injected between the
+        // file and its encoding.
+        consistency_check.check_storage_node_consistency();
+    }
+
+    /// Checks that a node stopping in the middle of reconciling its previous snapshot
+    /// publication, as a storage error there makes it do, neither loses that publication nor
+    /// publishes over it: after the restart it replays the boundary, reconciles the previous
+    /// publication, and publishes the new epoch's snapshot.
+    #[ignore = "ignore integration simtests by default"]
+    #[walrus_simtest]
+    async fn test_blob_info_snapshot_reconciliation_survives_a_crash() {
+        let consistency_check = BlobInfoConsistencyCheck::new();
+        // Sub-quorum, so that every publication must be cleaned up by the reconciliation.
+        let certify = [false, false, false, true, true];
+        let (_sui_cluster, walrus_cluster, client, _, _) = certification_cluster_builder(&certify)
+            .build_generic::<SimStorageNodeHandle>()
+            .await
+            .unwrap();
+        let client = Arc::new(client);
+        let workload_handle =
+            simtest_utils::start_background_workload(client.clone(), false, None, None);
+        let nodes = &walrus_cluster.nodes;
+        let (silent_nodes, attesting_nodes) = nodes.split_at(3);
+        assert!(certify[..3].iter().all(|certifies| !certifies));
+        assert!(certify[3..].iter().all(|certifies| *certifies));
+        let attesting_node_ids: HashSet<_> =
+            attesting_nodes.iter().map(node_capability_id).collect();
+
+        // Epoch 2: the attesting nodes publish as usual.
+        simtest_utils::wait_for_nodes_to_reach_epoch(nodes, 2, 2 * EPOCH_DURATION).await;
+        let stored = consistency_check
+            .wait_for_blob_info_snapshot_stored(2, attesting_node_ids.len(), EPOCH_DURATION)
+            .await;
+        assert_eq!(
+            stored.keys().copied().collect::<HashSet<_>>(),
+            attesting_node_ids
+        );
+
+        // At the boundary into epoch 3, the attesting nodes stop while reconciling the epoch-2
+        // publication, before it is cleaned up, and restart shortly after.
+        let crashes = simtest_utils::crash_nodes_once_at_blob_info_snapshot_reconciliation(
+            attesting_nodes,
+            Duration::from_secs(5),
+        );
+        simtest_utils::wait_for_nodes_to_reach_epoch(silent_nodes, 3, 2 * EPOCH_DURATION).await;
+        // The restarted nodes replay the boundary: the reconciliation runs again and cleans up
+        // the epoch-2 publication, and only then is the epoch-3 snapshot published. A restarted
+        // node reports the chain's epoch before it has replayed the boundary, so wait for the
+        // reconciliation itself rather than for the epoch.
+        simtest_utils::wait_for_nodes_to_reach_epoch(nodes, 3, 2 * EPOCH_DURATION).await;
+        assert_eq!(
+            crashes.load(std::sync::atomic::Ordering::SeqCst),
+            attesting_node_ids.len(),
+            "every attesting node must have crashed once at the reconciliation"
+        );
+        let reconciled = consistency_check
+            .wait_for_blob_info_snapshot_reconciled(2, attesting_node_ids.len(), EPOCH_DURATION)
+            .await;
+        assert_eq!(
+            reconciled,
+            attesting_node_ids
+                .iter()
+                .map(|node_id| (*node_id, false))
+                .collect(),
+            "exactly the attesting nodes must clean up their epoch-2 publication when replaying \
+            the boundary"
+        );
+        let blob_ids = consistency_check
+            .wait_for_blob_info_snapshot_blob_ids(3, nodes.len(), EPOCH_DURATION)
+            .await;
+        let blob_id = single_blob_id(&blob_ids, 3);
+        let stored = consistency_check
+            .wait_for_blob_info_snapshot_stored(3, attesting_node_ids.len(), EPOCH_DURATION)
+            .await;
+        assert_eq!(
+            stored.keys().copied().collect::<HashSet<_>>(),
+            attesting_node_ids,
+            "the attesting nodes must publish the epoch-3 snapshot after replaying the boundary"
+        );
+        for (node_id, stored_blob_id) in &stored {
+            assert_eq!(
+                *stored_blob_id, blob_id,
+                "node {node_id} must store the epoch-3 snapshot"
+            );
+        }
+
+        // The epoch-3 publication is reconciled at the next boundary like any other.
+        simtest_utils::wait_for_nodes_to_reach_epoch(nodes, 4, 2 * EPOCH_DURATION).await;
+        let reconciled = consistency_check
+            .wait_for_blob_info_snapshot_reconciled(3, attesting_node_ids.len(), EPOCH_DURATION)
+            .await;
+        assert_eq!(
+            reconciled,
+            attesting_node_ids
+                .iter()
+                .map(|node_id| (*node_id, false))
+                .collect(),
+            "exactly the attesting nodes must clean up their epoch-3 publication at the next \
+            boundary"
+        );
+        assert!(
+            client
+                .inner
+                .sui_client()
+                .read_client
+                .last_certified_snapshot_blob()
+                .await
+                .expect("reading the certified blob info snapshot should succeed")
+                .is_none(),
+            "no snapshot may be certified without a quorum"
+        );
+        workload_handle.abort();
+
+        consistency_check.check_storage_node_consistency();
+    }
+
+    /// Checks that a node that disables snapshots after publishing one still reconciles that
+    /// publication at the next boundary, so that its stored data is cleaned up.
+    #[ignore = "ignore integration simtests by default"]
+    #[walrus_simtest]
+    async fn test_blob_info_snapshot_publication_is_reconciled_when_snapshots_are_disabled() {
+        let consistency_check = BlobInfoConsistencyCheck::new();
+        // Sub-quorum, so that the publication must be cleaned up by the reconciliation.
+        let certify = [false, false, false, true, true];
+        let (_sui_cluster, mut walrus_cluster, client, _, _) =
+            certification_cluster_builder(&certify)
+                .build_generic::<SimStorageNodeHandle>()
+                .await
+                .unwrap();
+        let client = Arc::new(client);
+        let workload_handle =
+            simtest_utils::start_background_workload(client.clone(), false, None, None);
+        let attesting_indices: Vec<usize> = (0..certify.len()).filter(|i| certify[*i]).collect();
+        let attesting_node_ids: HashSet<_> = attesting_indices
+            .iter()
+            .map(|i| node_capability_id(&walrus_cluster.nodes[*i]))
+            .collect();
+
+        // Epoch 2: the attesting nodes publish as usual.
+        simtest_utils::wait_for_nodes_to_reach_epoch(&walrus_cluster.nodes, 2, 2 * EPOCH_DURATION)
+            .await;
+        let stored = consistency_check
+            .wait_for_blob_info_snapshot_stored(2, attesting_node_ids.len(), EPOCH_DURATION)
+            .await;
+        assert_eq!(
+            stored.keys().copied().collect::<HashSet<_>>(),
+            attesting_node_ids
+        );
+
+        // Restart the attesting nodes with snapshots disabled before the next boundary.
+        for index in &attesting_indices {
+            walrus_cluster.nodes[*index]
+                .storage_node_config
+                .blob_info_snapshot
+                .enabled = false;
+            simtest_utils::restart_node_with_checkpoints(&mut walrus_cluster, *index, |_| 20).await;
+        }
+        let nodes = &walrus_cluster.nodes;
+
+        // At the boundary into epoch 3 they reconcile the epoch-2 publication (cleaned up, as it
+        // never certified) although they no longer produce snapshots.
+        simtest_utils::wait_for_nodes_to_reach_epoch(nodes, 3, 2 * EPOCH_DURATION).await;
+        let reconciled = consistency_check
+            .wait_for_blob_info_snapshot_reconciled(2, attesting_node_ids.len(), EPOCH_DURATION)
+            .await;
+        assert_eq!(
+            reconciled,
+            attesting_node_ids
+                .iter()
+                .map(|node_id| (*node_id, false))
+                .collect(),
+            "the restarted nodes must clean up their epoch-2 publication with snapshots disabled"
+        );
+        let blob_ids = consistency_check.blob_info_snapshot_blob_ids(3);
+        assert!(
+            attesting_node_ids
+                .iter()
+                .all(|node_id| !blob_ids.contains_key(node_id)),
+            "nodes with snapshots disabled must not produce the epoch-3 snapshot: {blob_ids:?}"
+        );
+        assert!(
+            client
+                .inner
+                .sui_client()
+                .read_client
+                .last_certified_snapshot_blob()
+                .await
+                .expect("reading the certified blob info snapshot should succeed")
+                .is_none(),
+            "no snapshot may be certified without a quorum"
+        );
+        workload_handle.abort();
+
+        consistency_check.check_storage_node_consistency();
     }
 }


### PR DESCRIPTION
## Description

Stacked on #3751. Second of two PRs for the second milestone of WAL-1185, in two commits (the node, then the simtests): with the contract's `certify_snapshot_blob` in place, the storage node publishes its blob info snapshot for certification at every epoch boundary and reconciles the publication at the following one. Behind a new `blob_info_snapshot.certify` flag, default off, so this PR is inert until operators enable it.

**Publication record.** A new single-slot column family holds the record of the snapshot a node is publishing: the epoch, the blob ID, and how far the publication got (pending, stored, attested; a certified state is defined for the later resume path and not used yet). The value is a versioned enum, the table has its own entry in `DatabaseConfig`, and `Storage` exposes get, set, and clear. The record is written before anything is stored, so that the metadata and slivers of a snapshot that never certified, which have no blob-info entry and are therefore invisible to garbage collection, are always tracked and cleaned up.

**Ordering at `EpochChangeStart(E)`.** Report the epoch of the latest certified snapshot from the chain (a read bounded to thirty seconds, for the no-certification alert), reconcile the previous publication, serialize the snapshot (before `execute_epoch_change`, so the file is durable before the background finisher can mark the event complete, and skipped when the file already exists from a replay), apply the epoch change, then publish. Publishing encodes the file on every node, now with a full erasure encode rather than metadata only, to report the blob ID; when certification is on and the node is in the committee (and has not entered catch-up during the transition), it records the publication, stores the metadata and the slivers of its own shards under the incoming assignment, touching no other shard, and attests the blob through the new `SystemContractService::certify_snapshot_blob`. Errors in serialization, encoding, storing, and attesting are logged and counted and never fail the epoch change; a crash between them loses one attestation, which the quorum absorbs.

**Reconciliation.** It runs at every clean boundary, whether or not snapshots are enabled, and decides certification from the local blob-info entry for the recorded blob ID, which is exact by checkpoint ordering: a `BlobCertified` during E precedes `EpochChangeStart(E + 1)`, and the handler drains blob events first. A certified snapshot is left to garbage collection after its metadata is marked stored, if the row is present. An uncertified one has its metadata and slivers deleted unless a blob-info entry exists for the blob ID: the same content can be registered by anyone, and an entry means the regular lifecycle owns the bytes. The decision and the cleanup touch only local storage, so their errors fail the epoch change like any other storage error in event processing: the node stops before the boundary is marked complete and replays it on restart, and the reconciliation is idempotent, so a later publication never overwrites an unreconciled record.

**Metrics** cover the serialize, encode, and certify durations, errors per stage, uncertified cleanups, and the epoch of the latest certified snapshot for the no-certification alert. During the rollout, divergence is detected by comparing the per-node `blob_info_snapshot_blob_id` gauges.

**Deferred, tracked in Linear and marked as TODOs in the code:** classifying why a snapshot did not certify, no quorum or divergence, with metrics (WAL-1341); a garbage-collection guard for the bytes of a live publication (WAL-1340); classifying benign attestation aborts instead of counting them as errors (WAL-1342).

**Tests.** A per-node `certify` flag through the test cluster builders; the blob-info consistency observer gains the writer's simtest hooks (the blob ID each node encodes, the blob ID it stores, the reconciliation outcome) with wait helpers, plus helpers that wait on the on-chain pointer, crash a node once at the reconciliation, or make one node's snapshot blob diverge. Six tests on a five-node cluster published at the current contract version, next to the existing determinism test:

- certified by quorum: the on-chain history holds the recent epochs, each certified blob ID is the one every node produced, every node finds its snapshot certified at the next boundary and keeps it, and a certified snapshot reads back through the regular read path with the digest the nodes reported;
- certified by a quorum subset (the staged rollout): the same with one node not certifying, which keeps producing the identical snapshot;
- cleanup without quorum: with certification on two nodes holding 7 of 13 shards, nothing is certified, exactly the attesting nodes store the snapshot, and they clean it up at the next boundary;
- a divergent node cleans up: the lightest node encodes a different blob, the other four certify theirs, the divergent node cleans up its attempt, and the snapshot files stay identical so the digest check still holds;
- reconciliation survives a crash: the attesting nodes stop while reconciling their previous publication and, after the restart, reconcile it, publish the new epoch, and reconcile that one at the following boundary;
- reconciliation with snapshots disabled: the attesting nodes are restarted with snapshots off after publishing and still clean up at the next boundary while producing no new snapshot.

Notes for reviewers: the publication-state enum's `Certified` variant is reserved for the startup resume path (WAL-1252) and is harmless since the enum is a serialized value; the failpoint hooks in the writer compile to nothing outside the simulator; encoding runs on every node at every boundary even with `certify` off, and the extra memory during the rollout window is accepted rather than carrying a second encode path.

Rollout is three independently gated steps: roll the binary (certify off), upgrade and migrate the contract (#3751), then enable `certify` on weight comfortably above the quorum after comparing per-node snapshot digests for a few epochs. Handling a divergence, the startup resume, and the alert rules in sui-operations are follow-ups.

## Test plan

- Simtests: the six certification tests and the existing determinism test pass on seeds 1 to 3.
- Local testbed (4 nodes, an earlier revision of this branch that still kept a three-entry history on chain): with certify on all nodes, epochs 1 to 4 certified and listed on chain, all error counters zero, ordering serialize → transition → encode → attest confirmed in the node logs; with certify on 2 of 4 nodes (sub-quorum), both epochs cleaned up at the next boundary.
- The repository's pre-commit hooks pass on the changed files (cargo nextest, clippy with `-D warnings`, `cargo doc` with `-D warnings`, formatting).
- Two adversarial reviews of the branch (Claude and codex, independent then cross-examined) and a code-path audit against the four ways a snapshot blob differs from a client blob; all surviving findings are addressed or tracked above.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [x] Storage node: adds the `blob_info_snapshot.certify` config flag (default `false`), a new RocksDB column family `blob_info_snapshot_publication` (created automatically on the first start), and metrics under `blob_info_snapshot_*` for serialize, encode, and certify durations and errors, uncertified cleanups, and the epoch of the latest certified snapshot. Enabling `certify` requires the version-5 system contract; on an older contract the node's attestations fail and are counted, and nothing else changes. No operator action is required by default.
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
