### PR TITLE
feat: certify blob info snapshots on chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13893,6 +13893,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "twox-hash 2.1.3",
  "typed-store 1.57.0",
  "walrus-core",
  "walrus-proc-macros",

--- a/contracts/walrus/sources/init.move
+++ b/contracts/walrus/sources/init.move
@@ -83,6 +83,8 @@ public fun migrate(_staking: &mut Staking, _system: &mut System) {
 ///   - Do not use migration epoch.
 /// Migrate to version 4:
 ///   - Increase the max size of the active set to the updated `TEMP_ACTIVE_SET_SIZE_LIMIT`.
+/// Migrate to version 5:
+///   - Create the blob info snapshot certification state dynamic field on the system object.
 entry fun migrate_v2(staking: &mut Staking, system: &mut System, _ctx: &mut TxContext) {
     staking.migrate();
     system.migrate();

--- a/contracts/walrus/sources/staking.move
+++ b/contracts/walrus/sources/staking.move
@@ -29,7 +29,7 @@ const EWrongVersion: u64 = 1;
 const EDeprecatedFunction: u64 = 2;
 
 /// Flag to indicate the version of the Walrus system.
-const VERSION: u64 = 4;
+const VERSION: u64 = 5;
 
 /// The key for the migration epoch.
 const MIGRATION_EPOCH_KEY: vector<u8> = b"migration_epoch";
@@ -437,10 +437,10 @@ entry fun set_migration_epoch(staking: &mut Staking) {
 /// This function sets the new package id and version and can be modified in future versions
 /// to migrate changes in the `staking_inner` object if needed.
 public(package) fun migrate(staking: &mut Staking) {
-    // Below logic is for upgrading to version 4. When upgrading to future versions, this function
+    // Below logic is for upgrading to version 5. When upgrading to future versions, this function
     // needs to be revisited to perform correct migration steps.
     assert!(staking.version < VERSION, EInvalidMigration);
-    assert!(VERSION == 4, EInvalidMigration);
+    assert!(VERSION == 5, EInvalidMigration);
 
     // Move the old staking inner to the new version.
     let staking_inner: StakingInnerV1 = df::remove(&mut staking.id, staking.version);
@@ -452,9 +452,10 @@ public(package) fun migrate(staking: &mut Staking) {
     staking.package_id = staking.new_package_id.extract();
 
     // Apply the updated `TEMP_ACTIVE_SET_SIZE_LIMIT` to the existing `ActiveSet`, since the
-    // limit is only read when the `ActiveSet` is created.
-    // Note that this step is needed for version 4. When upgrading to future versions, this
-    // step needs to be revisited.
+    // limit is only read when the `ActiveSet` is created. This step was introduced for the
+    // version 4 migration and is safe to re-apply; it runs as part of this migration since no
+    // network has executed it yet. When upgrading to future versions, this step needs to be
+    // revisited.
     staking.inner_mut().update_active_set_max_size();
 }
 

--- a/contracts/walrus/sources/system.move
+++ b/contracts/walrus/sources/system.move
@@ -11,6 +11,7 @@ use walrus::{
     blob::Blob,
     bls_aggregate::BlsCommittee,
     epoch_parameters::EpochParams,
+    snapshot_blob::{Self, SnapshotBlobCertificationState},
     storage_accounting::FutureAccountingRingBuffer,
     storage_node::StorageNodeCap,
     storage_pool::StoragePool,
@@ -28,7 +29,13 @@ const EWrongVersion: u64 = 1;
 const EZeroExtractSize: u64 = 2;
 
 /// Flag to indicate the version of the system.
-const VERSION: u64 = 4;
+const VERSION: u64 = 5;
+
+/// Key for the dynamic field on `System` holding the blob info snapshot certification state.
+///
+/// A dedicated key type is used (rather than a `u64`) so that the key can never collide with
+/// the `u64` version keys under which the system state inner is stored.
+public struct SnapshotStateKey() has copy, drop, store;
 
 /// The one and only system object.
 public struct System has key {
@@ -49,6 +56,11 @@ public(package) fun create_empty(max_epochs_ahead: u32, package_id: ID, ctx: &mu
     };
     let system_state_inner = system_state_inner::create_empty(max_epochs_ahead, ctx);
     dynamic_field::add(&mut system.id, VERSION, system_state_inner);
+    dynamic_field::add(
+        &mut system.id,
+        SnapshotStateKey(),
+        snapshot_blob::create_with_empty_state(max_epochs_ahead),
+    );
     transfer::share_object(system);
 }
 
@@ -118,6 +130,61 @@ public fun certify_event_blob(
             epoch,
             ctx,
         )
+}
+
+/// Certifies a blob info snapshot blob for the given epoch.
+public fun certify_snapshot_blob(
+    system: &mut System,
+    cap: &StorageNodeCap,
+    blob_id: u256,
+    root_hash: u256,
+    size: u64,
+    encoding_type: u8,
+    snapshot_epoch: u32,
+    ctx: &mut TxContext,
+) {
+    assert!(system.version == VERSION, EWrongVersion);
+    // The certification state is temporarily detached because the system state inner is
+    // another dynamic field of the same object, and both must be mutably borrowed.
+    let mut state: SnapshotBlobCertificationState = dynamic_field::remove(
+        &mut system.id,
+        SnapshotStateKey(),
+    );
+    system
+        .inner_mut()
+        .certify_snapshot_blob(
+            &mut state,
+            cap,
+            blob_id,
+            root_hash,
+            size,
+            encoding_type,
+            snapshot_epoch,
+            ctx,
+        );
+    dynamic_field::add(&mut system.id, SnapshotStateKey(), state);
+}
+
+/// Sets the number of epochs ahead for which certified blob info snapshot blobs are stored.
+///
+/// The authorization is checked by the caller, `upgrade::set_snapshot_epochs_ahead`. The new
+/// value applies to snapshots certified after the change.
+public(package) fun set_snapshot_epochs_ahead(system: &mut System, epochs_ahead: u32) {
+    assert!(system.version == VERSION, EWrongVersion);
+    let max_epochs_ahead = system.inner().future_accounting().max_epochs_ahead();
+    let state: &mut SnapshotBlobCertificationState = dynamic_field::borrow_mut(
+        &mut system.id,
+        SnapshotStateKey(),
+    );
+    state.set_epochs_ahead(epochs_ahead, max_epochs_ahead);
+}
+
+/// Returns the blob info snapshot certification state.
+public(package) fun snapshot_blob_certification_state(
+    system: &System,
+): &SnapshotBlobCertificationState {
+    assert!(system.version == VERSION, EWrongVersion);
+    dynamic_field::borrow(&system.id, SnapshotStateKey())
 }
 
 /// Allows buying a storage reservation for a given period of epochs.
@@ -462,10 +529,10 @@ public(package) fun set_new_package_id(system: &mut System, new_package_id: ID) 
 /// This function sets the new package id and version and can be modified in future versions
 /// to migrate changes in the `system_state_inner` object if needed.
 public(package) fun migrate(system: &mut System) {
-    // Below logic is for upgrading to version 4. When upgrading to future versions, this function
+    // Below logic is for upgrading to version 5. When upgrading to future versions, this function
     // needs to be revisited to perform correct migration steps.
     assert!(system.version < VERSION, EInvalidMigration);
-    assert!(VERSION == 4, EInvalidMigration);
+    assert!(VERSION == 5, EInvalidMigration);
 
     // Move the old system state inner to the new version.
     let system_state_inner: SystemStateInnerV1 = dynamic_field::remove(
@@ -474,6 +541,14 @@ public(package) fun migrate(system: &mut System) {
     );
     dynamic_field::add(&mut system.id, VERSION, system_state_inner);
     system.version = VERSION;
+
+    // Create the blob info snapshot certification state introduced in version 5.
+    let max_epochs_ahead = system.inner().future_accounting().max_epochs_ahead();
+    dynamic_field::add(
+        &mut system.id,
+        SnapshotStateKey(),
+        snapshot_blob::create_with_empty_state(max_epochs_ahead),
+    );
 
     // Set the new package id.
     assert!(system.new_package_id.is_some(), EInvalidMigration);
@@ -516,7 +591,13 @@ public fun new_for_testing(ctx: &mut TxContext): System {
         new_package_id: option::none(),
     };
     let system_state_inner = system_state_inner::new_for_testing();
+    let max_epochs_ahead = system_state_inner.future_accounting().max_epochs_ahead();
     dynamic_field::add(&mut system.id, VERSION, system_state_inner);
+    dynamic_field::add(
+        &mut system.id,
+        SnapshotStateKey(),
+        snapshot_blob::create_with_empty_state(max_epochs_ahead),
+    );
     system
 }
 
@@ -529,7 +610,13 @@ public(package) fun new_for_testing_with_multiple_members(ctx: &mut TxContext): 
         new_package_id: option::none(),
     };
     let system_state_inner = system_state_inner::new_for_testing_with_multiple_members(ctx);
+    let max_epochs_ahead = system_state_inner.future_accounting().max_epochs_ahead();
     dynamic_field::add(&mut system.id, VERSION, system_state_inner);
+    dynamic_field::add(
+        &mut system.id,
+        SnapshotStateKey(),
+        snapshot_blob::create_with_empty_state(max_epochs_ahead),
+    );
     system
 }
 

--- a/contracts/walrus/sources/system/events.move
+++ b/contracts/walrus/sources/system/events.move
@@ -34,6 +34,12 @@ public struct BlobCertified has copy, drop {
     is_extension: bool,
 }
 
+#[test_only]
+/// Returns the end epoch of the certified blob, for tests that check storage lifetimes.
+public fun blob_certified_end_epoch(event: &BlobCertified): u32 {
+    event.end_epoch
+}
+
 /// Signals that a blob has been deleted.
 public struct BlobDeleted has copy, drop {
     epoch: u32,

--- a/contracts/walrus/sources/system/snapshot_blob.move
+++ b/contracts/walrus/sources/system/snapshot_blob.move
@@ -1,0 +1,269 @@
+// Copyright (c) Walrus Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+/// Module to certify blob info snapshot blobs.
+///
+/// A blob info snapshot is a deterministic serialization of the blob info tables that every
+/// storage node produces at the epoch boundary. All honest nodes produce bit-identical bytes,
+/// and therefore the same blob id, so certification is a per-epoch quorum vote on that blob id.
+/// This follows the event blob certification pattern (`event_blob.move`) with one
+/// simplification: there is exactly one snapshot per epoch, so attestations are keyed by epoch
+/// instead of by checkpoint, and no per-capability attestation bookkeeping is needed — a node
+/// may attest at most once per epoch, tracked in this state directly.
+module walrus::snapshot_blob;
+
+use sui::{vec_map::{Self, VecMap}, vec_set::{Self, VecSet}};
+
+// Error codes
+// Error types in `walrus-sui/types/move_errors.rs` are auto-generated from the Move error codes.
+/// The epoch of the certified snapshot must be strictly increasing.
+const EInvalidEpoch: u64 = 0;
+/// The snapshot storage lifetime must be at most the system's `max_epochs_ahead` and at least
+/// `MIN_SNAPSHOT_EPOCHS_AHEAD`, or `max_epochs_ahead` if that is smaller.
+const EInvalidEpochsAhead: u64 = 1;
+
+/// The smallest number of epochs ahead for which a certified snapshot blob may be stored.
+///
+/// A snapshot certified in epoch E with a lifetime of L epochs expires at epoch E + L. Storage
+/// nodes check whether it certified at the start of epoch E + 1, after expiring the blobs whose
+/// storage ends there, so a lifetime of one epoch would make every snapshot expire before that
+/// check and never leave it available for recovery.
+///
+/// A system whose `max_epochs_ahead` is below this minimum cannot store any blob that long. It
+/// is not made unmigratable for that: its lifetime is bounded by its maximum instead, and its
+/// snapshots expire before the next boundary's check, as described above.
+const MIN_SNAPSHOT_EPOCHS_AHEAD: u32 = 2;
+
+/// A certified blob info snapshot.
+public struct SnapshotBlob has copy, drop, store {
+    /// The walrus epoch whose boundary state the snapshot captures.
+    epoch: u32,
+    /// Blob id of the certified snapshot blob.
+    blob_id: u256,
+    /// The epoch at which the storage of the snapshot blob ends (exclusive). Recorded here
+    /// because the blob object is burned at certification, so the chain has no other record
+    /// of how long the snapshot stays retrievable.
+    end_epoch: u32,
+}
+
+/// State of blob info snapshot certification.
+///
+/// Lives in a dynamic field on the `System` object (see `system.move`) because the layout of
+/// `SystemStateInnerV1` is frozen and cannot gain a field.
+public struct SnapshotBlobCertificationState has store {
+    /// The certified snapshot blobs, oldest first: after every certification, the newest
+    /// entry, the previous one whatever its lifetime, and every older entry whose storage has
+    /// not ended. Expired entries are dropped only when a snapshot is certified, so readers
+    /// must compare `end_epoch` with the current epoch. Bounded by `max_epochs_ahead + 1`
+    /// entries, since at most one snapshot is certified per epoch.
+    certified: vector<SnapshotBlob>,
+    /// Number of epochs ahead for which a certified snapshot blob is stored.
+    epochs_ahead: u32,
+    /// The epoch the attestations below belong to. Attestations of an older epoch are cleared
+    /// lazily when the first attestation of a newer epoch arrives.
+    tally_epoch: u32,
+    /// Aggregate attested shard weight per snapshot blob id for `tally_epoch`.
+    aggregate_weight_per_blob: VecMap<u256, u16>,
+    /// Nodes that have attested a snapshot for `tally_epoch`.
+    attested_nodes: VecSet<ID>,
+}
+
+// === Accessors for SnapshotBlob ===
+
+/// Returns the epoch of the snapshot blob.
+public(package) fun epoch(self: &SnapshotBlob): u32 {
+    self.epoch
+}
+
+/// Returns the epoch at which the storage of the snapshot blob ends (exclusive).
+public(package) fun end_epoch(self: &SnapshotBlob): u32 {
+    self.end_epoch
+}
+
+/// Returns the blob id of the snapshot blob.
+public(package) fun blob_id(self: &SnapshotBlob): u256 {
+    self.blob_id
+}
+
+// === Accessors for SnapshotBlobCertificationState ===
+
+/// Creates a certification state with no certified snapshot and no attestations.
+///
+/// The snapshot storage lifetime starts at the system's `max_epochs_ahead`, the longest a blob
+/// can be stored: a recovering node needs the last certified snapshot to still be stored, so the
+/// lifetime bounds the certification outage the network can recover from, and the cost of the
+/// superseded snapshots this keeps is accepted for that. It can be lowered later through
+/// `set_epochs_ahead`.
+public(package) fun create_with_empty_state(max_epochs_ahead: u32): SnapshotBlobCertificationState {
+    assert_valid_epochs_ahead(max_epochs_ahead, max_epochs_ahead);
+    SnapshotBlobCertificationState {
+        certified: vector[],
+        epochs_ahead: max_epochs_ahead,
+        tally_epoch: 0,
+        aggregate_weight_per_blob: vec_map::empty(),
+        attested_nodes: vec_set::empty(),
+    }
+}
+
+/// Returns the number of epochs ahead for which a certified snapshot blob is stored.
+public(package) fun epochs_ahead(self: &SnapshotBlobCertificationState): u32 {
+    self.epochs_ahead
+}
+
+/// Sets the number of epochs ahead for which certified snapshot blobs are stored.
+///
+/// Applies to snapshots certified after the change; the storage of already certified snapshots
+/// is unaffected.
+public(package) fun set_epochs_ahead(
+    self: &mut SnapshotBlobCertificationState,
+    epochs_ahead: u32,
+    max_epochs_ahead: u32,
+) {
+    assert_valid_epochs_ahead(epochs_ahead, max_epochs_ahead);
+    self.epochs_ahead = epochs_ahead;
+}
+
+/// Aborts unless `min_epochs_ahead <= epochs_ahead <= max_epochs_ahead`, where the lower bound
+/// is `MIN_SNAPSHOT_EPOCHS_AHEAD` or, on a system whose `max_epochs_ahead` is smaller, that
+/// maximum: see the lower bound for why a shorter lifetime is useless, and the reservation is
+/// bounded by the system's accounting horizon.
+fun assert_valid_epochs_ahead(epochs_ahead: u32, max_epochs_ahead: u32) {
+    let min_epochs_ahead = MIN_SNAPSHOT_EPOCHS_AHEAD.min(max_epochs_ahead);
+    assert!(
+        epochs_ahead >= min_epochs_ahead && epochs_ahead <= max_epochs_ahead,
+        EInvalidEpochsAhead,
+    );
+}
+
+#[test_only]
+public fun destroy_for_testing(self: SnapshotBlobCertificationState) {
+    let SnapshotBlobCertificationState {
+        certified: _,
+        epochs_ahead: _,
+        tally_epoch: _,
+        aggregate_weight_per_blob: _,
+        attested_nodes: _,
+    } = self;
+}
+
+/// Returns the certified snapshot blobs kept in the state (see `certified`), oldest first.
+public(package) fun certified_history(
+    self: &SnapshotBlobCertificationState,
+): &vector<SnapshotBlob> {
+    &self.certified
+}
+
+/// Returns the latest certified snapshot blob.
+public(package) fun latest_certified(self: &SnapshotBlobCertificationState): Option<SnapshotBlob> {
+    let length = self.certified.length();
+    if (length == 0) {
+        option::none()
+    } else {
+        option::some(self.certified[length - 1])
+    }
+}
+
+/// Returns the certified snapshot blob of `epoch`, if it is among the ones kept in the state.
+public(package) fun certified_for_epoch(
+    self: &SnapshotBlobCertificationState,
+    epoch: u32,
+): Option<SnapshotBlob> {
+    let mut index = 0;
+    while (index < self.certified.length()) {
+        if (self.certified[index].epoch == epoch) {
+            return option::some(self.certified[index])
+        };
+        index = index + 1;
+    };
+    option::none()
+}
+
+/// Returns the epoch of the latest certified snapshot blob.
+public(package) fun get_latest_certified_epoch(self: &SnapshotBlobCertificationState): Option<u32> {
+    self.latest_certified().map!(|snapshot| snapshot.epoch())
+}
+
+/// Returns the blob id of the latest certified snapshot blob.
+public(package) fun get_latest_certified_blob_id(
+    self: &SnapshotBlobCertificationState,
+): Option<u256> {
+    self.latest_certified().map!(|snapshot| snapshot.blob_id())
+}
+
+/// Returns the number of snapshot blob ids being tracked for the current tally epoch.
+public(package) fun get_num_tracked_blobs(self: &SnapshotBlobCertificationState): u64 {
+    self.aggregate_weight_per_blob.length()
+}
+
+/// Returns true if a snapshot for `epoch` (or a later epoch) is already certified.
+public(package) fun is_epoch_certified(self: &SnapshotBlobCertificationState, epoch: u32): bool {
+    self.latest_certified().map!(|snapshot| snapshot.epoch() >= epoch).destroy_or!(false)
+}
+
+/// Returns true if `node_id` has already attested a snapshot for the current tally epoch.
+public(package) fun has_attested(self: &SnapshotBlobCertificationState, node_id: &ID): bool {
+    self.attested_nodes.contains(node_id)
+}
+
+/// Moves the tally to `epoch`, clearing all attestations of older epochs.
+///
+/// Called lazily on each attestation instead of during the epoch change, so that the epoch
+/// change transaction does not need to touch this state.
+public(package) fun advance_tally_epoch(self: &mut SnapshotBlobCertificationState, epoch: u32) {
+    if (self.tally_epoch != epoch) {
+        self.tally_epoch = epoch;
+        self.aggregate_weight_per_blob = vec_map::empty();
+        self.attested_nodes = vec_set::empty();
+    }
+}
+
+/// Records that `node_id` attested a snapshot for the current tally epoch.
+public(package) fun record_attestation(self: &mut SnapshotBlobCertificationState, node_id: ID) {
+    self.attested_nodes.insert(node_id);
+}
+
+/// Adds `weight` to the aggregate weight of the snapshot with the given blob id and returns
+/// the updated aggregate weight.
+public(package) fun add_aggregate_weight(
+    self: &mut SnapshotBlobCertificationState,
+    blob_id: u256,
+    weight: u16,
+): u16 {
+    if (!self.aggregate_weight_per_blob.contains(&blob_id)) {
+        self.aggregate_weight_per_blob.insert(blob_id, 0);
+    };
+    let aggregate_weight = &mut self.aggregate_weight_per_blob[&blob_id];
+    *aggregate_weight = *aggregate_weight + weight;
+    *aggregate_weight
+}
+
+/// Records the snapshot with the given blob id as certified for `epoch`, with storage ending at
+/// `end_epoch` (exclusive), drops the recorded snapshots whose storage has ended by `epoch`
+/// except the previously certified one, and stops tracking the attestations that led to it.
+///
+/// `epoch` is the current epoch, since only attestations for the current epoch are accepted.
+public(package) fun certify(
+    self: &mut SnapshotBlobCertificationState,
+    epoch: u32,
+    blob_id: u256,
+    end_epoch: u32,
+) {
+    self.get_latest_certified_epoch().do!(|latest_epoch| {
+        assert!(epoch > latest_epoch, EInvalidEpoch);
+    });
+    let length = self.certified.length();
+    let mut kept = vector[];
+    length.do!(|index| {
+        let snapshot = self.certified[index];
+        // Expired snapshots are dropped, except the latest one: storage nodes reconcile it at
+        // the next epoch boundary and a recovering node needs it as a fallback, whatever its
+        // lifetime.
+        if (snapshot.end_epoch > epoch || index + 1 == length) {
+            kept.push_back(snapshot);
+        };
+    });
+    kept.push_back(SnapshotBlob { epoch, blob_id, end_epoch });
+    self.certified = kept;
+    self.aggregate_weight_per_blob = vec_map::empty();
+    self.attested_nodes = vec_set::empty();
+}

--- a/contracts/walrus/sources/system/system_state_inner.move
+++ b/contracts/walrus/sources/system/system_state_inner.move
@@ -15,6 +15,7 @@ use walrus::{
     events,
     extended_field::{Self, ExtendedField},
     messages,
+    snapshot_blob::SnapshotBlobCertificationState,
     storage_accounting::{Self, FutureAccountingRingBuffer},
     storage_node::StorageNodeCap,
     storage_pool::{Self, StoragePool},
@@ -559,6 +560,82 @@ public(package) fun certify_event_blob(
     //       blob requires a pointer to previous certified blob, and we just certified blob at
     //       checkpoint X
     self.event_blob_certification_state.reset();
+    blob.burn();
+}
+
+/// Certifies a blob info snapshot blob for the current epoch.
+///
+/// Follows `certify_event_blob` with per-epoch keying: each committee member may attest at
+/// most one snapshot blob id per epoch, and the blob id reaching a quorum of shard weight is
+/// certified, stored without payment for the certification state's `epochs_ahead`, and
+/// burned. The certification state lives in a dynamic field on the `System` object because
+/// the layout of `SystemStateInnerV1` is frozen, so it is detached and passed in by
+/// `system.move`.
+public(package) fun certify_snapshot_blob(
+    self: &mut SystemStateInnerV1,
+    state: &mut SnapshotBlobCertificationState,
+    cap: &StorageNodeCap,
+    blob_id: u256,
+    root_hash: u256,
+    size: u64,
+    encoding_type: u8,
+    snapshot_epoch: u32,
+    ctx: &mut TxContext,
+) {
+    assert!(self.committee().contains(&cap.node_id()), ENotCommitteeMember);
+    assert!(snapshot_epoch == self.epoch(), EInvalidIdEpoch);
+
+    // Clears attestations of older epochs; done lazily here instead of in `advance_epoch` so
+    // that the epoch change transaction does not need to touch the snapshot state.
+    state.advance_tally_epoch(snapshot_epoch);
+
+    // A late attestation after this epoch's snapshot is already certified is a no-op.
+    if (state.is_epoch_certified(snapshot_epoch)) {
+        return
+    };
+
+    // There is exactly one snapshot per epoch, so each node may attest at most once per epoch.
+    assert!(!state.has_attested(&cap.node_id()), ERepeatedAttestation);
+    state.record_attestation(cap.node_id());
+
+    let weight = self.committee().get_member_weight(&cap.node_id());
+    let agg_weight = state.add_aggregate_weight(blob_id, weight);
+    if (!self.committee().is_quorum(agg_weight)) {
+        return
+    };
+
+    let num_shards = self.n_shards();
+    // The lifetime is a system parameter (see `snapshot_blob::set_epochs_ahead`), bounded by
+    // `max_epochs_ahead` when it is set.
+    let epochs_ahead = state.epochs_ahead();
+    let storage = self.reserve_space_without_payment(
+        encoded_blob_length(size, encoding_type, num_shards),
+        0,
+        epochs_ahead,
+        // Do not check total capacity, snapshot blobs are certified already at this point.
+        false,
+        ctx,
+    );
+    let mut blob = blob::new(
+        storage,
+        blob_id,
+        root_hash,
+        size,
+        encoding_type,
+        false,
+        self.epoch(),
+        self.n_shards(),
+        ctx,
+    );
+    // The snapshot blob is a permanent system blob exactly like an event blob, so the same
+    // certified message applies.
+    let certified_blob_msg = messages::certified_event_blob_message(blob_id);
+    blob.certify_with_certified_msg(self.epoch(), certified_blob_msg);
+    // Records the certification, with the storage end so that the chain keeps a record of how
+    // long the snapshot stays retrievable after the blob object is burned, and stops tracking
+    // this epoch's attestations. Late attestations for this epoch are rejected by the
+    // `is_epoch_certified` check above.
+    state.certify(snapshot_epoch, blob_id, blob.storage().end_epoch());
     blob.burn();
 }
 

--- a/contracts/walrus/sources/upgrade.move
+++ b/contracts/walrus/sources/upgrade.move
@@ -208,6 +208,20 @@ public fun cleanup_upgrade_proposals(
 
 // === Emergency Upgrade Cap Public API ===
 
+/// TODO(WAL-1344): no client call yet; invoke through a programmable transaction.
+/// Sets the number of epochs ahead for which certified blob info snapshot blobs are stored.
+///
+/// This is an internal system parameter without an economic stake for storage nodes, so it is
+/// gated by the emergency upgrade capability instead of a committee vote. The new value applies
+/// to snapshots certified after the change; already certified snapshots keep their storage.
+public fun set_snapshot_epochs_ahead(
+    _emergency_upgrade_cap: &EmergencyUpgradeCap,
+    system: &mut System,
+    epochs_ahead: u32,
+) {
+    system.set_snapshot_epochs_ahead(epochs_ahead);
+}
+
 /// Burns the emergency upgrade cap.
 ///
 /// This will prevent any further upgrades using the `EmergencyUpgradeCap` and will
@@ -246,6 +260,14 @@ macro fun package_digest($digest: vector<u8>): PackageDigest {
 }
 
 // === Test only ===
+
+#[test_only]
+public fun new_emergency_upgrade_cap_for_testing(ctx: &mut TxContext): EmergencyUpgradeCap {
+    EmergencyUpgradeCap {
+        id: object::new(ctx),
+        upgrade_manager_id: object::id_from_address(@0x0),
+    }
+}
 
 #[test_only]
 public fun digest_for_testing(ctx: &mut TxContext): vector<u8> {

--- a/contracts/walrus/tests/system/snapshot_blob_tests.move
+++ b/contracts/walrus/tests/system/snapshot_blob_tests.move
@@ -1,0 +1,392 @@
+// Copyright (c) Walrus Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module walrus::snapshot_blob_tests;
+
+use sui::event;
+use walrus::{
+    blob,
+    epoch_parameters::epoch_params_for_testing,
+    events::{Self, BlobCertified},
+    snapshot_blob,
+    storage_node,
+    system::{Self, System},
+    system_state_inner,
+    test_node::{test_nodes, TestStorageNode},
+    upgrade
+};
+
+const RS2: u8 = 1;
+
+const ROOT_HASH: u256 = 0xABC;
+const SIZE: u64 = 5_000_000;
+
+#[test]
+public fun test_snapshot_blob_certify_happy_path() {
+    let ctx = &mut tx_context::dummy();
+    let mut system = system::new_for_testing_with_multiple_members(ctx);
+    // Total of 10 nodes all with equal weights
+    assert!(system.committee().to_vec_map().length() == 10);
+    let mut nodes = test_nodes();
+    set_storage_node_caps(&system, &mut nodes, ctx);
+    let blob_id = blob::derive_blob_id(ROOT_HASH, RS2, SIZE);
+    let mut index = 0;
+    while (index < 10) {
+        system.certify_snapshot_blob(
+            nodes.borrow(index).cap(),
+            blob_id,
+            ROOT_HASH,
+            SIZE,
+            RS2,
+            0,
+            ctx,
+        );
+        let state = system.snapshot_blob_certification_state();
+        if (index < 6) {
+            assert!(state.get_latest_certified_epoch().is_none());
+        } else {
+            // 7th node attesting the blob triggers certification; further attestations for
+            // the same epoch are no-ops.
+            assert!(state.get_latest_certified_epoch() == option::some(0));
+            assert!(state.get_latest_certified_blob_id() == option::some(blob_id));
+            assert!(state.get_num_tracked_blobs() == 0);
+        };
+        index = index + 1
+    };
+    nodes.destroy!(|node| node.destroy());
+    system.destroy_for_testing()
+}
+
+#[test, expected_failure(abort_code = system_state_inner::ERepeatedAttestation)]
+public fun test_snapshot_blob_certify_repeated_attestation() {
+    let ctx = &mut tx_context::dummy();
+    let mut system = system::new_for_testing_with_multiple_members(ctx);
+    let mut nodes = test_nodes();
+    set_storage_node_caps(&system, &mut nodes, ctx);
+    let blob_id = blob::derive_blob_id(ROOT_HASH, RS2, SIZE);
+    let divergent_blob_id = blob::derive_blob_id(0xDEF, RS2, SIZE);
+
+    system.certify_snapshot_blob(
+        nodes.borrow(0).cap(),
+        blob_id,
+        ROOT_HASH,
+        SIZE,
+        RS2,
+        0,
+        ctx,
+    );
+
+    // A second attestation by the same node in the same epoch fails, even for a different
+    // blob id.
+    system.certify_snapshot_blob(
+        nodes.borrow(0).cap(),
+        divergent_blob_id,
+        0xDEF,
+        SIZE,
+        RS2,
+        0,
+        ctx,
+    );
+
+    nodes.destroy!(|node| node.destroy());
+    system.destroy_for_testing();
+}
+
+#[test]
+public fun test_snapshot_blob_divergent_attestations_and_epoch_rollover() {
+    let ctx = &mut tx_context::dummy();
+    let mut system = system::new_for_testing_with_multiple_members(ctx);
+    let mut nodes = test_nodes();
+    set_storage_node_caps(&system, &mut nodes, ctx);
+    let blob_id = blob::derive_blob_id(ROOT_HASH, RS2, SIZE);
+    let divergent_blob_id = blob::derive_blob_id(0xDEF, RS2, SIZE);
+
+    // 6 nodes attest the correct blob (one short of quorum), 4 divergent nodes attest a
+    // different blob: no certification, both blob ids are tracked.
+    let mut index = 0;
+    while (index < 10) {
+        let attested_blob_id = if (index < 6) { blob_id } else { divergent_blob_id };
+        let attested_root_hash = if (index < 6) { ROOT_HASH } else { 0xDEF };
+        system.certify_snapshot_blob(
+            nodes.borrow(index).cap(),
+            attested_blob_id,
+            attested_root_hash,
+            SIZE,
+            RS2,
+            0,
+            ctx,
+        );
+        index = index + 1
+    };
+    let state = system.snapshot_blob_certification_state();
+    assert!(state.get_latest_certified_epoch().is_none());
+    assert!(state.get_num_tracked_blobs() == 2);
+
+    // Increment epoch: the uncertified epoch-0 attestations become irrelevant.
+    let mut new_committee = *system.committee();
+    new_committee.increment_epoch_for_testing();
+    let (_, balances) = system
+        .advance_epoch(new_committee, &epoch_params_for_testing())
+        .into_keys_values();
+    balances.do!(|b| { b.destroy_for_testing(); });
+
+    // All nodes (including the previously divergent ones) attest the same blob for epoch 1;
+    // the stale epoch-0 attestations are lazily cleared, so re-attesting succeeds and the
+    // 7th node triggers certification.
+    index = 0;
+    while (index < 10) {
+        system.certify_snapshot_blob(
+            nodes.borrow(index).cap(),
+            blob_id,
+            ROOT_HASH,
+            SIZE,
+            RS2,
+            1,
+            ctx,
+        );
+        let state = system.snapshot_blob_certification_state();
+        if (index < 6) {
+            assert!(state.get_latest_certified_epoch().is_none());
+        } else {
+            assert!(state.get_latest_certified_epoch() == option::some(1));
+            assert!(state.get_latest_certified_blob_id() == option::some(blob_id));
+        };
+        index = index + 1
+    };
+    nodes.destroy!(|node| node.destroy());
+    system.destroy_for_testing();
+}
+
+#[test, expected_failure(abort_code = system_state_inner::EInvalidIdEpoch)]
+public fun test_snapshot_blob_certify_wrong_epoch() {
+    let ctx = &mut tx_context::dummy();
+    let mut system = system::new_for_testing_with_multiple_members(ctx);
+    let mut nodes = test_nodes();
+    set_storage_node_caps(&system, &mut nodes, ctx);
+    let blob_id = blob::derive_blob_id(ROOT_HASH, RS2, SIZE);
+
+    // The system is at epoch 0, so attesting a snapshot for epoch 1 fails.
+    system.certify_snapshot_blob(
+        nodes.borrow(0).cap(),
+        blob_id,
+        ROOT_HASH,
+        SIZE,
+        RS2,
+        1,
+        ctx,
+    );
+
+    nodes.destroy!(|node| node.destroy());
+    system.destroy_for_testing();
+}
+
+#[test, expected_failure(abort_code = system_state_inner::ENotCommitteeMember)]
+public fun test_snapshot_blob_certify_non_committee_member() {
+    let ctx = &mut tx_context::dummy();
+    let mut system = system::new_for_testing_with_multiple_members(ctx);
+    let blob_id = blob::derive_blob_id(ROOT_HASH, RS2, SIZE);
+
+    // A capability whose node is not part of the committee cannot attest.
+    let foreign_cap = storage_node::new_cap(
+        object::id_from_address(ctx.fresh_object_address()),
+        ctx,
+    );
+    system.certify_snapshot_blob(
+        &foreign_cap,
+        blob_id,
+        ROOT_HASH,
+        SIZE,
+        RS2,
+        0,
+        ctx,
+    );
+
+    transfer::public_transfer(foreign_cap, ctx.sender());
+    system.destroy_for_testing();
+}
+
+#[test, expected_failure(abort_code = snapshot_blob::EInvalidEpoch)]
+public fun test_snapshot_blob_certified_epoch_must_increase() {
+    // Unit test against the state module directly: the certified epoch is strictly
+    // monotonic. This cannot be reached through `certify_snapshot_blob`, which
+    // short-circuits on an already-certified epoch; the assertion is defense in depth.
+    let mut state = snapshot_blob::create_with_empty_state(53);
+    state.certify(1, 0xABC, 3);
+    state.certify(1, 0xDEF, 3);
+    abort 0
+}
+
+// === Helper functions ===
+
+#[test]
+public fun test_snapshot_epochs_ahead_defaults_to_max_epochs_ahead() {
+    let ctx = &mut tx_context::dummy();
+    let system = system::new_for_testing_with_multiple_members(ctx);
+    let max_epochs_ahead = system.future_accounting().max_epochs_ahead();
+    assert!(system.snapshot_blob_certification_state().epochs_ahead() == max_epochs_ahead);
+    system.destroy_for_testing()
+}
+
+#[test]
+public fun test_one_epoch_system_gets_a_one_epoch_snapshot_lifetime() {
+    // A system whose `max_epochs_ahead` is below the usual minimum lifetime must still be
+    // creatable and migratable; its lifetime is bounded by its maximum instead.
+    let mut state = snapshot_blob::create_with_empty_state(1);
+    assert!(state.epochs_ahead() == 1);
+    state.set_epochs_ahead(1, 1);
+    assert!(state.epochs_ahead() == 1);
+    state.destroy_for_testing();
+}
+
+#[test]
+public fun test_set_snapshot_epochs_ahead() {
+    let ctx = &mut tx_context::dummy();
+    let mut system = system::new_for_testing_with_multiple_members(ctx);
+    let cap = upgrade::new_emergency_upgrade_cap_for_testing(ctx);
+    let max_epochs_ahead = system.future_accounting().max_epochs_ahead();
+    upgrade::set_snapshot_epochs_ahead(&cap, &mut system, 2);
+    assert!(system.snapshot_blob_certification_state().epochs_ahead() == 2);
+    upgrade::set_snapshot_epochs_ahead(&cap, &mut system, max_epochs_ahead);
+    assert!(system.snapshot_blob_certification_state().epochs_ahead() == max_epochs_ahead);
+    upgrade::burn_emergency_upgrade_cap(cap);
+    system.destroy_for_testing()
+}
+
+#[test, expected_failure(abort_code = snapshot_blob::EInvalidEpochsAhead)]
+public fun test_set_snapshot_epochs_ahead_rejects_below_min() {
+    let ctx = &mut tx_context::dummy();
+    let mut system = system::new_for_testing_with_multiple_members(ctx);
+    let cap = upgrade::new_emergency_upgrade_cap_for_testing(ctx);
+    upgrade::set_snapshot_epochs_ahead(&cap, &mut system, 1);
+    upgrade::burn_emergency_upgrade_cap(cap);
+    system.destroy_for_testing()
+}
+
+#[test, expected_failure(abort_code = snapshot_blob::EInvalidEpochsAhead)]
+public fun test_set_snapshot_epochs_ahead_rejects_above_max() {
+    let ctx = &mut tx_context::dummy();
+    let mut system = system::new_for_testing_with_multiple_members(ctx);
+    let cap = upgrade::new_emergency_upgrade_cap_for_testing(ctx);
+    let max_epochs_ahead = system.future_accounting().max_epochs_ahead();
+    upgrade::set_snapshot_epochs_ahead(&cap, &mut system, max_epochs_ahead + 1);
+    upgrade::burn_emergency_upgrade_cap(cap);
+    system.destroy_for_testing()
+}
+
+#[test]
+public fun test_certified_snapshot_is_stored_for_the_configured_lifetime() {
+    let ctx = &mut tx_context::dummy();
+    let mut system = system::new_for_testing_with_multiple_members(ctx);
+    let mut nodes = test_nodes();
+    set_storage_node_caps(&system, &mut nodes, ctx);
+    let cap = upgrade::new_emergency_upgrade_cap_for_testing(ctx);
+    upgrade::set_snapshot_epochs_ahead(&cap, &mut system, 5);
+    let blob_id = blob::derive_blob_id(ROOT_HASH, RS2, SIZE);
+    let mut index = 0;
+    while (index < 7) {
+        system.certify_snapshot_blob(
+            nodes.borrow(index).cap(),
+            blob_id,
+            ROOT_HASH,
+            SIZE,
+            RS2,
+            0,
+            ctx,
+        );
+        index = index + 1;
+    };
+    let state = system.snapshot_blob_certification_state();
+    assert!(state.get_latest_certified_epoch() == option::some(0));
+    // The certified snapshot blob is stored for exactly the configured lifetime.
+    let certified_events = event::events_by_type<BlobCertified>();
+    assert!(certified_events.length() == 1);
+    assert!(events::blob_certified_end_epoch(&certified_events[0]) == 5);
+    // The recorded storage end matches the certified blob's.
+    assert!(state.latest_certified().map!(|s| s.end_epoch()) == option::some(5));
+    upgrade::burn_emergency_upgrade_cap(cap);
+    nodes.destroy!(|node| node.destroy());
+    system.destroy_for_testing()
+}
+
+#[test]
+public fun test_snapshot_certification_history_keeps_live_and_latest_snapshots() {
+    let ctx = &mut tx_context::dummy();
+    let mut system = system::new_for_testing_with_multiple_members(ctx);
+    let cap = upgrade::new_emergency_upgrade_cap_for_testing(ctx);
+    // With a lifetime of two epochs, the snapshot certified in epoch E is stored until epoch
+    // E + 2 (exclusive), so it expires by the certification of epoch E + 2.
+    upgrade::set_snapshot_epochs_ahead(&cap, &mut system, 2);
+    let mut nodes = test_nodes();
+    set_storage_node_caps(&system, &mut nodes, ctx);
+    // Certify one distinct snapshot per epoch for epochs 0, 1, and 3; no snapshot reaches a
+    // quorum in epoch 2.
+    let mut epoch: u32 = 0;
+    while (epoch < 4) {
+        if (epoch > 0) {
+            let mut new_committee = *system.committee();
+            new_committee.increment_epoch_for_testing();
+            let (_, balances) = system
+                .advance_epoch(new_committee, &epoch_params_for_testing())
+                .into_keys_values();
+            balances.do!(|b| { b.destroy_for_testing(); });
+        };
+        if (epoch == 2) {
+            epoch = epoch + 1;
+            continue
+        };
+        let root_hash = ROOT_HASH + (epoch as u256);
+        let blob_id = blob::derive_blob_id(root_hash, RS2, SIZE);
+        let mut index = 0;
+        while (index < 7) {
+            system.certify_snapshot_blob(
+                nodes.borrow(index).cap(),
+                blob_id,
+                root_hash,
+                SIZE,
+                RS2,
+                epoch,
+                ctx,
+            );
+            index = index + 1;
+        };
+        assert!(
+            system.snapshot_blob_certification_state().get_latest_certified_epoch()
+                == option::some(epoch),
+        );
+        epoch = epoch + 1;
+    };
+    let state = system.snapshot_blob_certification_state();
+    // By the certification of epoch 3, the snapshots of epochs 0 and 1 have both expired. The
+    // snapshot of epoch 0 was dropped; the snapshot of epoch 1 is kept because it was the latest
+    // certified one; epoch 3 is live.
+    let history = state.certified_history();
+    assert!(history.length() == 2);
+    assert!(history[0].epoch() == 1);
+    assert!(history[0].end_epoch() == 3);
+    assert!(history[1].epoch() == 3);
+    assert!(history[1].end_epoch() == 5);
+    assert!(state.certified_for_epoch(0).is_none());
+    assert!(state.certified_for_epoch(2).is_none());
+    let expected_epoch_1 = blob::derive_blob_id(ROOT_HASH + 1, RS2, SIZE);
+    assert!(state.certified_for_epoch(1).map!(|s| s.blob_id()) == option::some(expected_epoch_1));
+    let latest_blob_id = state.certified_for_epoch(3).map!(|s| s.blob_id());
+    assert!(state.get_latest_certified_blob_id() == latest_blob_id);
+    upgrade::burn_emergency_upgrade_cap(cap);
+    nodes.destroy!(|node| node.destroy());
+    system.destroy_for_testing()
+}
+
+fun set_storage_node_caps(
+    system: &System,
+    nodes: &mut vector<TestStorageNode>,
+    ctx: &mut TxContext,
+) {
+    let (node_ids, _values) = system.committee().to_vec_map().into_keys_values();
+    let mut index = 0;
+    node_ids.do!(|node_id| {
+        let storage_cap = storage_node::new_cap(node_id, ctx);
+        nodes[index].set_storage_node_cap(storage_cap);
+        index = index + 1;
+    });
+}

--- a/crates/walrus-sdk/src/node_client.rs
+++ b/crates/walrus-sdk/src/node_client.rs
@@ -3411,6 +3411,17 @@ mod tests {
         async fn last_certified_event_blob(&self) -> SuiClientResult<Option<EventBlob>> {
             unimplemented!()
         }
+        async fn last_certified_snapshot_blob(
+            &self,
+        ) -> SuiClientResult<Option<walrus_sui::types::move_structs::SnapshotBlob>> {
+            unimplemented!()
+        }
+        async fn certified_snapshot_blob_for_epoch(
+            &self,
+            _epoch: walrus_core::Epoch,
+        ) -> SuiClientResult<Option<walrus_sui::types::move_structs::SnapshotBlob>> {
+            unimplemented!()
+        }
         async fn refresh_package_id(&self) -> SuiClientResult<()> {
             unimplemented!()
         }

--- a/crates/walrus-service/node_config_example.yaml
+++ b/crates/walrus-service/node_config_example.yaml
@@ -80,6 +80,7 @@ db_config:
   storage_pool_info: null
   event_cursor: null
   pending_recover_blobs: null
+  blob_info_snapshot_publication: null
   shard: null
   shard_status: null
   shard_sync_progress: null
@@ -234,6 +235,7 @@ consistency_check:
   sliver_data_existence_check_sample_rate_percentage: 100
 blob_info_snapshot:
   enabled: true
+  certify: false
 checkpoint_config:
   max_db_checkpoints: 3
   db_checkpoint_interval:

--- a/crates/walrus-service/src/node/blob_info_snapshot_writer.rs
+++ b/crates/walrus-service/src/node/blob_info_snapshot_writer.rs
@@ -650,6 +650,11 @@ async fn encode_snapshot(
 
 /// Encodes the snapshot file, reports its blob ID for cross-node comparison, and returns the
 /// sliver pairs so that certification can store and attest them.
+///
+/// TODO(WAL-1345): this encodes every sliver pair, holding the full expansion of the snapshot
+/// (roughly 4.5x its size) while the node needs only its own shards' pairs. Once
+/// `compute_metadata_with_slivers_for_shards` (PR #3758) is available, use it with the node's
+/// shard assignment when certification is on, and `compute_metadata` when it is off.
 async fn try_encode_snapshot(
     node: &Arc<StorageNodeInner>,
     epoch: Epoch,

--- a/crates/walrus-service/src/node/blob_info_snapshot_writer.rs
+++ b/crates/walrus-service/src/node/blob_info_snapshot_writer.rs
@@ -6,7 +6,9 @@
 //! When enabled, this module serializes the three blob-info column families in-process at the
 //! post-GC-phase-1 epoch boundary and removes the previous epoch's snapshot, keeping at most one.
 //! The size and content digest are reported through metrics and a log line for cross-node
-//! comparison.
+//! comparison. Once the node's shard ownership has moved to the new epoch, the snapshot is
+//! encoded to report its blob ID and, when certification is enabled, stored and attested on chain
+//! (see [`publish_snapshot_after_epoch_change`]).
 
 #[cfg(msim)]
 use std::{collections::HashMap, sync::Mutex};
@@ -16,19 +18,35 @@ use std::{
     io::{BufWriter, Read as _, Write as _},
     path::{Path, PathBuf},
     sync::Arc,
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use anyhow::{Context, Result};
+use futures::future::try_join_all;
 use serde::{Deserialize, Serialize};
 #[cfg(msim)]
 use sui_types::base_types::ObjectID;
 use twox_hash::XxHash64;
-use walrus_core::{DEFAULT_ENCODING, Epoch, encoding::EncodingFactory as _};
+#[cfg(msim)]
+use walrus_core::BlobId;
+use walrus_core::{
+    DEFAULT_ENCODING,
+    Epoch,
+    Sliver,
+    SliverPairIndex,
+    encoding::{EncodingFactory as _, SliverPair},
+    metadata::VerifiedBlobMetadataWithId,
+};
+use walrus_sui::client::BlobObjectMetadata;
 
 use super::{
     StorageNodeInner,
-    storage::blob_info_snapshot::{SnapshotHeader, SnapshotStats},
+    errors::StoreSliverError,
+    storage::{
+        SnapshotPublication,
+        SnapshotPublicationState,
+        blob_info_snapshot::{SnapshotHeader, SnapshotStats},
+    },
 };
 use crate::event::events::EventStreamCursor;
 
@@ -44,13 +62,28 @@ pub struct BlobInfoSnapshotWriterConfig {
     /// encodes the snapshot to report its blob ID. Note that disabling this flag leaves the
     /// last snapshot file on disk until it is removed manually.
     pub enabled: bool,
+    /// Whether to certify the serialized snapshot on chain.
+    ///
+    /// The snapshot is encoded at every epoch boundary regardless, to report its blob ID.
+    /// When this is enabled (together with `enabled`), the node additionally stores its own
+    /// shards' slivers and attests the snapshot blob through the system contract, synchronously
+    /// once the epoch change has been applied locally. Has no effect if `enabled` is false.
+    pub certify: bool,
 }
 
 impl Default for BlobInfoSnapshotWriterConfig {
     fn default() -> Self {
-        Self { enabled: true }
+        Self {
+            enabled: true,
+            certify: false,
+        }
     }
 }
+
+/// Bound on the background chain read that reports the epoch of the latest certified snapshot.
+/// The read is best-effort and runs off the epoch-change path; the bound keeps a stuck full node
+/// from holding the task open indefinitely.
+const CHAIN_READ_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Number of epoch buckets used as the label of `blob_info_snapshot_blob_id`.
 ///
@@ -118,13 +151,16 @@ fn hash_file(path: &Path) -> std::io::Result<u64> {
 }
 
 /// Serializes the three blob info column families in-process at the epoch boundary, reports the
-/// duration, size, and digest, and removes older snapshot files. Then encodes the durable
-/// snapshot to report its blob ID.
+/// duration, size, and digest, and removes older snapshot files.
 ///
-/// Must be called at the post-GC-phase-1 point while event processing is blocked. `event_cursor`
-/// is the position of the `EpochChangeStart` being processed.
+/// Must be called at the post-GC-phase-1 point while event processing is blocked, and before
+/// `execute_epoch_change` spawns the finisher that marks the event complete: the durable file
+/// must exist before the boundary can stop being replayed, so a crash never skips a snapshot.
+/// `event_cursor` is the position of the `EpochChangeStart` being processed. Everything derived
+/// from the file (encoding, storing, attesting) happens in
+/// [`publish_snapshot_after_epoch_change`].
 pub(super) async fn serialize_snapshot_at_epoch_boundary(
-    node: Arc<StorageNodeInner>,
+    node: &Arc<StorageNodeInner>,
     epoch: Epoch,
     event_cursor: EventStreamCursor,
 ) -> Result<()> {
@@ -137,14 +173,39 @@ pub(super) async fn serialize_snapshot_at_epoch_boundary(
         // restart. Still drop any older snapshots so that at most one remains.
         tracing::debug!(walrus.epoch = epoch, "blob info snapshot already exists");
         remove_snapshot_files_matching(&base_dir, |snapshot_epoch| snapshot_epoch != epoch);
-    } else {
-        write_snapshot_file(&node, epoch, event_cursor, &base_dir, &final_path).await?;
+        return Ok(());
     }
+    write_snapshot_file(node, epoch, event_cursor, &base_dir, &final_path).await
+}
 
-    // TODO(WAL-1252): resume an interrupted publication here once snapshots are published and
-    // certified.
-    encode_snapshot(&node, epoch, &final_path).await;
-    Ok(())
+/// Encodes the durable snapshot of `epoch` to report its blob ID and, when certification is
+/// enabled, stores this node's slivers and attests it on chain, reporting errors through the log
+/// and metrics without failing the epoch change.
+///
+/// Must be called after `execute_epoch_change` has applied the epoch change locally, i.e., after
+/// the committee service has advanced to `epoch` and the storage holds this node's shards for
+/// that epoch. The contract tallies attestations by the new committee's shard weights and readers
+/// route the certified blob by the new committee's shard assignment, so the slivers must be stored
+/// under that assignment: storing them at the boundary, under the outgoing assignment, would leave
+/// them where the new epoch's shard sync deliberately does not look (it skips blobs certified in
+/// the epoch it is syncing, which are expected to have been written to their new owners
+/// directly). Runs whether the file was just written or already existed (a replayed boundary).
+/// Deliberately synchronous, like the serialization, to measure the full inline cost.
+///
+/// TODO(WAL-1252): resume an interrupted publication here once snapshots are published and
+/// certified.
+pub(super) async fn publish_snapshot_after_epoch_change(
+    node: &Arc<StorageNodeInner>,
+    epoch: Epoch,
+) {
+    let final_path = snapshot_file_path(&node.blob_info_snapshot_dir, epoch);
+    let Some((sliver_pairs, verified_metadata)) = encode_snapshot(node, epoch, &final_path).await
+    else {
+        return;
+    };
+    if node.blob_info_snapshot_config.certify {
+        certify_snapshot(node, epoch, &sliver_pairs, &verified_metadata).await;
+    }
 }
 
 /// Serializes the snapshot to `final_path` durably (write, fsync, rename, fsync dir), removes
@@ -242,26 +303,358 @@ async fn write_snapshot_file(
     Ok(())
 }
 
-/// Encodes the snapshot into a Walrus blob to report its blob ID, logging errors and counting
-/// them in metrics without failing the epoch change.
-async fn encode_snapshot(node: &Arc<StorageNodeInner>, epoch: Epoch, snapshot_path: &Path) {
-    if let Err(error) = try_encode_snapshot(node, epoch, snapshot_path).await {
-        node.metrics.blob_info_snapshot_encode_error_total.inc();
+/// Certifies the snapshot on chain, reporting errors through the log and metrics without
+/// failing the epoch change.
+async fn certify_snapshot(
+    node: &Arc<StorageNodeInner>,
+    epoch: Epoch,
+    sliver_pairs: &[SliverPair],
+    verified_metadata: &VerifiedBlobMetadataWithId,
+) {
+    if let Err(error) = try_certify_snapshot(node, epoch, sliver_pairs, verified_metadata).await {
+        // TODO(WAL-1342): benign contract aborts (a late attestation, a committee change, a
+        // replayed boundary) are counted as errors here; classify them as the event blob writer
+        // does.
+        node.metrics.blob_info_snapshot_certify_error_total.inc();
         tracing::warn!(
             ?error,
             walrus.epoch = epoch,
-            "failed to encode the blob info snapshot"
+            "failed to certify the blob info snapshot"
         );
     }
 }
 
-/// Computes the blob ID of the snapshot file and reports it for cross-node comparison; nothing
-/// is stored.
+/// Stores this node's slivers and the blob metadata, then attests the snapshot blob through the
+/// system contract.
+async fn try_certify_snapshot(
+    node: &Arc<StorageNodeInner>,
+    epoch: Epoch,
+    sliver_pairs: &[SliverPair],
+    verified_metadata: &VerifiedBlobMetadataWithId,
+) -> Result<()> {
+    // Only committee members can certify (the contract enforces membership), so skip the
+    // storage work and the doomed transaction locally, mirroring the event blob writer. This
+    // runs after the epoch change has been applied locally, so the committee service reports
+    // the committee of `epoch`: a node joining the committee at `epoch` attests and stores
+    // its new shards' slivers, and a node leaving at `epoch` skips, matching what the contract
+    // would decide. Note that a node processing this boundary late (after the chain moved past
+    // `epoch`) cannot be detected locally, since the committee service tracks the node's own
+    // processed position; the contract rejects such an attestation with `EInvalidIdEpoch`, and
+    // the catching-up and reprocessing cases never reach this code (see `should_serialize` at
+    // the call site in `epoch_change.rs`).
+    if !node
+        .committee_service
+        .active_committees()
+        .current_committee()
+        .contains(node.public_key())
+    {
+        tracing::debug!(
+            walrus.epoch = epoch,
+            "node is not in the committee; skipping blob info snapshot certification"
+        );
+        return Ok(());
+    }
+
+    // Record the publication before the first write, so that whatever gets stored is tracked
+    // and reconciled at the next epoch boundary even if the store or the attestation fails
+    // partway (see `reconcile_previous_publication`). This overwrites the single publication
+    // record, which is safe because the boundary handler reconciles the previous publication
+    // before publishing and fails the epoch change if that reconciliation errors.
+    let blob_id = *verified_metadata.blob_id();
+    let record = SnapshotPublication::new(epoch, blob_id);
+    node.storage()
+        .set_snapshot_publication(&record)
+        .context("failed to record the snapshot publication")?;
+
+    // TODO(WAL-1340): until the blob-info entry exists, garbage collection can delete these
+    // bytes if a stale entry for the same blob ID is left by another registration; make it
+    // honor the publication record.
+    let store_start = Instant::now();
+    node.storage()
+        .put_verified_metadata_without_blob_info(verified_metadata)
+        .context("failed to store the snapshot blob metadata")?;
+    store_own_slivers(node, verified_metadata, sliver_pairs).await?;
+    let store_elapsed = store_start.elapsed();
+    node.storage()
+        .set_snapshot_publication(&record.with_state(SnapshotPublicationState::Stored))
+        .context("failed to record the snapshot publication")?;
+    // No-op outside of simtest.
+    sui_macros::fail_point_arg!(
+        "storage_node_blob_info_snapshot_stored",
+        |stored_map: Arc<Mutex<HashMap<Epoch, HashMap<ObjectID, BlobId>>>>| {
+            stored_map
+                .lock()
+                .expect("failed to lock the stored map")
+                .entry(epoch)
+                .or_default()
+                .insert(node.node_capability, blob_id);
+        }
+    );
+
+    let certify_start = Instant::now();
+    let blob_metadata: BlobObjectMetadata = verified_metadata
+        .try_into()
+        .context("failed to convert the snapshot blob metadata")?;
+    node.contract_service
+        .certify_snapshot_blob(blob_metadata, epoch, node.node_capability())
+        .await?;
+    let certify_elapsed = certify_start.elapsed();
+    node.storage()
+        .set_snapshot_publication(&record.with_state(SnapshotPublicationState::Attested))
+        .context("failed to record the snapshot publication")?;
+    node.metrics
+        .blob_info_snapshot_certify_duration_seconds
+        .set(certify_elapsed.as_secs_f64());
+
+    tracing::info!(
+        walrus.epoch = epoch,
+        walrus.blob_id = %blob_id,
+        ?store_elapsed,
+        ?certify_elapsed,
+        "attested blob info snapshot on chain"
+    );
+    Ok(())
+}
+
+/// Reports the epoch of the latest blob info snapshot certified on chain through the
+/// `blob_info_snapshot_last_certified_epoch` gauge, so that an alert can detect a network that
+/// stops certifying (the distance to the current epoch grows). Every node reports it, whether or
+/// not it certifies, since it is a property of the network rather than of the node. A failed read
+/// is logged and the gauge keeps its previous value; a contract that predates certification
+/// reads as no certification. Runs in a background task at the epoch boundary, since only the
+/// gauge depends on the result.
+pub(super) async fn report_last_certified_snapshot_epoch(node: &Arc<StorageNodeInner>) {
+    match tokio::time::timeout(
+        CHAIN_READ_TIMEOUT,
+        node.contract_service.last_certified_snapshot_blob(),
+    )
+    .await
+    {
+        Ok(Ok(Some(certified))) => node
+            .metrics
+            .blob_info_snapshot_last_certified_epoch
+            .set(i64::from(certified.epoch)),
+        Ok(Ok(None)) => {}
+        Ok(Err(error)) => tracing::warn!(
+            ?error,
+            "failed to read the latest certified blob info snapshot"
+        ),
+        Err(_) => tracing::warn!(
+            timeout = ?CHAIN_READ_TIMEOUT,
+            "timed out reading the latest certified blob info snapshot"
+        ),
+    }
+}
+
+/// Reconciles the publication of the previous epoch's snapshot at the boundary of
+/// `current_epoch`, before this epoch's snapshot is produced.
+///
+/// Whether the previous snapshot certified is decided locally: a certification during epoch E
+/// emits `BlobCertified` before `EpochChangeStart(E + 1)` in the checkpoint-ordered event
+/// stream, and the boundary handler drains all blob events before calling this, so a blob-info
+/// entry for the snapshot's blob ID exists if and only if it certified. This relies on the
+/// contract's lower bound of two epochs on the snapshot lifetime: garbage collection phase 1
+/// runs before this and expires blobs whose storage ends at `E + 1`, which a one-epoch snapshot
+/// certified in E would, so its entry would be gone before it is checked. A snapshot that did not
+/// certify never will (the contract only accepts the current epoch), and its metadata and
+/// slivers have no blob-info entry, so garbage collection would never find them: they are
+/// deleted here. Why a snapshot did not certify (no quorum, or a divergence of this node's tables
+/// from the network's) is not classified here yet; fleet-wide detection comes from comparing the
+/// `blob_info_snapshot_blob_id` gauges across nodes (see `TODO(WAL-1341)` below).
+///
+/// Storage errors are returned to the caller, which fails the epoch change; the boundary is then
+/// replayed on restart and this function runs again. It is idempotent: the record is cleared only
+/// after the stored data is deleted, and deleting already-deleted data is a no-op.
+pub(super) async fn reconcile_previous_publication(
+    node: &Arc<StorageNodeInner>,
+    current_epoch: Epoch,
+) -> Result<()> {
+    let Some(record) = node
+        .storage()
+        .snapshot_publication()
+        .context("failed to read the snapshot publication record")?
+    else {
+        return Ok(());
+    };
+    let epoch = record.epoch();
+    if epoch >= current_epoch {
+        // The current epoch's publication (a replayed boundary) or, defensively, a newer one.
+        return Ok(());
+    }
+    let blob_id = record.blob_id();
+    // Lets a simtest crash the node here, where a storage error in the lookup below would stop
+    // it, to exercise the replay of this boundary. No-op outside of simtest.
+    sui_macros::fail_point_async!("storage_node_blob_info_snapshot_reconcile");
+    if node.is_blob_certified(&blob_id)? {
+        // Certified: from here on the blob is ordinary certified data owned by garbage
+        // collection. The metadata was stored before the blob had a blob-info entry, so mark
+        // it stored now, as for event blobs, provided it is still there; the node's own slivers
+        // were stored the same way and are found by the regular existence checks.
+        if node
+            .storage()
+            .get_metadata(&blob_id)
+            .context("failed to read the snapshot blob metadata")?
+            .is_some()
+        {
+            node.storage()
+                .update_blob_info_with_metadata(&blob_id)
+                .context("failed to mark the certified snapshot's metadata as stored")?;
+        }
+        node.storage()
+            .clear_snapshot_publication()
+            .context("failed to clear the snapshot publication record")?;
+        // No-op outside of simtest.
+        sui_macros::fail_point_arg!(
+            "storage_node_blob_info_snapshot_reconciled",
+            |reconciled_map: Arc<Mutex<HashMap<Epoch, HashMap<ObjectID, bool>>>>| {
+                reconciled_map
+                    .lock()
+                    .expect("failed to lock the reconciled map")
+                    .entry(epoch)
+                    .or_default()
+                    .insert(node.node_capability, true);
+            }
+        );
+        return Ok(());
+    }
+
+    // Never certified as a snapshot. Delete whatever was stored for it, unless a blob-info
+    // entry exists for the blob ID: the same content can be registered by anyone, and an entry
+    // means the regular lifecycle owns the bytes (garbage collection deletes them once nothing
+    // registers the blob), whereas without an entry nothing else would ever find them.
+    if node
+        .storage()
+        .get_blob_info(&blob_id)
+        .context("failed to read the snapshot blob info")?
+        .is_none()
+    {
+        node.storage
+            .delete_blob_data(&blob_id)
+            .await
+            .context("failed to delete the uncertified snapshot blob data")?;
+    }
+    node.metrics
+        .blob_info_snapshot_uncertified_cleanup_total
+        .inc();
+    node.storage()
+        .clear_snapshot_publication()
+        .context("failed to clear the snapshot publication record")?;
+    // No-op outside of simtest.
+    sui_macros::fail_point_arg!(
+        "storage_node_blob_info_snapshot_reconciled",
+        |reconciled_map: Arc<Mutex<HashMap<Epoch, HashMap<ObjectID, bool>>>>| {
+            reconciled_map
+                .lock()
+                .expect("failed to lock the reconciled map")
+                .entry(epoch)
+                .or_default()
+                .insert(node.node_capability, false);
+        }
+    );
+
+    // TODO(WAL-1341): classify why the snapshot did not certify (no quorum, or a divergence
+    // from the snapshot the network certified) from the on-chain history, and expose it through
+    // metrics; acting on a divergence is part of the recovery milestone (WAL-1252).
+    tracing::warn!(
+        walrus.epoch = epoch,
+        walrus.blob_id = %blob_id,
+        state = ?record.state(),
+        "the blob info snapshot was not certified; its stored data is cleaned up"
+    );
+    Ok(())
+}
+
+/// Stores the slivers of the shards assigned to this node in the current committee.
+///
+/// Only those sliver pairs are touched: the others belong to shards this node never looks up,
+/// including shards whose storage is being removed in the background at this boundary. A shard
+/// that is assigned but not yet owned by this node (still being synced) is skipped, as in the
+/// event blob writer.
+async fn store_own_slivers(
+    node: &Arc<StorageNodeInner>,
+    verified_metadata: &VerifiedBlobMetadataWithId,
+    sliver_pairs: &[SliverPair],
+) -> Result<()> {
+    let n_shards = node.encoding_config().n_shards();
+    let own_shards = node
+        .committee_service
+        .active_committees()
+        .current_committee()
+        .shards_for_node_public_key(node.public_key())
+        .to_vec();
+    let own_pairs: Vec<&SliverPair> = sliver_pairs
+        .iter()
+        .filter(|pair| {
+            own_shards.contains(
+                &pair
+                    .index()
+                    .to_shard_index(n_shards, verified_metadata.blob_id()),
+            )
+        })
+        .collect();
+    let metadata = Arc::new(verified_metadata.clone());
+    store_slivers_of_type(node, &metadata, &own_pairs, |pair| {
+        Sliver::Primary(pair.primary.clone())
+    })
+    .await?;
+    store_slivers_of_type(node, &metadata, &own_pairs, |pair| {
+        Sliver::Secondary(pair.secondary.clone())
+    })
+    .await
+}
+
+async fn store_slivers_of_type(
+    node: &Arc<StorageNodeInner>,
+    metadata: &Arc<VerifiedBlobMetadataWithId>,
+    sliver_pairs: &[&SliverPair],
+    sliver_of_pair: impl Fn(&SliverPair) -> Sliver,
+) -> Result<()> {
+    try_join_all(sliver_pairs.iter().map(|&sliver_pair| {
+        let metadata = metadata.clone();
+        let sliver = sliver_of_pair(sliver_pair);
+        let index: SliverPairIndex = sliver_pair.index();
+        async move {
+            match node.store_sliver_unchecked(metadata, index, sliver).await {
+                Err(StoreSliverError::ShardNotAssigned(_)) | Ok(_) => Ok(()),
+                Err(error) => Err(error),
+            }
+        }
+    }))
+    .await
+    .context("failed to store the snapshot blob slivers")?;
+    Ok(())
+}
+
+/// Encodes the snapshot into a Walrus blob and reports its blob ID, logging errors and counting
+/// them in metrics without failing the epoch change.
+///
+/// Returns `None` when the encoding failed, in which case certification cannot proceed either.
+async fn encode_snapshot(
+    node: &Arc<StorageNodeInner>,
+    epoch: Epoch,
+    snapshot_path: &Path,
+) -> Option<(Vec<SliverPair>, VerifiedBlobMetadataWithId)> {
+    match try_encode_snapshot(node, epoch, snapshot_path).await {
+        Ok(encoded) => Some(encoded),
+        Err(error) => {
+            node.metrics.blob_info_snapshot_encode_error_total.inc();
+            tracing::warn!(
+                ?error,
+                walrus.epoch = epoch,
+                "failed to encode the blob info snapshot"
+            );
+            None
+        }
+    }
+}
+
+/// Encodes the snapshot file, reports its blob ID for cross-node comparison, and returns the
+/// sliver pairs so that certification can store and attest them.
 async fn try_encode_snapshot(
     node: &Arc<StorageNodeInner>,
     epoch: Epoch,
     snapshot_path: &Path,
-) -> Result<()> {
+) -> Result<(Vec<SliverPair>, VerifiedBlobMetadataWithId)> {
     let encoding_config = node.encoding_config().get_for_type(DEFAULT_ENCODING);
     // Encoding is inherent to the protocol, so every valid system can encode. Committees of
     // fewer than four shards cannot: no shard may be faulty, so the encoding is left without
@@ -274,12 +667,24 @@ async fn try_encode_snapshot(
 
     let encode_start = Instant::now();
     let path = snapshot_path.to_path_buf();
-    let verified_metadata = tokio::task::spawn_blocking(move || {
+    let (sliver_pairs, verified_metadata) = tokio::task::spawn_blocking(move || {
         let content = fs::read(path)?;
-        // TODO(WAL-1250): certifying the snapshot needs its slivers, so this becomes a full
-        // encode rather than only the metadata.
+        // Lets a simtest make one node's snapshot blob differ from the other nodes', to exercise
+        // the divergence detection, without changing the snapshot file on disk.
+        #[cfg(msim)]
+        let content = {
+            let mut diverge = false;
+            sui_macros::fail_point_if!("storage_node_blob_info_snapshot_diverge", || {
+                diverge = true;
+            });
+            let mut content = content;
+            if diverge {
+                content.push(0);
+            }
+            content
+        };
         encoding_config
-            .compute_metadata(&content)
+            .encode_with_metadata(content)
             .map_err(anyhow::Error::from)
     })
     .await
@@ -311,7 +716,20 @@ async fn try_encode_snapshot(
         ?encode_elapsed,
         "encoded blob info snapshot"
     );
-    Ok(())
+
+    // No-op outside of simtest.
+    sui_macros::fail_point_arg!(
+        "storage_node_blob_info_snapshot_blob_id",
+        |blob_id_map: Arc<Mutex<HashMap<Epoch, HashMap<ObjectID, BlobId>>>>| {
+            blob_id_map
+                .lock()
+                .expect("failed to lock the blob id map")
+                .entry(epoch)
+                .or_default()
+                .insert(node.node_capability, blob_id);
+        }
+    );
+    Ok((sliver_pairs, verified_metadata))
 }
 
 /// Removes all snapshot files (including temporary ones) whose epoch matches `should_remove`.
@@ -343,15 +761,18 @@ mod tests {
 
     #[test]
     fn config_default_is_enabled() {
-        // Default is enabled, and an omitted field falls back to it.
+        // Default is enabled, and an omitted field falls back to it; certification is opt-in.
         assert!(BlobInfoSnapshotWriterConfig::default().enabled);
+        assert!(!BlobInfoSnapshotWriterConfig::default().certify);
         let empty: BlobInfoSnapshotWriterConfig =
             serde_yaml::from_str("{}\n").expect("config should deserialize");
         assert!(empty.enabled);
+        assert!(!empty.certify);
         // An explicit `enabled: false` still disables it.
         let disabled: BlobInfoSnapshotWriterConfig =
             serde_yaml::from_str("enabled: false\n").expect("config should deserialize");
         assert!(!disabled.enabled);
+        assert!(!disabled.certify);
     }
 
     #[test]

--- a/crates/walrus-service/src/node/contract_service.rs
+++ b/crates/walrus-service/src/node/contract_service.rs
@@ -33,7 +33,7 @@ use walrus_sui::{
         StorageNodeCap,
         UpdatePublicKeyParams,
         move_errors::{MoveExecutionError, StakingInnerError, WalrusSubsidiesInnerError},
-        move_structs::{EpochState, EventBlob},
+        move_structs::{EpochState, EventBlob, SnapshotBlob},
     },
 };
 use walrus_utils::{
@@ -114,6 +114,14 @@ pub trait SystemContractService: std::fmt::Debug + Sync + Send {
         node_capability_object_id: ObjectID,
     ) -> Result<(), SuiClientError>;
 
+    /// Certifies a blob info snapshot blob to the contract for the given epoch.
+    async fn certify_snapshot_blob(
+        &self,
+        blob_metadata: BlobObjectMetadata,
+        snapshot_epoch: u32,
+        node_capability_object_id: ObjectID,
+    ) -> Result<(), SuiClientError>;
+
     /// Refreshes the contract package that the service is using.
     async fn refresh_contract_package(&self) -> anyhow::Result<()>;
 
@@ -136,6 +144,9 @@ pub trait SystemContractService: std::fmt::Debug + Sync + Send {
 
     /// Returns the last certified event blob.
     async fn last_certified_event_blob(&self) -> Result<Option<EventBlob>, SuiClientError>;
+
+    /// Returns the last certified blob info snapshot blob.
+    async fn last_certified_snapshot_blob(&self) -> Result<Option<SnapshotBlob>, SuiClientError>;
 
     /// Flushes any cached data to ensure that the next requests are not affected by stale data.
     async fn flush_cache(&self);
@@ -651,6 +662,19 @@ impl SystemContractService for SuiSystemContractService {
             .await
     }
 
+    async fn certify_snapshot_blob(
+        &self,
+        blob_metadata: BlobObjectMetadata,
+        snapshot_epoch: u32,
+        node_capability_object_id: ObjectID,
+    ) -> Result<(), SuiClientError> {
+        self.contract_tx_client
+            .lock()
+            .await
+            .certify_snapshot_blob(blob_metadata, snapshot_epoch, node_capability_object_id)
+            .await
+    }
+
     async fn refresh_contract_package(&self) -> anyhow::Result<()> {
         self.contract_tx_client
             .lock()
@@ -698,6 +722,10 @@ impl SystemContractService for SuiSystemContractService {
 
     async fn last_certified_event_blob(&self) -> Result<Option<EventBlob>, SuiClientError> {
         self.read_client.last_certified_event_blob().await
+    }
+
+    async fn last_certified_snapshot_blob(&self) -> Result<Option<SnapshotBlob>, SuiClientError> {
+        self.read_client.last_certified_snapshot_blob().await
     }
 
     async fn flush_cache(&self) {

--- a/crates/walrus-service/src/node/epoch_change.rs
+++ b/crates/walrus-service/src/node/epoch_change.rs
@@ -296,34 +296,61 @@ impl StorageNode {
         // Serialize only when enabled, not reprocessing, and not catching up (a catching-up node's
         // blob info tables are not at the clean cross-node boundary). The node-status DB lookup
         // runs only after the other two checks short-circuit.
-        let should_serialize = self.inner.blob_info_snapshot_config.enabled
-            && !node_is_reprocessing_events
-            && !self.inner.storage.node_status()?.is_catching_up();
+        let at_clean_boundary =
+            !node_is_reprocessing_events && !self.inner.storage.node_status()?.is_catching_up();
+        let should_serialize = self.inner.blob_info_snapshot_config.enabled && at_clean_boundary;
+
+        // Report the latest certified snapshot epoch on chain, for the no-certification alert.
+        // Only a gauge depends on it, so the read runs in a background task and a slow full node
+        // cannot delay the boundary.
+        if should_serialize {
+            let node = self.inner.clone();
+            tokio::spawn(async move {
+                blob_info_snapshot_writer::report_last_certified_snapshot_epoch(&node).await;
+            });
+        }
+
+        // Reconcile the previous epoch's snapshot publication first: it decides, from the local
+        // blob info, whether that snapshot certified, and cleans up the stored data otherwise.
+        // It only touches local storage, so an error is a storage
+        // error and fails the epoch change like any other: the node stops before this boundary
+        // is marked complete and replays it on restart, so the publication below never
+        // overwrites an unreconciled record (the reconciliation is idempotent). It runs whether
+        // or not snapshots are enabled, so that disabling them after a publication still cleans
+        // that publication up; without a publication record it does nothing.
+        if at_clean_boundary {
+            blob_info_snapshot_writer::reconcile_previous_publication(&self.inner, event.epoch)
+                .await
+                .context("failed to reconcile the previous blob info snapshot publication")?;
+        }
 
         // Serialize after GC phase 1 has settled the tables and before `execute_epoch_change`
         // spawns the finisher that marks the event complete (so a crash before completion replays
         // and re-creates it). Errors are logged and counted, never failing epoch processing.
-        //
-        // TODO(WAL-1250): this only writes the snapshot to local disk. Publishing and certifying it
-        // on-chain (encode, store the node's own slivers, attest, track to certified) is future
-        // work.
-        if should_serialize
-            && let Err(error) = blob_info_snapshot_writer::serialize_snapshot_at_epoch_boundary(
-                self.inner.clone(),
+        // Everything derived from the durable file (encoding, storing, attesting) happens below,
+        // after the epoch change has been applied locally.
+        let snapshot_serialized = should_serialize
+            && match blob_info_snapshot_writer::serialize_snapshot_at_epoch_boundary(
+                &self.inner,
                 event.epoch,
                 // Mirror what the node persists after completing this event: the
                 // `EpochChangeStart`'s id, and its index + 1 as the next index to process.
                 EventStreamCursor::new(Some(event_handle.event_id()), event_index + 1),
             )
             .await
-        {
-            self.inner.metrics.blob_info_snapshot_error_total.inc();
-            tracing::warn!(
-                ?error,
-                walrus.epoch = event.epoch,
-                "failed to serialize the blob info snapshot in-process at the epoch boundary"
-            );
-        }
+            {
+                Ok(()) => true,
+                Err(error) => {
+                    self.inner.metrics.blob_info_snapshot_error_total.inc();
+                    tracing::warn!(
+                        ?error,
+                        walrus.epoch = event.epoch,
+                        "failed to serialize the blob info snapshot in-process at the epoch \
+                        boundary"
+                    );
+                    false
+                }
+            };
 
         // Now the general tasks around epoch change are done. Next, entering epoch change logic
         // to bring the node state to the next epoch. `execute_epoch_change` ends by spawning
@@ -338,6 +365,23 @@ impl StorageNode {
         self.inner
             .latest_event_epoch_sender
             .send(Some(event.epoch))?;
+
+        // Publish the snapshot (encode; store and attest when configured) only now:
+        // `execute_epoch_change` has advanced the committee and created this node's shards for
+        // the new epoch, so the slivers are stored under the assignment the contract tallies by
+        // and readers route by. Still inline, to measure the full cost at the boundary; the
+        // finisher may already have marked the event complete, so a crash from here on skips
+        // this epoch's publication (absorbed by the quorum; resume is TODO(WAL-1252)).
+        // A node that discovered inside `execute_epoch_change` that it is far behind enters
+        // catch-up there; its snapshot is then stale and its committee view has moved on, so
+        // the publication is skipped like the serialization would have been.
+        if snapshot_serialized && !self.inner.storage.node_status()?.is_catching_up() {
+            blob_info_snapshot_writer::publish_snapshot_after_epoch_change(
+                &self.inner,
+                event.epoch,
+            )
+            .await;
+        }
 
         // Schedule post-epoch-change subsidies to distribute usage-independent subsidies
         // for the epoch that just ended.

--- a/crates/walrus-service/src/node/metrics.rs
+++ b/crates/walrus-service/src/node/metrics.rs
@@ -239,6 +239,20 @@ walrus_utils::metrics::define_metric_set! {
         is epoch % SNAPSHOT_EPOCH_BUCKET_COUNT (see blob_info_snapshot_writer.rs)."]
         blob_info_snapshot_blob_id: IntGaugeVec["epoch"],
 
+        #[help = "The duration of the certify_snapshot_blob contract call, in seconds."]
+        blob_info_snapshot_certify_duration_seconds: Gauge[],
+
+        #[help = "The number of errors while certifying blob info snapshots."]
+        blob_info_snapshot_certify_error_total: IntCounter[],
+
+        #[help = "The number of blob info snapshot publications found uncertified at the next \
+        epoch boundary and cleaned up (no quorum, divergence, or a failed publication)."]
+        blob_info_snapshot_uncertified_cleanup_total: IntCounter[],
+
+        #[help = "The epoch of the latest blob info snapshot certified on chain, as read by this \
+        node at its last epoch boundary; 0 until a certification has been observed."]
+        blob_info_snapshot_last_certified_epoch: IntGauge[],
+
         #[help = "The number of certified per-object blobs scanned during the per-object blob info \
         consistency check."]
         per_object_blob_info_consistency_check_certified_scanned: IntCounterVec["epoch"],

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -83,6 +83,9 @@ mod metrics;
 mod pending_recover_blobs;
 pub(crate) use pending_recover_blobs::PendingRecoverBlob;
 use pending_recover_blobs::PendingRecoverBlobsTable;
+mod blob_info_snapshot_publication;
+use blob_info_snapshot_publication::SnapshotPublicationTable;
+pub(crate) use blob_info_snapshot_publication::{SnapshotPublication, SnapshotPublicationState};
 
 mod shard;
 
@@ -347,6 +350,7 @@ pub struct Storage {
     blob_info: BlobInfoTable,
     event_cursor: EventCursorTable,
     pending_recover_blobs: PendingRecoverBlobsTable,
+    snapshot_publication: SnapshotPublicationTable,
     garbage_collector_table: DBMap<String, Epoch>,
     shards: Arc<RwLock<HashMap<ShardIndex, Arc<ShardStorage>>>>,
     db_table_opts_factory: DatabaseTableOptionsFactory,
@@ -447,6 +451,8 @@ impl Storage {
             EventCursorTable::options(&db_table_opts_factory);
         let (pending_recover_blobs_cf_name, pending_recover_blobs_options) =
             PendingRecoverBlobsTable::options(&db_table_opts_factory);
+        let (snapshot_publication_cf_name, snapshot_publication_options) =
+            SnapshotPublicationTable::options(&db_table_opts_factory);
         let garbage_collector_table_cf_name = garbage_collector_table_cf_name();
         let garbage_collector_table_options = db_table_opts_factory.garbage_collector();
 
@@ -458,6 +464,7 @@ impl Storage {
                 (metadata_cf_name, metadata_options),
                 (event_cursor_cf_name, event_cursor_options),
                 (pending_recover_blobs_cf_name, pending_recover_blobs_options),
+                (snapshot_publication_cf_name, snapshot_publication_options),
                 (
                     garbage_collector_table_cf_name,
                     garbage_collector_table_options,
@@ -524,6 +531,7 @@ impl Storage {
 
         let event_cursor = EventCursorTable::reopen(&database)?;
         let pending_recover_blobs = PendingRecoverBlobsTable::reopen(&database)?;
+        let snapshot_publication = SnapshotPublicationTable::reopen(&database)?;
         let blob_info = BlobInfoTable::reopen(&database)?;
         let shards = Arc::new(RwLock::new(
             existing_shards_ids
@@ -553,6 +561,7 @@ impl Storage {
             blob_info,
             event_cursor,
             pending_recover_blobs,
+            snapshot_publication,
             garbage_collector_table,
             shards,
             db_table_opts_factory,
@@ -1552,6 +1561,26 @@ impl Storage {
     }
 
     /// Returns the number of pending-recovery records.
+    /// Returns the current blob info snapshot publication record, if any.
+    pub(crate) fn snapshot_publication(
+        &self,
+    ) -> Result<Option<SnapshotPublication>, TypedStoreError> {
+        self.snapshot_publication.get()
+    }
+
+    /// Sets the current blob info snapshot publication record.
+    pub(crate) fn set_snapshot_publication(
+        &self,
+        record: &SnapshotPublication,
+    ) -> Result<(), TypedStoreError> {
+        self.snapshot_publication.set(record)
+    }
+
+    /// Removes the current blob info snapshot publication record.
+    pub(crate) fn clear_snapshot_publication(&self) -> Result<(), TypedStoreError> {
+        self.snapshot_publication.clear()
+    }
+
     pub(crate) fn pending_recover_blob_count(&self) -> u64 {
         self.pending_recover_blobs.count()
     }

--- a/crates/walrus-service/src/node/storage/blob_info_snapshot_publication.rs
+++ b/crates/walrus-service/src/node/storage/blob_info_snapshot_publication.rs
@@ -1,0 +1,133 @@
+// Copyright (c) Walrus Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! The record of the blob info snapshot this node is publishing (storing and attesting).
+//!
+//! A snapshot that is not certified during its epoch is never certified: the contract rejects
+//! attestations for any epoch but the current one, and the next epoch produces a different blob
+//! ID. Metadata and slivers stored for such a snapshot have no blob-info entry and are therefore
+//! invisible to garbage collection, so the node tracks every publication attempt durably, from
+//! before the first write, and reconciles it at the next epoch boundary (see
+//! `blob_info_snapshot_writer::reconcile_previous_publication`).
+
+use std::sync::Arc;
+
+use rocksdb::Options;
+use serde::{Deserialize, Serialize};
+use typed_store::{
+    Map,
+    TypedStoreError,
+    rocks::{DBMap, ReadWriteOptions, RocksDB},
+};
+use walrus_core::{BlobId, Epoch};
+
+use super::{DatabaseTableOptionsFactory, constants::blob_info_snapshot_publication_cf_name};
+
+/// The progress of a snapshot publication attempt.
+#[derive(Eq, PartialEq, Debug, Clone, Copy, Deserialize, Serialize)]
+pub(crate) enum SnapshotPublicationState {
+    /// The record is written; metadata and slivers may be partially stored.
+    Pending,
+    /// The metadata and this node's slivers are stored.
+    Stored,
+    /// The snapshot blob is attested on chain.
+    Attested,
+    /// The snapshot blob is certified on chain.
+    Certified,
+}
+
+/// A versioned snapshot publication record.
+#[derive(Eq, PartialEq, Debug, Clone, Deserialize, Serialize)]
+pub(crate) enum SnapshotPublication {
+    V1(SnapshotPublicationV1),
+}
+
+/// Version 1 of the snapshot publication record.
+#[derive(Eq, PartialEq, Debug, Clone, Deserialize, Serialize)]
+pub(crate) struct SnapshotPublicationV1 {
+    epoch: Epoch,
+    blob_id: BlobId,
+    state: SnapshotPublicationState,
+}
+
+impl SnapshotPublication {
+    /// Creates a pending publication record for the snapshot of `epoch` with the given blob ID.
+    pub fn new(epoch: Epoch, blob_id: BlobId) -> Self {
+        Self::V1(SnapshotPublicationV1 {
+            epoch,
+            blob_id,
+            state: SnapshotPublicationState::Pending,
+        })
+    }
+
+    /// Returns the epoch of the snapshot.
+    pub fn epoch(&self) -> Epoch {
+        match self {
+            Self::V1(v1) => v1.epoch,
+        }
+    }
+
+    /// Returns the blob ID of the snapshot.
+    pub fn blob_id(&self) -> BlobId {
+        match self {
+            Self::V1(v1) => v1.blob_id,
+        }
+    }
+
+    /// Returns the state of the publication.
+    pub fn state(&self) -> SnapshotPublicationState {
+        match self {
+            Self::V1(v1) => v1.state,
+        }
+    }
+
+    /// Returns the record with the given state.
+    pub fn with_state(&self, state: SnapshotPublicationState) -> Self {
+        match self {
+            Self::V1(v1) => Self::V1(SnapshotPublicationV1 {
+                state,
+                ..v1.clone()
+            }),
+        }
+    }
+}
+
+/// The table holding the single current snapshot publication record.
+#[derive(Debug, Clone)]
+pub(super) struct SnapshotPublicationTable {
+    inner: DBMap<(), SnapshotPublication>,
+}
+
+impl SnapshotPublicationTable {
+    pub fn reopen(database: &Arc<RocksDB>) -> Result<Self, TypedStoreError> {
+        let inner = DBMap::reopen(
+            database,
+            Some(blob_info_snapshot_publication_cf_name()),
+            &ReadWriteOptions::default(),
+            false,
+        )?;
+        Ok(Self { inner })
+    }
+
+    pub fn options(db_table_opts_factory: &DatabaseTableOptionsFactory) -> (&'static str, Options) {
+        (
+            blob_info_snapshot_publication_cf_name(),
+            db_table_opts_factory.blob_info_snapshot_publication(),
+        )
+    }
+
+    /// Returns the current publication record, if any.
+    pub fn get(&self) -> Result<Option<SnapshotPublication>, TypedStoreError> {
+        self.inner.get(&())
+    }
+
+    /// Sets the current publication record, replacing any previous one.
+    pub fn set(&self, record: &SnapshotPublication) -> Result<(), TypedStoreError> {
+        self.inner.insert(&(), record)
+    }
+
+    /// Removes the current publication record.
+    pub fn clear(&self) -> Result<(), TypedStoreError> {
+        self.inner.remove(&())
+    }
+}

--- a/crates/walrus-service/src/node/storage/constants.rs
+++ b/crates/walrus-service/src/node/storage/constants.rs
@@ -17,6 +17,7 @@ const GARBAGE_COLLECTOR_TABLE_COLUMN_FAMILY_NAME: &str = "garbage_collector_last
 const GARBAGE_COLLECTOR_LAST_STARTED_EPOCH_KEY: &str = "started";
 const GARBAGE_COLLECTOR_LAST_COMPLETED_EPOCH_KEY: &str = "completed";
 const PENDING_RECOVER_BLOBS_COLUMN_FAMILY_NAME: &str = "pending_recover_blobs";
+const BLOB_INFO_SNAPSHOT_PUBLICATION_COLUMN_FAMILY_NAME: &str = "blob_info_snapshot_publication";
 
 // Base name for shard-related column families
 const SHARD_BASE_COLUMN_FAMILY_NAME: &str = "shard";
@@ -93,6 +94,11 @@ pub fn pending_recover_blobs_cf_name() -> &'static str {
     PENDING_RECOVER_BLOBS_COLUMN_FAMILY_NAME
 }
 
+/// Returns the name of the blob info snapshot publication column family.
+pub fn blob_info_snapshot_publication_cf_name() -> &'static str {
+    BLOB_INFO_SNAPSHOT_PUBLICATION_COLUMN_FAMILY_NAME
+}
+
 /// Returns the column family name for primary slivers of a shard.
 pub fn primary_slivers_column_family_name(id: ShardIndex) -> String {
     format!(
@@ -151,6 +157,10 @@ mod tests {
         assert_eq!(node_status_cf_name(), "node_status");
         assert_eq!(event_index_cf_name(), "latest_handled_event_index");
         assert_eq!(pending_recover_blobs_cf_name(), "pending_recover_blobs");
+        assert_eq!(
+            blob_info_snapshot_publication_cf_name(),
+            "blob_info_snapshot_publication"
+        );
 
         let shard = ShardIndex(900);
         assert_eq!(base_column_family_name(shard), "shard-900");

--- a/crates/walrus-service/src/node/storage/database_config.rs
+++ b/crates/walrus-service/src/node/storage/database_config.rs
@@ -350,6 +350,8 @@ pub struct DatabaseConfig {
     pub(super) event_cursor: Option<DatabaseTableOptions>,
     /// Pending recover blobs database options.
     pub(super) pending_recover_blobs: Option<DatabaseTableOptions>,
+    /// Blob info snapshot publication database options.
+    pub(super) blob_info_snapshot_publication: Option<DatabaseTableOptions>,
     /// Shard database options.
     pub(super) shard: Option<DatabaseTableOptions>,
     /// Shard status database options.
@@ -475,6 +477,11 @@ impl DatabaseConfig {
         Self::inherit_from_or_use_template(&self.pending_recover_blobs, self.standard())
     }
 
+    /// Returns the blob info snapshot publication database option.
+    pub fn blob_info_snapshot_publication(&self) -> DatabaseTableOptions {
+        Self::inherit_from_or_use_template(&self.blob_info_snapshot_publication, self.standard())
+    }
+
     /// Returns the shard database option.
     pub fn shard(&self) -> DatabaseTableOptions {
         Self::inherit_from_or_use_template(&self.shard, self.optimized_for_blobs())
@@ -557,6 +564,7 @@ impl Default for DatabaseConfig {
             storage_pool_info: None,
             event_cursor: None,
             pending_recover_blobs: None,
+            blob_info_snapshot_publication: None,
             shard: None,
             shard_status: None,
             shard_sync_progress: None,
@@ -782,6 +790,11 @@ impl DatabaseTableOptionsFactory {
     /// Returns the pending recover blobs database option.
     pub fn pending_recover_blobs(&self) -> Options {
         self.to_options(&self.config.pending_recover_blobs(), false)
+    }
+
+    /// Returns the blob info snapshot publication database option.
+    pub fn blob_info_snapshot_publication(&self) -> Options {
+        self.to_options(&self.config.blob_info_snapshot_publication(), false)
     }
 
     // Below 4 options are for shard storage column families.

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -96,6 +96,7 @@ use crate::{
         GarbageCollectionConfig,
         Storage,
         StorageNode,
+        blob_info_snapshot_writer::BlobInfoSnapshotWriterConfig,
         committee::{
             BeginCommitteeChangeError,
             CommitteeLookupService,
@@ -225,6 +226,7 @@ pub struct TestNodesConfig {
     blocklist_dir: Option<PathBuf>,
     enable_node_config_synchronizer: bool,
     node_recovery_config: Option<NodeRecoveryConfig>,
+    blob_info_snapshot_certify: Vec<bool>,
 }
 
 impl TestNodesConfig {
@@ -253,6 +255,13 @@ impl TestNodesConfig {
         self.node_recovery_config.as_ref()
     }
 
+    /// Returns, per node, whether the node certifies blob info snapshots on chain.
+    ///
+    /// Empty if no node certifies.
+    pub fn blob_info_snapshot_certify(&self) -> &[bool] {
+        &self.blob_info_snapshot_certify
+    }
+
     /// Creates a new builder for `TestNodesConfig`.
     pub fn builder() -> TestNodesConfigBuilder {
         TestNodesConfigBuilder::new()
@@ -273,6 +282,7 @@ pub struct TestNodesConfigBuilder {
     blocklist_dir: Option<PathBuf>,
     enable_node_config_synchronizer: bool,
     node_recovery_config: Option<NodeRecoveryConfig>,
+    blob_info_snapshot_certify: Vec<bool>,
 }
 
 impl Default for TestNodesConfigBuilder {
@@ -294,6 +304,7 @@ impl TestNodesConfigBuilder {
             blocklist_dir: None,
             enable_node_config_synchronizer: false,
             node_recovery_config: None,
+            blob_info_snapshot_certify: vec![],
         }
     }
 
@@ -336,6 +347,14 @@ impl TestNodesConfigBuilder {
         self
     }
 
+    /// Sets, per node, whether the node certifies blob info snapshots on chain.
+    ///
+    /// The slice must have one entry per node weight.
+    pub fn with_blob_info_snapshot_certify(mut self, certify: &[bool]) -> Self {
+        self.blob_info_snapshot_certify = certify.to_vec();
+        self
+    }
+
     /// Builds the [`TestNodesConfig`], validating constraints.
     ///
     /// # Panics
@@ -353,12 +372,22 @@ impl TestNodesConfigBuilder {
             );
         }
 
+        assert!(
+            self.blob_info_snapshot_certify.is_empty()
+                || self.blob_info_snapshot_certify.len() == self.node_weights.len(),
+            "TestNodesConfig: blob_info_snapshot_certify must have one entry per node, but \
+            {:?} was given for node_weights {:?}.",
+            self.blob_info_snapshot_certify,
+            self.node_weights
+        );
+
         TestNodesConfig {
             node_weights: self.node_weights,
             disable_event_blob_writer: self.disable_event_blob_writer,
             blocklist_dir: self.blocklist_dir,
             enable_node_config_synchronizer: self.enable_node_config_synchronizer,
             node_recovery_config: self.node_recovery_config,
+            blob_info_snapshot_certify: self.blob_info_snapshot_certify,
         }
     }
 }
@@ -872,6 +901,7 @@ pub struct StorageNodeHandleBuilder {
     garbage_collection_config: Option<GarbageCollectionConfig>,
     event_stream_catchup_min_checkpoint_lag: Option<u64>,
     max_epochs_ahead: Option<u32>,
+    blob_info_snapshot_certify: bool,
 }
 
 impl StorageNodeHandleBuilder {
@@ -949,6 +979,12 @@ impl StorageNodeHandleBuilder {
     /// Enable or disable event blob writer on the node.
     pub fn with_disabled_event_blob_writer(mut self, disable: bool) -> Self {
         self.disable_event_blob_writer = disable;
+        self
+    }
+
+    /// Enable or disable certifying blob info snapshots on chain.
+    pub fn with_blob_info_snapshot_certify(mut self, certify: bool) -> Self {
+        self.blob_info_snapshot_certify = certify;
         self
     }
 
@@ -1114,6 +1150,10 @@ impl StorageNodeHandleBuilder {
             blocklist_path: self.blocklist_path,
             shard_sync_config: self.shard_sync_config.unwrap_or_default(),
             disable_event_blob_writer: self.disable_event_blob_writer,
+            blob_info_snapshot: BlobInfoSnapshotWriterConfig {
+                certify: self.blob_info_snapshot_certify,
+                ..Default::default()
+            },
             config_synchronizer: ConfigSynchronizerConfig {
                 interval: Duration::from_secs(5),
                 enabled: self.enable_node_config_synchronizer,
@@ -1295,6 +1335,10 @@ impl StorageNodeHandleBuilder {
             },
             pending_sliver_cache: Default::default(),
             disable_event_blob_writer,
+            blob_info_snapshot: BlobInfoSnapshotWriterConfig {
+                certify: self.blob_info_snapshot_certify,
+                ..Default::default()
+            },
             sui: Some(SuiConfig {
                 rpc: sui_rpc_urls.remove(0),
                 contract_config: ContractConfig::new(
@@ -1407,6 +1451,7 @@ impl Default for StorageNodeHandleBuilder {
             garbage_collection_config: None,
             event_stream_catchup_min_checkpoint_lag: None,
             max_epochs_ahead: None,
+            blob_info_snapshot_certify: false,
         }
     }
 }
@@ -2069,6 +2114,7 @@ pub struct TestClusterBuilder {
     num_checkpoints_per_blob: Option<u32>,
     blocklist_files: Vec<Option<PathBuf>>,
     disable_event_blob_writer: Vec<bool>,
+    blob_info_snapshot_certify: Vec<bool>,
     enable_node_config_synchronizer: bool,
     node_recovery_config: Option<NodeRecoveryConfig>,
     event_stream_catchup_min_checkpoint_lag: Option<u64>,
@@ -2127,6 +2173,7 @@ impl TestClusterBuilder {
         self.committee_services = configs.iter().map(|_| None).collect();
         self.storage_capabilities = configs.iter().map(|_| None).collect();
         self.node_wallet_dirs = configs.iter().map(|_| None).collect();
+        self.blob_info_snapshot_certify = configs.iter().map(|_| false).collect();
         self.storage_node_configs = configs;
 
         self.n_shards = assignment
@@ -2251,6 +2298,14 @@ impl TestClusterBuilder {
         self
     }
 
+    /// Specifies, per node, whether the node certifies blob info snapshots on chain.
+    ///
+    /// Should be called after the storage nodes have been specified.
+    pub fn with_blob_info_snapshot_certify(mut self, certify: Vec<bool>) -> Self {
+        self.blob_info_snapshot_certify = certify;
+        self
+    }
+
     /// Sets the sui wallet config directory for each storage node.
     pub fn with_blocklist_files(mut self, blocklist_files: Vec<PathBuf>) -> Self {
         self.blocklist_files = blocklist_files.into_iter().map(Some).collect();
@@ -2303,6 +2358,7 @@ impl TestClusterBuilder {
             start_node_from_beginning: bool,
             blocklist_file: Option<PathBuf>,
             disable_event_blob_writer: bool,
+            blob_info_snapshot_certify: bool,
         }
 
         let node_setups = izip!(
@@ -2314,7 +2370,8 @@ impl TestClusterBuilder {
             self.node_wallet_dirs.into_iter(),
             self.start_node_from_beginning.into_iter(),
             self.blocklist_files.into_iter(),
-            self.disable_event_blob_writer.into_iter()
+            self.disable_event_blob_writer.into_iter(),
+            self.blob_info_snapshot_certify.into_iter()
         )
         .map(
             |(
@@ -2327,6 +2384,7 @@ impl TestClusterBuilder {
                 start_node_from_beginning,
                 blocklist_file,
                 disable_event_blob_writer,
+                blob_info_snapshot_certify,
             )| NodeSetup {
                 storage_node_config,
                 event_provider,
@@ -2337,6 +2395,7 @@ impl TestClusterBuilder {
                 start_node_from_beginning,
                 blocklist_file,
                 disable_event_blob_writer,
+                blob_info_snapshot_certify,
             },
         )
         .collect::<Vec<_>>();
@@ -2354,6 +2413,7 @@ impl TestClusterBuilder {
                 .with_blocklist_file(node_setup.blocklist_file)
                 .with_shard_sync_config(self.shard_sync_config.clone().unwrap_or_default())
                 .with_disabled_event_blob_writer(node_setup.disable_event_blob_writer)
+                .with_blob_info_snapshot_certify(node_setup.blob_info_snapshot_certify)
                 .with_enable_node_config_synchronizer(self.enable_node_config_synchronizer)
                 .with_node_recovery_config(self.node_recovery_config.clone().unwrap_or_default())
                 .with_event_stream_catchup_min_checkpoint_lag(
@@ -2565,6 +2625,7 @@ impl Default for TestClusterBuilder {
             start_node_from_beginning: shard_assignment.iter().map(|_| true).collect(),
             blocklist_files: shard_assignment.iter().map(|_| None).collect(),
             disable_event_blob_writer: shard_assignment.iter().map(|_| false).collect(),
+            blob_info_snapshot_certify: shard_assignment.iter().map(|_| false).collect(),
             storage_node_configs: shard_assignment
                 .into_iter()
                 .map(|shards| StorageNodeTestConfig::new(shards, false))
@@ -2943,6 +3004,7 @@ pub mod test_cluster {
             let mut node_wallet_dirs = Vec::with_capacity(n_nodes);
             let mut blocklist_files = Vec::with_capacity(n_nodes);
             let mut disable_event_blob_writers = Vec::with_capacity(n_nodes);
+            let mut blob_info_snapshot_certify = Vec::with_capacity(n_nodes);
 
             for (i, wallet) in
                 test_utils::create_and_fund_wallets_on_cluster(sui_cluster.clone(), n_nodes)
@@ -2970,6 +3032,13 @@ pub mod test_cluster {
                 let blocklist_dir = test_nodes_config.blocklist_dir.clone().unwrap_or(temp_dir);
                 blocklist_files.push(blocklist_dir.join(format!("blocklist-{i}.yaml")));
                 disable_event_blob_writers.push(test_nodes_config.disable_event_blob_writer);
+                blob_info_snapshot_certify.push(
+                    test_nodes_config
+                        .blob_info_snapshot_certify
+                        .get(i)
+                        .copied()
+                        .unwrap_or(false),
+                );
                 // In simtest, storage nodes load the Sui wallet config from the `temp_dir`. We
                 // need to keep the directory alive throughout the test.
                 #[cfg(msim)]
@@ -3071,6 +3140,7 @@ pub mod test_cluster {
                         .collect(),
                 )
                 .with_disable_event_blob_writer(disable_event_blob_writers)
+                .with_blob_info_snapshot_certify(blob_info_snapshot_certify)
                 .with_blocklist_files(blocklist_files)
                 .with_enable_node_config_synchronizer(
                     test_nodes_config.enable_node_config_synchronizer,

--- a/crates/walrus-service/src/test_utils.rs
+++ b/crates/walrus-service/src/test_utils.rs
@@ -72,7 +72,7 @@ use walrus_sui::{
         NodeRegistrationParams,
         StorageNode as SuiStorageNode,
         StorageNodeCap,
-        move_structs::{EpochState, EventBlob, NodeMetadata},
+        move_structs::{EpochState, EventBlob, NodeMetadata, SnapshotBlob},
     },
 };
 use walrus_test_utils::WithTempDir;
@@ -1855,6 +1855,19 @@ impl SystemContractService for StubContractService {
         Ok(None)
     }
 
+    async fn certify_snapshot_blob(
+        &self,
+        _blob_metadata: BlobObjectMetadata,
+        _snapshot_epoch: u32,
+        _node_capability_object_id: ObjectID,
+    ) -> Result<(), SuiClientError> {
+        Ok(())
+    }
+
+    async fn last_certified_snapshot_blob(&self) -> Result<Option<SnapshotBlob>, SuiClientError> {
+        Ok(None)
+    }
+
     fn is_subsidies_object_configured(&self) -> bool {
         false
     }
@@ -2655,6 +2668,22 @@ where
 
     async fn last_certified_event_blob(&self) -> Result<Option<EventBlob>, SuiClientError> {
         self.as_ref().inner.last_certified_event_blob().await
+    }
+
+    async fn certify_snapshot_blob(
+        &self,
+        blob_metadata: BlobObjectMetadata,
+        snapshot_epoch: u32,
+        node_capability_object_id: ObjectID,
+    ) -> Result<(), SuiClientError> {
+        self.as_ref()
+            .inner
+            .certify_snapshot_blob(blob_metadata, snapshot_epoch, node_capability_object_id)
+            .await
+    }
+
+    async fn last_certified_snapshot_blob(&self) -> Result<Option<SnapshotBlob>, SuiClientError> {
+        self.as_ref().inner.last_certified_snapshot_blob().await
     }
 
     fn is_subsidies_object_configured(&self) -> bool {

--- a/crates/walrus-simtest/Cargo.toml
+++ b/crates/walrus-simtest/Cargo.toml
@@ -22,6 +22,7 @@ sui-types.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+twox-hash.workspace = true
 typed-store.workspace = true
 walrus-core.workspace = true
 walrus-proc-macros = { workspace = true, features = ["walrus-simtest"] }

--- a/crates/walrus-simtest/src/test_utils.rs
+++ b/crates/walrus-simtest/src/test_utils.rs
@@ -7,7 +7,11 @@
 pub mod simtest_utils {
     use std::{
         collections::{HashMap, HashSet},
-        sync::{Arc, Mutex, atomic::AtomicBool},
+        sync::{
+            Arc,
+            Mutex,
+            atomic::{AtomicBool, AtomicUsize},
+        },
         time::{Duration, Instant},
     };
 
@@ -17,6 +21,7 @@ pub mod simtest_utils {
     use sui_types::base_types::ObjectID;
     use tokio::{sync::RwLock, task::JoinHandle};
     use walrus_core::{
+        BlobId,
         Epoch,
         EpochCount,
         encoding::{Primary, Secondary},
@@ -35,7 +40,7 @@ pub mod simtest_utils {
     use walrus_storage_node_client::api::ServiceHealthInfo;
     use walrus_sui::{
         client::{BlobPersistence, ReadClient, SuiContractClient},
-        types::move_structs::EventBlob,
+        types::move_structs::{EventBlob, SnapshotBlob},
     };
     use walrus_test_utils::WithTempDir;
 
@@ -115,6 +120,87 @@ pub mod simtest_utils {
             tokio::time::sleep(Duration::from_secs(1)).await;
         }
         None
+    }
+
+    /// Makes the blob info snapshot blob of the given node differ from the other nodes' from now
+    /// on, so that its publications diverge from the certified snapshot.
+    ///
+    /// The snapshot file is left untouched; the node encodes a modified copy, so the digest
+    /// consistency check still passes.
+    pub fn diverge_blob_info_snapshot_of_node(node: &SimStorageNodeHandle) {
+        let target_node_id = node.node_id.expect("simulator nodes have a node id");
+        sui_macros::register_fail_point_if("storage_node_blob_info_snapshot_diverge", move || {
+            sui_simulator::current_simnode_id() == target_node_id
+        });
+    }
+
+    /// Crashes each of the given nodes once, the next time it reconciles a previous blob info
+    /// snapshot publication at an epoch boundary, where a storage error would stop the node.
+    /// The node restarts after `down_duration` and replays the boundary.
+    ///
+    /// Returns a counter of the crashes that have happened.
+    pub fn crash_nodes_once_at_blob_info_snapshot_reconciliation<'a>(
+        nodes: impl IntoIterator<Item = &'a SimStorageNodeHandle>,
+        down_duration: Duration,
+    ) -> Arc<AtomicUsize> {
+        let remaining: Arc<Mutex<HashSet<_>>> = Arc::new(Mutex::new(
+            nodes
+                .into_iter()
+                .map(|node| node.node_id.expect("simulator nodes have a node id"))
+                .collect(),
+        ));
+        let crashes = Arc::new(AtomicUsize::new(0));
+        let crashes_clone = crashes.clone();
+        sui_macros::register_fail_point_async(
+            "storage_node_blob_info_snapshot_reconcile",
+            move || {
+                let remaining = remaining.clone();
+                let crashes = crashes_clone.clone();
+                async move {
+                    let current_node = sui_simulator::current_simnode_id();
+                    if !remaining.lock().unwrap().remove(&current_node) {
+                        return;
+                    }
+                    crashes.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    tracing::info!(
+                        ?current_node,
+                        "crashing the node at the blob info snapshot reconciliation"
+                    );
+                    sui_simulator::task::kill_current_node(Some(down_duration));
+                    // Do not put any code after this point, as it won't be executed.
+                    // kill_current_node is implemented using a panic.
+                }
+            },
+        );
+        crashes
+    }
+
+    /// Waits until the last certified blob info snapshot on chain is of `min_epoch` or later, and
+    /// returns it.
+    pub async fn wait_for_certified_snapshot_blob(
+        client: &Arc<WithTempDir<WalrusNodeClient<SuiContractClient>>>,
+        min_epoch: Epoch,
+        timeout: Duration,
+    ) -> SnapshotBlob {
+        let start = Instant::now();
+        loop {
+            let latest = client
+                .inner
+                .sui_client()
+                .read_client
+                .last_certified_snapshot_blob()
+                .await
+                .expect("reading the certified blob info snapshot should succeed");
+            match latest {
+                Some(snapshot) if snapshot.epoch >= min_epoch => return snapshot,
+                latest => assert!(
+                    start.elapsed() < timeout,
+                    "timed out waiting for a certified blob info snapshot of epoch {min_epoch} or \
+                    later; latest: {latest:?}"
+                ),
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
     }
 
     /// Helper function to write a random blob, read it back and check that it is the same.
@@ -466,6 +552,13 @@ pub mod simtest_utils {
         // Per epoch, the blob info snapshot digest of all nodes, paired with the number of
         // entries the snapshot holds in its two pool sections.
         blob_info_snapshot_digest_map: Arc<Mutex<HashMap<Epoch, HashMap<ObjectID, u64>>>>,
+        // Per epoch, the blob info snapshot blob ID of all nodes.
+        blob_info_snapshot_blob_id_map: Arc<Mutex<HashMap<Epoch, HashMap<ObjectID, BlobId>>>>,
+        // Per epoch, the blob ID of the blob info snapshot each node stored for certification.
+        blob_info_snapshot_stored_map: Arc<Mutex<HashMap<Epoch, HashMap<ObjectID, BlobId>>>>,
+        // Per epoch, whether each node found its blob info snapshot certified when reconciling
+        // the publication at the next epoch boundary (`false` means it was cleaned up).
+        blob_info_snapshot_reconciled_map: Arc<Mutex<HashMap<Epoch, HashMap<ObjectID, bool>>>>,
         checked: Arc<AtomicBool>,
     }
 
@@ -484,6 +577,12 @@ pub mod simtest_utils {
             let blob_existence_check_map_clone = blob_existence_check_map.clone();
             let blob_info_snapshot_digest_map = Arc::new(Mutex::new(HashMap::new()));
             let blob_info_snapshot_digest_map_clone = blob_info_snapshot_digest_map.clone();
+            let blob_info_snapshot_blob_id_map = Arc::new(Mutex::new(HashMap::new()));
+            let blob_info_snapshot_blob_id_map_clone = blob_info_snapshot_blob_id_map.clone();
+            let blob_info_snapshot_stored_map = Arc::new(Mutex::new(HashMap::new()));
+            let blob_info_snapshot_stored_map_clone = blob_info_snapshot_stored_map.clone();
+            let blob_info_snapshot_reconciled_map = Arc::new(Mutex::new(HashMap::new()));
+            let blob_info_snapshot_reconciled_map_clone = blob_info_snapshot_reconciled_map.clone();
 
             sui_macros::register_fail_point_arg(
                 "storage_node_event_index_source",
@@ -527,6 +626,27 @@ pub mod simtest_utils {
                 },
             );
 
+            sui_macros::register_fail_point_arg(
+                "storage_node_blob_info_snapshot_blob_id",
+                move || -> Option<Arc<Mutex<HashMap<Epoch, HashMap<ObjectID, BlobId>>>>> {
+                    Some(blob_info_snapshot_blob_id_map_clone.clone())
+                },
+            );
+
+            sui_macros::register_fail_point_arg(
+                "storage_node_blob_info_snapshot_stored",
+                move || -> Option<Arc<Mutex<HashMap<Epoch, HashMap<ObjectID, BlobId>>>>> {
+                    Some(blob_info_snapshot_stored_map_clone.clone())
+                },
+            );
+
+            sui_macros::register_fail_point_arg(
+                "storage_node_blob_info_snapshot_reconciled",
+                move || -> Option<Arc<Mutex<HashMap<Epoch, HashMap<ObjectID, bool>>>>> {
+                    Some(blob_info_snapshot_reconciled_map_clone.clone())
+                },
+            );
+
             Self {
                 event_source_map,
                 certified_blob_digest_map,
@@ -534,6 +654,9 @@ pub mod simtest_utils {
                 per_object_pooled_blob_digest_map,
                 blob_existence_check_map,
                 blob_info_snapshot_digest_map,
+                blob_info_snapshot_blob_id_map,
+                blob_info_snapshot_stored_map,
+                blob_info_snapshot_reconciled_map,
                 checked: Arc::new(AtomicBool::new(false)),
             }
         }
@@ -591,6 +714,117 @@ pub mod simtest_utils {
                     continue;
                 }
                 Self::check_digests_are_equal(*epoch, node_digest_map);
+            }
+        }
+
+        /// Returns the blob info snapshot digest each node reported for `epoch`.
+        pub fn blob_info_snapshot_digests(&self, epoch: Epoch) -> HashMap<ObjectID, u64> {
+            self.blob_info_snapshot_digest_map
+                .lock()
+                .unwrap()
+                .get(&epoch)
+                .cloned()
+                .unwrap_or_default()
+        }
+
+        /// Returns the blob info snapshot blob ID each node reported for `epoch`.
+        pub fn blob_info_snapshot_blob_ids(&self, epoch: Epoch) -> HashMap<ObjectID, BlobId> {
+            Self::entries_for_epoch(&self.blob_info_snapshot_blob_id_map, epoch)
+        }
+
+        /// Waits until `n_nodes` nodes have reported their blob info snapshot blob ID for `epoch`
+        /// and returns the blob IDs.
+        pub async fn wait_for_blob_info_snapshot_blob_ids(
+            &self,
+            epoch: Epoch,
+            n_nodes: usize,
+            timeout: Duration,
+        ) -> HashMap<ObjectID, BlobId> {
+            Self::wait_for_entries(
+                &self.blob_info_snapshot_blob_id_map,
+                "blob ID",
+                epoch,
+                n_nodes,
+                timeout,
+            )
+            .await
+        }
+
+        /// Returns the blob ID of the blob info snapshot each node stored for certification in
+        /// `epoch`. Nodes that do not certify have no entry.
+        pub fn blob_info_snapshot_stored(&self, epoch: Epoch) -> HashMap<ObjectID, BlobId> {
+            Self::entries_for_epoch(&self.blob_info_snapshot_stored_map, epoch)
+        }
+
+        /// Waits until `n_nodes` nodes have stored their blob info snapshot of `epoch` for
+        /// certification and returns the stored blob IDs.
+        pub async fn wait_for_blob_info_snapshot_stored(
+            &self,
+            epoch: Epoch,
+            n_nodes: usize,
+            timeout: Duration,
+        ) -> HashMap<ObjectID, BlobId> {
+            Self::wait_for_entries(
+                &self.blob_info_snapshot_stored_map,
+                "stored blob ID",
+                epoch,
+                n_nodes,
+                timeout,
+            )
+            .await
+        }
+
+        /// Returns, per node that reconciled its blob info snapshot publication of `epoch` at the
+        /// next epoch boundary, whether the snapshot was found certified (`true`) or was cleaned
+        /// up (`false`). Nodes that did not publish have no entry.
+        pub fn blob_info_snapshot_reconciled(&self, epoch: Epoch) -> HashMap<ObjectID, bool> {
+            Self::entries_for_epoch(&self.blob_info_snapshot_reconciled_map, epoch)
+        }
+
+        /// Waits until `n_nodes` nodes have reconciled their blob info snapshot publication of
+        /// `epoch` and returns the outcomes (see [`Self::blob_info_snapshot_reconciled`]).
+        pub async fn wait_for_blob_info_snapshot_reconciled(
+            &self,
+            epoch: Epoch,
+            n_nodes: usize,
+            timeout: Duration,
+        ) -> HashMap<ObjectID, bool> {
+            Self::wait_for_entries(
+                &self.blob_info_snapshot_reconciled_map,
+                "reconciliation outcome",
+                epoch,
+                n_nodes,
+                timeout,
+            )
+            .await
+        }
+
+        fn entries_for_epoch<V: Clone>(
+            map: &Mutex<HashMap<Epoch, HashMap<ObjectID, V>>>,
+            epoch: Epoch,
+        ) -> HashMap<ObjectID, V> {
+            map.lock().unwrap().get(&epoch).cloned().unwrap_or_default()
+        }
+
+        async fn wait_for_entries<V: Clone + std::fmt::Debug>(
+            map: &Mutex<HashMap<Epoch, HashMap<ObjectID, V>>>,
+            what: &str,
+            epoch: Epoch,
+            n_nodes: usize,
+            timeout: Duration,
+        ) -> HashMap<ObjectID, V> {
+            let start = Instant::now();
+            loop {
+                let entries = Self::entries_for_epoch(map, epoch);
+                if entries.len() >= n_nodes {
+                    return entries;
+                }
+                assert!(
+                    start.elapsed() < timeout,
+                    "timed out waiting for {n_nodes} nodes to report the blob info snapshot \
+                    {what} of epoch {epoch}; reported: {entries:?}"
+                );
+                tokio::time::sleep(Duration::from_secs(1)).await;
             }
         }
 

--- a/crates/walrus-simtest/tests/simtest_blob_info_snapshot.rs
+++ b/crates/walrus-simtest/tests/simtest_blob_info_snapshot.rs
@@ -1,17 +1,31 @@
 // Copyright (c) Walrus Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-//! Contains simtests for the cross-node determinism of blob info snapshots.
+//! Contains simtests for the cross-node determinism and the on-chain certification of blob info
+//! snapshots.
 
 #![recursion_limit = "256"]
 
 #[cfg(msim)]
 mod tests {
-    use std::{sync::Arc, time::Duration};
+    use std::{
+        collections::{HashMap, HashSet},
+        sync::Arc,
+        time::Duration,
+    };
 
+    use sui_types::base_types::ObjectID;
+    use twox_hash::XxHash64;
+    use walrus_core::{BlobId, Epoch, encoding::Primary};
     use walrus_proc_macros::walrus_simtest;
     use walrus_service::test_utils::{SimStorageNodeHandle, TestNodesConfig, test_cluster};
     use walrus_simtest::test_utils::simtest_utils::{self, BlobInfoConsistencyCheck};
+    use walrus_sui::client::ReadClient;
+
+    const EPOCH_DURATION: Duration = Duration::from_secs(30);
+
+    /// The node weights of the certification clusters: 13 shards, so that a quorum needs 9.
+    const NODE_WEIGHTS: [u16; 5] = [1, 2, 3, 3, 4];
 
     /// Checks that all nodes serialize identical blob info snapshots at each epoch boundary.
     #[ignore = "ignore integration simtests by default"]
@@ -40,5 +54,512 @@ mod tests {
         workload_handle.abort();
 
         blob_info_consistency_check.check_storage_node_consistency();
+    }
+
+    /// Returns a cluster builder with [`NODE_WEIGHTS`] in which the nodes flagged in `certify`
+    /// certify their blob info snapshots on chain.
+    fn certification_cluster_builder(certify: &[bool]) -> test_cluster::E2eTestSetupBuilder {
+        test_cluster::E2eTestSetupBuilder::new()
+            .with_epoch_duration(EPOCH_DURATION)
+            .with_test_nodes_config(
+                TestNodesConfig::builder()
+                    .with_node_weights(&NODE_WEIGHTS)
+                    .with_blob_info_snapshot_certify(certify)
+                    .build(),
+            )
+    }
+
+    fn node_capability_id(node: &SimStorageNodeHandle) -> ObjectID {
+        node.storage_node_capability
+            .as_ref()
+            .expect("nodes of an e2e cluster have a storage node capability")
+            .id
+    }
+
+    /// Returns the blob ID all nodes reported for the snapshot of `epoch`, asserting that they
+    /// agree.
+    fn single_blob_id(blob_ids: &HashMap<ObjectID, BlobId>, epoch: Epoch) -> BlobId {
+        let distinct: HashSet<_> = blob_ids.values().copied().collect();
+        assert_eq!(
+            distinct.len(),
+            1,
+            "nodes disagree on the snapshot blob ID of epoch {epoch}: {blob_ids:?}"
+        );
+        *distinct
+            .into_iter()
+            .next()
+            .as_ref()
+            .expect("one distinct blob ID")
+    }
+
+    /// Checks that, with certification enabled on every node, the snapshot of each epoch is
+    /// certified on chain, that the certified blob ID is the one every node produced, that every
+    /// node finds its snapshot certified at the next boundary (and so keeps it), and that a
+    /// certified snapshot can be read back through the regular read path.
+    #[ignore = "ignore integration simtests by default"]
+    #[walrus_simtest]
+    async fn test_blob_info_snapshot_certified_by_quorum() {
+        certified_by_quorum_scenario([true; 5]).await;
+    }
+
+    /// Checks the same with certification enabled on a quorum subset only (the staged rollout):
+    /// the non-attesting node produces the same snapshot, keeps nothing to reconcile, and the
+    /// snapshots of all nodes stay identical after the certified blob is recovered by it.
+    #[ignore = "ignore integration simtests by default"]
+    #[walrus_simtest]
+    async fn test_blob_info_snapshot_certified_by_quorum_subset() {
+        // The lightest node does not certify; the other four hold 12 of the 13 shards.
+        certified_by_quorum_scenario([false, true, true, true, true]).await;
+    }
+
+    async fn certified_by_quorum_scenario(certify: [bool; 5]) {
+        let consistency_check = BlobInfoConsistencyCheck::new();
+        let (_sui_cluster, walrus_cluster, client, _, _) = certification_cluster_builder(&certify)
+            .build_generic::<SimStorageNodeHandle>()
+            .await
+            .unwrap();
+        let client = Arc::new(client);
+        let workload_handle =
+            simtest_utils::start_background_workload(client.clone(), false, None, None);
+        let nodes = &walrus_cluster.nodes;
+        let node_ids: Vec<_> = nodes.iter().map(node_capability_id).collect();
+
+        // The snapshot of epoch E is certified during E, and the contract keeps every
+        // certification whose storage has not ended, so waiting for epoch 4 leaves a few epochs
+        // of history to check.
+        const TARGET_EPOCH: Epoch = 4;
+        let latest = simtest_utils::wait_for_certified_snapshot_blob(
+            &client,
+            TARGET_EPOCH,
+            EPOCH_DURATION * (TARGET_EPOCH + 2),
+        )
+        .await;
+        tracing::info!(?latest, "latest certified blob info snapshot");
+        // Once every node has applied the latest epoch, all of them have processed the
+        // certification events of the earlier epochs and reconciled those publications.
+        simtest_utils::wait_for_nodes_to_reach_epoch(nodes, latest.epoch, 2 * EPOCH_DURATION).await;
+
+        let mut certified_blob_ids = HashMap::new();
+        for epoch in latest.epoch - 2..=latest.epoch {
+            let certified = client
+                .inner
+                .sui_client()
+                .read_client
+                .certified_snapshot_blob_for_epoch(epoch)
+                .await
+                .expect("reading the certification history should succeed")
+                .unwrap_or_else(|| panic!("the snapshot of epoch {epoch} must be certified"));
+            let blob_ids = consistency_check
+                .wait_for_blob_info_snapshot_blob_ids(epoch, node_ids.len(), EPOCH_DURATION)
+                .await;
+            for node_id in &node_ids {
+                assert_eq!(
+                    blob_ids.get(node_id),
+                    Some(&certified.blob_id),
+                    "node {node_id} must have produced the certified snapshot of epoch {epoch}"
+                );
+            }
+            if epoch < latest.epoch {
+                let reconciled = consistency_check.blob_info_snapshot_reconciled(epoch);
+                for (node_id, certifies) in node_ids.iter().zip(certify) {
+                    let expected = if certifies { Some(&true) } else { None };
+                    assert_eq!(
+                        reconciled.get(node_id),
+                        expected,
+                        "node {node_id} (certifies: {certifies}) has the wrong reconciliation \
+                        outcome for epoch {epoch}"
+                    );
+                }
+            }
+            certified_blob_ids.insert(epoch, certified.blob_id);
+        }
+        workload_handle.abort();
+
+        // Reading a certified snapshot back exercises the slivers stored by the committee of its
+        // epoch, and the content must hash to the digest the nodes reported.
+        let read_epoch = latest.epoch - 1;
+        let content = client
+            .inner
+            .read_blob::<Primary>(&certified_blob_ids[&read_epoch])
+            .await
+            .expect("the certified blob info snapshot must be readable");
+        let digest = XxHash64::oneshot(0, &content);
+        let node_digests = consistency_check.blob_info_snapshot_digests(read_epoch);
+        assert_eq!(node_digests.len(), node_ids.len());
+        for (node_id, node_digest) in node_digests {
+            assert_eq!(
+                node_digest, digest,
+                "the certified snapshot of epoch {read_epoch} read back must match the digest \
+                reported by node {node_id}"
+            );
+        }
+
+        consistency_check.check_storage_node_consistency();
+    }
+
+    /// Checks that, with certification enabled on a sub-quorum of the committee only, nothing is
+    /// certified on chain, and that the attesting nodes store the snapshot blob during its epoch
+    /// and clean it up at the next epoch boundary.
+    #[ignore = "ignore integration simtests by default"]
+    #[walrus_simtest]
+    async fn test_blob_info_snapshot_cleanup_without_quorum() {
+        let consistency_check = BlobInfoConsistencyCheck::new();
+        // The two heaviest nodes hold 7 of the 13 shards, below the quorum of 9.
+        let certify = [false, false, false, true, true];
+        let (_sui_cluster, walrus_cluster, client, _, _) = certification_cluster_builder(&certify)
+            .build_generic::<SimStorageNodeHandle>()
+            .await
+            .unwrap();
+        let client = Arc::new(client);
+        let workload_handle =
+            simtest_utils::start_background_workload(client.clone(), false, None, None);
+        let nodes = &walrus_cluster.nodes;
+        let attesting_node_ids: HashSet<_> = nodes
+            .iter()
+            .zip(certify)
+            .filter(|(_, certifies)| *certifies)
+            .map(|(node, _)| node_capability_id(node))
+            .collect();
+        let silent_node_ids: Vec<_> = nodes
+            .iter()
+            .zip(certify)
+            .filter(|(_, certifies)| !*certifies)
+            .map(|(node, _)| node_capability_id(node))
+            .collect();
+
+        // The first boundary is processed while the cluster starts up; observe the next ones.
+        for epoch in 2..=3 {
+            simtest_utils::wait_for_nodes_to_reach_epoch(nodes, epoch, 2 * EPOCH_DURATION).await;
+            let blob_ids = consistency_check
+                .wait_for_blob_info_snapshot_blob_ids(epoch, nodes.len(), EPOCH_DURATION)
+                .await;
+            let blob_id = single_blob_id(&blob_ids, epoch);
+
+            let stored = consistency_check
+                .wait_for_blob_info_snapshot_stored(epoch, attesting_node_ids.len(), EPOCH_DURATION)
+                .await;
+            assert_eq!(
+                stored.keys().copied().collect::<HashSet<_>>(),
+                attesting_node_ids,
+                "exactly the attesting nodes must store the snapshot of epoch {epoch}"
+            );
+            for (node_id, stored_blob_id) in &stored {
+                assert_eq!(
+                    *stored_blob_id, blob_id,
+                    "node {node_id} must store the snapshot it produced for epoch {epoch}"
+                );
+            }
+
+            // The uncertified attempts are reconciled at the next boundary, before the nodes
+            // apply the new epoch.
+            simtest_utils::wait_for_nodes_to_reach_epoch(nodes, epoch + 1, 2 * EPOCH_DURATION)
+                .await;
+            let reconciled = consistency_check.blob_info_snapshot_reconciled(epoch);
+            for node_id in &attesting_node_ids {
+                assert_eq!(
+                    reconciled.get(node_id),
+                    Some(&false),
+                    "node {node_id} must clean up its uncertified snapshot of epoch {epoch}"
+                );
+            }
+            for node_id in &silent_node_ids {
+                assert_eq!(
+                    reconciled.get(node_id),
+                    None,
+                    "node {node_id} does not certify and has nothing to reconcile for epoch \
+                    {epoch}"
+                );
+            }
+            assert!(
+                client
+                    .inner
+                    .sui_client()
+                    .read_client
+                    .last_certified_snapshot_blob()
+                    .await
+                    .expect("reading the certified blob info snapshot should succeed")
+                    .is_none(),
+                "no snapshot may be certified without a quorum"
+            );
+        }
+        workload_handle.abort();
+
+        consistency_check.check_storage_node_consistency();
+    }
+
+    /// Checks that a node whose snapshot blob differs from the one a quorum certifies cleans up
+    /// its uncertified attempt at the next epoch boundary, while the other nodes certify and keep
+    /// theirs.
+    #[ignore = "ignore integration simtests by default"]
+    #[walrus_simtest]
+    async fn test_blob_info_snapshot_divergent_node_cleans_up() {
+        let consistency_check = BlobInfoConsistencyCheck::new();
+        let (_sui_cluster, walrus_cluster, client, _, _) =
+            certification_cluster_builder(&[true; 5])
+                .build_generic::<SimStorageNodeHandle>()
+                .await
+                .unwrap();
+        let client = Arc::new(client);
+        let workload_handle =
+            simtest_utils::start_background_workload(client.clone(), false, None, None);
+        let nodes = &walrus_cluster.nodes;
+
+        // The lightest node diverges; the other four hold 12 of the 13 shards and still certify.
+        let divergent_node = &nodes[0];
+        assert_eq!(NODE_WEIGHTS[0], 1);
+        let divergent_node_id = node_capability_id(divergent_node);
+        let honest_node_ids: Vec<_> = nodes.iter().skip(1).map(node_capability_id).collect();
+        simtest_utils::diverge_blob_info_snapshot_of_node(divergent_node);
+
+        // The first boundary may have been processed before the divergence was armed; observe
+        // the next ones.
+        for epoch in 2..=3 {
+            simtest_utils::wait_for_nodes_to_reach_epoch(nodes, epoch, 2 * EPOCH_DURATION).await;
+            let blob_ids = consistency_check
+                .wait_for_blob_info_snapshot_blob_ids(epoch, nodes.len(), EPOCH_DURATION)
+                .await;
+            let honest_blob_ids: HashMap<_, _> = blob_ids
+                .iter()
+                .filter(|(node_id, _)| **node_id != divergent_node_id)
+                .map(|(node_id, blob_id)| (*node_id, *blob_id))
+                .collect();
+            let honest_blob_id = single_blob_id(&honest_blob_ids, epoch);
+            let divergent_blob_id = blob_ids[&divergent_node_id];
+            assert_ne!(
+                divergent_blob_id, honest_blob_id,
+                "the divergent node must produce a different snapshot blob for epoch {epoch}"
+            );
+
+            // The honest nodes' quorum certifies their snapshot during the epoch.
+            simtest_utils::wait_for_certified_snapshot_blob(&client, epoch, 2 * EPOCH_DURATION)
+                .await;
+            let certified = client
+                .inner
+                .sui_client()
+                .read_client
+                .certified_snapshot_blob_for_epoch(epoch)
+                .await
+                .expect("reading the certification history should succeed")
+                .unwrap_or_else(|| panic!("the snapshot of epoch {epoch} must be certified"));
+            assert_eq!(
+                certified.blob_id, honest_blob_id,
+                "the quorum must certify the honest nodes' snapshot of epoch {epoch}"
+            );
+
+            // At the next boundary, the honest nodes keep their certified snapshot, and the
+            // divergent node cleans up its attempt.
+            simtest_utils::wait_for_nodes_to_reach_epoch(nodes, epoch + 1, 2 * EPOCH_DURATION)
+                .await;
+            let reconciled = consistency_check.blob_info_snapshot_reconciled(epoch);
+            for node_id in &honest_node_ids {
+                assert_eq!(
+                    reconciled.get(node_id),
+                    Some(&true),
+                    "node {node_id} must have found its snapshot of epoch {epoch} certified"
+                );
+            }
+            assert_eq!(
+                reconciled.get(&divergent_node_id),
+                Some(&false),
+                "the divergent node must clean up its uncertified snapshot of epoch {epoch}"
+            );
+        }
+        workload_handle.abort();
+
+        // The snapshot files stay identical across nodes: the divergence is injected between the
+        // file and its encoding.
+        consistency_check.check_storage_node_consistency();
+    }
+
+    /// Checks that a node stopping in the middle of reconciling its previous snapshot
+    /// publication, as a storage error there makes it do, neither loses that publication nor
+    /// publishes over it: after the restart it replays the boundary, reconciles the previous
+    /// publication, and publishes the new epoch's snapshot.
+    #[ignore = "ignore integration simtests by default"]
+    #[walrus_simtest]
+    async fn test_blob_info_snapshot_reconciliation_survives_a_crash() {
+        let consistency_check = BlobInfoConsistencyCheck::new();
+        // Sub-quorum, so that every publication must be cleaned up by the reconciliation.
+        let certify = [false, false, false, true, true];
+        let (_sui_cluster, walrus_cluster, client, _, _) = certification_cluster_builder(&certify)
+            .build_generic::<SimStorageNodeHandle>()
+            .await
+            .unwrap();
+        let client = Arc::new(client);
+        let workload_handle =
+            simtest_utils::start_background_workload(client.clone(), false, None, None);
+        let nodes = &walrus_cluster.nodes;
+        let (silent_nodes, attesting_nodes) = nodes.split_at(3);
+        assert!(certify[..3].iter().all(|certifies| !certifies));
+        assert!(certify[3..].iter().all(|certifies| *certifies));
+        let attesting_node_ids: HashSet<_> =
+            attesting_nodes.iter().map(node_capability_id).collect();
+
+        // Epoch 2: the attesting nodes publish as usual.
+        simtest_utils::wait_for_nodes_to_reach_epoch(nodes, 2, 2 * EPOCH_DURATION).await;
+        let stored = consistency_check
+            .wait_for_blob_info_snapshot_stored(2, attesting_node_ids.len(), EPOCH_DURATION)
+            .await;
+        assert_eq!(
+            stored.keys().copied().collect::<HashSet<_>>(),
+            attesting_node_ids
+        );
+
+        // At the boundary into epoch 3, the attesting nodes stop while reconciling the epoch-2
+        // publication, before it is cleaned up, and restart shortly after.
+        let crashes = simtest_utils::crash_nodes_once_at_blob_info_snapshot_reconciliation(
+            attesting_nodes,
+            Duration::from_secs(5),
+        );
+        simtest_utils::wait_for_nodes_to_reach_epoch(silent_nodes, 3, 2 * EPOCH_DURATION).await;
+        // The restarted nodes replay the boundary: the reconciliation runs again and cleans up
+        // the epoch-2 publication, and only then is the epoch-3 snapshot published. A restarted
+        // node reports the chain's epoch before it has replayed the boundary, so wait for the
+        // reconciliation itself rather than for the epoch.
+        simtest_utils::wait_for_nodes_to_reach_epoch(nodes, 3, 2 * EPOCH_DURATION).await;
+        assert_eq!(
+            crashes.load(std::sync::atomic::Ordering::SeqCst),
+            attesting_node_ids.len(),
+            "every attesting node must have crashed once at the reconciliation"
+        );
+        let reconciled = consistency_check
+            .wait_for_blob_info_snapshot_reconciled(2, attesting_node_ids.len(), EPOCH_DURATION)
+            .await;
+        assert_eq!(
+            reconciled,
+            attesting_node_ids
+                .iter()
+                .map(|node_id| (*node_id, false))
+                .collect(),
+            "exactly the attesting nodes must clean up their epoch-2 publication when replaying \
+            the boundary"
+        );
+        let blob_ids = consistency_check
+            .wait_for_blob_info_snapshot_blob_ids(3, nodes.len(), EPOCH_DURATION)
+            .await;
+        let blob_id = single_blob_id(&blob_ids, 3);
+        let stored = consistency_check
+            .wait_for_blob_info_snapshot_stored(3, attesting_node_ids.len(), EPOCH_DURATION)
+            .await;
+        assert_eq!(
+            stored.keys().copied().collect::<HashSet<_>>(),
+            attesting_node_ids,
+            "the attesting nodes must publish the epoch-3 snapshot after replaying the boundary"
+        );
+        for (node_id, stored_blob_id) in &stored {
+            assert_eq!(
+                *stored_blob_id, blob_id,
+                "node {node_id} must store the epoch-3 snapshot"
+            );
+        }
+
+        // The epoch-3 publication is reconciled at the next boundary like any other.
+        simtest_utils::wait_for_nodes_to_reach_epoch(nodes, 4, 2 * EPOCH_DURATION).await;
+        let reconciled = consistency_check
+            .wait_for_blob_info_snapshot_reconciled(3, attesting_node_ids.len(), EPOCH_DURATION)
+            .await;
+        assert_eq!(
+            reconciled,
+            attesting_node_ids
+                .iter()
+                .map(|node_id| (*node_id, false))
+                .collect(),
+            "exactly the attesting nodes must clean up their epoch-3 publication at the next \
+            boundary"
+        );
+        assert!(
+            client
+                .inner
+                .sui_client()
+                .read_client
+                .last_certified_snapshot_blob()
+                .await
+                .expect("reading the certified blob info snapshot should succeed")
+                .is_none(),
+            "no snapshot may be certified without a quorum"
+        );
+        workload_handle.abort();
+
+        consistency_check.check_storage_node_consistency();
+    }
+
+    /// Checks that a node that disables snapshots after publishing one still reconciles that
+    /// publication at the next boundary, so that its stored data is cleaned up.
+    #[ignore = "ignore integration simtests by default"]
+    #[walrus_simtest]
+    async fn test_blob_info_snapshot_publication_is_reconciled_when_snapshots_are_disabled() {
+        let consistency_check = BlobInfoConsistencyCheck::new();
+        // Sub-quorum, so that the publication must be cleaned up by the reconciliation.
+        let certify = [false, false, false, true, true];
+        let (_sui_cluster, mut walrus_cluster, client, _, _) =
+            certification_cluster_builder(&certify)
+                .build_generic::<SimStorageNodeHandle>()
+                .await
+                .unwrap();
+        let client = Arc::new(client);
+        let workload_handle =
+            simtest_utils::start_background_workload(client.clone(), false, None, None);
+        let attesting_indices: Vec<usize> = (0..certify.len()).filter(|i| certify[*i]).collect();
+        let attesting_node_ids: HashSet<_> = attesting_indices
+            .iter()
+            .map(|i| node_capability_id(&walrus_cluster.nodes[*i]))
+            .collect();
+
+        // Epoch 2: the attesting nodes publish as usual.
+        simtest_utils::wait_for_nodes_to_reach_epoch(&walrus_cluster.nodes, 2, 2 * EPOCH_DURATION)
+            .await;
+        let stored = consistency_check
+            .wait_for_blob_info_snapshot_stored(2, attesting_node_ids.len(), EPOCH_DURATION)
+            .await;
+        assert_eq!(
+            stored.keys().copied().collect::<HashSet<_>>(),
+            attesting_node_ids
+        );
+
+        // Restart the attesting nodes with snapshots disabled before the next boundary.
+        for index in &attesting_indices {
+            walrus_cluster.nodes[*index]
+                .storage_node_config
+                .blob_info_snapshot
+                .enabled = false;
+            simtest_utils::restart_node_with_checkpoints(&mut walrus_cluster, *index, |_| 20).await;
+        }
+        let nodes = &walrus_cluster.nodes;
+
+        // At the boundary into epoch 3 they reconcile the epoch-2 publication (cleaned up, as it
+        // never certified) although they no longer produce snapshots.
+        simtest_utils::wait_for_nodes_to_reach_epoch(nodes, 3, 2 * EPOCH_DURATION).await;
+        let reconciled = consistency_check
+            .wait_for_blob_info_snapshot_reconciled(2, attesting_node_ids.len(), EPOCH_DURATION)
+            .await;
+        assert_eq!(
+            reconciled,
+            attesting_node_ids
+                .iter()
+                .map(|node_id| (*node_id, false))
+                .collect(),
+            "the restarted nodes must clean up their epoch-2 publication with snapshots disabled"
+        );
+        let blob_ids = consistency_check.blob_info_snapshot_blob_ids(3);
+        assert!(
+            attesting_node_ids
+                .iter()
+                .all(|node_id| !blob_ids.contains_key(node_id)),
+            "nodes with snapshots disabled must not produce the epoch-3 snapshot: {blob_ids:?}"
+        );
+        assert!(
+            client
+                .inner
+                .sui_client()
+                .read_client
+                .last_certified_snapshot_blob()
+                .await
+                .expect("reading the certified blob info snapshot should succeed")
+                .is_none(),
+            "no snapshot may be certified without a quorum"
+        );
+        workload_handle.abort();
+
+        consistency_check.check_storage_node_consistency();
     }
 }

--- a/crates/walrus-simtest/tests/simtest_core.rs
+++ b/crates/walrus-simtest/tests/simtest_core.rs
@@ -1448,7 +1448,8 @@ mod tests {
         assert_eq!(end_upgrade_epoch, upgrade_epoch);
         tracing::info!(upgrade_epoch, "upgraded contract");
 
-        // Migrate the objects (v4 migration does not require set_migration_epoch or epoch wait)
+        // Migrate the objects (the v5 migration does not require set_migration_epoch or an epoch
+        // wait)
         client
             .as_ref()
             .inner
@@ -1458,17 +1459,20 @@ mod tests {
 
         client.as_ref().inner.sui_client().flush_cache().await;
 
-        // Check the version
-        assert_eq!(
-            client
-                .as_ref()
-                .inner
-                .sui_client()
-                .read_client()
-                .system_object_version()
-                .await?,
-            previous_version + 1
-        );
+        // Check the version: the migration lands on the development contracts' current version,
+        // which can be more than one ahead of the deployed testnet-contracts lineage (a single
+        // migration applies all pending steps). Keep in sync with `VERSION` in
+        // `contracts/walrus/sources/system.move`.
+        const EXPECTED_POST_MIGRATION_VERSION: u64 = 5;
+        let migrated_version = client
+            .as_ref()
+            .inner
+            .sui_client()
+            .read_client()
+            .system_object_version()
+            .await?;
+        assert!(migrated_version > previous_version);
+        assert_eq!(migrated_version, EXPECTED_POST_MIGRATION_VERSION);
 
         let blobs = walrus_test_utils::random_data_list(314, 1);
         let store_args = StoreArgs::default_with_epochs(1)

--- a/crates/walrus-sui/src/client.rs
+++ b/crates/walrus-sui/src/client.rs
@@ -101,7 +101,7 @@ pub mod rpc_client;
 pub mod rpc_config;
 
 pub mod transaction_builder;
-use crate::types::move_structs::EventBlob;
+use crate::types::move_structs::{EventBlob, SnapshotBlob};
 
 pub mod contract_config;
 
@@ -2041,6 +2041,19 @@ impl ReadClient for SuiContractClient {
 
     async fn last_certified_event_blob(&self) -> SuiClientResult<Option<EventBlob>> {
         self.read_client.last_certified_event_blob().await
+    }
+
+    async fn last_certified_snapshot_blob(&self) -> SuiClientResult<Option<SnapshotBlob>> {
+        self.read_client.last_certified_snapshot_blob().await
+    }
+
+    async fn certified_snapshot_blob_for_epoch(
+        &self,
+        epoch: walrus_core::Epoch,
+    ) -> SuiClientResult<Option<SnapshotBlob>> {
+        self.read_client
+            .certified_snapshot_blob_for_epoch(epoch)
+            .await
     }
 
     async fn refresh_package_id(&self) -> SuiClientResult<()> {

--- a/crates/walrus-sui/src/client/owned_blob_ops.rs
+++ b/crates/walrus-sui/src/client/owned_blob_ops.rs
@@ -135,6 +135,27 @@ impl SuiContractClient {
         .await
     }
 
+    /// Certifies the specified blob info snapshot blob on Sui, with the given metadata and epoch.
+    pub async fn certify_snapshot_blob(
+        &self,
+        blob_metadata: BlobObjectMetadata,
+        snapshot_epoch: u32,
+        node_capability_object_id: ObjectID,
+    ) -> SuiClientResult<()> {
+        self.retry_on_wrong_version(|| async {
+            self.inner
+                .lock()
+                .await
+                .certify_snapshot_blob(
+                    blob_metadata.clone(),
+                    snapshot_epoch,
+                    node_capability_object_id,
+                )
+                .await
+        })
+        .await
+    }
+
     /// Invalidates the specified blob id on Sui, given a certificate that confirms that it is
     /// invalid.
     pub async fn invalidate_blob_id(
@@ -728,6 +749,32 @@ impl SuiContractClientInner {
             .await?;
         let transaction = pt_builder.build_transaction_data(self.gas_budget).await?;
         self.sign_and_send_transaction(transaction, "certify_event_blob")
+            .await?;
+        Ok(())
+    }
+
+    /// Certifies the specified blob info snapshot blob on Sui, with the given metadata and epoch.
+    pub async fn certify_snapshot_blob(
+        &mut self,
+        blob_metadata: BlobObjectMetadata,
+        snapshot_epoch: u32,
+        node_capability_object_id: ObjectID,
+    ) -> SuiClientResult<()> {
+        tracing::debug!(
+            %node_capability_object_id,
+            "calling certify_snapshot_blob"
+        );
+
+        let mut pt_builder = self.transaction_builder();
+        pt_builder
+            .certify_snapshot_blob(
+                blob_metadata,
+                node_capability_object_id.into(),
+                snapshot_epoch,
+            )
+            .await?;
+        let transaction = pt_builder.build_transaction_data(self.gas_budget).await?;
+        self.sign_and_send_transaction(transaction, "certify_snapshot_blob")
             .await?;
         Ok(())
     }

--- a/crates/walrus-sui/src/client/read_client.rs
+++ b/crates/walrus-sui/src/client/read_client.rs
@@ -52,6 +52,9 @@ use crate::{
             EventBlob,
             NodeMetadata,
             SharedBlob,
+            SnapshotBlob,
+            SnapshotBlobCertificationState,
+            SnapshotStateKey,
             StakingInnerV1,
             StakingObjectForDeserialization,
             StakingPool,
@@ -190,6 +193,29 @@ pub trait ReadClient: Send + Sync {
     fn last_certified_event_blob(
         &self,
     ) -> impl Future<Output = SuiClientResult<Option<EventBlob>>> + Send;
+
+    /// Returns the last certified blob info snapshot blob.
+    ///
+    /// Returns `None` if no snapshot has been certified yet, or if the deployed contract
+    /// version does not support snapshot certification. The blob's storage may have ended:
+    /// the contract keeps the latest certification whatever its lifetime, so compare the
+    /// returned `end_epoch` with the current epoch before fetching the blob.
+    fn last_certified_snapshot_blob(
+        &self,
+    ) -> impl Future<Output = SuiClientResult<Option<SnapshotBlob>>> + Send;
+
+    /// Returns the certified blob info snapshot blob of `epoch`.
+    ///
+    /// Returns `None` if no snapshot was certified for that epoch, if the contract dropped the
+    /// entry (it drops expired entries at each certification, except the latest one), or if the
+    /// deployed contract version does not support snapshot certification. A returned entry may
+    /// still have expired: the latest certification is kept whatever its lifetime, and entries
+    /// are only pruned when a snapshot certifies, so compare its `end_epoch` with the current
+    /// epoch before fetching the blob. The certification itself is a fact regardless of expiry.
+    fn certified_snapshot_blob_for_epoch(
+        &self,
+        epoch: walrus_core::Epoch,
+    ) -> impl Future<Output = SuiClientResult<Option<SnapshotBlob>>> + Send;
 
     /// Refreshes the Walrus package ID.
     ///
@@ -1228,6 +1254,48 @@ enum WhichCommittee {
     Next,
 }
 
+impl SuiReadClient {
+    /// Reads the blob info snapshot certification state from the system object.
+    ///
+    /// Returns `None` if the deployed contract version does not define the state.
+    async fn snapshot_certification_state(
+        &self,
+    ) -> SuiClientResult<Option<SnapshotBlobCertificationState>> {
+        // The key type only exists in contract versions that support snapshot certification;
+        // for older deployed contracts, and for a supporting version whose migration has not
+        // run yet, report that no snapshot is certified.
+        let Ok(key_tag) = contracts::system::SnapshotStateKey
+            .to_move_struct_tag_with_type_map(&self.type_origin_map().clone(), &[])
+        else {
+            tracing::debug!(
+                "the deployed contract does not define the snapshot certification state"
+            );
+            return Ok(None);
+        };
+        let state: SnapshotBlobCertificationState = match self
+            .sui_client
+            .get_dynamic_field(
+                self.system_object_id,
+                key_tag.into(),
+                SnapshotStateKey { dummy_field: false },
+            )
+            .await
+        {
+            Ok(state) => state,
+            // Between the publication of a package version that defines the key type and the
+            // migration that creates the field, the type exists but the field does not.
+            Err(SuiClientError::GrpcError(status)) if status.code() == tonic::Code::NotFound => {
+                tracing::debug!(
+                    "the snapshot certification state does not exist yet on the deployed contract"
+                );
+                return Ok(None);
+            }
+            Err(error) => return Err(error),
+        };
+        Ok(Some(state))
+    }
+}
+
 impl ReadClient for SuiReadClient {
     #[tracing::instrument(err, skip(self))]
     async fn storage_price_per_unit_size(&self) -> SuiClientResult<u64> {
@@ -1259,6 +1327,28 @@ impl ReadClient for SuiReadClient {
             .await?
             .latest_certified_event_blob();
         Ok(blob)
+    }
+
+    async fn last_certified_snapshot_blob(&self) -> SuiClientResult<Option<SnapshotBlob>> {
+        Ok(self
+            .snapshot_certification_state()
+            .await?
+            .and_then(|state| state.certified.last().cloned()))
+    }
+
+    async fn certified_snapshot_blob_for_epoch(
+        &self,
+        epoch: walrus_core::Epoch,
+    ) -> SuiClientResult<Option<SnapshotBlob>> {
+        Ok(self
+            .snapshot_certification_state()
+            .await?
+            .and_then(|state| {
+                state
+                    .certified
+                    .into_iter()
+                    .find(|snapshot| snapshot.epoch == epoch)
+            }))
     }
 
     async fn get_blob_event(&self, event_id: EventID) -> SuiClientResult<BlobEvent> {

--- a/crates/walrus-sui/src/client/transaction_builder/owned_blob_ops.rs
+++ b/crates/walrus-sui/src/client/transaction_builder/owned_blob_ops.rs
@@ -225,6 +225,27 @@ impl WalrusPtbBuilder {
         Ok(())
     }
 
+    /// Adds a call to `certify_snapshot_blob` to the `pt_builder`.
+    pub async fn certify_snapshot_blob(
+        &mut self,
+        blob_metadata: BlobObjectMetadata,
+        storage_node_cap: ArgumentOrOwnedObject,
+        snapshot_epoch: u32,
+    ) -> SuiClientResult<()> {
+        let arguments = vec![
+            self.system_arg(SharedObjectMutability::Mutable)?,
+            self.argument_from_arg_or_obj(storage_node_cap).await?,
+            self.pt_builder.pure(blob_metadata.blob_id)?,
+            self.pt_builder.pure(blob_metadata.root_hash.bytes())?,
+            self.pt_builder.pure(blob_metadata.unencoded_size)?,
+            self.pt_builder
+                .pure(u8::from(blob_metadata.encoding_type))?,
+            self.pt_builder.pure(snapshot_epoch)?,
+        ];
+        self.walrus_move_call(contracts::system::certify_snapshot_blob, arguments)?;
+        Ok(())
+    }
+
     /// Adds a call to `delete_blob` to the `pt_builder` and returns the result [`Argument`].
     pub async fn delete_blob(
         &mut self,

--- a/crates/walrus-sui/src/contracts.rs
+++ b/crates/walrus-sui/src/contracts.rs
@@ -225,6 +225,8 @@ pub mod system {
     contract_ident!(fn system::invalidate_blob_id);
     contract_ident!(fn system::delete_blob);
     contract_ident!(fn system::certify_event_blob);
+    contract_ident!(fn system::certify_snapshot_blob);
+    contract_ident!(struct system::SnapshotStateKey);
     contract_ident!(fn system::extend_blob);
     contract_ident!(fn system::create_storage_pool);
     contract_ident!(fn system::register_pooled_blob);

--- a/crates/walrus-sui/src/types/move_structs.rs
+++ b/crates/walrus-sui/src/types/move_structs.rs
@@ -631,6 +631,45 @@ pub struct EventBlobCertificationState {
     pub aggregate_weight_per_blob: Vec<(EventBlob, u16)>,
 }
 
+/// A certified blob info snapshot blob.
+#[derive(Debug, PartialEq, Eq, Clone, Deserialize)]
+pub struct SnapshotBlob {
+    /// The walrus epoch whose boundary state the snapshot captures.
+    pub epoch: u32,
+    /// The blob ID of the certified snapshot blob.
+    pub blob_id: BlobId,
+    /// The epoch at which the storage of the snapshot blob ends (exclusive).
+    pub end_epoch: u32,
+}
+
+/// State holding the certification of blob info snapshot blobs.
+///
+/// Lives in a dynamic field on the `System` object keyed by `SnapshotStateKey`.
+#[derive(Debug, PartialEq, Eq, Clone, Deserialize)]
+pub struct SnapshotBlobCertificationState {
+    /// The most recently certified snapshot blobs, oldest first (at most three).
+    pub certified: Vec<SnapshotBlob>,
+    /// Number of epochs ahead for which a certified snapshot blob is stored.
+    pub epochs_ahead: u32,
+    /// The epoch the attestations below belong to.
+    pub tally_epoch: u32,
+    /// Aggregate attested shard weight per snapshot blob id for the tally epoch.
+    pub aggregate_weight_per_blob: Vec<(BlobId, u16)>,
+    /// Nodes that have attested a snapshot for the tally epoch.
+    pub attested_nodes: Vec<ObjectID>,
+}
+
+/// Sui type for the dynamic field key of the snapshot blob certification state on `System`.
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+pub(crate) struct SnapshotStateKey {
+    /// To match empty struct in Move.
+    pub dummy_field: bool,
+}
+
+impl AssociatedContractStruct for SnapshotStateKey {
+    const CONTRACT_STRUCT: StructTag<'static> = contracts::system::SnapshotStateKey;
+}
+
 /// State holding the certification of event blobs.
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize)]
 pub struct EventBlobCertificationStateTestnet {


### PR DESCRIPTION
## Description

Combined view of #3751 (contract and Rust client) and #3752 (storage node and simtests), for reading the whole change in one diff; the four commits are the same as in the two stacked PRs.

Storage nodes already serialize a deterministic blob info snapshot of their storage-pool tables at every epoch boundary and encode it into a Walrus blob (#3480 and follow-ups; byte identity across nodes has held in production and in the determinism simtest #3633 since v1.51.1). This is the second milestone of WAL-1185, in which the network agrees on one snapshot per epoch and certifies it on chain so that a recovering node has a quorum-backed snapshot to load. Loading the snapshot is the next milestone. The node side is behind a new `blob_info_snapshot.certify` flag, default off, so the change is inert until operators enable it.

**Contract** (`contracts/walrus`, package version 4 → 5). A new module `snapshot_blob` holds the certification state as a dynamic field of the `System` object under a dedicated key type, created in `create_empty`, by `migrate`, and by the test constructors. The system and staking package versions move from 4 to 5 in lockstep; the version-4 active-set migration step is re-applied as part of this migration, which is safe because no network has executed it yet.

`system::certify_snapshot_blob` accepts one attestation per node and epoch from a current committee member for the current epoch, tallies attestations per blob ID by shard weight, and on a quorum reserves storage without payment, creates a non-deletable blob, certifies it through the ordinary `BlobRegistered` and `BlobCertified` events (no new event types, so older binaries keep parsing the stream), burns the object, and records the epoch, blob ID, and storage end of the certified snapshot in a list readable by epoch that keeps, after every certification, the newest entry, the previous one whatever its lifetime, and every older one whose storage has not ended. The blob object is burned, so this list is the chain's only record of which snapshots are still retrievable and until when, for external users and for out-of-band backups, and the previous entry is what storage nodes reconcile at the next boundary. Expired entries are dropped at certification, which bounds the list by `max_epochs_ahead + 1`. The tally is cleared lazily when the epoch advances. An attestation for another epoch, a repeated attestation, or one from a non-member aborts; an attestation arriving after the epoch's snapshot is already certified is a no-op.

The certified snapshot's lifetime is an on-chain parameter, initialized to `max_epochs_ahead` and settable by the emergency upgrade capability through `upgrade::set_snapshot_epochs_ahead`, bounded to at least two epochs because a node reconciles its publication one epoch after the certification and must still find the blob certified (or to the system's maximum where that is smaller, so that a system with a one-epoch storage horizon stays creatable and migratable). Certified lifetimes are frozen at certification time. The setter has no client call yet (WAL-1344); it is callable through a programmable transaction meanwhile.

**Rust client** (`walrus-sui`, `walrus-sdk`). Move mirrors for `SnapshotBlob` (epoch, blob ID, storage end) and the certification state, the two typed dynamic-field reads `last_certified_snapshot_blob` and `certified_snapshot_blob_for_epoch`, and the `certify_snapshot_blob` transaction with the usual retry on a stale package version. Both reads return `None` when the deployed contract predates the key type, and also when the type exists but the field does not, which is the window between publishing the package version and running its migration; other errors propagate. A returned entry may have expired, since the contract keeps the latest certification whatever its lifetime and prunes expired entries only when a snapshot certifies, so callers that fetch the blob compare its `end_epoch` with the current epoch.

**Storage node: publication record.** A new single-slot column family holds the record of the snapshot a node is publishing: the epoch, the blob ID, and how far the publication got (pending, stored, attested; a certified state is defined for the later resume path and not used yet). The value is a versioned enum, the table has its own entry in `DatabaseConfig`, and `Storage` exposes get, set, and clear. The record is written before anything is stored, so that the metadata and slivers of a snapshot that never certified, which have no blob-info entry and are therefore invisible to garbage collection, are always tracked and cleaned up.

**Storage node: ordering at `EpochChangeStart(E)`.** Report the epoch of the latest certified snapshot from the chain (a read bounded to thirty seconds, for the no-certification alert), reconcile the previous publication, serialize the snapshot (before `execute_epoch_change`, so the file is durable before the background finisher can mark the event complete, and skipped when the file already exists from a replay), apply the epoch change, then publish. Publishing encodes the file on every node, now with a full erasure encode rather than metadata only, to report the blob ID; when certification is on and the node is in the committee (and has not entered catch-up during the transition), it records the publication, stores the metadata and the slivers of its own shards under the incoming assignment, touching no other shard, and attests the blob through the new `SystemContractService::certify_snapshot_blob`. Errors in serialization, encoding, storing, and attesting are logged and counted and never fail the epoch change; a crash between them loses one attestation, which the quorum absorbs.

**Storage node: reconciliation.** It runs at every clean boundary, whether or not snapshots are enabled, and decides certification from the local blob-info entry for the recorded blob ID, which is exact by checkpoint ordering: a `BlobCertified` during E precedes `EpochChangeStart(E + 1)`, and the handler drains blob events first. A certified snapshot is left to garbage collection after its metadata is marked stored, if the row is present. An uncertified one has its metadata and slivers deleted unless a blob-info entry exists for the blob ID: the same content can be registered by anyone, and an entry means the regular lifecycle owns the bytes. The decision and the cleanup touch only local storage, so their errors fail the epoch change like any other storage error in event processing: the node stops before the boundary is marked complete and replays it on restart, and the reconciliation is idempotent, so a later publication never overwrites an unreconciled record.

**Metrics** cover the serialize, encode, and certify durations, errors per stage, uncertified cleanups, and the epoch of the latest certified snapshot for the no-certification alert. During the rollout, divergence is detected by comparing the per-node `blob_info_snapshot_blob_id` gauges.

**Deferred, tracked in Linear and marked as TODOs in the code:** classifying why a snapshot did not certify, no quorum or divergence, with metrics (WAL-1341); a garbage-collection guard for the bytes of a live publication (WAL-1340); classifying benign attestation aborts instead of counting them as errors (WAL-1342); a client call for the lifetime setter (WAL-1344).

**Tests.** A per-node `certify` flag through the test cluster builders; the blob-info consistency observer gains the writer's simtest hooks (the blob ID each node encodes, the blob ID it stores, the reconciliation outcome) with wait helpers, plus helpers that wait on the on-chain pointer, crash a node once at the reconciliation, or make one node's snapshot blob diverge. Six tests on a five-node cluster published at the current contract version, next to the existing determinism test:

- certified by quorum: the on-chain history holds the recent epochs, each certified blob ID is the one every node produced, every node finds its snapshot certified at the next boundary and keeps it, and a certified snapshot reads back through the regular read path with the digest the nodes reported;
- certified by a quorum subset (the staged rollout): the same with one node not certifying, which keeps producing the identical snapshot;
- cleanup without quorum: with certification on two nodes holding 7 of 13 shards, nothing is certified, exactly the attesting nodes store the snapshot, and they clean it up at the next boundary;
- a divergent node cleans up: the lightest node encodes a different blob, the other four certify theirs, the divergent node cleans up its attempt, and the snapshot files stay identical so the digest check still holds;
- reconciliation survives a crash: the attesting nodes stop while reconciling their previous publication and, after the restart, reconcile it, publish the new epoch, and reconcile that one at the following boundary;
- reconciliation with snapshots disabled: the attesting nodes are restarted with snapshots off after publishing and still clean up at the next boundary while producing no new snapshot.

Notes for reviewers: the publication-state enum's `Certified` variant is reserved for the startup resume path (WAL-1252) and is harmless since the enum is a serialized value; the failpoint hooks in the writer compile to nothing outside the simulator; encoding runs on every node at every boundary even with `certify` off, and the extra memory during the rollout window is accepted rather than carrying a second encode path.

Rollout is three independently gated steps: roll the binary (certify off), upgrade and migrate the contract through the usual emergency-cap upgrade and `migrate`, then enable `certify` on weight comfortably above the quorum after comparing per-node snapshot digests for a few epochs. The two deployments can happen in either order. Handling a divergence, the startup resume, and the alert rules in sui-operations are follow-ups.

## Test plan

- Move tests: the full `contracts/walrus` suite passes (`./scripts/move_tests.sh`), including new tests for the quorum path, repeated, late, wrong-epoch, and non-member attestations, divergent attestations across an epoch rollover, the lifetime parameter and its bounds, the stored lifetime, the expiry-pruned history with a missed epoch, and a one-epoch system.
- `test_quorum_contract_upgrade` (v3/v4 → v5 migration rehearsal) passes; a live upgrade rehearsal on a local testbed from a testnet-contracts v3 genesis through emergency upgrade and migrate 3 → 5 created the new state.
- Simtests: the six certification tests and the existing determinism test pass on seeds 1 to 3.
- Local testbed (4 nodes, an earlier revision of this branch that still kept a three-entry history on chain): with certify on all nodes, epochs 1 to 4 certified and listed on chain, all error counters zero, ordering serialize → transition → encode → attest confirmed in the node logs; with certify on 2 of 4 nodes (sub-quorum), both epochs cleaned up at the next boundary.
- The repository's pre-commit hooks pass on the changed files (cargo nextest, cargo fmt, clippy with `-D warnings`, `cargo doc` with `-D warnings`, Move tests and formatting).
- Two adversarial reviews of the branch (Claude and codex, independent then cross-examined) and a code-path audit against the four ways a snapshot blob differs from a client blob; all surviving findings are addressed or tracked above.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.
For each box you select, include information after the relevant heading that describes the impact of your changes that
a user might notice and any actions they must take to implement updates. (Add release notes after the colon for each item)

- [x] Storage node: adds the `blob_info_snapshot.certify` config flag (default `false`), a new RocksDB column family `blob_info_snapshot_publication` (created automatically on the first start), and metrics under `blob_info_snapshot_*` for serialize, encode, and certify durations and errors, uncertified cleanups, and the epoch of the latest certified snapshot. Enabling `certify` requires the version-5 system contract; on an older contract the node's attestations fail and are counted, and nothing else changes. No operator action is required by default.
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI:
