### PR TITLE
docs: fix oyster API reference iframe

### DIFF
--- a/docs/site/src/scripts/transform-oyster-docs.js
+++ b/docs/site/src/scripts/transform-oyster-docs.js
@@ -18,10 +18,6 @@ const SITE_ROOT = path.resolve(__dirname, "../../");
 const CACHE_DIR = path.join(SITE_ROOT, ".cache-oyster/docs/src");
 const OUTPUT_DIR = path.resolve(SITE_ROOT, "../oyster-content");
 
-// External Scalar URL (hosted by the Oyster testnet, not on Walrus Sites)
-const SCALAR_EXTERNAL_URL =
-  "https://oyster.testnet.mystenlabs.com/api/docs";
-
 // ── Frontmatter injection ─────────────────────────────────────────────
 
 function extractTitle(content) {
@@ -171,66 +167,21 @@ hide_title: true
 ---
 
 import BrowserOnly from '@docusaurus/BrowserOnly';
-import React from 'react';
 
 <BrowserOnly>
-  {() => {
-    const style = document.createElement('style');
-    style.textContent = \`
-      .docMainContainer_t2hy, [class*="docMainContainer"] { max-width: 100% !important; }
-      .container { max-width: 100% !important; padding: 0 8px !important; }
-      .col { max-width: 100% !important; flex: 0 0 100% !important; padding: 0 !important; }
-      [class*="docItemContainer"] { max-width: 100% !important; padding: 0 !important; }
-      .theme-doc-breadcrumbs, .pagination-nav, article > header,
-      .theme-doc-toc-desktop, .theme-doc-toc-mobile,
-      [class*="copyPageButton"], .theme-doc-markdown > p,
-      .theme-doc-markdown > h1, .theme-doc-markdown > header,
-      [class*="docTitle"], [class*="docFooter"],
-      footer.py-6, .theme-doc-footer { display: none !important; }
-      .theme-doc-markdown { margin: 0 !important; }
-      .padding-top--md { padding-top: 0 !important; }
-      .padding-bottom--lg { padding-bottom: 0 !important; }
-    \`;
-    document.head.appendChild(style);
-    return null;
-  }}
-</BrowserOnly>
-
-<BrowserOnly>
-  {() => {
-    const [failed, setFailed] = React.useState(false);
-
-    if (failed) {
-      return (
-        <div style={{ padding: '2rem', textAlign: 'center' }}>
-          <p>The interactive API reference cannot load in this environment.</p>
-          <p><a href="${SCALAR_EXTERNAL_URL}" target="_blank" rel="noopener noreferrer">Open the API reference in a new tab</a></p>
-        </div>
-      );
-    }
-
-    return (
-      <iframe
-        src="${SCALAR_EXTERNAL_URL}"
-        style={{
-          width: '100%',
-          height: 'calc(100vh - 120px)',
-          border: 'none',
-          display: 'block',
-        }}
-        title="Walrus Oyster API Reference"
-        onError={() => setFailed(true)}
-        onLoad={(e) => {
-          try {
-            const doc = e.target.contentDocument;
-            if (!doc || !doc.body || doc.body.innerHTML === '') setFailed(true);
-          } catch (_) {
-            // Cross-origin iframe loaded successfully
-          }
-        }}
-      />
-    );
-  }}
+  {() => (
+    <iframe
+      src="https://oyster.testnet.mystenlabs.com/api/docs"
+      style={{
+        width: '100%',
+        height: 'calc(100vh - 60px)',
+        border: 'none',
+        display: 'block',
+      }}
+      title="Walrus Oyster API Reference"
+      allow="clipboard-write"
+    />
+  )}
 </BrowserOnly>
 `;
 }


### PR DESCRIPTION
## Summary

The API reference page shows "cannot load in this environment" because the React error detection code (`useState`/`onLoad`/`catch`) incorrectly triggers the fallback on cross-origin iframes. The `contentDocument` access throws a security error which the catch handler interprets as a failure.

**Fix:** Replace the complex React component with a plain iframe — no state, no error handlers, just the iframe pointing to the live Scalar instance at `oyster.testnet.mystenlabs.com/api/docs`.

Also skips copying `openapi.json` (85KB) and `scalar.html` (848KB) into the build to prevent Walrus Sites 503s.

## Test plan

- [ ] Verify `/oyster/api-reference` shows the embedded Scalar UI
- [ ] Verify other oyster doc pages load normally
- [ ] Verify no 503 errors on docs.wal.app