### PR TITLE
docs: fix vercel.json paths for docs/site root directory

### DIFF
--- a/docs/site/vercel.json
+++ b/docs/site/vercel.json
@@ -1,7 +1,8 @@
 {
-  "buildCommand": "cd docs/site && pnpm install && pnpm run build",
-  "outputDirectory": "docs/site/build",
+  "buildCommand": "pnpm install && pnpm run build",
+  "outputDirectory": "build",
   "framework": null,
+  "installCommand": "pnpm install",
   "headers": [
     {
       "source": "/(.*)\\.html",


### PR DESCRIPTION
## Summary

Fix `vercel.json` build paths. When the Vercel project root is set to `docs/site`, the paths should be relative to that directory, not the repo root.

- `buildCommand`: remove `cd docs/site &&` prefix
- `outputDirectory`: `build` instead of `docs/site/build`
- Add explicit `installCommand`

## Test plan

- [ ] Verify Vercel can import the project with root directory `docs/site`
- [ ] Verify build succeeds on Vercel