### PR TITLE
docs: fix oyster 503s by removing large blobs from Walrus Sites

### DIFF
--- a/docs/site/src/scripts/fetch-oyster-docs.js
+++ b/docs/site/src/scripts/fetch-oyster-docs.js
@@ -75,12 +75,15 @@ function main() {
     const now = new Date();
     fs.utimesSync(sourceDir, now, now);
 
-    // Copy static files (llms.txt, openapi.json, scalar.html) into
-    // the Docusaurus static/oyster/ directory.
+    // Copy only small static files (llms.txt) into Docusaurus
+    // static/oyster/. Large files (openapi.json, scalar.html) are
+    // excluded because they cause 503s on Walrus Sites.
     const upstreamStatic = path.join(CACHE_DIR, STATIC_PATH);
+    const SKIP = new Set(["openapi.json", "scalar.html"]);
     if (fs.existsSync(upstreamStatic)) {
       fs.mkdirSync(STATIC_DIR, { recursive: true });
       for (const f of fs.readdirSync(upstreamStatic)) {
+        if (SKIP.has(f)) continue;
         fs.copyFileSync(
           path.join(upstreamStatic, f),
           path.join(STATIC_DIR, f),

--- a/docs/site/src/scripts/transform-oyster-docs.js
+++ b/docs/site/src/scripts/transform-oyster-docs.js
@@ -18,8 +18,9 @@ const SITE_ROOT = path.resolve(__dirname, "../../");
 const CACHE_DIR = path.join(SITE_ROOT, ".cache-oyster/docs/src");
 const OUTPUT_DIR = path.resolve(SITE_ROOT, "../oyster-content");
 
-// Path to the OpenAPI spec (fetched by fetch-oyster-docs.js into static/)
-const OPENAPI_SPEC_PATH = "/oyster/openapi.json";
+// External Scalar URL (hosted by the Oyster testnet, not on Walrus Sites)
+const SCALAR_EXTERNAL_URL =
+  "https://oyster.testnet.mystenlabs.com/api/docs";
 
 // ── Frontmatter injection ─────────────────────────────────────────────
 
@@ -162,7 +163,6 @@ function transformFile(content, relPath) {
 }
 
 function generateApiReferencePage() {
-  const scalarUrl = OPENAPI_SPEC_PATH.replace('openapi.json', 'scalar.html');
   return `---
 title: "Interactive API Reference"
 description: "Explore the Walrus Oyster API interactively using the OpenAPI specification."
@@ -177,41 +177,19 @@ import React from 'react';
   {() => {
     const style = document.createElement('style');
     style.textContent = \`
-      /* Let the iframe fill the content area next to the sidebar */
       .docMainContainer_t2hy, [class*="docMainContainer"] { max-width: 100% !important; }
       .container { max-width: 100% !important; padding: 0 8px !important; }
       .col { max-width: 100% !important; flex: 0 0 100% !important; padding: 0 !important; }
       [class*="docItemContainer"] { max-width: 100% !important; padding: 0 !important; }
-      .theme-doc-breadcrumbs,
-      .pagination-nav,
-      article > header,
-      .theme-doc-toc-desktop,
-      .theme-doc-toc-mobile,
-      [class*="copyPageButton"],
-      .theme-doc-markdown > p,
-      .theme-doc-markdown > h1,
-      .theme-doc-markdown > header,
-      [class*="docTitle"],
-      [class*="docFooter"],
-      footer.py-6,
-      .theme-doc-footer { display: none !important; }
+      .theme-doc-breadcrumbs, .pagination-nav, article > header,
+      .theme-doc-toc-desktop, .theme-doc-toc-mobile,
+      [class*="copyPageButton"], .theme-doc-markdown > p,
+      .theme-doc-markdown > h1, .theme-doc-markdown > header,
+      [class*="docTitle"], [class*="docFooter"],
+      footer.py-6, .theme-doc-footer { display: none !important; }
       .theme-doc-markdown { margin: 0 !important; }
       .padding-top--md { padding-top: 0 !important; }
       .padding-bottom--lg { padding-bottom: 0 !important; }
-      [class*="docItemContainer"], [class*="docItemCol"],
-      article, .theme-doc-markdown, main,
-      [class*="mainWrapper"], [class*="docsWrapper"],
-      [class*="docSidebarContainer"], [class*="sidebarViewport"],
-      [class*="sidebar_"], aside {
-        border: none !important;
-        border-right: none !important;
-        box-shadow: none !important;
-        outline: none !important;
-      }
-      /* Kill any pseudo-element borders on the sidebar */
-      [class*="docSidebarContainer"]::after,
-      [class*="sidebarViewport"]::after,
-      aside::after { display: none !important; }
     \`;
     document.head.appendChild(style);
     return null;
@@ -221,36 +199,33 @@ import React from 'react';
 <BrowserOnly>
   {() => {
     const [failed, setFailed] = React.useState(false);
-    const iframeUrl = '${scalarUrl}';
 
     if (failed) {
       return (
         <div style={{ padding: '2rem', textAlign: 'center' }}>
           <p>The interactive API reference cannot load in this environment.</p>
-          <p><a href={iframeUrl} target="_blank" rel="noopener noreferrer">Open the API reference in a new tab</a></p>
+          <p><a href="${SCALAR_EXTERNAL_URL}" target="_blank" rel="noopener noreferrer">Open the API reference in a new tab</a></p>
         </div>
       );
     }
 
     return (
       <iframe
-        src={iframeUrl}
+        src="${SCALAR_EXTERNAL_URL}"
         style={{
           width: '100%',
           height: 'calc(100vh - 120px)',
           border: 'none',
           display: 'block',
-          borderRadius: '4px',
         }}
         title="Walrus Oyster API Reference"
         onError={() => setFailed(true)}
         onLoad={(e) => {
           try {
-            // Detect blocked iframe (github.io X-Frame-Options)
             const doc = e.target.contentDocument;
             if (!doc || !doc.body || doc.body.innerHTML === '') setFailed(true);
           } catch (_) {
-            setFailed(true);
+            // Cross-origin iframe loaded successfully
           }
         }}
       />


### PR DESCRIPTION
## Summary

The `openapi.json` (85KB) and `scalar.html` (848KB) blobs are causing 503 errors and 20+ second load times on the Walrus Sites portal, breaking the entire docs site.

- Skip copying `openapi.json` and `scalar.html` into the Docusaurus build output
- Iframe the live Scalar instance at `oyster.testnet.mystenlabs.com/api/docs` instead of hosting a local copy (zero blob storage needed)
- Keep only small static files (`llms.txt`, `llms-full.txt`) from upstream

## Test plan

- [ ] Verify docs.wal.app loads without 503 errors
- [ ] Verify `/oyster/api-reference` shows the embedded Scalar UI
- [ ] Verify other oyster pages load normally