### PR TITLE
refactor(storage): abstract sliver storage backend

### DIFF
--- a/crates/walrus-service/src/node.rs
+++ b/crates/walrus-service/src/node.rs
@@ -26,8 +26,6 @@ use consistency_check::StorageNodeConsistencyCheckConfig;
 use epoch_change_driver::EpochChangeDriver;
 use errors::{ListSymbolsError, Unavailable};
 use fastcrypto::traits::KeyPair;
-#[cfg(not(msim))]
-use futures::stream::FuturesUnordered;
 use futures::{
     FutureExt as _,
     StreamExt,
@@ -2198,150 +2196,23 @@ impl StorageNodeInner {
         Ok(())
     }
 
-    async fn first_shard_failing_storage_check(
-        &self,
-        blob_id: BlobId,
-        shard_storages: &[(ShardIndex, Arc<ShardStorage>)],
-        check: fn(&ShardStorage, &BlobId) -> Result<bool, TypedStoreError>,
-    ) -> anyhow::Result<Option<ShardIndex>> {
-        #[cfg(msim)]
-        {
-            for (shard, shard_storage) in shard_storages {
-                let passed =
-                    check(shard_storage.as_ref(), &blob_id).map_err(anyhow::Error::from)?;
-                if !passed {
-                    return Ok(Some(*shard));
-                }
-            }
-            return Ok(None);
-        }
-
-        #[cfg(not(msim))]
-        {
-            const MAX_CONCURRENT_SHARD_STORAGE_CHECKS: usize = 4;
-
-            let thread_pool = self.thread_pool.clone();
-            let make_check = |shard: ShardIndex, shard_storage: Arc<ShardStorage>| {
-                let thread_pool = thread_pool.clone();
-
-                async move {
-                    let passed = thread_pool
-                        .oneshot(move || check(shard_storage.as_ref(), &blob_id))
-                        .map(thread_pool::unwrap_or_resume_panic)
-                        .await
-                        .map_err(anyhow::Error::from)?;
-                    Ok::<_, anyhow::Error>((shard, passed))
-                }
-            };
-
-            let mut shard_iter = shard_storages.iter();
-            let mut checks = FuturesUnordered::new();
-            for _ in 0..MAX_CONCURRENT_SHARD_STORAGE_CHECKS {
-                let Some((shard, shard_storage)) = shard_iter.next() else {
-                    break;
-                };
-                checks.push(make_check(*shard, Arc::clone(shard_storage)));
-            }
-
-            let mut first_failed_shard = None;
-            let mut first_error = None;
-
-            while let Some(result) = checks.next().await {
-                match result {
-                    Ok((shard, false)) => {
-                        if first_failed_shard.is_none() {
-                            first_failed_shard = Some(shard);
-                        }
-                    }
-                    Ok((_, true)) => {}
-                    Err(error) => {
-                        if first_error.is_none() {
-                            first_error = Some(error);
-                        }
-                    }
-                }
-
-                // `oneshot()` schedules detached blocking work underneath. Once a shard check
-                // fails, stop enqueueing new probes but still drain the ones already started so
-                // we don't leave background work behind.
-                if first_failed_shard.is_none()
-                    && first_error.is_none()
-                    && let Some((shard, shard_storage)) = shard_iter.next()
-                {
-                    checks.push(make_check(*shard, Arc::clone(shard_storage)));
-                }
-            }
-
-            if let Some(error) = first_error {
-                Err(error)
-            } else {
-                Ok(first_failed_shard)
-            }
-        }
-    }
-
     #[tracing::instrument(skip_all)]
     async fn is_stored_at_specific_shards(
         &self,
         blob_id: &BlobId,
         shards: &[ShardIndex],
     ) -> anyhow::Result<bool> {
-        let blob_id = *blob_id;
-        let mut shard_storages = Vec::with_capacity(shards.len());
-
-        for shard in shards {
-            let Some(shard_storage) = self.storage.shard_storage(*shard).await else {
-                tracing::warn!(
-                    %shard,
-                    "failed to check if blob is stored at shard: shard does not exist"
-                );
-                return Ok(false);
-            };
-            shard_storages.push((*shard, shard_storage));
-        }
-
-        if shard_storages.len() > 1 {
-            match self
-                .first_shard_failing_storage_check(
-                    blob_id,
-                    &shard_storages,
-                    ShardStorage::may_have_sliver_pair,
-                )
-                .await
-            {
-                Ok(Some(shard)) => {
-                    if cfg!(msim) {
-                        // Extremely helpful for debugging consistency issue in simtest.
-                        tracing::debug!(%blob_id, %shard, "blob not stored at shard");
-                    }
-                    return Ok(false);
-                }
-                Ok(None) => {}
-                Err(error) => {
-                    tracing::warn!(?error, "failed to check if blob is stored at shard");
-                    return Ok(false);
-                }
-            }
-        }
-
         match self
-            .first_shard_failing_storage_check(
-                blob_id,
-                &shard_storages,
-                ShardStorage::is_sliver_pair_stored,
-            )
+            .storage
+            .contains_sliver_pairs_in_all(blob_id, shards)
             .await
         {
-            Ok(Some(shard)) => {
-                if cfg!(msim) {
-                    // Extremely helpful for debugging consistency issue in simtest.
-                    tracing::debug!(%blob_id, %shard, "blob not stored at shard");
-                }
-                Ok(false)
-            }
-            Ok(None) => Ok(true),
+            Ok(is_stored) => Ok(is_stored),
             Err(error) => {
-                tracing::warn!(?error, "failed to check if blob is stored at shard");
+                tracing::warn!(
+                    ?error,
+                    "failed to check if blob is stored in required shards"
+                );
                 Ok(false)
             }
         }
@@ -2419,25 +2290,9 @@ impl StorageNodeInner {
         blob_id: &BlobId,
         active_shard_storages: &[Arc<ShardStorage>],
     ) -> anyhow::Result<bool> {
-        // Mirror `is_stored_at_specific_shards`: run the cheap `may_have_sliver_pair` pre-check
-        // first (only when more than one shard), then the authoritative `is_sliver_pair_stored`.
-        if active_shard_storages.len() > 1 {
-            for shard_storage in active_shard_storages {
-                if !shard_storage.may_have_sliver_pair(blob_id)? {
-                    let shard = shard_storage.id();
-                    tracing::debug!(%blob_id, %shard, "blob not stored at shard");
-                    return Ok(false);
-                }
-            }
-        }
-        for shard_storage in active_shard_storages {
-            if !shard_storage.is_sliver_pair_stored(blob_id)? {
-                let shard = shard_storage.id();
-                tracing::debug!(%blob_id, %shard, "blob not stored at shard");
-                return Ok(false);
-            }
-        }
-        Ok(true)
+        Ok(self
+            .storage
+            .contains_sliver_pairs_in_all_snapshot(blob_id, active_shard_storages)?)
     }
 
     pub(crate) fn storage(&self) -> &Storage {
@@ -6891,18 +6746,16 @@ mod tests {
         assert_eq!(response[0].0, blob_id);
         assert_eq!(
             response[0].1,
-            Sliver::Primary(
-                cluster.nodes[0]
-                    .storage_node
-                    .inner
-                    .storage
-                    .shard_storage(ShardIndex(0))
-                    .await
-                    .unwrap()
-                    .get_primary_sliver(&blob_id)
-                    .unwrap()
-                    .unwrap()
-            )
+            cluster.nodes[0]
+                .storage_node
+                .inner
+                .storage
+                .shard_storage(ShardIndex(0))
+                .await
+                .unwrap()
+                .get_sliver(&blob_id, SliverType::Primary)
+                .unwrap()
+                .unwrap()
         );
 
         Ok(())

--- a/crates/walrus-service/src/node/storage.rs
+++ b/crates/walrus-service/src/node/storage.rs
@@ -85,8 +85,11 @@ pub(crate) use pending_recover_blobs::PendingRecoverBlob;
 use pending_recover_blobs::PendingRecoverBlobsTable;
 
 mod shard;
+mod sliver_store;
 
-pub(crate) use shard::{PrimarySliverData, SecondarySliverData, ShardStatus, ShardStorage};
+pub(crate) use shard::{ShardStatus, ShardStorage};
+use sliver_store::SliverStore;
+pub(crate) use sliver_store::{PrimarySliverData, SecondarySliverData};
 
 /// The status of the node.
 ///
@@ -342,6 +345,7 @@ impl Display for NodeStatus {
 #[derive(Debug, Clone)]
 pub struct Storage {
     database: Arc<RocksDB>,
+    sliver_store: SliverStore,
     node_status: DBMap<(), NodeStatus>,
     metadata: DBMap<BlobId, BlobMetadata>,
     blob_info: BlobInfoTable,
@@ -482,6 +486,9 @@ impl Storage {
             )?
         };
 
+        let sliver_store =
+            SliverStore::new_rocksdb(Arc::clone(&database), db_table_opts_factory.clone());
+
         let node_status = DBMap::reopen(
             &database,
             Some(node_status_cf_name),
@@ -532,6 +539,7 @@ impl Storage {
                     ShardStorage::create_or_reopen(
                         id,
                         &database,
+                        &sliver_store,
                         &db_table_opts_factory,
                         None,
                         &metrics_registry,
@@ -548,6 +556,7 @@ impl Storage {
 
         let storage = Self {
             database,
+            sliver_store,
             node_status,
             metadata,
             blob_info,
@@ -694,6 +703,7 @@ impl Storage {
             let shard_storage = ShardStorage::create_or_reopen(
                 shard_index,
                 &self.database,
+                &self.sliver_store,
                 &self.db_table_opts_factory,
                 Some(ShardStatus::None),
                 &self.metrics_registry,
@@ -1328,6 +1338,51 @@ impl Storage {
             shard.delete_sliver_pair_in_transaction(transaction, blob_id)?;
         }
         Ok(())
+    }
+
+    /// Returns whether both sliver types are stored for `blob_id` in every required shard.
+    ///
+    /// The operation is delegated as one unit so storage backends that index a blob across shards
+    /// can answer it without issuing one lookup per shard.
+    pub(crate) async fn contains_sliver_pairs_in_all(
+        &self,
+        blob_id: &BlobId,
+        required_shards: &[ShardIndex],
+    ) -> Result<bool, TypedStoreError> {
+        let shard_stores = {
+            let shards = self.shards.read().await;
+            let mut stores = Vec::with_capacity(required_shards.len());
+            for shard in required_shards {
+                let Some(storage) = shards.get(shard) else {
+                    tracing::warn!(
+                        %shard,
+                        "failed to check if blob is stored at shard: shard does not exist"
+                    );
+                    return Ok(false);
+                };
+                stores.push((*shard, storage.sliver_store()));
+            }
+            stores
+        };
+
+        self.sliver_store
+            .contains_sliver_pairs_in_all(*blob_id, shard_stores)
+            .await
+    }
+
+    /// Synchronous coverage check for callers that already run on a blocking executor.
+    #[cfg(msim)]
+    pub(crate) fn contains_sliver_pairs_in_all_snapshot(
+        &self,
+        blob_id: &BlobId,
+        shard_storages: &[Arc<ShardStorage>],
+    ) -> Result<bool, TypedStoreError> {
+        let stores = shard_storages
+            .iter()
+            .map(|storage| (storage.id(), storage.sliver_store()))
+            .collect::<Vec<_>>();
+        self.sliver_store
+            .contains_sliver_pairs_in_all_sync(blob_id, &stores)
     }
 
     /// Returns true if the provided blob-id is stored at the specified shard.
@@ -2039,6 +2094,54 @@ pub(crate) mod tests {
             let result: Vec<_> = storage.as_ref().shards_with_sliver_pairs(&BLOB_ID).await?;
 
             assert_eq!(result, [OTHER_SHARD_INDEX]);
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn checks_sliver_pair_coverage_as_one_storage_operation() -> TestResult {
+            let storage = populated_storage(&[
+                (SHARD_INDEX, vec![(BLOB_ID, WhichSlivers::Both)]),
+                (OTHER_SHARD_INDEX, vec![(BLOB_ID, WhichSlivers::Both)]),
+            ])
+            .await?;
+
+            assert!(
+                storage
+                    .as_ref()
+                    .contains_sliver_pairs_in_all(&BLOB_ID, &[SHARD_INDEX, OTHER_SHARD_INDEX])
+                    .await?
+            );
+            assert!(
+                storage
+                    .as_ref()
+                    .contains_sliver_pairs_in_all(&BLOB_ID, &[])
+                    .await?
+            );
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn coverage_is_false_for_an_incomplete_or_missing_shard() -> TestResult {
+            let storage = populated_storage(&[
+                (SHARD_INDEX, vec![(BLOB_ID, WhichSlivers::Both)]),
+                (OTHER_SHARD_INDEX, vec![(BLOB_ID, WhichSlivers::Primary)]),
+            ])
+            .await?;
+
+            assert!(
+                !storage
+                    .as_ref()
+                    .contains_sliver_pairs_in_all(&BLOB_ID, &[SHARD_INDEX, OTHER_SHARD_INDEX])
+                    .await?
+            );
+            assert!(
+                !storage
+                    .as_ref()
+                    .contains_sliver_pairs_in_all(&BLOB_ID, &[ShardIndex(u16::MAX)])
+                    .await?
+            );
 
             Ok(())
         }

--- a/crates/walrus-service/src/node/storage/shard.rs
+++ b/crates/walrus-service/src/node/storage/shard.rs
@@ -38,8 +38,7 @@ use walrus_core::{
     ShardIndex,
     Sliver,
     SliverType,
-    by_axis::ByAxis,
-    encoding::{EncodingAxis, Primary, PrimarySliver, Secondary, SecondarySliver},
+    encoding::{EncodingAxis, Primary, Secondary},
 };
 use walrus_utils::{metrics::Registry, tracing_sampled};
 
@@ -48,16 +47,14 @@ use super::{
     blob_info::{BlobInfo, BlobInfoIterator, CertifiedBlobInfoApi},
     constants,
     metrics::{CommonDatabaseMetrics, Labels, OperationType},
+    sliver_store::{ShardSliverStore, SliverStore},
 };
-use crate::{
-    node::{
-        StorageNodeInner,
-        blob_retirement_notifier::ExecutionResultWithRetirementCheck,
-        config::ShardSyncConfig,
-        errors::{StoreSliverError, SyncShardClientError},
-        shard_sync,
-    },
-    utils,
+use crate::node::{
+    StorageNodeInner,
+    blob_retirement_notifier::ExecutionResultWithRetirementCheck,
+    config::ShardSyncConfig,
+    errors::{StoreSliverError, SyncShardClientError},
+    shard_sync,
 };
 
 type ShardMetrics = CommonDatabaseMetrics;
@@ -96,16 +93,6 @@ struct ShardColumnFamilyNames {
     secondary_slivers: String,
     shard_status: String,
     shard_sync_progress: String,
-}
-
-impl ShardColumnFamilyNames {
-    fn generic_slivers(&self, axis: SliverType) -> &str {
-        if axis.is_primary() {
-            "shard/primary-slivers"
-        } else {
-            "shard/secondary-slivers"
-        }
-    }
 }
 
 impl ShardColumnFamilyNames {
@@ -261,64 +248,15 @@ pub(crate) enum ShardLastSyncStatus {
     Recovery,
 }
 
-/// Primary sliver data stored in the database.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum PrimarySliverData {
-    V1(PrimarySliver),
-}
-
-impl From<PrimarySliver> for PrimarySliverData {
-    fn from(sliver: PrimarySliver) -> Self {
-        Self::V1(sliver)
-    }
-}
-
-impl From<PrimarySliverData> for PrimarySliver {
-    fn from(data: PrimarySliverData) -> Self {
-        match data {
-            PrimarySliverData::V1(sliver) => sliver,
-        }
-    }
-}
-
-/// Secondary sliver data stored in the database.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum SecondarySliverData {
-    V1(SecondarySliver),
-}
-
-impl From<SecondarySliver> for SecondarySliverData {
-    fn from(sliver: SecondarySliver) -> Self {
-        Self::V1(sliver)
-    }
-}
-
-impl From<SecondarySliverData> for SecondarySliver {
-    fn from(data: SecondarySliverData) -> Self {
-        match data {
-            SecondarySliverData::V1(sliver) => sliver,
-        }
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct ShardStorage {
     id: ShardIndex,
+    database: Arc<RocksDB>,
     shard_status: Arc<RwLock<ShardStatusState>>,
-    primary_slivers: DBMap<BlobId, PrimarySliverData>,
-    secondary_slivers: DBMap<BlobId, SecondarySliverData>,
+    slivers: ShardSliverStore,
     shard_sync_progress: DBMap<(), ShardSyncProgress>,
     pending_recover_slivers: DBMap<(SliverType, BlobId), ()>,
-    metrics: ShardMetrics,
     cf_names: Arc<ShardColumnFamilyNames>,
-    sst_primary_buffer: Arc<
-        OnceLock<std::sync::Mutex<typed_store::rocks::SstIngestBuffer<BlobId, PrimarySliverData>>>,
-    >,
-    sst_secondary_buffer: Arc<
-        OnceLock<
-            std::sync::Mutex<typed_store::rocks::SstIngestBuffer<BlobId, SecondarySliverData>>,
-        >,
-    >,
 }
 
 macro_rules! reopen_cf {
@@ -340,6 +278,7 @@ impl ShardStorage {
     pub(crate) fn create_or_reopen(
         id: ShardIndex,
         database: &Arc<RocksDB>,
+        sliver_store: &SliverStore,
         db_table_opts_factory: &DatabaseTableOptionsFactory,
         initial_shard_status: Option<ShardStatus>,
         registry: &Registry,
@@ -358,6 +297,7 @@ impl ShardStorage {
         let response = Self::create_or_reopen_inner(
             id,
             database,
+            sliver_store,
             db_table_opts_factory,
             initial_shard_status,
             metrics.clone(),
@@ -374,6 +314,7 @@ impl ShardStorage {
     fn create_or_reopen_inner(
         id: ShardIndex,
         database: &Arc<RocksDB>,
+        sliver_store: &SliverStore,
         db_table_opts_factory: &DatabaseTableOptionsFactory,
         initial_shard_status: Option<ShardStatus>,
         metrics: ShardMetrics,
@@ -420,38 +361,18 @@ impl ShardStorage {
             rw_options
         );
 
-        // Make sure that sliver column families are created last. They are used to identify
-        // whether the shard storage is initialized in `existing_cf_shards_ids`.
-        let primary_slivers = reopen_cf!(
-            (
-                &cf_names.primary_slivers,
-                "primary_slivers",
-                db_table_opts_factory.shard(),
-            ),
-            database,
-            rw_options
-        );
-        let secondary_slivers = reopen_cf!(
-            (
-                &cf_names.secondary_slivers,
-                "secondary_slivers",
-                db_table_opts_factory.shard(),
-            ),
-            database,
-            rw_options
-        );
+        // Open sliver storage last. For RocksDB, its column families remain the completion marker
+        // used by `existing_cf_shards_ids`.
+        let slivers = sliver_store.open_shard(id, metrics)?;
 
         Ok(Self {
             id,
+            database: Arc::clone(database),
             shard_status,
-            primary_slivers,
-            secondary_slivers,
+            slivers,
             shard_sync_progress,
             pending_recover_slivers,
-            metrics,
             cf_names: Arc::new(cf_names),
-            sst_primary_buffer: Arc::new(OnceLock::new()),
-            sst_secondary_buffer: Arc::new(OnceLock::new()),
         })
     }
 
@@ -462,42 +383,15 @@ impl ShardStorage {
         blob_id: BlobId,
         sliver: Sliver,
     ) -> Result<(), TypedStoreError> {
-        let start = Instant::now();
-        let labels = Labels {
-            collection_name: self.cf_names.generic_slivers(sliver.r#type()),
-            operation_name: OperationType::Insert,
-            query_summary: "INSERT (blob_id, sliver)",
-            ..Default::default()
-        };
-
-        let response = match sliver {
-            Sliver::Primary(primary) => {
-                let table = self.primary_slivers.clone();
-
-                tokio::task::spawn_blocking(move || {
-                    table.insert(&blob_id, &PrimarySliverData::from(primary))
-                })
-                .await
-            }
-            Sliver::Secondary(secondary) => {
-                let table = self.secondary_slivers.clone();
-
-                tokio::task::spawn_blocking(move || {
-                    table.insert(&blob_id, &SecondarySliverData::from(secondary))
-                })
-                .await
-            }
-        };
-        let response = utils::unwrap_or_resume_unwind(response);
-
-        self.metrics
-            .observe_operation_duration(labels.with_response(response.as_ref()), start.elapsed());
-
-        response
+        self.slivers.put(blob_id, sliver).await
     }
 
     pub(crate) fn id(&self) -> ShardIndex {
         self.id
+    }
+
+    pub(super) fn sliver_store(&self) -> ShardSliverStore {
+        self.slivers.clone()
     }
 
     /// Returns the sliver of the specified type that is stored for that Blob ID, if any.
@@ -507,104 +401,13 @@ impl ShardStorage {
         blob_id: &BlobId,
         sliver_type: SliverType,
     ) -> Result<Option<Sliver>, TypedStoreError> {
-        match sliver_type {
-            SliverType::Primary => self
-                .get_primary_sliver(blob_id)
-                .map(|s| s.map(Sliver::Primary)),
-            SliverType::Secondary => self
-                .get_secondary_sliver(blob_id)
-                .map(|s| s.map(Sliver::Secondary)),
-        }
-    }
-
-    /// Retrieves the stored primary sliver for the given blob ID.
-    #[tracing::instrument(skip_all, fields(walrus.shard_index = %self.id), err)]
-    pub(crate) fn get_primary_sliver(
-        &self,
-        blob_id: &BlobId,
-    ) -> Result<Option<PrimarySliver>, TypedStoreError> {
-        let start = Instant::now();
-        let labels = Labels {
-            collection_name: self.cf_names.generic_slivers(SliverType::Primary),
-            operation_name: OperationType::Get,
-            query_summary: "GET primary_sliver BY blob_id",
-            ..Labels::default()
-        };
-
-        let response = self
-            .primary_slivers
-            .get(blob_id)
-            .map(|s| s.map(|s| s.into()));
-
-        self.metrics
-            .observe_operation_duration(labels.with_response(response.as_ref()), start.elapsed());
-
-        response
-    }
-
-    /// Retrieves the stored secondary sliver for the given blob ID.
-    #[tracing::instrument(skip_all, fields(walrus.shard_index = %self.id), err)]
-    pub(crate) fn get_secondary_sliver(
-        &self,
-        blob_id: &BlobId,
-    ) -> Result<Option<SecondarySliver>, TypedStoreError> {
-        let start = Instant::now();
-        let labels = Labels {
-            collection_name: self.cf_names.generic_slivers(SliverType::Secondary),
-            operation_name: OperationType::Get,
-            query_summary: "GET secondary_sliver BY blob_id",
-            ..Labels::default()
-        };
-
-        let response = self
-            .secondary_slivers
-            .get(blob_id)
-            .map(|s| s.map(|s| s.into()));
-
-        self.metrics
-            .observe_operation_duration(labels.with_response(response.as_ref()), start.elapsed());
-
-        response
-    }
-
-    /// Returns false only if the shard can prove the sliver-pair is absent.
-    /// May return true for absent sliver-pairs due to bloom-filter false positives.
-    #[tracing::instrument(skip_all, fields(walrus.shard_index = %self.id), err)]
-    pub(crate) fn may_have_sliver_pair(&self, blob_id: &BlobId) -> Result<bool, TypedStoreError> {
-        Ok(self.may_have_sliver_type(blob_id, SliverType::Primary)?
-            && self.may_have_sliver_type(blob_id, SliverType::Secondary)?)
-    }
-
-    #[tracing::instrument(skip_all, fields(walrus.shard_index = %self.id), err)]
-    fn may_have_sliver_type(
-        &self,
-        blob_id: &BlobId,
-        type_: SliverType,
-    ) -> Result<bool, TypedStoreError> {
-        let start = Instant::now();
-        let labels = Labels {
-            collection_name: self.cf_names.generic_slivers(type_),
-            operation_name: OperationType::ContainsKey,
-            query_summary: "KEY_MAY_EXIST blob_id",
-            ..Labels::default()
-        };
-
-        let response = match type_ {
-            SliverType::Primary => self.primary_slivers.may_contain_key(blob_id),
-            SliverType::Secondary => self.secondary_slivers.may_contain_key(blob_id),
-        };
-
-        self.metrics
-            .observe_operation_duration(labels.with_response(response.as_ref()), start.elapsed());
-
-        response
+        self.slivers.get(blob_id, sliver_type)
     }
 
     /// Returns true iff the sliver-pair for the given blob ID is stored by the shard.
     #[tracing::instrument(skip_all, fields(walrus.shard_index = %self.id), err)]
     pub(crate) fn is_sliver_pair_stored(&self, blob_id: &BlobId) -> Result<bool, TypedStoreError> {
-        Ok(self.is_sliver_stored::<Primary>(blob_id)?
-            && self.is_sliver_stored::<Secondary>(blob_id)?)
+        self.slivers.is_sliver_pair_stored(blob_id)
     }
 
     #[tracing::instrument(skip_all, fields(walrus.shard_index = %self.id), err)]
@@ -621,23 +424,7 @@ impl ShardStorage {
         blob_id: &BlobId,
         type_: SliverType,
     ) -> Result<bool, TypedStoreError> {
-        let start = Instant::now();
-        let labels = Labels {
-            collection_name: self.cf_names.generic_slivers(type_),
-            operation_name: OperationType::ContainsKey,
-            query_summary: "CONTAINS_KEY blob_id",
-            ..Labels::default()
-        };
-
-        let response = match type_ {
-            SliverType::Primary => self.primary_slivers.contains_key(blob_id),
-            SliverType::Secondary => self.secondary_slivers.contains_key(blob_id),
-        };
-
-        self.metrics
-            .observe_operation_duration(labels.with_response(response.as_ref()), start.elapsed());
-
-        response
+        self.slivers.contains(blob_id, type_)
     }
 
     /// Deletes the sliver pair for the given [`BlobId`].
@@ -647,9 +434,7 @@ impl ShardStorage {
         batch: &mut DBBatch,
         blob_id: &BlobId,
     ) -> Result<(), TypedStoreError> {
-        batch.delete_batch(&self.primary_slivers, std::iter::once(blob_id))?;
-        batch.delete_batch(&self.secondary_slivers, std::iter::once(blob_id))?;
-        Ok(())
+        self.slivers.delete_pair_in_batch(batch, blob_id)
     }
 
     /// Deletes the sliver pair for the given [`BlobId`] within a DB transaction.
@@ -658,11 +443,8 @@ impl ShardStorage {
         transaction: &Transaction<'_, rocksdb::OptimisticTransactionDB>,
         blob_id: &BlobId,
     ) -> anyhow::Result<()> {
-        let column_families = [self.primary_slivers.cf()?, self.secondary_slivers.cf()?];
-        for cf in column_families {
-            transaction.delete_cf(&cf, blob_id)?;
-        }
-        Ok(())
+        self.slivers
+            .delete_pair_in_transaction(transaction, blob_id)
     }
 
     /// Returns the ids of existing shards that are fully initialized in the database at the
@@ -778,14 +560,6 @@ impl ShardStorage {
         sliver_type: SliverType,
         slivers_to_fetch: &[BlobId],
     ) -> Result<Vec<(BlobId, Sliver)>, TypedStoreError> {
-        let start = Instant::now();
-        let labels = Labels {
-            collection_name: self.cf_names.generic_slivers(sliver_type),
-            operation_name: OperationType::MultiGet,
-            query_summary: "MULTI_GET sliver BY blob_id_list",
-            ..Labels::default()
-        };
-
         #[cfg(msim)]
         {
             let mut return_empty = false;
@@ -796,39 +570,8 @@ impl ShardStorage {
             }
         }
 
-        let response = ByAxis::from(sliver_type)
-            .map(
-                // TODO(#648): compare multi_get with scan for large value size.
-                |_| self.primary_slivers.multi_get(slivers_to_fetch),
-                |_| self.secondary_slivers.multi_get(slivers_to_fetch),
-            )
-            .transpose();
-
-        self.metrics.observe_operation_duration(
-            labels.with_response(response.as_ref().map(|_| &())),
-            start.elapsed(),
-        );
-
-        let output = match response? {
-            ByAxis::Primary(slivers) => slivers_to_fetch
-                .iter()
-                .zip(slivers)
-                .filter_map(|(&blob_id, sliver)| {
-                    let PrimarySliverData::V1(sliver) = sliver?;
-                    Some((blob_id, Sliver::Primary(sliver)))
-                })
-                .collect(),
-            ByAxis::Secondary(slivers) => slivers_to_fetch
-                .iter()
-                .zip(slivers)
-                .filter_map(|(&blob_id, sliver)| {
-                    let SecondarySliverData::V1(sliver) = sliver?;
-                    Some((blob_id, Sliver::Secondary(sliver)))
-                })
-                .collect(),
-        };
-
-        Ok(output)
+        // TODO(#648): compare multi_get with scan for large value size.
+        self.slivers.get_many(sliver_type, slivers_to_fetch)
     }
 
     /// Syncs the shard to the current epoch from the previous shard owner.
@@ -883,16 +626,7 @@ impl ShardStorage {
         // Ensure any residual SST ingest buffers are reset before starting (or resuming) sync.
         // This protects from out-of-order appends after a failed/resumed run.
         if config.sst_ingestion_config.is_some() {
-            if let Some(m) = self.sst_primary_buffer.get()
-                && let Ok(mut buf) = m.lock()
-            {
-                buf.clear()?;
-            }
-            if let Some(m) = self.sst_secondary_buffer.get()
-                && let Ok(mut buf) = m.lock()
-            {
-                buf.clear()?;
-            }
+            self.slivers.clear_sst_buffers()?;
         }
 
         #[cfg(msim)]
@@ -1054,10 +788,7 @@ impl ShardStorage {
                     epoch,
                     next_starting_blob_id,
                 );
-                let mut batch = match sliver_type {
-                    SliverType::Primary => self.primary_slivers.batch(),
-                    SliverType::Secondary => self.secondary_slivers.batch(),
-                };
+                let mut batch = self.slivers.batch(sliver_type);
 
                 walrus_utils::with_label!(
                     node.metrics.sync_shard_sync_sliver_progress,
@@ -1190,61 +921,16 @@ impl ShardStorage {
         sst_file_threshold: usize,
         compact_after_sync: bool,
     ) -> Result<(), TypedStoreError> {
-        let flushed = match sliver_type {
-            SliverType::Primary => {
-                if let Some(buf_mutex) = self.sst_primary_buffer.get() {
-                    self.flush_sst(
-                        buf_mutex,
-                        &self.primary_slivers,
-                        end_of_range,
-                        sst_file_threshold,
-                        compact_after_sync,
-                    )?
-                } else {
-                    false
-                }
-            }
-            SliverType::Secondary => {
-                if let Some(buf_mutex) = self.sst_secondary_buffer.get() {
-                    self.flush_sst(
-                        buf_mutex,
-                        &self.secondary_slivers,
-                        end_of_range,
-                        sst_file_threshold,
-                        compact_after_sync,
-                    )?
-                } else {
-                    false
-                }
-            }
-        };
+        let flushed = self.slivers.flush_sst(
+            sliver_type,
+            end_of_range,
+            sst_file_threshold,
+            compact_after_sync,
+        )?;
         if flushed && let Some(id) = last_pushed {
             self.record_last_synced_blob_id(batch, sliver_type, id)?;
         }
         Ok(())
-    }
-
-    fn flush_sst<V>(
-        &self,
-        buf_mutex: &std::sync::Mutex<typed_store::rocks::SstIngestBuffer<BlobId, V>>,
-        table: &DBMap<BlobId, V>,
-        end_of_range: bool,
-        sst_file_threshold: usize,
-        compact_after_sync: bool,
-    ) -> Result<bool, TypedStoreError>
-    where
-        V: serde::Serialize,
-    {
-        let mut buf = buf_mutex.lock().expect("lock should succeed");
-        let should_flush = buf.size() >= sst_file_threshold || end_of_range;
-        if !should_flush {
-            return Ok(false);
-        }
-        buf.flush()?;
-        if end_of_range && compact_after_sync {
-            table.compact_range_to_bottom(&BlobId::ZERO, &BlobId::MAX)?;
-        }
-        Ok(true)
     }
 
     /// Helper function to add fetched slivers to the db batch and check for missing blobs.
@@ -1324,55 +1010,13 @@ impl ShardStorage {
                     dir_name: None,
                     assume_sorted: true,
                 };
-                match sliver {
-                    Sliver::Primary(primary) => {
-                        assert_eq!(sliver_type, SliverType::Primary);
-                        let buffer_mutex = self.sst_primary_buffer.get_or_init(|| {
-                            let buf = typed_store::rocks::SstIngestBuffer::new(
-                                &self.primary_slivers,
-                                options,
-                            )
-                            .expect("SST buffer creation should succeed");
-                            std::sync::Mutex::new(buf)
-                        });
-                        let mut buffer = buffer_mutex.lock().expect("lock should succeed");
-                        buffer
-                            .push(*blob_id, PrimarySliverData::from(primary.clone()))
-                            .map_err(|e| SyncShardClientError::Internal(anyhow::anyhow!(e)))?;
-                    }
-                    Sliver::Secondary(secondary) => {
-                        assert_eq!(sliver_type, SliverType::Secondary);
-                        let buffer_mutex = self.sst_secondary_buffer.get_or_init(|| {
-                            let buf = typed_store::rocks::SstIngestBuffer::new(
-                                &self.secondary_slivers,
-                                options,
-                            )
-                            .expect("SST buffer creation should succeed");
-                            std::sync::Mutex::new(buf)
-                        });
-                        let mut buffer = buffer_mutex.lock().expect("lock should succeed");
-                        buffer
-                            .push(*blob_id, SecondarySliverData::from(secondary.clone()))
-                            .map_err(|e| SyncShardClientError::Internal(anyhow::anyhow!(e)))?;
-                    }
-                }
+                assert_eq!(sliver_type, sliver.r#type());
+                self.slivers
+                    .push_sst(*blob_id, sliver, options)
+                    .map_err(|e| SyncShardClientError::Internal(anyhow::anyhow!(e)))?;
             } else {
-                match sliver {
-                    Sliver::Primary(primary) => {
-                        assert_eq!(sliver_type, SliverType::Primary);
-                        batch.insert_batch(
-                            &self.primary_slivers,
-                            [(blob_id, &PrimarySliverData::from(primary.clone()))],
-                        )?;
-                    }
-                    Sliver::Secondary(secondary) => {
-                        assert_eq!(sliver_type, SliverType::Secondary);
-                        batch.insert_batch(
-                            &self.secondary_slivers,
-                            [(blob_id, &SecondarySliverData::from(secondary.clone()))],
-                        )?;
-                    }
-                }
+                assert_eq!(sliver_type, sliver.r#type());
+                self.slivers.insert_in_batch(batch, blob_id, sliver)?;
             }
 
             next_blob_info = self.check_and_record_missing_blobs(
@@ -1893,22 +1537,20 @@ impl ShardStorage {
 
     /// Deletes the storage for the shard.
     pub fn delete_shard_storage(&self) -> Result<(), TypedStoreError> {
-        let rocksdb = self.primary_slivers.rocksdb.clone();
-
         // Drop column families in reverse order of creation in ShardStorage::create_or_reopen.
-        rocksdb
+        self.database
             .drop_cf(&self.cf_names.secondary_slivers)
             .map_err(typed_store_err_from_rocks_err)?;
-        rocksdb
+        self.database
             .drop_cf(&self.cf_names.primary_slivers)
             .map_err(typed_store_err_from_rocks_err)?;
-        rocksdb
+        self.database
             .drop_cf(&self.cf_names.pending_recover_slivers)
             .map_err(typed_store_err_from_rocks_err)?;
-        rocksdb
+        self.database
             .drop_cf(&self.cf_names.shard_sync_progress)
             .map_err(typed_store_err_from_rocks_err)?;
-        rocksdb
+        self.database
             .drop_cf(&self.cf_names.shard_status)
             .map_err(typed_store_err_from_rocks_err)?;
         Ok(())
@@ -1925,16 +1567,7 @@ impl ShardStorage {
 
     #[cfg(test)]
     pub(crate) fn sliver_count(&self, sliver_type: SliverType) -> Result<usize, TypedStoreError> {
-        match sliver_type {
-            SliverType::Primary => self
-                .primary_slivers
-                .safe_iter()?
-                .try_fold(0, |count, e| e.map(|_| count + 1)),
-            SliverType::Secondary => self
-                .secondary_slivers
-                .safe_iter()?
-                .try_fold(0, |count, e| e.map(|_| count + 1)),
-        }
+        self.slivers.sliver_count(sliver_type)
     }
 
     #[cfg(test)]

--- a/crates/walrus-service/src/node/storage/sliver_store.rs
+++ b/crates/walrus-service/src/node/storage/sliver_store.rs
@@ -1,0 +1,702 @@
+// Copyright (c) Walrus Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Backend abstraction for primary and secondary sliver storage.
+
+use std::{
+    sync::{Arc, OnceLock},
+    time::Instant,
+};
+
+use futures::{StreamExt, stream::FuturesUnordered};
+use rocksdb::Transaction;
+use serde::{Deserialize, Serialize};
+use typed_store::{
+    Map, TypedStoreError,
+    rocks::{
+        DBBatch, DBMap, ReadWriteOptions, RocksDB, SstIngestBuffer, SstIngestOptions,
+        errors::typed_store_err_from_rocks_err,
+    },
+};
+use walrus_core::{
+    BlobId, ShardIndex, Sliver, SliverType,
+    by_axis::ByAxis,
+    encoding::{PrimarySliver, SecondarySliver},
+};
+
+use super::{
+    DatabaseTableOptionsFactory, constants,
+    metrics::{CommonDatabaseMetrics, Labels, OperationType},
+};
+use crate::utils;
+
+/// Primary sliver data stored in the database.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PrimarySliverData {
+    V1(PrimarySliver),
+}
+
+impl From<PrimarySliver> for PrimarySliverData {
+    fn from(sliver: PrimarySliver) -> Self {
+        Self::V1(sliver)
+    }
+}
+
+impl From<PrimarySliverData> for PrimarySliver {
+    fn from(data: PrimarySliverData) -> Self {
+        match data {
+            PrimarySliverData::V1(sliver) => sliver,
+        }
+    }
+}
+
+/// Secondary sliver data stored in the database.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SecondarySliverData {
+    V1(SecondarySliver),
+}
+
+impl From<SecondarySliver> for SecondarySliverData {
+    fn from(sliver: SecondarySliver) -> Self {
+        Self::V1(sliver)
+    }
+}
+
+impl From<SecondarySliverData> for SecondarySliver {
+    fn from(data: SecondarySliverData) -> Self {
+        match data {
+            SecondarySliverData::V1(sliver) => sliver,
+        }
+    }
+}
+
+/// Node-wide sliver storage backend.
+///
+/// Cross-shard operations live on this type so a backend can answer them without Walrus issuing a
+/// separate lookup for every shard. Per-shard operations are exposed through [`ShardSliverStore`].
+#[derive(Debug, Clone)]
+pub(crate) struct SliverStore {
+    backend: Arc<SliverStoreBackend>,
+}
+
+#[derive(Debug)]
+enum SliverStoreBackend {
+    RocksDb(RocksDbSliverStore),
+}
+
+#[derive(Debug)]
+struct RocksDbSliverStore {
+    database: Arc<RocksDB>,
+    table_options: DatabaseTableOptionsFactory,
+}
+
+impl SliverStore {
+    pub(crate) fn new_rocksdb(
+        database: Arc<RocksDB>,
+        table_options: DatabaseTableOptionsFactory,
+    ) -> Self {
+        Self {
+            backend: Arc::new(SliverStoreBackend::RocksDb(RocksDbSliverStore {
+                database,
+                table_options,
+            })),
+        }
+    }
+
+    /// Opens the backend storage for one Walrus shard.
+    pub(super) fn open_shard(
+        &self,
+        shard: ShardIndex,
+        metrics: CommonDatabaseMetrics,
+    ) -> Result<ShardSliverStore, TypedStoreError> {
+        match self.backend.as_ref() {
+            SliverStoreBackend::RocksDb(store) => store.open_shard(shard, metrics),
+        }
+    }
+
+    /// Returns whether both sliver types exist for `blob_id` in every required Walrus shard.
+    ///
+    /// The required shards are selected by the caller because committee and epoch policy do not
+    /// belong in the storage backend. An empty set is complete by definition.
+    pub(crate) async fn contains_sliver_pairs_in_all(
+        &self,
+        blob_id: BlobId,
+        shards: Vec<(ShardIndex, ShardSliverStore)>,
+    ) -> Result<bool, TypedStoreError> {
+        match self.backend.as_ref() {
+            SliverStoreBackend::RocksDb(_) => {
+                if shards.len() > 1
+                    && first_shard_failing_check(
+                        blob_id,
+                        &shards,
+                        ShardSliverStore::may_have_sliver_pair,
+                    )
+                    .await?
+                    .is_some()
+                {
+                    return Ok(false);
+                }
+
+                Ok(first_shard_failing_check(
+                    blob_id,
+                    &shards,
+                    ShardSliverStore::is_sliver_pair_stored,
+                )
+                .await?
+                .is_none())
+            }
+        }
+    }
+
+    /// Synchronous counterpart used when the caller already runs on a blocking executor.
+    #[cfg(msim)]
+    pub(crate) fn contains_sliver_pairs_in_all_sync(
+        &self,
+        blob_id: &BlobId,
+        shards: &[(ShardIndex, ShardSliverStore)],
+    ) -> Result<bool, TypedStoreError> {
+        match self.backend.as_ref() {
+            SliverStoreBackend::RocksDb(_) => {
+                if shards.len() > 1 {
+                    for (_, store) in shards {
+                        if !store.may_have_sliver_pair(blob_id)? {
+                            return Ok(false);
+                        }
+                    }
+                }
+                for (_, store) in shards {
+                    if !store.is_sliver_pair_stored(blob_id)? {
+                        return Ok(false);
+                    }
+                }
+                Ok(true)
+            }
+        }
+    }
+}
+
+impl RocksDbSliverStore {
+    fn open_shard(
+        &self,
+        shard: ShardIndex,
+        metrics: CommonDatabaseMetrics,
+    ) -> Result<ShardSliverStore, TypedStoreError> {
+        let rw_options = ReadWriteOptions::default();
+
+        macro_rules! reopen_cf {
+            ($name:expr, $class:expr) => {{
+                let name = $name;
+                if self.database.cf_handle(&name).is_none() {
+                    #[cfg(msim)]
+                    sui_macros::fail_point!("create-cf-before");
+                    self.database
+                        .create_cf(&name, &self.table_options.shard())
+                        .map_err(typed_store_err_from_rocks_err)?;
+                }
+                DBMap::reopen_with_class(
+                    &self.database,
+                    Some(&name),
+                    Some($class),
+                    &rw_options,
+                    false,
+                )?
+            }};
+        }
+
+        // Sliver column families are deliberately opened after the shard control tables. Their
+        // presence is the existing RocksDB completion marker for shard creation.
+        let primary_slivers = reopen_cf!(
+            constants::primary_slivers_column_family_name(shard),
+            "primary_slivers"
+        );
+        let secondary_slivers = reopen_cf!(
+            constants::secondary_slivers_column_family_name(shard),
+            "secondary_slivers"
+        );
+
+        Ok(ShardSliverStore {
+            metrics,
+            backend: ShardSliverStoreBackend::RocksDb(RocksDbShardSliverStore {
+                primary_slivers,
+                secondary_slivers,
+                sst_primary_buffer: Arc::new(OnceLock::new()),
+                sst_secondary_buffer: Arc::new(OnceLock::new()),
+            }),
+        })
+    }
+}
+
+/// Backend storage for a single Walrus shard.
+#[derive(Debug, Clone)]
+pub(crate) struct ShardSliverStore {
+    metrics: CommonDatabaseMetrics,
+    backend: ShardSliverStoreBackend,
+}
+
+#[derive(Debug, Clone)]
+enum ShardSliverStoreBackend {
+    RocksDb(RocksDbShardSliverStore),
+}
+
+#[derive(Debug, Clone)]
+struct RocksDbShardSliverStore {
+    primary_slivers: DBMap<BlobId, PrimarySliverData>,
+    secondary_slivers: DBMap<BlobId, SecondarySliverData>,
+    sst_primary_buffer: Arc<OnceLock<std::sync::Mutex<SstIngestBuffer<BlobId, PrimarySliverData>>>>,
+    sst_secondary_buffer:
+        Arc<OnceLock<std::sync::Mutex<SstIngestBuffer<BlobId, SecondarySliverData>>>>,
+}
+
+impl ShardSliverStore {
+    /// Stores one sliver. This remains the normal foreground write API; bulk writes are only an
+    /// implementation option for workflows such as shard sync.
+    ///
+    /// Successful completion is the durability boundary used by subsequent control-state writes.
+    /// A backend that persists in the background must wait until the LSN corresponding to this
+    /// write has been published durably before returning.
+    pub(crate) async fn put(&self, blob_id: BlobId, sliver: Sliver) -> Result<(), TypedStoreError> {
+        let start = Instant::now();
+        let sliver_type = sliver.r#type();
+        let response = match &self.backend {
+            ShardSliverStoreBackend::RocksDb(store) => match sliver {
+                Sliver::Primary(primary) => {
+                    let table = store.primary_slivers.clone();
+                    utils::unwrap_or_resume_unwind(
+                        tokio::task::spawn_blocking(move || {
+                            table.insert(&blob_id, &PrimarySliverData::from(primary))
+                        })
+                        .await,
+                    )
+                }
+                Sliver::Secondary(secondary) => {
+                    let table = store.secondary_slivers.clone();
+                    utils::unwrap_or_resume_unwind(
+                        tokio::task::spawn_blocking(move || {
+                            table.insert(&blob_id, &SecondarySliverData::from(secondary))
+                        })
+                        .await,
+                    )
+                }
+            },
+        };
+        self.metrics.observe_operation_duration(
+            sliver_labels(
+                sliver_type,
+                OperationType::Insert,
+                "INSERT (blob_id, sliver)",
+            )
+            .with_response(response.as_ref()),
+            start.elapsed(),
+        );
+        response
+    }
+
+    pub(crate) fn get(
+        &self,
+        blob_id: &BlobId,
+        sliver_type: SliverType,
+    ) -> Result<Option<Sliver>, TypedStoreError> {
+        let start = Instant::now();
+        let query_summary = if sliver_type.is_primary() {
+            "GET primary_sliver BY blob_id"
+        } else {
+            "GET secondary_sliver BY blob_id"
+        };
+        let response = match sliver_type {
+            SliverType::Primary => self
+                .get_primary(blob_id)
+                .map(|sliver| sliver.map(Sliver::Primary)),
+            SliverType::Secondary => self
+                .get_secondary(blob_id)
+                .map(|sliver| sliver.map(Sliver::Secondary)),
+        };
+        self.metrics.observe_operation_duration(
+            sliver_labels(sliver_type, OperationType::Get, query_summary)
+                .with_response(response.as_ref()),
+            start.elapsed(),
+        );
+        response
+    }
+
+    fn get_primary(&self, blob_id: &BlobId) -> Result<Option<PrimarySliver>, TypedStoreError> {
+        match &self.backend {
+            ShardSliverStoreBackend::RocksDb(store) => store
+                .primary_slivers
+                .get(blob_id)
+                .map(|sliver| sliver.map(Into::into)),
+        }
+    }
+
+    fn get_secondary(&self, blob_id: &BlobId) -> Result<Option<SecondarySliver>, TypedStoreError> {
+        match &self.backend {
+            ShardSliverStoreBackend::RocksDb(store) => store
+                .secondary_slivers
+                .get(blob_id)
+                .map(|sliver| sliver.map(Into::into)),
+        }
+    }
+
+    pub(crate) fn may_have_sliver_pair(&self, blob_id: &BlobId) -> Result<bool, TypedStoreError> {
+        Ok(self.may_have(blob_id, SliverType::Primary)?
+            && self.may_have(blob_id, SliverType::Secondary)?)
+    }
+
+    pub(crate) fn may_have(
+        &self,
+        blob_id: &BlobId,
+        sliver_type: SliverType,
+    ) -> Result<bool, TypedStoreError> {
+        let start = Instant::now();
+        let response = match (&self.backend, sliver_type) {
+            (ShardSliverStoreBackend::RocksDb(store), SliverType::Primary) => {
+                store.primary_slivers.may_contain_key(blob_id)
+            }
+            (ShardSliverStoreBackend::RocksDb(store), SliverType::Secondary) => {
+                store.secondary_slivers.may_contain_key(blob_id)
+            }
+        };
+        self.metrics.observe_operation_duration(
+            sliver_labels(
+                sliver_type,
+                OperationType::ContainsKey,
+                "KEY_MAY_EXIST blob_id",
+            )
+            .with_response(response.as_ref()),
+            start.elapsed(),
+        );
+        response
+    }
+
+    pub(crate) fn is_sliver_pair_stored(&self, blob_id: &BlobId) -> Result<bool, TypedStoreError> {
+        Ok(self.contains(blob_id, SliverType::Primary)?
+            && self.contains(blob_id, SliverType::Secondary)?)
+    }
+
+    pub(crate) fn contains(
+        &self,
+        blob_id: &BlobId,
+        sliver_type: SliverType,
+    ) -> Result<bool, TypedStoreError> {
+        let start = Instant::now();
+        let response = match (&self.backend, sliver_type) {
+            (ShardSliverStoreBackend::RocksDb(store), SliverType::Primary) => {
+                store.primary_slivers.contains_key(blob_id)
+            }
+            (ShardSliverStoreBackend::RocksDb(store), SliverType::Secondary) => {
+                store.secondary_slivers.contains_key(blob_id)
+            }
+        };
+        self.metrics.observe_operation_duration(
+            sliver_labels(
+                sliver_type,
+                OperationType::ContainsKey,
+                "CONTAINS_KEY blob_id",
+            )
+            .with_response(response.as_ref()),
+            start.elapsed(),
+        );
+        response
+    }
+
+    pub(crate) fn get_many(
+        &self,
+        sliver_type: SliverType,
+        blob_ids: &[BlobId],
+    ) -> Result<Vec<(BlobId, Sliver)>, TypedStoreError> {
+        let start = Instant::now();
+        let response = match &self.backend {
+            ShardSliverStoreBackend::RocksDb(store) => ByAxis::from(sliver_type)
+                .map(
+                    |_| store.primary_slivers.multi_get(blob_ids),
+                    |_| store.secondary_slivers.multi_get(blob_ids),
+                )
+                .transpose(),
+        };
+
+        self.metrics.observe_operation_duration(
+            sliver_labels(
+                sliver_type,
+                OperationType::MultiGet,
+                "MULTI_GET sliver BY blob_id_list",
+            )
+            .with_response_as_unit(response.as_ref()),
+            start.elapsed(),
+        );
+
+        let output = match response? {
+            ByAxis::Primary(slivers) => blob_ids
+                .iter()
+                .zip(slivers)
+                .filter_map(|(&blob_id, sliver)| {
+                    let PrimarySliverData::V1(sliver) = sliver?;
+                    Some((blob_id, Sliver::Primary(sliver)))
+                })
+                .collect(),
+            ByAxis::Secondary(slivers) => blob_ids
+                .iter()
+                .zip(slivers)
+                .filter_map(|(&blob_id, sliver)| {
+                    let SecondarySliverData::V1(sliver) = sliver?;
+                    Some((blob_id, Sliver::Secondary(sliver)))
+                })
+                .collect(),
+        };
+        Ok(output)
+    }
+
+    pub(crate) fn batch(&self, sliver_type: SliverType) -> DBBatch {
+        match (&self.backend, sliver_type) {
+            (ShardSliverStoreBackend::RocksDb(store), SliverType::Primary) => {
+                store.primary_slivers.batch()
+            }
+            (ShardSliverStoreBackend::RocksDb(store), SliverType::Secondary) => {
+                store.secondary_slivers.batch()
+            }
+        }
+    }
+
+    pub(crate) fn insert_in_batch(
+        &self,
+        batch: &mut DBBatch,
+        blob_id: &BlobId,
+        sliver: &Sliver,
+    ) -> Result<(), TypedStoreError> {
+        match (&self.backend, sliver) {
+            (ShardSliverStoreBackend::RocksDb(store), Sliver::Primary(primary)) => batch
+                .insert_batch(
+                    &store.primary_slivers,
+                    [(blob_id, &PrimarySliverData::from(primary.clone()))],
+                )
+                .map(|_| ()),
+            (ShardSliverStoreBackend::RocksDb(store), Sliver::Secondary(secondary)) => batch
+                .insert_batch(
+                    &store.secondary_slivers,
+                    [(blob_id, &SecondarySliverData::from(secondary.clone()))],
+                )
+                .map(|_| ()),
+        }
+    }
+
+    pub(crate) fn push_sst(
+        &self,
+        blob_id: BlobId,
+        sliver: &Sliver,
+        options: SstIngestOptions,
+    ) -> Result<(), TypedStoreError> {
+        match (&self.backend, sliver) {
+            (ShardSliverStoreBackend::RocksDb(store), Sliver::Primary(primary)) => {
+                let buffer = store.sst_primary_buffer.get_or_init(|| {
+                    std::sync::Mutex::new(
+                        SstIngestBuffer::new(&store.primary_slivers, options)
+                            .expect("SST buffer creation should succeed"),
+                    )
+                });
+                buffer
+                    .lock()
+                    .expect("lock should succeed")
+                    .push(blob_id, PrimarySliverData::from(primary.clone()))
+            }
+            (ShardSliverStoreBackend::RocksDb(store), Sliver::Secondary(secondary)) => {
+                let buffer = store.sst_secondary_buffer.get_or_init(|| {
+                    std::sync::Mutex::new(
+                        SstIngestBuffer::new(&store.secondary_slivers, options)
+                            .expect("SST buffer creation should succeed"),
+                    )
+                });
+                buffer
+                    .lock()
+                    .expect("lock should succeed")
+                    .push(blob_id, SecondarySliverData::from(secondary.clone()))
+            }
+        }
+    }
+
+    pub(crate) fn clear_sst_buffers(&self) -> Result<(), TypedStoreError> {
+        match &self.backend {
+            ShardSliverStoreBackend::RocksDb(store) => {
+                if let Some(buffer) = store.sst_primary_buffer.get()
+                    && let Ok(mut buffer) = buffer.lock()
+                {
+                    buffer.clear()?;
+                }
+                if let Some(buffer) = store.sst_secondary_buffer.get()
+                    && let Ok(mut buffer) = buffer.lock()
+                {
+                    buffer.clear()?;
+                }
+                Ok(())
+            }
+        }
+    }
+
+    pub(crate) fn flush_sst(
+        &self,
+        sliver_type: SliverType,
+        end_of_range: bool,
+        sst_file_threshold: usize,
+        compact_after_sync: bool,
+    ) -> Result<bool, TypedStoreError> {
+        match (&self.backend, sliver_type) {
+            (ShardSliverStoreBackend::RocksDb(store), SliverType::Primary) => flush_sst_buffer(
+                store.sst_primary_buffer.get(),
+                &store.primary_slivers,
+                end_of_range,
+                sst_file_threshold,
+                compact_after_sync,
+            ),
+            (ShardSliverStoreBackend::RocksDb(store), SliverType::Secondary) => flush_sst_buffer(
+                store.sst_secondary_buffer.get(),
+                &store.secondary_slivers,
+                end_of_range,
+                sst_file_threshold,
+                compact_after_sync,
+            ),
+        }
+    }
+
+    pub(crate) fn delete_pair_in_batch(
+        &self,
+        batch: &mut DBBatch,
+        blob_id: &BlobId,
+    ) -> Result<(), TypedStoreError> {
+        match &self.backend {
+            ShardSliverStoreBackend::RocksDb(store) => {
+                batch.delete_batch(&store.primary_slivers, std::iter::once(blob_id))?;
+                batch.delete_batch(&store.secondary_slivers, std::iter::once(blob_id))?;
+                Ok(())
+            }
+        }
+    }
+
+    pub(crate) fn delete_pair_in_transaction(
+        &self,
+        transaction: &Transaction<'_, rocksdb::OptimisticTransactionDB>,
+        blob_id: &BlobId,
+    ) -> anyhow::Result<()> {
+        match &self.backend {
+            ShardSliverStoreBackend::RocksDb(store) => {
+                let column_families = [store.primary_slivers.cf()?, store.secondary_slivers.cf()?];
+                for cf in column_families {
+                    transaction.delete_cf(&cf, blob_id)?;
+                }
+                Ok(())
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn sliver_count(&self, sliver_type: SliverType) -> Result<usize, TypedStoreError> {
+        match (&self.backend, sliver_type) {
+            (ShardSliverStoreBackend::RocksDb(store), SliverType::Primary) => store
+                .primary_slivers
+                .safe_iter()?
+                .try_fold(0, |count, entry| entry.map(|_| count + 1)),
+            (ShardSliverStoreBackend::RocksDb(store), SliverType::Secondary) => store
+                .secondary_slivers
+                .safe_iter()?
+                .try_fold(0, |count, entry| entry.map(|_| count + 1)),
+        }
+    }
+}
+
+fn sliver_labels(
+    sliver_type: SliverType,
+    operation_name: OperationType,
+    query_summary: &'static str,
+) -> Labels<'static> {
+    Labels {
+        collection_name: if sliver_type.is_primary() {
+            "shard/primary-slivers"
+        } else {
+            "shard/secondary-slivers"
+        },
+        operation_name,
+        query_summary,
+        ..Labels::default()
+    }
+}
+
+fn flush_sst_buffer<V>(
+    buffer: Option<&std::sync::Mutex<SstIngestBuffer<BlobId, V>>>,
+    table: &DBMap<BlobId, V>,
+    end_of_range: bool,
+    sst_file_threshold: usize,
+    compact_after_sync: bool,
+) -> Result<bool, TypedStoreError>
+where
+    V: Serialize,
+{
+    let Some(buffer) = buffer else {
+        return Ok(false);
+    };
+    let mut buffer = buffer.lock().expect("lock should succeed");
+    if buffer.size() < sst_file_threshold && !end_of_range {
+        return Ok(false);
+    }
+    buffer.flush()?;
+    if end_of_range && compact_after_sync {
+        table.compact_range_to_bottom(&BlobId::ZERO, &BlobId::MAX)?;
+    }
+    Ok(true)
+}
+
+async fn first_shard_failing_check(
+    blob_id: BlobId,
+    shards: &[(ShardIndex, ShardSliverStore)],
+    check: fn(&ShardSliverStore, &BlobId) -> Result<bool, TypedStoreError>,
+) -> Result<Option<ShardIndex>, TypedStoreError> {
+    #[cfg(msim)]
+    {
+        for (shard, store) in shards {
+            if !check(store, &blob_id)? {
+                return Ok(Some(*shard));
+            }
+        }
+        return Ok(None);
+    }
+
+    #[cfg(not(msim))]
+    {
+        const MAX_CONCURRENT_SHARD_STORAGE_CHECKS: usize = 4;
+
+        let make_check = |shard: ShardIndex, store: ShardSliverStore| async move {
+            let passed = utils::unwrap_or_resume_unwind(
+                tokio::task::spawn_blocking(move || check(&store, &blob_id)).await,
+            )?;
+            Ok::<_, TypedStoreError>((shard, passed))
+        };
+
+        let mut shard_iter = shards.iter();
+        let mut checks = FuturesUnordered::new();
+        for _ in 0..MAX_CONCURRENT_SHARD_STORAGE_CHECKS {
+            let Some((shard, store)) = shard_iter.next() else {
+                break;
+            };
+            checks.push(make_check(*shard, store.clone()));
+        }
+
+        let mut first_failed_shard = None;
+        let mut first_error = None;
+        while let Some(result) = checks.next().await {
+            match result {
+                Ok((shard, false)) if first_failed_shard.is_none() => {
+                    first_failed_shard = Some(shard);
+                }
+                Ok(_) => {}
+                Err(error) if first_error.is_none() => first_error = Some(error),
+                Err(_) => {}
+            }
+
+            // Already-started blocking probes are drained, but no new work is queued after the
+            // result is known.
+            if first_failed_shard.is_none()
+                && first_error.is_none()
+                && let Some((shard, store)) = shard_iter.next()
+            {
+                checks.push(make_check(*shard, store.clone()));
+            }
+        }
+
+        first_error.map_or(Ok(first_failed_shard), Err)
+    }
+}


### PR DESCRIPTION
## Description

Introduce a storage boundary specifically for primary and secondary slivers, while keeping RocksDB as the only implementation in this PR.
This is a preparatory refactor: it does not add the Strata dependency or change storage behavior. The backend-specific shard-sync and garbage-collection ordering can be implemented in the Strata follow-up without spreading primary/secondary storage details through `ShardStorage`.

## Test plan

- `cargo check -p walrus-service --features node`
- `cargo clippy -p walrus-service --features node --lib`
- `cargo test -p walrus-service --features node node::storage::shard::tests --lib` (31 passed)
- `cargo test -p walrus-service --features node node::storage::tests --lib` (38 passed)
- `cargo test -p walrus-service --features node sync_shard_node_api_success --lib` (1 passed)

---

## Release notes

- [ ] Storage node:
- [ ] Aggregator:
- [ ] Publisher:
- [ ] CLI: