### PR TITLE
docs: swap Walrus Console and Walrus Skills card placement on homepage

### DIFF
--- a/docs/content/console/api-reference.mdx
+++ b/docs/content/console/api-reference.mdx
@@ -1,10 +1,10 @@
 ---
 title: API Reference
-description: The Console developer API surface for spaces, buckets, files, search, signed downloads, and Seal sponsorship, including authentication, conventions, rate limits, and error codes.
-keywords: [walrus console, api reference, spaces, buckets, files, search, seal, api keys]
+description: The Console developer API surface for spaces, folders, files, search, signed downloads, and Seal sponsorship, including authentication, conventions, rate limits, and error codes.
+keywords: [walrus console, api reference, spaces, folders, files, search, seal, api keys]
 ---
 
-The Console developer API covers the endpoints third-party developers use to manage spaces, buckets, and files, plus the [Seal](/docs/data-security) endpoints that back private-bucket access control.
+The Console developer API covers the endpoints third-party developers use to manage spaces, folders, and files, plus the [Seal](/docs/data-security) endpoints that back private-folder access control.
 
 :::info
 
@@ -22,7 +22,7 @@ Authorization: Bearer hbr_…
 
 Mint keys through the Console web interface. Each key carries one of three scopes:
 
-1. `read_write` keys can change state: create and delete buckets, upload and delete files, and finalize private buckets.
+1. `read_write` keys can change state: create and delete folders, upload and delete files, and finalize private folders.
 2. `read_only` keys can list, check status, mint download URLs, and download. Any other write with a read-only key returns `403` with code `read_only_api_key`.
 3. `key_admin` keys belong to Management API keys. They reach only the API-key endpoints and the Seal sponsor endpoints, and every data-plane endpoint returns `403`. This page covers the data-plane keys. For programmatic key minting, see the [MCP server](./mcp-server#mint-keys-for-other-agents).
 
@@ -40,11 +40,11 @@ Request and response bodies are JSON unless noted. File upload uses `multipart/f
 
 ### Pagination
 
-List endpoints return an opaque cursor. Pass `limit` to set page size and `cursor` to fetch the next page. When there are no further results, the cursor field returns `null`. Bucket lists return the cursor as `next_cursor`. File lists and search return a `pagination` object with `limit`, `has_more`, and `next_cursor`.
+List endpoints return an opaque cursor. Pass `limit` to set page size and `cursor` to fetch the next page. When there are no further results, the cursor field returns `null`. Folder lists return the cursor as `next_cursor`. File lists and search return a `pagination` object with `limit`, `has_more`, and `next_cursor`.
 
 ### Asynchronous operations
 
-Console processes upload and delete operations asynchronously. Upload returns `202` with a file ID, then you poll the file status endpoint until the job state is `completed`. Delete returns `204` immediately and releases storage after a background worker confirms the removal. Deleting a bucket also deletes every file in it.
+Console processes upload and delete operations asynchronously. Upload returns `202` with a file ID, then you poll the file status endpoint until the job state is `completed`. Delete returns `204` immediately and releases storage after a background worker confirms the removal. Deleting a folder also deletes every file in it.
 
 ## Errors
 
@@ -54,7 +54,7 @@ Most error responses use the shape:
 { "error": "Human-readable message", "code": "machine_readable_code" }
 ```
 
-The `code` field is present when a machine-readable value applies. Some bucket errors, such as a `409` name conflict, carry `error` only. Validation failures on the file and search routes return `400` with code `bad_request`. Validation failures on the other routes return `400` with the raw validator output instead:
+The `code` field is present when a machine-readable value applies. Some folder errors, such as a `409` name conflict, carry `error` only. Validation failures on the file and search routes return `400` with code `bad_request`. Validation failures on the other routes return `400` with the raw validator output instead:
 
 ```json
 { "success": false, "error": { "name": "ZodError", "issues": [ … ] } }
@@ -68,15 +68,15 @@ Common error codes include:
 | `401` | `api_key_registering` / `api_key_revoking` / `api_key_revoked` | The key is not currently usable. |
 | `403` | `read_only_api_key` | A write was attempted with a read-only key. |
 | `403` | `insufficient_scope` | The key's scope does not cover the endpoint. |
-| `403` | `bucket_not_in_scope` | The key cannot access the target bucket, or the space in the path is not the key's space. |
+| `403` | `bucket_not_in_scope` | The key cannot access the target folder, or the space in the path is not the key's space. |
 | `403` | `mirror_missing_grant` | The onchain access grant has not yet mirrored into the access index. Retry. |
-| `409` | `bucket_not_finalized` | The bucket has not completed the finalize step. |
-| `409` | `bucket_deleting` / `bucket_gone` | The bucket is being deleted, or its storage is already gone. |
+| `409` | `bucket_not_finalized` | The folder has not completed the finalize step. |
+| `409` | `bucket_deleting` / `bucket_gone` | The folder is being deleted, or its storage is already gone. |
 | `410` | `sponsor_digest_expired` | The sponsor digest is unknown, expired, or bound to a different key. |
 | `413` | `payload_too_large` | The upload exceeds the 100 MiB per-upload cap. |
 | `415` | `unsupported_file_type` | The request content type is not accepted. |
 | `422` | `quota_exceeded` | The operation exceeds the storage quota. |
-| `422` | `plan_limit_exceeded` | The operation exceeds the bucket or storage limit. See the shape below. |
+| `422` | `plan_limit_exceeded` | The operation exceeds the folder or storage limit. See the shape below. |
 | `423` | `file_deleting` | The file is being deleted. |
 | `429` | `TooManyRequestsError` | The rate limit was exceeded. Read `Retry-After`. |
 | `400` | `bad_request` | The request failed validation on a file or search route. |
@@ -93,7 +93,7 @@ Requests that exceed a limit return `422` with a distinct shape:
 }
 ```
 
-The `limit` value is one of `storage`, `users`, or `buckets`. `limit_value` is present for `buckets` and `users`. Each space allows 5 GB of storage and five buckets, and each upload is capped at 100 MiB.
+The `limit` value is one of `storage`, `users`, or `buckets`. `limit_value` is present for `buckets` and `users`. Each space allows 5 GB of storage and five folders, and each upload is capped at 100 MiB.
 
 ## Spaces
 
@@ -117,7 +117,7 @@ Returns `200` with a `data` array of spaces. Each space includes `id`, `type`, `
 
 Returns the storage usage of the key's space. Returns `200` with `data.storage_used`, `data.storage_cap`, and `data.available` in bytes, `data.percent_used` as a fraction from 0 to 1, and `data.breakdown` with the usage grouped by file category and by file format.
 
-### List buckets in a space
+### List folders in a space
 
 `GET /api/v1/spaces/{id}/buckets`
 
@@ -126,18 +126,18 @@ Returns the storage usage of the key's space. Returns `200` with `data.storage_u
 | `id` | path | Yes | Space UUID. |
 | `limit` | query | No | Page size, 1 to 1000. Default 100. |
 | `cursor` | query | No | Cursor from a previous page. |
-| `q` | query | No | Case-insensitive substring match on bucket name. |
+| `q` | query | No | Case-insensitive substring match on folder name. |
 | `visibility` | query | No | Filter by `public` or `private`. |
 | `sortField` | query | No | `name`, `date`, or `storage`. Default `date`. |
 | `sortOrder` | query | No | `asc` or `desc`. Default `desc`. |
 
-Returns `200` with `buckets` and `next_cursor`. Each bucket has the fields listed under [Get a bucket](#get-a-bucket).
+Returns `200` with `buckets` and `next_cursor`. Each folder has the fields listed under [Get a folder](#get-a-folder).
 
-### Create a bucket
+### Create a folder
 
 `POST /api/v1/spaces/{id}/buckets`
 
-Reserves a private bucket. This is the first step of the reserve, sign, and finalize handshake. In beta, `scope` accepts `private` only.
+Reserves a private folder. This is the first step of the reserve, sign, and finalize handshake. In beta, `scope` accepts `private` only.
 
 Body:
 
@@ -158,13 +158,13 @@ Returns `201` with the reservation:
 }
 ```
 
-Sign `bytes` locally with your service key, then call the finalize endpoint. `owner_address` is the Sui address of the Console account that owns the bucket. `admin_signer_address` is the address of the space's Management API key signer, or `null` when the space has none. A bucket in `pending_policy` is not visible to the file endpoints, which return `404` for it until finalize succeeds. A name conflict returns `409`. Exceeding the bucket limit returns `422`. See the [Quick Start](./quickstart) for the full signing flow.
+Sign `bytes` locally with your service key, then call the finalize endpoint. `owner_address` is the Sui address of the Console account that owns the folder. `admin_signer_address` is the address of the space's Management API key signer, or `null` when the space has none. A folder in `pending_policy` is not visible to the file endpoints, which return `404` for it until finalize succeeds. A name conflict returns `409`. Exceeding the folder limit returns `422`. See the [Quick Start](./quickstart) for the full signing flow.
 
 ### List files in a space
 
 `GET /api/v1/spaces/{id}/files`
 
-Lists files across every bucket in the space.
+Lists files across every folder in the space.
 
 | **Parameter** | **Location** | **Required** | **Description** |
 | --- | --- | --- | --- |
@@ -177,35 +177,35 @@ Lists files across every bucket in the space.
 
 Returns `200` with `data` and a `pagination` object (`limit`, `has_more`, `next_cursor`).
 
-## Buckets
+## Folders
 
-A bucket holds files inside a space. Private buckets store [Seal](/docs/data-security) ciphertext only.
+A folder holds files inside a space. Private folders store [Seal](/docs/data-security) ciphertext only.
 
-### Get a bucket
+### Get a folder
 
 `GET /api/v1/buckets/{id}`
 
-Returns `200` with the bucket under `data`: `id`, `space_id`, `name`, `oyster_bucket_name`, `walrus_bucket_id`, `visibility`, `status`, `provisioning_state`, `seal_policy_id`, `storage_used`, `file_count`, `metadata`, `last_opened_at`, `expires_at`, `created_at`, and `updated_at`. `status` is one of `active`, `deleting`, or `deleted`. Just after finalize, this endpoint can also return `403` with code `mirror_missing_grant` until the access grant propagates.
+Returns `200` with the folder under `data`: `id`, `space_id`, `name`, `oyster_bucket_name`, `walrus_bucket_id`, `visibility`, `status`, `provisioning_state`, `seal_policy_id`, `storage_used`, `file_count`, `metadata`, `last_opened_at`, `expires_at`, `created_at`, and `updated_at`. `status` is one of `active`, `deleting`, or `deleted`. Just after finalize, this endpoint can also return `403` with code `mirror_missing_grant` until the access grant propagates.
 
-### Update a bucket
+### Update a folder
 
 `PUT /api/v1/buckets/{id}`
 
 | **Field** | **Required** | **Description** |
 | --- | --- | --- |
-| `name` | Yes | New bucket name, 1 to 100 characters in length. |
-| `sealPolicyId` | No | Seal policy ID. A private bucket cannot clear it. |
+| `name` | Yes | New folder name, 1 to 100 characters in length. |
+| `sealPolicyId` | No | Seal policy ID. A private folder cannot clear it. |
 | `visibility` | No | Immutable in v1. Changing it returns `403`. |
 
-Returns `200` with the updated bucket under `data` (`id`, `name`, `visibility`, `updated_at`). A name conflict returns `409`. Unknown fields return `400`.
+Returns `200` with the updated folder under `data` (`id`, `name`, `visibility`, `updated_at`). A name conflict returns `409`. Unknown fields return `400`.
 
-### Get bucket metadata
+### Get folder metadata
 
 `GET /api/v1/buckets/{id}/metadata`
 
-Returns `200` with the bucket's description, tags, and statistics under `data`: `description`, `tags`, `size`, `asset_count`, `created_at`, `updated_at`, and `last_opened_at`.
+Returns `200` with the folder's description, tags, and statistics under `data`: `description`, `tags`, `size`, `asset_count`, `created_at`, `updated_at`, and `last_opened_at`.
 
-### Update bucket metadata
+### Update folder metadata
 
 `PATCH /api/v1/buckets/{id}/metadata`
 
@@ -216,17 +216,17 @@ Returns `200` with the bucket's description, tags, and statistics under `data`: 
 
 Send at least one field. Returns `200` with the same shape as the metadata endpoint under `data`.
 
-### Delete a bucket
+### Delete a folder
 
 `DELETE /api/v1/buckets/{id}?confirm=true`
 
-Requires the `confirm=true` query parameter. The delete cascades to every file in the bucket: each file moves to `deleting`, and a background worker releases the storage afterward. Returns `204` with an `X-Deleted-Id` header. A missing confirmation or a validation error returns `400`.
+Requires the `confirm=true` query parameter. The delete cascades to every file in the folder: each file moves to `deleting`, and a background worker releases the storage afterward. Returns `204` with an `X-Deleted-Id` header. A missing confirmation or a validation error returns `400`.
 
-### Finalize a private bucket
+### Finalize a private folder
 
 `POST /api/v1/buckets/{id}/finalize`
 
-Submits the signature over the reserved transaction bytes to activate a pending private bucket.
+Submits the signature over the reserved transaction bytes to activate a pending private folder.
 
 Body:
 
@@ -240,9 +240,9 @@ Returns `200`:
 { "bucket_id": "…", "seal_policy_id": "…", "provisioning_state": "active" }
 ```
 
-`seal_policy_id` is the onchain bucket-policy object ID used by Seal for access checks. You can now upload to the bucket.
+`seal_policy_id` is the onchain bucket-policy object ID used by Seal for access checks. You can now upload to the folder.
 
-### List files in a bucket
+### List files in a folder
 
 `GET /api/v1/buckets/{id}/files`
 
@@ -256,12 +256,12 @@ Uploads a file asynchronously using `multipart/form-data`.
 
 | **Field** | **Required** | **Description** |
 | --- | --- | --- |
-| `file` | Yes | The file bytes. For private buckets, upload the Seal-encrypted object. |
+| `file` | Yes | The file bytes. For private folders, upload the Seal-encrypted object. |
 | `name` | No | File name, up to 255 characters in length. |
 | `contentSize` | No | Plaintext byte count for a ciphertext upload, so Console can show the original size. |
 | `metadata` | No | JSON object string persisted with the file. Maximum 8 KiB. |
 
-Returns `202` with the file summary under `data`. Poll the status endpoint until the job state is `completed`, at which point the file status is `active`. When the name already exists in the bucket, Console renames the new file to `<name> (1).<ext>` and still returns `202`.
+Returns `202` with the file summary under `data`. Poll the status endpoint until the job state is `completed`, at which point the file status is `active`. When the name already exists in the folder, Console renames the new file to `<name> (1).<ext>` and still returns `202`.
 
 :::info
 
@@ -269,7 +269,7 @@ After finalize, the onchain access grant takes a few seconds to propagate to the
 
 :::
 
-Other responses include `404` (the bucket is still in `pending_policy`), `413` (payload too large), `415` (unsupported content type), `422` (quota exceeded), and `429` (rate limited).
+Other responses include `404` (the folder is still in `pending_policy`), `413` (payload too large), `415` (unsupported content type), `422` (quota exceeded), and `429` (rate limited).
 
 ## Files
 
@@ -279,13 +279,13 @@ File endpoints address a single file by ID: metadata, upload status, download, s
 
 `GET /api/v1/buckets/{id}/files/{fileId}`
 
-Returns `200` with the file summary under `data`: `id`, `bucket_id`, `name`, `blob_id`, `oyster_object_id`, `size`, `content_size`, `mime_type`, `status`, `metadata`, `last_opened_at`, `created_at`, `updated_at`, and `deleted_at`. `status` is one of `pending`, `uploading`, `active`, `deleting`, `failed`, or `deleted`. `mime_type` is the type recorded at upload, which for a private bucket is the type of the ciphertext.
+Returns `200` with the file summary under `data`: `id`, `bucket_id`, `name`, `blob_id`, `oyster_object_id`, `size`, `content_size`, `mime_type`, `status`, `metadata`, `last_opened_at`, `created_at`, `updated_at`, and `deleted_at`. `status` is one of `pending`, `uploading`, `active`, `deleting`, `failed`, or `deleted`. `mime_type` is the type recorded at upload, which for a private folder is the type of the ciphertext.
 
 ### Update a file
 
 `PATCH /api/v1/files/{id}`
 
-Renames a file or edits its description and tags. This endpoint takes the file ID directly, not nested under a bucket.
+Renames a file or edits its description and tags. This endpoint takes the file ID directly, not nested under a folder.
 
 | **Field** | **Required** | **Description** |
 | --- | --- | --- |
@@ -317,7 +317,7 @@ Returns `307` with a `Location` header that points at a short-lived signed URL o
 
 Clients drop the `Authorization` header on the redirect hop, which is correct. The token in the signed URL is the credential, and the API key must never reach the user-content host. Do not configure your client to forward the header.
 
-For a private bucket, the bytes are the Seal ciphertext, which you decrypt client-side. See the [Quick Start](./quickstart) for the decrypt flow.
+For a private folder, the bytes are the Seal ciphertext, which you decrypt client-side. See the [Quick Start](./quickstart) for the decrypt flow.
 
 A file in `deleting` or `deleted` status returns `423`.
 
@@ -362,7 +362,7 @@ Builds a sponsored bucket-policy transaction and returns the bytes to sign plus 
 
 | **`kind`** | **Purpose** | **Additional fields** | **Who can call it** |
 | --- | --- | --- | --- |
-| `bucket_group_create` | Create the access group for a reserved bucket. | `bucketId` | Any key, but only for a bucket that same key just reserved. The create-bucket response already returns these bytes, so most callers never call this kind directly. |
+| `bucket_group_create` | Create the access group for a reserved folder. | `bucketId` | Any key, but only for a folder that same key just reserved. The create-folder response already returns these bytes, so most callers never call this kind directly. |
 | `grant_bucket_access` | Grant access to a recipient. | `groupIds` (1 to 1000), `recipientAddress`, `scope` (`read` or `readwrite`) | `key_admin` keys only. |
 
 Other kinds exist for the Console web app and return `403` to every API key.

--- a/docs/content/console/auth.mdx
+++ b/docs/content/console/auth.mdx
@@ -20,7 +20,7 @@ Console uses Sui [zkLogin](https://docs.sui.io/concepts/cryptography/zklogin). Y
 
 1. Visit the [Walrus Console app](https://console.walrus.xyz/).
 2. Choose **Google** or **Apple** and complete the provider sign-in.
-3. Console provisions your account and a [Personal Space](./overview#core-concepts-spaces-buckets-and-files), then takes you to the dashboard.
+3. Console provisions your account and a [Personal Space](./overview#core-concepts-spaces-folders-and-files), then takes you to the dashboard.
 
 Apple sign-in derives your Sui address from your Apple identity the same way. It accepts Apple's private email relay, so you can use the **Hide My Email** option.
 

--- a/docs/content/console/faq.mdx
+++ b/docs/content/console/faq.mdx
@@ -11,8 +11,8 @@ questions:
 answer: >-
   Walrus Console stores files on Walrus and lets you manage them from a browser or from code.
   You sign in with a Google or Apple account, mint an API key, and upload. Console limits each
-  space to 5 GB of storage and five buckets, with 100 MiB per file, extends the storage of files you upload through
-  Console automatically, and exposes file and bucket operations
+  space to 5 GB of storage and five folders, with 100 MiB per file, extends the storage of files you upload through
+  Console automatically, and exposes file and folder operations
   to AI clients through an open-source MCP server that reuses the Console keys you already minted.
 ---
 
@@ -38,11 +38,11 @@ With a Google account or an Apple account. Console uses Sui [zkLogin](https://do
 
 ### What are the storage limits?
 
-Each space holds up to 5 GB of storage and five buckets, and each upload is capped at 100 MiB. See [Storage limits](./overview#storage-limits).
+Each space holds up to 5 GB of storage and five folders, and each upload is capped at 100 MiB. See [Storage limits](./overview#storage-limits).
 
 ### What happens when you hit a limit?
 
-Uploads stop at the storage cap, and a sixth bucket returns a `plan_limit_exceeded` error. Delete files or buckets to free space.
+Uploads stop at the storage cap, and a sixth folder returns a `plan_limit_exceeded` error. Delete files or folders to free space.
 
 ## Your files
 
@@ -74,7 +74,7 @@ Everything programmatic. Both the MCP server and any application you write again
 
 ### How do you use Console with Claude Code or Cursor?
 
-Through the Walrus Console MCP server, the npm package `@mysten-incubation/walrus-console-mcp`, which publishes with the Console beta. It exposes file and bucket operations as tools your agent calls. Run `npx -y @mysten-incubation/walrus-console-mcp@beta install` and give it the two values Console showed you when you minted the key: the `hbr_` API key and the `suiprivkey1` service private key. The installer stores them outside your client configuration, so no key goes in the MCP config file. See [Connect AI clients with the MCP server](./mcp-server).
+Through the Walrus Console MCP server, the npm package `@mysten-incubation/walrus-console-mcp`, which publishes with the Console beta. It exposes file and folder operations as tools your agent calls. Run `npx -y @mysten-incubation/walrus-console-mcp@beta install` and give it the two values Console showed you when you minted the key: the `hbr_` API key and the `suiprivkey1` service private key. The installer stores them outside your client configuration, so no key goes in the MCP config file. See [Connect AI clients with the MCP server](./mcp-server).
 
 ### Can your team share one account?
 

--- a/docs/content/console/mcp-server.mdx
+++ b/docs/content/console/mcp-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Connect AI Clients with the MCP Server
-description: Install the Walrus Console MCP server, register it with Claude Code, Codex, Cursor, or Claude Desktop, and use the file and bucket tools it exposes to your agent.
-keywords: [walrus console, mcp server, claude code, codex, cursor, api key, agent, tools]
+description: Install the Walrus Console MCP server, register it with Claude Code, Codex, Cursor, or Claude Desktop, and use the file and folder tools it exposes to your agent.
+keywords: [walrus console, mcp server, claude code, codex, cursor, api key, agent, tools, folders]
 questions:
   - How do I connect Walrus Console to Claude Code?
   - How do I install the Walrus Console MCP server?
@@ -12,11 +12,11 @@ answer: >-
   credential bundle Console shows when you mint a key, or for the `hbr_` API key and the
   `suiprivkey1` service private key one at a time, stores them outside your client configuration,
   and registers the server with the agents it detects. Call `ping_console` to confirm. The server
-  exposes seventeen tools covering spaces, buckets, and files, and encrypts every file locally
+  exposes seventeen tools covering spaces, folders, and files, and encrypts every file locally
   before upload.
 ---
 
-The Walrus Console MCP server gives an AI client the same file and bucket operations you get in the web app. Your agent creates buckets, uploads and downloads files, and checks storage usage, while encryption and signing stay on your machine.
+The Walrus Console MCP server gives an AI client the same file and folder operations you get in the web app. Your agent creates folders, uploads and downloads files, and checks storage usage, while encryption and signing stay on your machine.
 
 The package is `@mysten-incubation/walrus-console-mcp`, licensed MIT.
 
@@ -86,16 +86,16 @@ Ask the agent to call `ping_console`. It confirms which credentials the server l
 | `ping_console` | Confirm the configured keys | Read |
 | `list_spaces` | List your Personal and Team spaces | Read |
 | `get_storage_usage` | Aggregate storage usage for a space | Read |
-| `list_buckets` | List the buckets in a space | Read |
-| `get_bucket` | Fetch one bucket's metadata | Read |
-| `get_bucket_metadata` | Fetch a bucket's custom metadata | Read |
-| `create_bucket` | Create a private encrypted bucket. Needs the pinned account address | Write |
-| `rename_bucket` | Rename a bucket | Write |
-| `update_bucket_metadata` | Set a bucket's custom metadata | Write |
-| `delete_bucket` | Delete a bucket and its files permanently | Write |
+| `list_buckets` | List the folders in a space | Read |
+| `get_bucket` | Fetch one folder's metadata | Read |
+| `get_bucket_metadata` | Fetch a folder's custom metadata | Read |
+| `create_bucket` | Create a private encrypted folder. Needs the pinned account address | Write |
+| `rename_bucket` | Rename a folder | Write |
+| `update_bucket_metadata` | Set a folder's custom metadata | Write |
+| `delete_bucket` | Delete a folder and its files permanently | Write |
 | `upload_file` | Encrypt and upload a local file | Write |
 | `download_file` | Download and decrypt a file to disk | Read |
-| `list_files` | List the files in a bucket, with search | Read |
+| `list_files` | List the files in a folder, with search | Read |
 | `get_file_status` | Check upload progress | Read |
 | `update_file` | Update a file's name, description, or tags | Write |
 | `delete_file` | Delete one file permanently | Write |
@@ -121,7 +121,7 @@ The server resolves symlinks before it checks containment, so a link inside an a
 
 | **Credential** | **Prefix** | **What it can do** |
 | --- | --- | --- |
-| Working key | `hbr_` | List and create buckets, upload and download files. Cannot mint. |
+| Working key | `hbr_` | List and create folders, upload and download files. Cannot mint. |
 | Key-Admin | `hbradm_` | Mint child keys and sign their access grants. No data-plane access. |
 
 Keep the working key on every host, and the Key-Admin credential on the provisioning host only. Configure it with the installed launcher, either interactively with `config` and the **Management key** choice, or scripted:
@@ -134,7 +134,7 @@ Given a permission and an optional label, the tool generates a child keypair loc
 
 The Key-Admin credential determines the space. You pass `spaceId` so the tool can check, after the mint, that the key landed where you expected. When a step after the mint fails, the result is `ok: false` with a `stage` of `space-check`, `grant`, `activation`, or `persist`, and it usually still carries the credential file. The key already exists at that point, so do not call the tool again to retry. A second call mints a second key and orphans the first, and only the Console web app can revoke it.
 
-The mint-time grant covers the private buckets that already exist in the space. A bucket the server creates later includes a child key only when that key is still active and is already a member of one of the access groups the server recorded. Keys the server had to leave off appear in `roster.droppedCandidates` of the `create_bucket` result. Repair them with a Key-Admin grant, not a new mint.
+The mint-time grant covers the private folders that already exist in the space. A folder the server creates later includes a child key only when that key is still active and is already a member of one of the access groups the server recorded. Keys the server had to leave off appear in `roster.droppedCandidates` of the `create_bucket` result. Repair them with a Key-Admin grant, not a new mint.
 
 Calling `generate_api_key` with only a working key configured returns an error and makes no network call.
 

--- a/docs/content/console/overview.mdx
+++ b/docs/content/console/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: What is Walrus Console?
-description: What Walrus Console is, how it relates to Walrus, and the core concepts you work with (spaces, buckets, files, and asset types).
-keywords: [walrus console, spaces, buckets, files, asset types, zklogin, api keys, seal]
+description: What Walrus Console is, how it relates to Walrus, and the core concepts you work with (spaces, folders, files, and asset types).
+keywords: [walrus console, spaces, folders, files, asset types, zklogin, api keys, seal]
 ---
 
 Walrus Console is the developer-first interface for interacting with the Walrus network. It gives you a hosted place to store, manage, and serve data without running your own Walrus client or handling wallets and tokens directly. You sign in and upload your first file in minutes, then manage everything from one place; when you want programmatic access, you mint an API key.
@@ -18,15 +18,15 @@ Walrus is the underlying protocol: a decentralized network that stores data as b
 
 Walrus Console sits on top of that protocol as a managed developer surface. It handles the parts that are otherwise manual: account and wallet provisioning, storage payment, metadata, and a dashboard and API for organizing your data. Use the CLI and SDKs when you want direct protocol access, and use Console when you want a hosted, managed experience.
 
-## Core concepts: spaces, buckets, and files
+## Core concepts: spaces, folders, and files
 
 Console organizes your data in three levels.
 
 1. A **space** is the top-level container tied to your account. Console creates a **Personal Space** for you automatically when you sign up. A space tracks how much storage you have used against your storage cap. Team Spaces, which let a group share storage under one managed API key, arrive after GA.
 
-2. A **bucket** is a named container inside a space that holds files. Every bucket has a visibility setting. In the current beta, all buckets are private and encrypted with [Seal](/docs/data-security); public buckets are planned for a later release.
+2. A **folder** is a named container inside a space that holds files. Every folder has a visibility setting. In the current beta, all folders are private and encrypted with [Seal](/docs/data-security); public folders are planned for a later release.
 
-3. A **file** is an individual object that lives inside a bucket. Uploads are asynchronous: you upload a file, then poll its status until Console confirms that Walrus stores it. Each file can carry metadata you define, which you can use later to search and organize your data.
+3. A **file** is an individual object that lives inside a folder. Uploads are asynchronous: you upload a file, then poll its status until Console confirms that Walrus stores it. Each file can carry metadata you define, which you can use later to search and organize your data.
 
 ## Encryption and privacy
 
@@ -36,7 +36,7 @@ On Walrus, anyone who has a blob ID can read the bytes of a stored blob. Do not 
 
 :::
 
-Console private buckets solve this by encrypting every file client-side with [Seal](/docs/data-security) before upload. Console stores ciphertext only and never sees your plaintext or your decryption keys. Setting up a private bucket uses a short reserve, sign, and finalize handshake that provisions the bucket's Seal access policy onchain. Encryption on upload and decryption on download both happen on your machine.
+Console private folders solve this by encrypting every file client-side with [Seal](/docs/data-security) before upload. Console stores ciphertext only and never sees your plaintext or your decryption keys. Setting up a private folder uses a short reserve, sign, and finalize handshake that provisions the folder's Seal access policy onchain. Encryption on upload and decryption on download both happen on your machine.
 
 ## Asset types
 
@@ -58,11 +58,11 @@ You own your data. Console does not migrate data you previously stored on Walrus
 
 You mint API keys under **Integrations** in the Console web app, choosing a `read_write` or `read_only` role for each. A plain **API key** works with the MCP server and with any application you write against the API, but it cannot mint further keys. A **Management API key** mints keys programmatically instead, and cannot upload, download, or manage assets. The choice is not permanent, so you can create a Management API key at any time. Console shows the full key (prefixed `hbr_`) once, at creation, and cannot recover it afterward, so store it like a cloud secret access key. For what each role can do, see the [API reference](./api-reference).
 
-Alongside the API key, Console generates a service private key (prefixed `suiprivkey1`) in your browser and shows it once next to the API key. Console stores only the derived public address. You keep the private key locally and use it to sign the transaction that finalizes a private bucket and to authenticate decrypt sessions with Seal. It does not need a token balance.
+Alongside the API key, Console generates a service private key (prefixed `suiprivkey1`) in your browser and shows it once next to the API key. Console stores only the derived public address. You keep the private key locally and use it to sign the transaction that finalizes a private folder and to authenticate decrypt sessions with Seal. It does not need a token balance.
 
 ### Connect AI clients with the MCP server
 
-Console publishes an open-source [MCP](https://modelcontextprotocol.io/) server that exposes file and bucket operations as tools for AI clients, available in beta. See [Connect AI clients with the MCP server](./mcp-server) for installation, the tools it exposes, and how it handles your credentials.
+Console publishes an open-source [MCP](https://modelcontextprotocol.io/) server that exposes file and folder operations as tools for AI clients, available in beta. See [Connect AI clients with the MCP server](./mcp-server) for installation, the tools it exposes, and how it handles your credentials.
 
 ## Storage, epochs, and renewal
 
@@ -72,7 +72,7 @@ Console extends the storage of your files automatically before it expires, so yo
 
 ## Storage limits
 
-Each space holds up to 5 GB of storage and five buckets, and each upload is capped at 100 MiB. Console manages WAL token handling on your behalf.
+Each space holds up to 5 GB of storage and five folders, and each upload is capped at 100 MiB. Console manages WAL token handling on your behalf.
 
 ## What is available in beta
 
@@ -81,7 +81,7 @@ Capabilities roll out in phases. The current beta is a subset of the full produc
 | **Capability** | **Availability** |
 | --- | --- |
 | Google and Apple sign-in, Personal Space | Beta |
-| Private, Seal-encrypted buckets and file upload or download | Beta |
+| Private, Seal-encrypted folders and file upload or download | Beta |
 | API keys and the MCP server | Beta |
 | Automatic storage renewal | Beta |
 | Memory as an asset type | GA |

--- a/docs/content/console/quickstart.mdx
+++ b/docs/content/console/quickstart.mdx
@@ -1,14 +1,14 @@
 ---
 title: Quick Start
-description: Sign up for Walrus Console, mint an API key, then create a Seal-encrypted bucket and upload and download your first file.
-keywords: [walrus console, quickstart, api key, seal, encrypted bucket, upload]
+description: Sign up for Walrus Console, mint an API key, then create a Seal-encrypted folder and upload and download your first file.
+keywords: [walrus console, quickstart, api key, seal, encrypted folder, upload]
 ---
 
-Go from sign-up to a working encrypted upload: create an account, mint an API key, then create a Seal-encrypted bucket and upload, download, and decrypt a file.
+Go from sign-up to a working encrypted upload: create an account, mint an API key, then create a Seal-encrypted folder and upload, download, and decrypt a file.
 
 :::info
 
-The Console developer API is in beta at `api.console.walrus.xyz`. Endpoint shapes might change before GA. In beta, all bucket creation goes through the private, Seal-encrypted flow; Console disables public bucket creation at the API boundary. For the full endpoint surface, see the [API reference](./api-reference); for the product model, see the [concepts and overview](./overview).
+The Console developer API is in beta at `api.console.walrus.xyz`. Endpoint shapes might change before GA. In beta, all folder creation goes through the private, Seal-encrypted flow; Console disables public folder creation at the API boundary. For the full endpoint surface, see the [API reference](./api-reference); for the product model, see the [concepts and overview](./overview).
 
 :::
 
@@ -43,9 +43,9 @@ Authorization: Bearer hbr_…
 
 A `read_only` key (listing, status, and download only) is also available for downstream consumers that should not change your data; every write endpoint returns `403` with code `read_only_api_key` for those keys. The encrypted flow below needs a write-capable key and both secrets above.
 
-## Create an encrypted bucket and upload a file
+## Create an encrypted folder and upload a file
 
-Private buckets are encrypted client-side, so Console stores ciphertext only and never sees your plaintext or decryption material. With your key in hand, creation goes through a reserve, sign, and finalize handshake, then a local encrypt on upload and decrypt on download:
+Private folders are encrypted client-side, so Console stores ciphertext only and never sees your plaintext or decryption material. With your key in hand, creation goes through a reserve, sign, and finalize handshake, then a local encrypt on upload and decrypt on download:
 
 ```
 get space → reserve → sign → finalize → encrypt → upload → poll → download → decrypt
@@ -59,7 +59,7 @@ GET /api/v1/spaces
 
 The response's `data[]` array holds your spaces. Copy the `id` of the Personal Space created at sign-up.
 
-### Step 2: Reserve the bucket
+### Step 2: Reserve the folder
 
 ```http
 POST /api/v1/spaces/{spaceId}/buckets
@@ -81,7 +81,7 @@ Response (`201`):
 }
 ```
 
-`bytes` is the sponsored Sui transaction that creates the bucket's [Seal](/docs/data-security) access policy, with your service key's address as the sender. Console has already attached the gas sponsor's signature, so your service key only needs to add its own. `digest` is the sponsor digest, which Console uses at finalize to look up the sponsored transaction. The bucket stays in `pending_policy` until finalize succeeds. Until then, the file endpoints return `404` for it.
+`bytes` is the sponsored Sui transaction that creates the folder's [Seal](/docs/data-security) access policy, with your service key's address as the sender. Console has already attached the gas sponsor's signature, so your service key only needs to add its own. `digest` is the sponsor digest, which Console uses at finalize to look up the sponsored transaction. The folder stays in `pending_policy` until finalize succeeds. Until then, the file endpoints return `404` for it.
 
 ### The helper code
 
@@ -302,11 +302,11 @@ Console combines your signature with the gas-sponsor signature and broadcasts th
 { "bucket_id": "…", "seal_policy_id": "…", "provisioning_state": "active" }
 ```
 
-`seal_policy_id` is the onchain bucket-policy object ID that Seal uses for access checks. You can now use the bucket.
+`seal_policy_id` is the onchain bucket-policy object ID that Seal uses for access checks. You can now use the folder.
 
 ### Step 5: Encrypt the file with Seal
 
-Encrypt locally against the `seal_policy_id` from finalize. `encryptBytes` (in `seal.ts`) derives a per-file Seal identity and encrypts against the bucket policy using `ORIGINAL_PACKAGE_ID` from `config.ts`. Seal pins identity derivation to the original package ID, so this value must stay fixed across package upgrades, otherwise an upgrade would invalidate every previously encrypted blob's key. This script wires it up:
+Encrypt locally against the `seal_policy_id` from finalize. `encryptBytes` (in `seal.ts`) derives a per-file Seal identity and encrypts against the folder policy using `ORIGINAL_PACKAGE_ID` from `config.ts`. Seal pins identity derivation to the original package ID, so this value must stay fixed across package upgrades, otherwise an upgrade would invalidate every previously encrypted blob's key. This script wires it up:
 
 ```ts title="encrypt-file.ts"
 import { readFile, writeFile } from 'node:fs/promises';

--- a/docs/content/console/storage-epochs.mdx
+++ b/docs/content/console/storage-epochs.mdx
@@ -24,8 +24,8 @@ To keep developers from losing data because they forgot to renew, Console extend
 
 ## Checking storage status
 
-Your dashboard shows how much storage each space is using. Storage used and your storage cap also appear per space when you list spaces through the API, and each bucket reports an `expires_at` timestamp.
+Your dashboard shows how much storage each space is using. Storage used and your storage cap also appear per space when you list spaces through the API, and each folder reports an `expires_at` timestamp.
 
 ## Storage limits
 
-Each space holds up to 5 GB of storage and five buckets, and each upload is capped at 100 MiB.
+Each space holds up to 5 GB of storage and five folders, and each upload is capped at 100 MiB.

--- a/docs/site/src/components/LandingPage.tsx
+++ b/docs/site/src/components/LandingPage.tsx
@@ -189,19 +189,19 @@ const HOME_CARDS = [
     href: '/walrus-memory',
   },
   {
+    image: '/img/home/walrus-sites.webp',
+    title: 'Walrus Console',
+    description:
+      'Manage, protect, and use your data across apps and AI tools.',
+    href: '/docs/console/overview',
+  },
+  {
     image: '/img/home/walrus-skills.webp',
     title: 'Walrus Skills',
     description:
       'Pre-built skills for AI coding agents that accelerate '
       + 'Walrus development.',
     href: '/skills',
-  },
-  {
-    image: '/img/home/walrus-sites.webp',
-    title: 'Walrus Console',
-    description:
-      'Manage, protect, and use your data across apps and AI tools.',
-    href: '/docs/console/overview',
   },
 ];
 


### PR DESCRIPTION
## Summary

Swap the homepage card order so Walrus Console comes before Walrus Skills.

Cards are now: Walrus, Walrus Memory, **Walrus Console**, **Walrus Skills**

## Test plan

- [ ] Verify homepage card order